### PR TITLE
feat: complete Docker Compose setup with Redis sessions and dev hot-reload (#62)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# ── Build artifacts & caches ──────────────────────────────
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+node_modules/
+apps/web/dist/
+apps/web/coverage/
+apps/web/coverage-temp/
+
+# ── Dev / test / IDE ─────────────────────────────────────
+.git/
+.github/
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# ── Environment & secrets ────────────────────────────────
+.env
+.env.*
+!.env.example
+
+# ── Data files ───────────────────────────────────────────
+*.db
+*.db-shm
+*.db-wal
+cloudblocks.db*
+
+# ── Documentation (not needed in image) ──────────────────
+docs/
+*.md
+!README.md
+LICENSE
+
+# ── Infrastructure configs (not app code) ────────────────
+infra/terraform/
+infra/k8s/
+
+# ── Misc ─────────────────────────────────────────────────
+cloudblocks-ui-current.png
+examples/
+scripts/

--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,18 @@ CLOUDBLOCKS_DATABASE_URL=sqlite+aiosqlite:///cloudblocks.db
 
 # CORS
 CLOUDBLOCKS_CORS_ORIGINS=["http://localhost:5173"]
+
+# Session Backend (sqlite | redis)
+CLOUDBLOCKS_SESSION_BACKEND=sqlite
+
+# Redis (required when SESSION_BACKEND=redis)
+CLOUDBLOCKS_REDIS_URL=redis://localhost:6379/0
+CLOUDBLOCKS_REDIS_SESSION_SLIDING_TTL_DAYS=14
+CLOUDBLOCKS_REDIS_SESSION_ABSOLUTE_TTL_DAYS=30
+
+# Docker Compose — PostgreSQL (used by docker-compose.yml)
+POSTGRES_USER=cloudblocks
+POSTGRES_PASSWORD=cloudblocks-dev
+JWT_SECRET=change-me-in-production
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -18,6 +18,17 @@ pytest
 ruff check .
 ```
 
+### Docker Compose (Full Stack)
+
+```bash
+# From the monorepo root:
+cp .env.example .env
+docker compose up -d
+
+# With hot-reload for API development:
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
 ## Architecture
 
 The backend is a **thin orchestration layer** — it mediates between the UI, GitHub, and the code generation engine. It does NOT store architecture specs or generated code (those live in GitHub repos).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,23 @@
+# Docker Compose — development overrides (hot-reload)
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# Or set COMPOSE_FILE in your shell:
+#   export COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml
+#   docker compose up
+
+services:
+  api:
+    build:
+      target: builder
+    volumes:
+      - ./apps/api:/app
+    command: >
+      uvicorn app.main:app
+      --host 0.0.0.0
+      --port 8000
+      --reload
+      --reload-dir /app/app
+    environment:
+      CLOUDBLOCKS_APP_DEBUG: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+# Docker Compose — CloudBlocks local development stack
 
 services:
   # ─── PostgreSQL Database ──────────────────────────────────────
@@ -43,11 +43,15 @@ services:
       - "8000:8000"
     environment:
       CLOUDBLOCKS_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-cloudblocks}:${POSTGRES_PASSWORD:-cloudblocks-dev}@postgres:5432/cloudblocks
+      CLOUDBLOCKS_SESSION_BACKEND: redis
+      CLOUDBLOCKS_REDIS_URL: redis://redis:6379/0
       CLOUDBLOCKS_APP_ENV: development
       CLOUDBLOCKS_JWT_SECRET: ${JWT_SECRET:-change-me-in-production}
       CLOUDBLOCKS_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:-}
       CLOUDBLOCKS_GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:-}
+      CLOUDBLOCKS_GITHUB_REDIRECT_URI: http://localhost:8000/api/v1/auth/github/callback
       CLOUDBLOCKS_CORS_ORIGINS: '["http://localhost:5173","http://localhost:80"]'
+      CLOUDBLOCKS_FRONTEND_URL: http://localhost:5173
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -71,28 +71,41 @@ cd apps/web && pnpm build
 
 ### Option 2: Full Stack (Milestone 5+)
 
