### PR TITLE
test(design): brick design system shape, height, and stud compliance (#79)

### DIFF
--- a/apps/web/src/entities/block/__tests__/silhouettes.test.ts
+++ b/apps/web/src/entities/block/__tests__/silhouettes.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { SILHOUETTE_GENERATORS } from '../silhouettes';
+import {
+  BLOCK_VISUAL_PROFILES,
+  type BlockCategory,
+  type BrickSilhouette,
+  type BrickSizeTier,
+} from '../../../shared/types/index';
+
+const blockCategories: BlockCategory[] = [
+  'compute',
+  'database',
+  'storage',
+  'gateway',
+  'function',
+  'queue',
+  'event',
+  'timer',
+];
+
+const silhouetteTypes: BrickSilhouette[] = ['tower', 'heavy', 'shield', 'module'];
+const sizeTiers: BrickSizeTier[] = ['signal', 'light', 'service', 'core', 'anchor'];
+
+function makeDimensions(sideWallPx: number) {
+  return {
+    screenWidth: 224,
+    diamondHeight: 112,
+    sideWallPx,
+    cx: 112,
+    topY: 10,
+    midY: 66,
+    bottomY: 122,
+    leftX: 10,
+    rightX: 214,
+    margin: 10,
+    padding: 10,
+  };
+}
+
+describe('block silhouettes', () => {
+  it.each(silhouetteTypes)('%s generator returns non-empty polygon strings', (silhouette) => {
+    const generator = SILHOUETTE_GENERATORS[silhouette];
+    const polygons = generator(makeDimensions(24));
+
+    expect(typeof polygons.topFacePoints).toBe('string');
+    expect(polygons.topFacePoints.trim().length).toBeGreaterThan(0);
+    expect(typeof polygons.leftSidePoints).toBe('string');
+    expect(polygons.leftSidePoints.trim().length).toBeGreaterThan(0);
+    expect(typeof polygons.rightSidePoints).toBe('string');
+    expect(polygons.rightSidePoints.trim().length).toBeGreaterThan(0);
+  });
+
+  it.each(silhouetteTypes)('%s generator output changes with height changes', (silhouette) => {
+    const generator = SILHOUETTE_GENERATORS[silhouette];
+    const low = generator(makeDimensions(16));
+    const high = generator(makeDimensions(48));
+
+    expect(low.leftSidePoints).not.toBe(high.leftSidePoints);
+    expect(low.rightSidePoints).not.toBe(high.rightSidePoints);
+  });
+});
+
+describe('visual profile coverage', () => {
+  it('covers every block category with a profile', () => {
+    expect(Object.keys(BLOCK_VISUAL_PROFILES).sort()).toEqual([...blockCategories].sort());
+  });
+
+  it('uses valid tier and silhouette values for each category profile', () => {
+    for (const category of blockCategories) {
+      const profile = BLOCK_VISUAL_PROFILES[category];
+
+      expect(profile).toBeDefined();
+      expect(sizeTiers).toContain(profile.tier);
+      expect(silhouetteTypes).toContain(profile.silhouette);
+      expect(profile.surface).toBe('studded');
+      expect(SILHOUETTE_GENERATORS[profile.silhouette]).toBeTypeOf('function');
+    }
+  });
+});

--- a/apps/web/src/shared/tokens/__tests__/designTokens.test.ts
+++ b/apps/web/src/shared/tokens/__tests__/designTokens.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BLOCK_WORLD_HEIGHT,
+  STUD_RX,
+  STUD_RY,
+  TIER_HEIGHTS,
+  TILE_H,
+  TILE_W,
+  TILE_Z,
+  getBlockWorldHeight,
+} from '../designTokens';
+import { BLOCK_VISUAL_PROFILES, type BlockCategory, type BrickSizeTier } from '../../types/index';
+
+const blockCategories: BlockCategory[] = [
+  'compute',
+  'database',
+  'storage',
+  'gateway',
+  'function',
+  'queue',
+  'event',
+  'timer',
+];
+
+const sizeTiers: BrickSizeTier[] = ['signal', 'light', 'service', 'core', 'anchor'];
+
+const tierScales: Record<BrickSizeTier, number> = {
+  signal: 0.5,
+  light: 0.6,
+  service: 0.8,
+  core: 1.0,
+  anchor: 1.2,
+};
+
+describe('design tokens - heights', () => {
+  it('defines TIER_HEIGHTS for all expected tiers', () => {
+    expect(Object.keys(TIER_HEIGHTS).sort()).toEqual([...sizeTiers].sort());
+  });
+
+  it('uses expected height scale values per tier', () => {
+    expect(TIER_HEIGHTS).toEqual(tierScales);
+  });
+
+  it('returns correct per-category height scale from visual profile tier', () => {
+    for (const category of blockCategories) {
+      const expectedTier = BLOCK_VISUAL_PROFILES[category].tier;
+      expect(getBlockWorldHeight(category)).toBe(tierScales[expectedTier]);
+    }
+  });
+
+  it('supports deriving absolute world height from base height and tier scale', () => {
+    for (const category of blockCategories) {
+      const tier = BLOCK_VISUAL_PROFILES[category].tier;
+      const absoluteHeight = BLOCK_WORLD_HEIGHT * getBlockWorldHeight(category);
+      expect(absoluteHeight).toBe(BLOCK_WORLD_HEIGHT * tierScales[tier]);
+    }
+  });
+});
+
+describe('design tokens - core dimensions and stud compliance', () => {
+  it('uses expected tile dimensions', () => {
+    expect(TILE_W).toBe(64);
+    expect(TILE_H).toBe(32);
+    expect(TILE_Z).toBe(32);
+  });
+
+  it('keeps universal stud rx/ry dimensions consistent', () => {
+    expect(STUD_RX).toBe(12);
+    expect(STUD_RY).toBe(6);
+  });
+});


### PR DESCRIPTION
## Summary
- Add silhouette system tests for all four generators (`tower`, `heavy`, `shield`, `module`) to verify non-empty polygon output and height-sensitive geometry changes.
- Add visual profile coverage tests to ensure every `BlockCategory` has a profile and valid `tier`/`silhouette` values mapped to implemented generators.
- Add design token tests for tier scales, block height resolution behavior, tile dimensions, and universal stud constants.

## Validation
- `cd apps/web && npx vitest run` (1062 passed)
- `pnpm lint`
- `pnpm build`

## Notes
- Current code constants validated by tests: `STUD_RX=12`, `STUD_RY=6`, `TILE_Z=32`.

Closes #79