### PR TITLE
feat: add Redis session backend for multi-replica support (#61)

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -28,6 +28,11 @@ class Settings(BaseSettings):
     # Database
     database_url: str = "sqlite+aiosqlite:///cloudblocks.db"
 
+    session_backend: str = "sqlite"
+    redis_url: str = "redis://localhost:6379/0"
+    redis_session_sliding_ttl_days: int = 14
+    redis_session_absolute_ttl_days: int = 30
+
     # CORS
     cors_origins: list[str] = ["http://localhost:5173"]
 

--- a/apps/api/app/core/dependencies.py
+++ b/apps/api/app/core/dependencies.py
@@ -20,6 +20,8 @@ from app.domain.models.repositories import (
     UserRepository,
     WorkspaceRepository,
 )
+from app.infrastructure.cache.redis_client import RedisClient
+from app.infrastructure.cache.redis_session_repo import RedisSessionRepository
 from app.infrastructure.db.connection import (
     Database,
     DatabaseProtocol,
@@ -35,6 +37,7 @@ _github_service = GitHubService(
 
 
 _db = create_database(settings.database_url)
+_redis_client: RedisClient | None = None
 
 
 def get_database() -> DatabaseProtocol:
@@ -94,6 +97,17 @@ def get_generation_run_repo(
 
 
 def get_session_repo(db: Annotated[DatabaseProtocol, Depends(get_database)]) -> SessionRepository:
+    if settings.session_backend == "redis":
+        if _redis_client is None:
+            raise RuntimeError(
+                "Redis session backend is enabled but Redis client is not initialized."
+            )
+        return RedisSessionRepository(
+            _redis_client,
+            sliding_ttl_days=settings.redis_session_sliding_ttl_days,
+            absolute_ttl_days=settings.redis_session_absolute_ttl_days,
+        )
+
     if isinstance(db, PostgresDatabase):
         from app.infrastructure.db.pg_repositories import PgSessionRepository
 

--- a/apps/api/app/infrastructure/cache/__init__.py
+++ b/apps/api/app/infrastructure/cache/__init__.py
@@ -1,1 +1,6 @@
-"""CloudBlocks API - Cache infrastructure."""
+from __future__ import annotations
+
+from app.infrastructure.cache.redis_client import RedisClient, create_redis_client
+from app.infrastructure.cache.redis_session_repo import RedisSessionRepository
+
+__all__ = ["RedisClient", "RedisSessionRepository", "create_redis_client"]

--- a/apps/api/app/infrastructure/cache/redis_client.py
+++ b/apps/api/app/infrastructure/cache/redis_client.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib
+from typing import Protocol, cast
+
+
+class RedisAsyncClientProtocol(Protocol):
+    async def ping(self) -> object: ...
+
+    async def aclose(self) -> None: ...
+
+    async def get(self, key: str) -> str | bytes | None: ...
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> object: ...
+
+    async def delete(self, *keys: str) -> int: ...
+
+    async def sadd(self, key: str, *values: str) -> int: ...
+
+    async def srem(self, key: str, *values: str) -> int: ...
+
+    async def smembers(self, key: str) -> set[str | bytes]: ...
+
+    async def scan(
+        self,
+        cursor: int | str = 0,
+        match: str | None = None,
+        count: int | None = None,
+    ) -> tuple[int | str, list[str | bytes]]: ...
+
+
+class RedisClient:
+    def __init__(self, url: str) -> None:
+        self._url: str = url
+        self._client: RedisAsyncClientProtocol | None = None
+
+    async def connect(self) -> None:
+        if self._client is not None:
+            return
+
+        redis_async = importlib.import_module("redis.asyncio")
+        client = cast(
+            RedisAsyncClientProtocol,
+            redis_async.from_url(self._url, decode_responses=True),
+        )
+        await client.ping()
+        self._client = client
+
+    async def disconnect(self) -> None:
+        if self._client is None:
+            return
+        await self._client.aclose()
+        self._client = None
+
+    @property
+    def client(self) -> RedisAsyncClientProtocol:
+        if self._client is None:
+            raise RuntimeError("Redis client not connected. Call connect() first.")
+        return self._client
+
+
+def create_redis_client(url: str) -> RedisClient:
+    return RedisClient(url)

--- a/apps/api/app/infrastructure/cache/redis_session_repo.py
+++ b/apps/api/app/infrastructure/cache/redis_session_repo.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+
+from app.domain.models.entities import Session
+from app.domain.models.repositories import SessionRepository
+from app.infrastructure.cache.redis_client import RedisClient
+
+
+class RedisSessionRepository(SessionRepository):
+    def __init__(
+        self,
+        redis_client: RedisClient,
+        sliding_ttl_days: int = 14,
+        absolute_ttl_days: int = 30,
+        now_fn: Callable[[], int] | None = None,
+    ) -> None:
+        self._redis_client = redis_client
+        self._sliding_ttl_seconds = sliding_ttl_days * 24 * 3600
+        self._absolute_ttl_seconds = absolute_ttl_days * 24 * 3600
+        self._now_fn = now_fn or (lambda: int(time.time()))
+
+    @property
+    def _redis(self):
+        return self._redis_client.client
+
+    def _now(self) -> int:
+        return self._now_fn()
+
+    @staticmethod
+    def _session_key(session_id: str) -> str:
+        return f"cb:sess:{session_id}"
+
+    @staticmethod
+    def _user_session_index_key(user_id: str) -> str:
+        return f"cb:user_sess:{user_id}"
+
+    @staticmethod
+    def _decode(value: str | bytes) -> str:
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return value
+
+    def _effective_expiry(self, created_at: int, now: int) -> int:
+        absolute_deadline = created_at + self._absolute_ttl_seconds
+        sliding_deadline = now + self._sliding_ttl_seconds
+        return min(absolute_deadline, sliding_deadline)
+
+    def _ttl_seconds(self, created_at: int, now: int) -> int:
+        return self._effective_expiry(created_at, now) - now
+
+    @staticmethod
+    def _serialize(session: Session) -> str:
+        return json.dumps(session.model_dump())
+
+    @staticmethod
+    def _deserialize(payload: str | bytes) -> Session:
+        return Session.model_validate(json.loads(RedisSessionRepository._decode(payload)))
+
+    async def _read_session(self, session_id: str) -> Session | None:
+        payload = await self._redis.get(self._session_key(session_id))
+        if payload is None:
+            return None
+        return self._deserialize(payload)
+
+    async def create(self, session: Session) -> Session:
+        now = self._now()
+        ttl_seconds = self._ttl_seconds(session.created_at, now)
+        if ttl_seconds <= 0:
+            return session
+
+        session.expires_at = self._effective_expiry(session.created_at, now)
+        await self._redis.set(
+            self._session_key(session.id),
+            self._serialize(session),
+            ex=ttl_seconds,
+        )
+        await self._redis.sadd(self._user_session_index_key(session.user_id), session.id)
+        return session
+
+    async def get_by_id(self, session_id: str) -> Session | None:
+        session = await self._read_session(session_id)
+        if session is None:
+            return None
+
+        now = self._now()
+        if session.expires_at < now or session.revoked_at is not None:
+            return None
+        return session
+
+    async def revoke(self, session_id: str) -> None:
+        session = await self._read_session(session_id)
+        if session is None:
+            return
+
+        now = self._now()
+        if session.revoked_at is None:
+            session.revoked_at = now
+
+        ttl_seconds = self._ttl_seconds(session.created_at, now)
+        if ttl_seconds <= 0:
+            await self._redis.delete(self._session_key(session_id))
+        else:
+            await self._redis.set(
+                self._session_key(session_id),
+                self._serialize(session),
+                ex=ttl_seconds,
+            )
+        await self._redis.srem(self._user_session_index_key(session.user_id), session.id)
+
+    async def update_last_seen(self, session_id: str, timestamp: int) -> None:
+        session = await self._read_session(session_id)
+        if session is None:
+            return
+
+        session.last_seen_at = timestamp
+        session.expires_at = self._effective_expiry(session.created_at, timestamp)
+
+        now = self._now()
+        ttl_seconds = session.expires_at - now
+        if ttl_seconds <= 0:
+            await self._redis.delete(self._session_key(session_id))
+            await self._redis.srem(self._user_session_index_key(session.user_id), session.id)
+            return
+
+        await self._redis.set(
+            self._session_key(session.id),
+            self._serialize(session),
+            ex=ttl_seconds,
+        )
+
+    async def revoke_all_for_user(self, user_id: str) -> None:
+        user_index_key = self._user_session_index_key(user_id)
+        session_ids = await self._redis.smembers(user_index_key)
+        for session_id in session_ids:
+            await self.revoke(self._decode(session_id))
+        await self._redis.delete(user_index_key)
+
+    async def update_workspace(
+        self,
+        session_id: str,
+        workspace_id: str,
+        repo_full_name: str | None,
+    ) -> None:
+        session = await self._read_session(session_id)
+        if session is None:
+            return
+
+        session.current_workspace_id = workspace_id
+        session.current_repo_full_name = repo_full_name
+
+        now = self._now()
+        ttl_seconds = self._ttl_seconds(session.created_at, now)
+        if ttl_seconds <= 0:
+            await self._redis.delete(self._session_key(session_id))
+            await self._redis.srem(self._user_session_index_key(session.user_id), session.id)
+            return
+
+        await self._redis.set(
+            self._session_key(session.id),
+            self._serialize(session),
+            ex=ttl_seconds,
+        )
+
+    async def cleanup_expired(self) -> int:
+        deleted = 0
+        cursor: int | str = 0
+        now = self._now()
+
+        while True:
+            cursor, keys = await self._redis.scan(cursor=cursor, match="cb:sess:*")
+            for raw_key in keys:
+                key = self._decode(raw_key)
+                payload = await self._redis.get(key)
+                if payload is None:
+                    continue
+
+                remove_key = False
+                user_id: str | None = None
+                session_id: str | None = None
+
+                try:
+                    session = self._deserialize(payload)
+                    user_id = session.user_id
+                    session_id = session.id
+                    if session.expires_at < now or session.revoked_at is not None:
+                        remove_key = True
+                except (json.JSONDecodeError, ValueError):
+                    remove_key = True
+
+                if remove_key:
+                    result = await self._redis.delete(key)
+                    if result:
+                        deleted += int(result)
+                    if user_id is not None and session_id is not None:
+                        await self._redis.srem(self._user_session_index_key(user_id), session_id)
+
+            if str(cursor) == "0":
+                break
+
+        return deleted

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -23,9 +23,11 @@ from app.api.routes.generation import router as generation_router
 from app.api.routes.github import router as github_router
 from app.api.routes.session import router as session_router
 from app.api.routes.workspaces import router as workspace_router
+from app.core import dependencies as dependency_container
 from app.core.config import settings
 from app.core.dependencies import get_database
 from app.core.errors import AppError
+from app.infrastructure.cache.redis_client import create_redis_client
 
 
 @asynccontextmanager
@@ -33,7 +35,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     """Application lifespan — connect/disconnect database."""
     db = get_database()
     await db.connect()
+    redis_client = None
+    if settings.session_backend == "redis":
+        redis_client = create_redis_client(settings.redis_url)
+        await redis_client.connect()
+        dependency_container._redis_client = redis_client
     yield
+    if redis_client is not None:
+        await redis_client.disconnect()
+        dependency_container._redis_client = None
     await db.disconnect()
 
 

--- a/apps/api/app/tests/unit/test_config.py
+++ b/apps/api/app/tests/unit/test_config.py
@@ -24,6 +24,10 @@ def test_settings_instantiation_with_defaults() -> None:
     assert cfg.jwt_expiration_seconds == 3600
     assert cfg.jwt_refresh_expiration_seconds == 86400 * 7
     assert cfg.database_url == "sqlite+aiosqlite:///cloudblocks.db"
+    assert cfg.session_backend == "sqlite"
+    assert cfg.redis_url == "redis://localhost:6379/0"
+    assert cfg.redis_session_sliding_ttl_days == 14
+    assert cfg.redis_session_absolute_ttl_days == 30
     assert cfg.cors_origins == ["http://localhost:5173"]
 
 

--- a/apps/api/app/tests/unit/test_redis_client.py
+++ b/apps/api/app/tests/unit/test_redis_client.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.infrastructure.cache.redis_client import RedisClient, create_redis_client
+
+
+@pytest.mark.asyncio
+async def test_connect_creates_client_and_pings() -> None:
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+    redis_async_module = SimpleNamespace(from_url=MagicMock(return_value=mock_redis))
+
+    with patch(
+        "app.infrastructure.cache.redis_client.importlib.import_module",
+        return_value=redis_async_module,
+    ) as import_module:
+        client = RedisClient("redis://localhost:6379/0")
+        await client.connect()
+        await client.connect()
+
+    import_module.assert_called_once_with("redis.asyncio")
+    redis_async_module.from_url.assert_called_once_with(
+        "redis://localhost:6379/0",
+        decode_responses=True,
+    )
+    mock_redis.ping.assert_awaited_once()
+    assert client.client is mock_redis
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_pool_and_clears_client() -> None:
+    mock_redis = AsyncMock()
+    mock_redis.ping = AsyncMock(return_value=True)
+    mock_redis.aclose = AsyncMock(return_value=None)
+    redis_async_module = SimpleNamespace(from_url=MagicMock(return_value=mock_redis))
+
+    with patch(
+        "app.infrastructure.cache.redis_client.importlib.import_module",
+        return_value=redis_async_module,
+    ):
+        client = RedisClient("redis://localhost:6379/0")
+        await client.connect()
+
+    await client.disconnect()
+    mock_redis.aclose.assert_awaited_once()
+
+    with pytest.raises(RuntimeError, match="Redis client not connected"):
+        _ = client.client
+
+
+@pytest.mark.asyncio
+async def test_disconnect_is_noop_when_not_connected() -> None:
+    client = RedisClient("redis://localhost:6379/0")
+    await client.disconnect()
+
+
+def test_create_redis_client_factory() -> None:
+    client = create_redis_client("redis://localhost:6379/0")
+    assert isinstance(client, RedisClient)

--- a/apps/api/app/tests/unit/test_redis_session.py
+++ b/apps/api/app/tests/unit/test_redis_session.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.domain.models.entities import Session
+from app.infrastructure.cache.redis_client import RedisClient
+from app.infrastructure.cache.redis_session_repo import RedisSessionRepository
+
+SECONDS_PER_DAY = 24 * 3600
+
+
+def make_session(
+    *,
+    session_id: str = "sess-1",
+    user_id: str = "user-1",
+    created_at: int = 1_700_000_000,
+    expires_at: int = 1_700_100_000,
+    revoked_at: int | None = None,
+    last_seen_at: int | None = None,
+    current_workspace_id: str | None = None,
+    current_repo_full_name: str | None = None,
+) -> Session:
+    return Session(
+        id=session_id,
+        user_id=user_id,
+        created_at=created_at,
+        expires_at=expires_at,
+        revoked_at=revoked_at,
+        last_seen_at=last_seen_at,
+        current_workspace_id=current_workspace_id,
+        current_repo_full_name=current_repo_full_name,
+    )
+
+
+def build_repo(redis_mock: AsyncMock, now: int) -> RedisSessionRepository:
+    client = RedisClient("redis://localhost:6379/0")
+    client._client = redis_mock
+    return RedisSessionRepository(
+        client,
+        sliding_ttl_days=14,
+        absolute_ttl_days=30,
+        now_fn=lambda: now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_stores_session_and_user_index() -> None:
+    now = 1_710_000_000
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.sadd = AsyncMock(return_value=1)
+    repo = build_repo(redis_mock, now)
+
+    session = make_session(created_at=now - 100)
+    created = await repo.create(session)
+
+    expected_ttl = 14 * SECONDS_PER_DAY
+    set_args = redis_mock.set.await_args
+    assert set_args.args[0] == "cb:sess:sess-1"
+    assert set_args.kwargs["ex"] == expected_ttl
+    stored_payload = json.loads(set_args.args[1])
+    assert stored_payload["expires_at"] == now + expected_ttl
+    redis_mock.sadd.assert_awaited_once_with("cb:user_sess:user-1", "sess-1")
+    assert created.expires_at == now + expected_ttl
+
+
+@pytest.mark.asyncio
+async def test_create_enforces_absolute_cap_for_ttl() -> None:
+    now = 1_710_000_000
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.sadd = AsyncMock(return_value=1)
+    repo = build_repo(redis_mock, now)
+
+    created_at = now - (29 * SECONDS_PER_DAY)
+    session = make_session(created_at=created_at)
+    await repo.create(session)
+
+    expected_ttl = SECONDS_PER_DAY
+    set_args = redis_mock.set.await_args
+    assert set_args.kwargs["ex"] == expected_ttl
+    payload = json.loads(set_args.args[1])
+    assert payload["expires_at"] == now + expected_ttl
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_none_for_missing() -> None:
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value=None)
+    repo = build_repo(redis_mock, 1_710_000_000)
+
+    assert await repo.get_by_id("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_filters_revoked_and_expired() -> None:
+    now = 1_710_000_000
+    revoked = make_session(expires_at=now + 100, revoked_at=now - 1)
+    expired = make_session(expires_at=now - 1, revoked_at=None)
+
+    redis_mock_revoked = AsyncMock()
+    redis_mock_revoked.get = AsyncMock(return_value=json.dumps(revoked.model_dump()))
+    repo_revoked = build_repo(redis_mock_revoked, now)
+    assert await repo_revoked.get_by_id(revoked.id) is None
+
+    redis_mock_expired = AsyncMock()
+    redis_mock_expired.get = AsyncMock(return_value=json.dumps(expired.model_dump()))
+    repo_expired = build_repo(redis_mock_expired, now)
+    assert await repo_expired.get_by_id(expired.id) is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_marks_session_and_removes_from_user_index() -> None:
+    now = 1_710_000_000
+    session = make_session(created_at=now - 100)
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value=json.dumps(session.model_dump()))
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.srem = AsyncMock(return_value=1)
+    repo = build_repo(redis_mock, now)
+
+    await repo.revoke(session.id)
+
+    set_args = redis_mock.set.await_args
+    payload = json.loads(set_args.args[1])
+    assert payload["revoked_at"] == now
+    redis_mock.srem.assert_awaited_once_with("cb:user_sess:user-1", "sess-1")
+
+
+@pytest.mark.asyncio
+async def test_revoke_already_revoked_keeps_existing_timestamp() -> None:
+    now = 1_710_000_000
+    existing_revoked_at = now - 500
+    session = make_session(created_at=now - 100, revoked_at=existing_revoked_at)
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value=json.dumps(session.model_dump()))
+    redis_mock.set = AsyncMock(return_value=True)
+    redis_mock.srem = AsyncMock(return_value=1)
+    repo = build_repo(redis_mock, now)
+
+    await repo.revoke(session.id)
+
+    payload = json.loads(redis_mock.set.await_args.args[1])
+    assert payload["revoked_at"] == existing_revoked_at
+
+
+@pytest.mark.asyncio
+async def test_update_last_seen_refreshes_sliding_ttl() -> None:
+    now = 1_710_000_000
+    session = make_session(created_at=now - 2 * SECONDS_PER_DAY)
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value=json.dumps(session.model_dump()))
+    redis_mock.set = AsyncMock(return_value=True)
+    repo = build_repo(redis_mock, now)
+
+    await repo.update_last_seen(session.id, now)
+
+    set_args = redis_mock.set.await_args
+    assert set_args.kwargs["ex"] == 14 * SECONDS_PER_DAY
+    payload = json.loads(set_args.args[1])
+    assert payload["last_seen_at"] == now
+    assert payload["expires_at"] == now + 14 * SECONDS_PER_DAY
+
+
+@pytest.mark.asyncio
+async def test_update_last_seen_respects_absolute_cap() -> None:
+    now = 1_710_000_000
+    session = make_session(created_at=now - (29 * SECONDS_PER_DAY))
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value=json.dumps(session.model_dump()))
+    redis_mock.set = AsyncMock(return_value=True)
+    repo = build_repo(redis_mock, now)
+
+    await repo.update_last_seen(session.id, now)
+
+    set_args = redis_mock.set.await_args
+    assert set_args.kwargs["ex"] == SECONDS_PER_DAY
+    payload = json.loads(set_args.args[1])
+    assert payload["expires_at"] == now + SECONDS_PER_DAY
+
+
+@pytest.mark.asyncio
+async def test_revoke_all_for_user_revokes_all_and_deletes_index() -> None:
+    redis_mock = AsyncMock()
+    redis_mock.smembers = AsyncMock(return_value={b"sid-1", "sid-2"})
+    redis_mock.delete = AsyncMock(return_value=1)
+    repo = build_repo(redis_mock, 1_710_000_000)
+    repo.revoke = AsyncMock(return_value=None)
+
+    await repo.revoke_all_for_user("user-1")
+
+    repo.revoke.assert_any_await("sid-1")
+    repo.revoke.assert_any_await("sid-2")
+    assert repo.revoke.await_count == 2
+    redis_mock.delete.assert_awaited_once_with("cb:user_sess:user-1")
+
+
+@pytest.mark.asyncio
+async def test_update_workspace_updates_fields() -> None:
+    now = 1_710_000_000
+    session = make_session(created_at=now - 1_000)
+    redis_mock = AsyncMock()
+    redis_mock.get = AsyncMock(return_value=json.dumps(session.model_dump()))
+    redis_mock.set = AsyncMock(return_value=True)
+    repo = build_repo(redis_mock, now)
+
+    await repo.update_workspace("sess-1", "ws-123", "org/repo")
+
+    payload = json.loads(redis_mock.set.await_args.args[1])
+    assert payload["current_workspace_id"] == "ws-123"
+    assert payload["current_repo_full_name"] == "org/repo"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_deletes_revoked_and_expired_sessions() -> None:
+    now = 1_710_000_000
+    active = make_session(session_id="active", expires_at=now + 10_000)
+    revoked = make_session(session_id="revoked", expires_at=now + 10_000, revoked_at=now - 1)
+    expired = make_session(session_id="expired", expires_at=now - 1)
+
+    payloads = {
+        "cb:sess:active": json.dumps(active.model_dump()),
+        "cb:sess:revoked": json.dumps(revoked.model_dump()),
+        "cb:sess:expired": json.dumps(expired.model_dump()),
+    }
+
+    redis_mock = AsyncMock()
+    redis_mock.scan = AsyncMock(return_value=("0", list(payloads.keys())))
+
+    async def get_payload(key: str) -> str | None:
+        return payloads.get(key)
+
+    redis_mock.get = AsyncMock(side_effect=get_payload)
+    redis_mock.delete = AsyncMock(return_value=1)
+    redis_mock.srem = AsyncMock(return_value=1)
+    repo = build_repo(redis_mock, now)
+
+    deleted = await repo.cleanup_expired()
+
+    assert deleted == 2
+    redis_mock.delete.assert_any_await("cb:sess:revoked")
+    redis_mock.delete.assert_any_await("cb:sess:expired")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_expired_returns_zero_when_none_expired() -> None:
+    now = 1_710_000_000
+    active = make_session(expires_at=now + 10_000)
+    redis_mock = AsyncMock()
+    redis_mock.scan = AsyncMock(return_value=("0", ["cb:sess:active"]))
+    redis_mock.get = AsyncMock(return_value=json.dumps(active.model_dump()))
+    redis_mock.delete = AsyncMock(return_value=0)
+    redis_mock.srem = AsyncMock(return_value=0)
+    repo = build_repo(redis_mock, now)
+
+    deleted = await repo.cleanup_expired()
+
+    assert deleted == 0
+    redis_mock.delete.assert_not_awaited()

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "PyJWT>=2.8.0",
     "httpx>=0.27.0",
     "cryptography>=42.0.0",
+    "redis[hiredis]>=5.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- Implements `RedisSessionRepository` as an alternative session backend for multi-replica deployment on Azure Container Apps
- Adds `RedisClient` with connection pooling, Protocol-based typing, and FastAPI lifespan integration
- Config-driven backend selection via `CLOUDBLOCKS_SESSION_BACKEND=redis|sqlite`

## Changes

### New Files
- `apps/api/app/infrastructure/cache/redis_client.py` — Redis client wrapper with Protocol for type safety
- `apps/api/app/infrastructure/cache/redis_session_repo.py` — Full `SessionRepository` ABC implementation
- `apps/api/app/tests/unit/test_redis_client.py` — RedisClient unit tests
- `apps/api/app/tests/unit/test_redis_session.py` — RedisSessionRepository unit tests

### Modified Files
- `apps/api/pyproject.toml` — Added `redis[hiredis]>=5.0.0` dependency
- `apps/api/app/core/config.py` — Added `session_backend`, `redis_url`, TTL config fields
- `apps/api/app/core/dependencies.py` — Updated `get_session_repo()` for Redis backend
- `apps/api/app/main.py` — Redis client lifecycle in FastAPI lifespan

### Redis Session Design
- **Key patterns**: `cb:sess:{sid}` for session data, `cb:user_sess:{uid}` for logout-all index
- **TTL strategy**: 14-day sliding TTL with 30-day absolute cap (configurable)
- **Logout all**: User session index enables instant revocation across all devices

## Verification
- 202 tests passing, 93.10% coverage (≥90% threshold)
- Ruff lint clean
- No real Redis required for tests (fully mocked)

Closes #61