-#### Docker Deployment
+#### Docker Compose (Full Stack)
+
+The `docker-compose.yml` starts all services: PostgreSQL, Redis, API, and Web frontend.
 
 ```bash
-# Build frontend
-docker build -t cloudblocks-web -f infra/docker/web.Dockerfile .
+# Copy and fill in environment variables
+cp .env.example .env
 
-# Build backend
-docker build -t cloudblocks-api -f infra/docker/api.Dockerfile .
-
-# Start local supporting services (optional)
+# Start all services
 docker compose up -d
+
+# Check service health
+docker compose ps
 ```
 
-> **Note**: The backend deployment model is Docker-first (see `infra/docker/api.Dockerfile`) and is deployed to Azure container infrastructure for production environments. The current `docker-compose.yml` does **not** include `web` or `api` service definitions — those are built separately via Dockerfiles listed above.
+#### docker-compose.yml Services
 
-#### docker-compose.yml Services (Current)
+| Service | Image / Build | Purpose |
+|---------|--------------|---------|
+| `postgres` | `postgres:16-alpine` | Relational metadata store |
+| `redis` | `redis:7-alpine` | Session cache & revocation (sliding TTL) |
+| `api` | `infra/docker/api.Dockerfile` | FastAPI backend |
+| `web` | `infra/docker/web.Dockerfile` | Nginx-served SPA frontend |
 
-| Service | Purpose |
-|---------|---------|
-| *(none required for auth/session flow)* | Current session auth uses SQLite + cookies only |
+#### Development with Hot-Reload
 
-> **Phase 8 (planned)**: PostgreSQL + Redis will be introduced for production-scale metadata and cache/queue workloads.
+Use the dev override to mount the API source and enable `--reload`:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+```
+
+This mounts `apps/api/` into the container so code changes restart the server automatically.
+
+> **Tip**: Set `COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml` in your shell to avoid typing the `-f` flags every time.
 
 ### Option 3: Cloud Deployment
 
@@ -102,8 +115,8 @@ docker compose up -d
 |-----------|---------|------|
 | Frontend | Vercel / Cloudflare Pages | Free |
 | Backend API | Azure Container Apps / Azure App Service | ~$5/mo |
-| Metadata + Session DB | SQLite (backend volume) | Free |
-| Cache/Queue (Phase 8) | Redis | Planned |
+| Metadata DB | PostgreSQL (managed or container) | ~$5/mo |
+| Session Cache | Redis (managed or container) | ~$5/mo |
 | Data Store | GitHub (user repos) | Free |
 
 **Total initial cost: $0 – $5/month**
@@ -154,37 +167,45 @@ VITE_GITHUB_APP_CLIENT_ID=your_github_app_client_id
 
 ### Backend (.env)
 
+All backend variables use the `CLOUDBLOCKS_` prefix. See `.env.example` for a complete template.
+
 ```bash
 # Application
-APP_ENV=development
-APP_PORT=8000
-APP_DEBUG=true
+CLOUDBLOCKS_APP_ENV=development
+CLOUDBLOCKS_APP_PORT=8000
+CLOUDBLOCKS_APP_DEBUG=true
 
-# Session auth
-SESSION_SECRET_KEY=your-32-plus-char-random-string
-SESSION_EXPIRY_HOURS=24
+# Database (SQLite or PostgreSQL)
+CLOUDBLOCKS_DATABASE_URL=sqlite+aiosqlite:///cloudblocks.db
+# CLOUDBLOCKS_DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/cloudblocks
+
+# Session backend (sqlite | redis)
+CLOUDBLOCKS_SESSION_BACKEND=sqlite
+CLOUDBLOCKS_REDIS_URL=redis://localhost:6379/0
 
 # GitHub OAuth
-GITHUB_CLIENT_ID=your_github_client_id
-GITHUB_CLIENT_SECRET=your_github_client_secret
-GITHUB_REDIRECT_URI=http://localhost:8000/api/v1/auth/github/callback
+CLOUDBLOCKS_GITHUB_CLIENT_ID=your_github_client_id
+CLOUDBLOCKS_GITHUB_CLIENT_SECRET=your_github_client_secret
+CLOUDBLOCKS_GITHUB_REDIRECT_URI=http://localhost:8000/api/v1/auth/github/callback
+
+# JWT
+CLOUDBLOCKS_JWT_SECRET=your-32-plus-char-random-string
 
 # CORS
