### PR TITLE
chore: add User Story and Epic issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,93 @@
+name: Epic
+description: A major feature area spanning multiple sub-issues and PRs
+title: "[Epic] "
+labels: ["epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Epics group related work under a milestone. Each epic decomposes into focused sub-issues (one branch, one PR each).
+
+        **Naming**: `[Epic] <feature area>`
+        **Labels**: `epic` + one or more domain labels (`frontend`, `backend`, `ux`, etc.)
+        **Milestone**: Assign to a milestone before submitting.
+
+  - type: textarea
+    id: overview
+    attributes:
+      label: Overview
+      description: |
+        What is this epic about? What user problem does it solve?
+        Keep it high-level — details go in sub-issues.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problems-solved
+    attributes:
+      label: Problems Solved
+      description: |
+        What specific problems or gaps does this epic address?
+      placeholder: |
+        1. Users cannot X, which blocks Y
+        2. Current implementation of Z is fragile because...
+    validations:
+      required: true
+
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Architecture
+      description: |
+        High-level technical approach. Which modules/layers are affected?
+        Reference ADRs or design specs if applicable.
+      placeholder: |
+        - New Zustand slice in `entities/store/`
+        - Widget in `widgets/` following FSD structure
+        - Extends existing validation engine in `entities/validation/`
+    validations:
+      required: true
+
+  - type: textarea
+    id: sub-issues
+    attributes:
+      label: Sub-Issues
+      description: |
+        Break down into focused sub-issues. Each should fit in one branch and one PR.
+        Use checkbox format — these become the tracking checklist.
+      placeholder: |
+        - [ ] #XX — Store: add new state slice
+        - [ ] #XX — UI: create widget component
+        - [ ] #XX — Logic: implement business rules
+        - [ ] #XX — Tests: add integration tests
+        - [ ] #XX — Docs: update design spec
+    validations:
+      required: true
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: |
+        Other epics, issues, or external factors this epic depends on.
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: |
+        Technical constraints, design principles, or invariants that must be respected.
+      placeholder: |
+        - Must follow FSD layer rules (no widget importing from another widget)
+        - Universal stud standard must be maintained (rx=19, ry=9.5)
+        - No new runtime dependencies > 50kb
+
+  - type: input
+    id: branch-name
+    attributes:
+      label: Branch Name
+      description: |
+        Base branch name for this epic's work. Sub-issues branch from this or use their own feature branches.
+      placeholder: "feature/epic-name"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -1,0 +1,93 @@
+name: User Story
+description: A user-facing feature described from the user's perspective with acceptance criteria
+title: "[Story]: "
+labels: ["enhancement", "user-story"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe a feature from the **user's perspective**. Focus on what the user wants to achieve and how we'll verify it works.
+
+  - type: textarea
+    id: story
+    attributes:
+      label: User Story
+      description: |
+        Use the standard format: As a [role], I want [goal], so that [benefit].
+      placeholder: |
+        As a developer,
+        I want to visually build cloud architecture using blocks,
+        So that I can quickly prototype infra without writing Terraform.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: |
+        Concrete, testable conditions that must ALL be true for this story to be complete.
+        Use checkbox format. Each criterion should be independently verifiable.
+      placeholder: |
+        - [ ] User can drag a block from the resource palette onto the canvas
+        - [ ] Block snaps to the nearest grid position on drop
+        - [ ] Block appears with correct category icon and label
+        - [ ] Undo restores canvas to pre-drag state
+        - [ ] Screen reader announces "Block placed on [plate name]"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which part of CloudBlocks does this affect?
+      options:
+        - Frontend (Visual Editor)
+        - Code Generation
+        - Templates
+        - Workspace Management
+        - Validation Engine
+        - Backend / API
+        - GitHub Integration
+        - Learning Mode
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: design-notes
+    attributes:
+      label: Design & UX Notes
+      description: |
+        Mockups, wireframes, interaction details, or references to existing design specs.
+        Link to VISUAL_DESIGN_SPEC.md sections if applicable.
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: |
+        Explicitly list what this story does NOT cover to prevent scope creep.
+
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: |
+        Other issues, PRs, or external factors that must be resolved first.
+      placeholder: |
+        - Depends on #XX (store refactor)
+        - Requires design approval for new icon set
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: Estimated Size
+      description: Rough implementation effort.
+      options:
+        - "S — < 1 day (single file, small change)"
+        - "M — 1-3 days (multiple files, one feature slice)"
+        - "L — 3-5 days (cross-cutting, multiple components)"
+    validations:
+      required: true


### PR DESCRIPTION
## Summary

Adds two new GitHub issue templates to enforce structured planning for UI-facing features:

- **User Story template** — User perspective format (`As a [role], I want [goal], so that [benefit]`) with mandatory Acceptance Criteria, scope, design/UX notes, out-of-scope section, dependencies, and size estimate
- **Epic template** — Matches the AGENTS.md planning workflow structure: Overview, Problems Solved, Architecture, Sub-Issues (checkbox tracking), Dependencies, Constraints, Branch Name

Also created the `user-story` label (blue) for tagging story issues.

## Motivation

The project has UI as its primary surface. Task-oriented decomposition works for backend/infra, but UX-facing features benefit from User Story format with explicit Acceptance Criteria for:
- Clear definition of done
- QA-verifiable outcomes
- UX design alignment

## Changes

- `.github/ISSUE_TEMPLATE/user_story.yml` — new
- `.github/ISSUE_TEMPLATE/epic.yml` — new
- `user-story` label created via API

No code changes. No config.yml changes needed (existing `blank_issues_enabled: false` works).