### PR TITLE
ci: disable auto-deploy until Azure secrets are configured

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,10 @@
 name: Deploy
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:  # Manual trigger until Azure secrets are configured
+  # Uncomment below once AZURE_* secrets are set in repo settings:
+  # push:
+  #   branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Switch Deploy workflow trigger from `push` to `workflow_dispatch` (manual)
- Deploy was failing on every push to main because Azure secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_SWA_TOKEN`) are not yet configured
- Re-enable push trigger by uncommenting once secrets are set in repo settings