-ALLOWED_ORIGINS=http://localhost:5173
+CLOUDBLOCKS_CORS_ORIGINS=["http://localhost:5173"]
 ```
 
-> **Important**: Current session auth uses httpOnly cookies (`cb_oauth`, `cb_session`) and server-side SQLite sessions. Frontend API calls must use `credentials: 'include'`.
+> **Important**: Session auth uses httpOnly cookies (`cb_oauth`, `cb_session`) and server-side sessions. Frontend API calls must use `credentials: 'include'`.
 
 ### Production Secrets (set via secret manager)
 
 | Secret | Description |
 |--------|-------------|
-| `SESSION_SECRET_KEY` | Strong random string for session signing/encryption |
-| `SESSION_EXPIRY_HOURS` | Session TTL in hours |
-| `GITHUB_CLIENT_SECRET` | GitHub App OAuth secret |
-| `GITHUB_CLIENT_ID` | GitHub OAuth client ID |
-| `GITHUB_REDIRECT_URI` | OAuth callback URL |
-| `ALLOWED_ORIGINS` | Allowed browser origins for credentialed CORS |
+| `CLOUDBLOCKS_JWT_SECRET` | Strong random string (≥32 chars) for JWT signing |
+| `CLOUDBLOCKS_TOKEN_ENCRYPTION_SALT` | Strong random string (≥16 chars) for token encryption |
+| `CLOUDBLOCKS_GITHUB_CLIENT_SECRET` | GitHub App OAuth secret |
+| `CLOUDBLOCKS_GITHUB_CLIENT_ID` | GitHub OAuth client ID |
+| `CLOUDBLOCKS_CORS_ORIGINS` | JSON array of allowed browser origins |
 
 ## CI/CD Pipeline
 
@@ -239,7 +260,8 @@ Recommended monitoring:
 - **Errors**: Sentry (free tier: 5K events/month)
 - **Metrics**: Container platform metrics + application logs
 
-### Phase 8 Infrastructure (Planned)
+### Phase 8 Infrastructure
 
-- PostgreSQL for production-scale relational metadata
-- Redis for distributed cache, rate limiting, and queue primitives
+- PostgreSQL for production-scale relational metadata (implemented via `CLOUDBLOCKS_DATABASE_URL`)
+- Redis for session caching with sliding TTL and logout-all support (implemented via `CLOUDBLOCKS_SESSION_BACKEND=redis`)
+- Docker Compose stack with healthchecks and dev hot-reload


### PR DESCRIPTION
## Summary

- Completes Docker Compose configuration with Redis session backend, PostgreSQL, and full environment variables
- Adds dev hot-reload override for API development without rebuilding
- Adds `.dockerignore` and updates deployment documentation

## Changes

### New Files
- `docker-compose.dev.yml` — Development override with source mounting and `--reload`
- `.dockerignore` — Optimizes Docker build context

### Modified Files
- `docker-compose.yml` — Added `CLOUDBLOCKS_SESSION_BACKEND=redis`, `CLOUDBLOCKS_REDIS_URL`, `CLOUDBLOCKS_GITHUB_REDIRECT_URI`, `CLOUDBLOCKS_FRONTEND_URL`
- `.env.example` — Added session backend, Redis, and Docker Compose variables
- `docs/guides/DEPLOYMENT.md` — Updated Docker Compose instructions, environment variables, Phase 8 status
- `apps/api/README.md` — Added Docker Compose quick start section

## Docker Compose Services

| Service | Image | Purpose |
|---------|-------|---------|
| `postgres` | postgres:16-alpine | Relational metadata (healthcheck enabled) |
| `redis` | redis:7-alpine | Session cache with sliding TTL (healthcheck enabled) |
| `api` | infra/docker/api.Dockerfile | FastAPI backend |
| `web` | infra/docker/web.Dockerfile | Nginx-served SPA frontend |

## Usage

```bash
# Production-like
docker compose up -d

# Development with hot-reload
docker compose -f docker-compose.yml -f docker-compose.dev.yml up
```

Closes #62