### PR TITLE
feat: enable Azure Container Apps multi-replica deployment with Redis and auto-scaling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,10 @@
 #   AZURE_CLIENT_ID        — Azure AD app (service principal) client ID for OIDC
 #   AZURE_TENANT_ID        — Azure AD tenant ID
 #   AZURE_SUBSCRIPTION_ID  — Azure subscription ID
-#   ACR_NAME               — Azure Container Registry name (e.g. cloudblocksacr)
-#   ACR_LOGIN_SERVER       — ACR login server URL (e.g. cloudblocksacr.azurecr.io)
+#   ACR_NAME               — Azure Container Registry name (e.g. cloudblocksdeyacr)
+#   ACR_LOGIN_SERVER       — ACR login server URL (e.g. cloudblocksdevacr.azurecr.io)
 #   AZURE_RESOURCE_GROUP   — Target resource group name
+#   CONTAINER_APP_NAME     — Container App name (e.g. ca-cloudblocks-api-dev)
 #   AZURE_SWA_TOKEN        — Azure Static Web Apps deployment token
 
 name: Deploy
@@ -25,10 +26,15 @@ permissions:
   id-token: write   # Required for OIDC token exchange with Azure
   contents: read
 
+env:
+  IMAGE_NAME: cloudblocks-api
+
 jobs:
   build-api:
     name: Build & Push API Image
     runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -43,8 +49,8 @@ jobs:
       - name: Build and push API image to ACR
         run: |
           az acr build --registry ${{ secrets.ACR_NAME }} \
-            --image cloudblocks-api:${{ github.sha }} \
-            --image cloudblocks-api:latest \
+            --image ${{ env.IMAGE_NAME }}:${{ github.sha }} \
+            --image ${{ env.IMAGE_NAME }}:latest \
             --file infra/docker/api.Dockerfile .
 
   deploy-api:
@@ -59,12 +65,47 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy API to Container Apps
+      - name: Deploy new revision
         run: |
           az containerapp update \
-            --name cloudblocks-api \
+            --name ${{ secrets.CONTAINER_APP_NAME }} \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --image ${{ secrets.ACR_LOGIN_SERVER }}/cloudblocks-api:${{ github.sha }}
+            --image ${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Wait for revision to become active
+        run: |
+          echo "Waiting for new revision to become active..."
+          for i in $(seq 1 30); do
+            STATUS=$(az containerapp revision list \
+              --name ${{ secrets.CONTAINER_APP_NAME }} \
+              --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+              --query "[?properties.active==\`true\`].properties.healthState" \
+              --output tsv 2>/dev/null || echo "Unknown")
+            echo "  Attempt $i/30: status=$STATUS"
+            if [ "$STATUS" = "Healthy" ]; then
+              echo "✅ Revision is healthy"
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "⚠️ Revision health check timed out (5 min). Check Azure Portal."
+          exit 1
+
+      - name: Verify health endpoint
+        run: |
+          APP_URL=$(az containerapp show \
+            --name ${{ secrets.CONTAINER_APP_NAME }} \
+            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
+            --query "properties.configuration.ingress.fqdn" \
+            --output tsv)
+          echo "Checking https://${APP_URL}/health ..."
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://${APP_URL}/health" --max-time 10 || echo "000")
+          echo "  HTTP status: $HTTP_CODE"
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ Health check passed"
+          else
+            echo "⚠️ Health check returned $HTTP_CODE (may still be warming up)"
+          fi
 
   deploy-web:
     name: Deploy Web to Static Web Apps

--- a/docs/guides/DEPLOYMENT.md
+++ b/docs/guides/DEPLOYMENT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-CloudBlocks is designed for **lightweight deployment** with minimal infrastructure. The frontend is a static SPA, and the backend is a thin orchestration layer with SQLite-backed metadata and session storage.
+CloudBlocks is designed for **lightweight deployment** with minimal infrastructure. The frontend is a static SPA, and the backend is a thin orchestration layer. Production deployments use PostgreSQL for metadata and Redis for session caching, enabling horizontal scaling with multiple container replicas.
 
 ## Local Development
 
@@ -38,17 +38,48 @@ make dev
 
 ## Architecture
 
+### Single-Replica (Development / Staging)
+
 ```
 Static Frontend (SPA)
      ↓
-Backend API (Thin Orchestration Layer)
+Backend API (Single Container)
      ↓
 ┌─────────────┬──────────────┐
-│ SQLite      │ GitHub API   │
-│ (metadata + │ (data store) │
-│ sessions)   │              │
+│ PostgreSQL  │ GitHub API   │
+│ (metadata)  │ (data store) │
+├─────────────┤              │
+│ Redis       │              │
+│ (sessions)  │              │
 └─────────────┴──────────────┘
 ```
+
+### Multi-Replica (Production)
+
+```
+Azure Static Web App (SPA)
+     ↓ (HTTPS)
+Azure Container Apps
+┌─────────┬─────────┬─────────┐
+│Replica 1│Replica 2│Replica N│  ← HTTP auto-scaling
+└────┬────┴────┬────┴────┬────┘
+     │         │         │
+     ├─────────┼─────────┤
+     ↓         ↓         ↓
+┌──────────────────────────────┐
+│  Azure Database for PostgreSQL│  ← Shared metadata
+│  (Flexible Server)           │
+├──────────────────────────────┤
+│  Azure Cache for Redis        │  ← Shared sessions
+│  (Basic C0)                  │
+└──────────────────────────────┘
+```
+
+**Multi-replica prerequisites** (all met since Phase 8):
+- ✅ All persistent data in PostgreSQL (not SQLite)
+- ✅ Sessions in Redis (not SQLite)
+- ✅ OAuth state is stateless (cookie-based)
+- ✅ No in-memory state in application code
 
 ## Deployment Options
 
@@ -69,7 +100,7 @@ cd apps/web && pnpm build
 # - S3 + CloudFront
 ```
 
-### Option 2: Full Stack (Milestone 5+)
+### Option 2: Full Stack with Docker Compose
 
 #### Docker Compose (Full Stack)
 
@@ -107,54 +138,111 @@ This mounts `apps/api/` into the container so code changes restart the server au
 
 > **Tip**: Set `COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml` in your shell to avoid typing the `-f` flags every time.
 
-### Option 3: Cloud Deployment
+### Option 3: Azure Container Apps (Production)
 
-#### Recommended Stack
+#### Managed Azure Stack
 
-| Component | Service | Cost |
-|-----------|---------|------|
-| Frontend | Vercel / Cloudflare Pages | Free |
-| Backend API | Azure Container Apps / Azure App Service | ~$5/mo |
-| Metadata DB | PostgreSQL (managed or container) | ~$5/mo |
-| Session Cache | Redis (managed or container) | ~$5/mo |
-| Data Store | GitHub (user repos) | Free |
+| Component | Azure Service | SKU / Tier | Est. Cost |
+|-----------|--------------|------------|-----------|
+| Frontend | Azure Static Web Apps | Free | $0/mo |
+| Backend API | Azure Container Apps | Consumption | ~$5/mo |
+| Metadata DB | Azure Database for PostgreSQL | B_Standard_B1ms | ~$13/mo |
+| Session Cache | Azure Cache for Redis | Basic C0 (250MB) | ~$16/mo |
+| Container Registry | Azure Container Registry | Basic | ~$5/mo |
+| Data Store | GitHub (user repos) | — | Free |
 
-**Total initial cost: $0 – $5/month**
+**Total estimated cost: ~$39/month** (dev environment)
 
-#### Vercel + Azure Container Apps + SQLite (Recommended)
+#### Terraform Provisioning
 
-```
-Frontend (Vercel)
-     ↓
-Backend API (Azure Container Apps)
-     ↓
-┌──────────────┬──────────────┐
-│ SQLite       │ GitHub API   │
-│ (session +   │              │
-│ metadata DB) │              │
-└──────────────┴──────────────┘
-```
-
-1. Deploy frontend to Vercel (auto-deploy from GitHub)
-2. Deploy backend container to Azure (Container Apps or App Service)
-3. Mount persistent volume for SQLite database
-4. Configure GitHub OAuth app credentials
-5. Configure CORS allowed origins for frontend domains
-
-#### Terraform Deployment (Self-Hosted)
+All Azure infrastructure is defined in `infra/terraform/environments/dev/`.
 
 ```bash
-cd infra/terraform/environments/production
+cd infra/terraform/environments/dev
+
+# Copy and fill in variables
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
 
 # Initialize
 terraform init
 
-# Plan
+# Plan (review changes)
 terraform plan -var-file="terraform.tfvars"
 
 # Apply
 terraform apply -var-file="terraform.tfvars"
 ```
+
+#### Resources Provisioned by Terraform
+
+| Resource | Name Pattern | Purpose |
+|----------|-------------|---------|
+| Resource Group | `rg-cloudblocks-{env}` | Logical grouping |
+| Log Analytics | `law-cloudblocks-{env}` | Container logs & metrics |
+| Container App Environment | `cae-cloudblocks-{env}` | Container Apps hosting |
+| Container Registry | `cloudblocks{env}acr` | Docker image storage |
+| PostgreSQL Flexible Server | `psql-cloudblocks-{env}` | Metadata database |
+| Azure Cache for Redis | `redis-cloudblocks-{env}` | Session cache |
+| Container App (API) | `ca-cloudblocks-api-{env}` | Backend API |
+| Static Web App | `swa-cloudblocks-{env}` | Frontend SPA |
+
+#### Scaling Configuration
+
+The Container App scales horizontally based on HTTP concurrent requests:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `container_min_replicas` | 1 | Minimum replicas (0 = scale to zero) |
+| `container_max_replicas` | 3 | Maximum replicas |
+| `scaling_concurrent_requests` | 50 | Requests/replica before scaling out |
+| `container_cpu` | 0.5 | CPU cores per replica |
+| `container_memory` | 1Gi | Memory per replica |
+
+To adjust scaling, update `terraform.tfvars`:
+
+```hcl
+container_min_replicas      = 1
+container_max_replicas      = 5
+scaling_concurrent_requests = "100"
+```
+
+#### Health Probes
+
+The Container App configures three probe types:
+
+| Probe | Path | Interval | Purpose |
+|-------|------|----------|---------|
+| Startup | `/health` | 5s | Wait for app to start (up to 50s) |
+| Liveness | `/health` | 30s | Restart unhealthy containers |
+| Readiness | `/health/ready` | 15s | Remove from load balancer if DB unavailable |
+
+## CI/CD Pipeline
+
+### GitHub Actions
+
+The deploy workflow (`.github/workflows/deploy.yml`) runs on manual dispatch (or push to main when configured):
+
+**Required GitHub Secrets:**
+
+| Secret | Description |
+|--------|-------------|
+| `AZURE_CLIENT_ID` | Azure AD service principal client ID (OIDC) |
+| `AZURE_TENANT_ID` | Azure AD tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+| `ACR_NAME` | Container Registry name |
+| `ACR_LOGIN_SERVER` | Container Registry login server URL |
+| `AZURE_RESOURCE_GROUP` | Target resource group name |
+| `CONTAINER_APP_NAME` | Container App name (from Terraform output) |
+| `AZURE_SWA_TOKEN` | Static Web Apps deployment token |
+
+**Pipeline jobs:**
+
+1. **build-api** — Builds Docker image via `az acr build` and pushes to ACR (tagged with git SHA + `latest`)
+2. **deploy-api** — Updates Container App with new image, waits for healthy revision, verifies `/health` endpoint
+3. **deploy-web** — Builds frontend SPA and deploys to Azure Static Web Apps
+
+To enable automatic deployment on push to main, uncomment the `push` trigger in `.github/workflows/deploy.yml`.
 
 ## Environment Variables
 
@@ -207,61 +295,31 @@ CLOUDBLOCKS_CORS_ORIGINS=["http://localhost:5173"]
 | `CLOUDBLOCKS_GITHUB_CLIENT_ID` | GitHub OAuth client ID |
 | `CLOUDBLOCKS_CORS_ORIGINS` | JSON array of allowed browser origins |
 
-## CI/CD Pipeline
-
-### GitHub Actions
-
-```yaml
-# .github/workflows/deploy.yml
-on:
-  push:
-    branches: [main]
-
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
-      - run: pnpm install
-      - run: pnpm -r build
-      - run: pnpm -r test
-
-  deploy-frontend:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-
-  deploy-backend:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: railway up --service api
-```
-
 ## Health Checks
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /health` | Basic health check |
-| `GET /health/ready` | Readiness (SQLite + GitHub API) |
+| `GET /health` | Basic health check (liveness) |
+| `GET /health/ready` | Readiness check (verifies database connectivity) |
 
 ## Monitoring
 
-Application logs are written to stdout/stderr and collected by the container platform's logging driver.
+Application logs are written to stdout/stderr in JSON format and collected by:
+- **Azure Container Apps**: Log Analytics workspace (auto-configured by Terraform)
+- **Docker Compose**: Container logging driver
 
 Recommended monitoring:
 - **Uptime**: Better Uptime / UptimeRobot (free tier)
 - **Errors**: Sentry (free tier: 5K events/month)
-- **Metrics**: Container platform metrics + application logs
+- **Metrics**: Azure Monitor metrics + Log Analytics queries
+- **Scaling**: Azure Portal → Container App → Metrics → Replica Count
 
-### Phase 8 Infrastructure
+### Phase 8 Infrastructure (Complete)
 
-- PostgreSQL for production-scale relational metadata (implemented via `CLOUDBLOCKS_DATABASE_URL`)
-- Redis for session caching with sliding TTL and logout-all support (implemented via `CLOUDBLOCKS_SESSION_BACKEND=redis`)
-- Docker Compose stack with healthchecks and dev hot-reload
+- ✅ PostgreSQL for production-scale relational metadata (`CLOUDBLOCKS_DATABASE_URL`)
+- ✅ Redis for session caching with sliding TTL and logout-all support (`CLOUDBLOCKS_SESSION_BACKEND=redis`)
+- ✅ Docker Compose stack with healthchecks and dev hot-reload
+- ✅ Azure Container Apps multi-replica deployment with auto-scaling
+- ✅ Azure Cache for Redis (Basic C0) for shared session state
+- ✅ CI/CD pipeline with image build, deploy, and health verification
+- ✅ Health probes (startup, liveness, readiness) for container orchestration

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,13 +1,49 @@
 # CloudBlocks Infrastructure - Terraform
 
-Terraform configurations for deploying CloudBlocks to cloud environments.
+Terraform configurations for deploying CloudBlocks to Azure.
 
 ## Environments
 
-- `dev/` - Development environment
-- `staging/` - Staging environment
-- `production/` - Production environment
+- `environments/dev/` — Development environment
 
-## Modules
+## Resources Provisioned
 
-Shared Terraform modules used across environments.
+| Resource | Azure Service | Purpose |
+|----------|--------------|---------|
+| Resource Group | `azurerm_resource_group` | Logical grouping for all resources |
+| Log Analytics | `azurerm_log_analytics_workspace` | Container logs and metrics |
+| Container App Environment | `azurerm_container_app_environment` | Hosting environment for Container Apps |
+| Container Registry | `azurerm_container_registry` | Docker image storage (Basic SKU) |
+| PostgreSQL | `azurerm_postgresql_flexible_server` | Relational metadata (B_Standard_B1ms) |
+| Redis | `azurerm_redis_cache` | Session cache (Basic C0, 250MB) |
+| Container App | `azurerm_container_app` | Backend API with auto-scaling |
+| Static Web App | `azurerm_static_web_app` | Frontend SPA hosting (Free tier) |
+
+## Quick Start
+
+```bash
+cd environments/dev
+
+# Copy and configure variables
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with your values
+
+# Initialize, plan, apply
+terraform init
+terraform plan -var-file="terraform.tfvars"
+terraform apply -var-file="terraform.tfvars"
+```
+
+## Scaling
+
+The Container App scales horizontally based on HTTP concurrent requests. Configure via `terraform.tfvars`:
+
+```hcl
+container_min_replicas      = 1    # Minimum replicas
+container_max_replicas      = 5    # Maximum replicas
+scaling_concurrent_requests = "50" # Requests/replica threshold
+```
+
+## Required Variables
+
+See `environments/dev/terraform.tfvars.example` for all variables with descriptions. Sensitive values (passwords, secrets) should use a `.tfvars` file excluded from version control or be passed via environment variables (`TF_VAR_*`).

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -39,6 +39,8 @@ resource "azurerm_container_registry" "this" {
   tags                = local.tags
 }
 
+# ---------- PostgreSQL ----------
+
 resource "azurerm_postgresql_flexible_server" "this" {
   name                   = "psql-${var.project_name}-${var.environment}"
   resource_group_name    = azurerm_resource_group.this.name
@@ -49,8 +51,8 @@ resource "azurerm_postgresql_flexible_server" "this" {
   sku_name               = "B_Standard_B1ms"
   storage_mb             = 32768
 
-  backup_retention_days        = 7
-  geo_redundant_backup_enabled = false
+  backup_retention_days         = 7
+  geo_redundant_backup_enabled  = false
   public_network_access_enabled = true
 
   tags = local.tags
@@ -76,6 +78,27 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure_service
   end_ip_address   = "0.0.0.0"
 }
 
+# ---------- Azure Cache for Redis ----------
+
+resource "azurerm_redis_cache" "this" {
+  name                = "redis-${var.project_name}-${var.environment}"
+  resource_group_name = azurerm_resource_group.this.name
+  location            = azurerm_resource_group.this.location
+  capacity            = 0
+  family              = "C"
+  sku_name            = var.redis_sku
+  enable_non_ssl_port = false
+  minimum_tls_version = "1.2"
+
+  redis_configuration {
+    maxmemory_policy = "allkeys-lru"
+  }
+
+  tags = local.tags
+}
+
+# ---------- Container App (API) ----------
+
 resource "azurerm_container_app" "api" {
   name                         = "ca-${var.project_name}-api-${var.environment}"
   container_app_environment_id = azurerm_container_app_environment.this.id
@@ -90,12 +113,22 @@ resource "azurerm_container_app" "api" {
 
   secret {
     name  = "database-url"
-    value = "postgresql://${var.postgres_admin_username}:${var.postgres_admin_password}@${azurerm_postgresql_flexible_server.this.fqdn}:5432/${azurerm_postgresql_flexible_server_database.cloudblocks.name}?sslmode=require"
+    value = "postgresql+asyncpg://${var.postgres_admin_username}:${var.postgres_admin_password}@${azurerm_postgresql_flexible_server.this.fqdn}:5432/${azurerm_postgresql_flexible_server_database.cloudblocks.name}?ssl=require"
+  }
+
+  secret {
+    name  = "redis-url"
+    value = "rediss://:${azurerm_redis_cache.this.primary_access_key}@${azurerm_redis_cache.this.hostname}:${azurerm_redis_cache.this.ssl_port}/0"
   }
 
   secret {
     name  = "jwt-secret"
     value = var.jwt_secret
+  }
+
+  secret {
+    name  = "session-secret"
+    value = var.session_secret
   }
 
   secret {
@@ -125,23 +158,46 @@ resource "azurerm_container_app" "api" {
   }
 
   template {
-    min_replicas = 0
-    max_replicas = 1
+    min_replicas = var.container_min_replicas
+    max_replicas = var.container_max_replicas
+
+    http_scale_rule {
+      name                = "http-scaling"
+      concurrent_requests = var.scaling_concurrent_requests
+    }
 
     container {
       name   = "cloudblocks-api"
       image  = "${azurerm_container_registry.this.login_server}/cloudblocks-api:${var.container_image_tag}"
-      cpu    = 0.5
-      memory = "1Gi"
+      cpu    = var.container_cpu
+      memory = var.container_memory
 
+      # --- Database ---
       env {
-        name        = "DATABASE_URL"
+        name        = "CLOUDBLOCKS_DATABASE_URL"
         secret_name = "database-url"
       }
 
+      # --- Redis / Sessions ---
+      env {
+        name  = "CLOUDBLOCKS_SESSION_BACKEND"
+        value = "redis"
+      }
+
+      env {
+        name        = "CLOUDBLOCKS_REDIS_URL"
+        secret_name = "redis-url"
+      }
+
+      # --- Auth ---
       env {
         name        = "CLOUDBLOCKS_JWT_SECRET"
         secret_name = "jwt-secret"
+      }
+
+      env {
+        name        = "CLOUDBLOCKS_TOKEN_ENCRYPTION_SALT"
+        secret_name = "session-secret"
       }
 
       env {
@@ -155,12 +211,75 @@ resource "azurerm_container_app" "api" {
       }
 
       env {
-        name  = "CLOUDBLOCKS_ENV"
-        value = var.environment
+        name  = "CLOUDBLOCKS_GITHUB_REDIRECT_URI"
+        value = "https://${azurerm_container_app.api.ingress[0].fqdn}/api/v1/auth/github/callback"
+      }
+
+      # --- CORS & Frontend ---
+      env {
+        name  = "CLOUDBLOCKS_CORS_ORIGINS"
+        value = jsonencode(var.cors_origins)
+      }
+
+      env {
+        name  = "CLOUDBLOCKS_FRONTEND_URL"
+        value = var.frontend_url
+      }
+
+      # --- Application ---
+      env {
+        name  = "CLOUDBLOCKS_APP_ENV"
+        value = var.environment == "production" ? "production" : "staging"
+      }
+
+      env {
+        name  = "CLOUDBLOCKS_APP_DEBUG"
+        value = var.environment == "production" ? "false" : "true"
+      }
+
+      # --- Cookie security ---
+      env {
+        name  = "CLOUDBLOCKS_SESSION_COOKIE_SECURE"
+        value = "true"
+      }
+
+      liveness_probe {
+        transport = "HTTP"
+        path      = "/health"
+        port      = 8000
+
+        initial_delay    = 10
+        interval_seconds = 30
+        timeout          = 5
+        failure_count_threshold = 3
+      }
+
+      readiness_probe {
+        transport = "HTTP"
+        path      = "/health/ready"
+        port      = 8000
+
+        initial_delay    = 5
+        interval_seconds = 15
+        timeout          = 5
+        failure_count_threshold = 3
+      }
+
+      startup_probe {
+        transport = "HTTP"
+        path      = "/health"
+        port      = 8000
+
+        initial_delay    = 3
+        interval_seconds = 5
+        timeout          = 5
+        failure_count_threshold = 10
       }
     }
   }
 }
+
+# ---------- Static Web App (Frontend) ----------
 
 resource "azurerm_static_web_app" "frontend" {
   name                = "swa-${var.project_name}-${var.environment}"

--- a/infra/terraform/environments/dev/outputs.tf
+++ b/infra/terraform/environments/dev/outputs.tf
@@ -13,6 +13,11 @@ output "container_app_url" {
   value       = "https://${azurerm_container_app.api.ingress[0].fqdn}"
 }
 
+output "container_app_name" {
+  description = "Container app name (used by CI/CD for deployments)"
+  value       = azurerm_container_app.api.name
+}
+
 output "static_web_app_url" {
   description = "Default hostname for the static web app"
   value       = "https://${azurerm_static_web_app.frontend.default_host_name}"
@@ -21,4 +26,19 @@ output "static_web_app_url" {
 output "postgres_fqdn" {
   description = "PostgreSQL flexible server fully qualified domain name"
   value       = azurerm_postgresql_flexible_server.this.fqdn
+}
+
+output "redis_hostname" {
+  description = "Azure Cache for Redis hostname"
+  value       = azurerm_redis_cache.this.hostname
+}
+
+output "redis_ssl_port" {
+  description = "Azure Cache for Redis SSL port"
+  value       = azurerm_redis_cache.this.ssl_port
+}
+
+output "max_replicas" {
+  description = "Maximum API container replicas configured"
+  value       = var.container_max_replicas
 }

--- a/infra/terraform/environments/dev/terraform.tfvars.example
+++ b/infra/terraform/environments/dev/terraform.tfvars.example
@@ -7,11 +7,20 @@ environment = "dev"
 # Project prefix used in resource names.
 project_name = "cloudblocks"
 
+# ---------- PostgreSQL ----------
+
 # PostgreSQL admin username (must not be a reserved username).
 postgres_admin_username = "cloudblocksadmin"
 
 # PostgreSQL admin password (use a strong secret in real tfvars file).
 postgres_admin_password = "replace-with-strong-password"
+
+# ---------- Redis ----------
+
+# Azure Cache for Redis SKU: Basic (dev), Standard (staging), Premium (production).
+redis_sku = "Basic"
+
+# ---------- Auth / Secrets ----------
 
 # GitHub OAuth client ID for CloudBlocks API.
 github_client_id = "replace-with-github-client-id"
@@ -19,8 +28,36 @@ github_client_id = "replace-with-github-client-id"
 # GitHub OAuth client secret for CloudBlocks API.
 github_client_secret = "replace-with-github-client-secret"
 
-# JWT signing secret used by CloudBlocks API.
+# JWT signing secret used by CloudBlocks API (min 32 chars).
 jwt_secret = "replace-with-long-random-jwt-secret"
+
+# Token encryption salt for GitHub OAuth tokens (min 16 chars).
+session_secret = "replace-with-long-random-session-secret"
+
+# ---------- Container App ----------
 
 # Docker image tag to deploy for API container.
 container_image_tag = "latest"
+
+# CPU cores per replica (0.25, 0.5, 1.0, 2.0).
+container_cpu = 0.5
+
+# Memory per replica (must match CPU: 0.5Gi, 1Gi, 2Gi, 4Gi).
+container_memory = "1Gi"
+
+# Minimum replicas (0 = scale to zero, 1 = always running).
+container_min_replicas = 1
+
+# Maximum replicas for horizontal scaling.
+container_max_replicas = 3
+
+# Concurrent HTTP requests per replica before scaling out.
+scaling_concurrent_requests = "50"
+
+# ---------- Frontend / CORS ----------
+
+# Frontend URL (used for OAuth redirect and CORS).
+frontend_url = "https://cloudblocks.example.com"
+
+# Allowed CORS origins for the API.
+cors_origins = ["https://cloudblocks.example.com"]

--- a/infra/terraform/environments/dev/variables.tf
+++ b/infra/terraform/environments/dev/variables.tf
@@ -16,6 +16,8 @@ variable "project_name" {
   default     = "cloudblocks"
 }
 
+# ---------- PostgreSQL ----------
+
 variable "postgres_admin_username" {
   description = "Administrator username for PostgreSQL flexible server"
   type        = string
@@ -26,6 +28,16 @@ variable "postgres_admin_password" {
   type        = string
   sensitive   = true
 }
+
+# ---------- Redis ----------
+
+variable "redis_sku" {
+  description = "Azure Cache for Redis SKU (Basic, Standard, Premium)"
+  type        = string
+  default     = "Basic"
+}
+
+# ---------- Auth / Secrets ----------
 
 variable "github_client_id" {
   description = "GitHub OAuth client ID used by API"
@@ -40,13 +52,65 @@ variable "github_client_secret" {
 }
 
 variable "jwt_secret" {
-  description = "JWT signing secret used by API"
+  description = "JWT signing secret used by API (min 32 chars)"
   type        = string
   sensitive   = true
 }
+
+variable "session_secret" {
+  description = "Token encryption salt for GitHub OAuth tokens (min 16 chars)"
+  type        = string
+  sensitive   = true
+}
+
+# ---------- Container App ----------
 
 variable "container_image_tag" {
   description = "Docker tag for the cloudblocks-api image in ACR"
   type        = string
   default     = "latest"
+}
+
+variable "container_cpu" {
+  description = "CPU cores allocated to each API container replica"
+  type        = number
+  default     = 0.5
+}
+
+variable "container_memory" {
+  description = "Memory allocated to each API container replica"
+  type        = string
+  default     = "1Gi"
+}
+
+variable "container_min_replicas" {
+  description = "Minimum number of API container replicas (0 = scale to zero)"
+  type        = number
+  default     = 1
+}
+
+variable "container_max_replicas" {
+  description = "Maximum number of API container replicas"
+  type        = number
+  default     = 3
+}
+
+variable "scaling_concurrent_requests" {
+  description = "Number of concurrent HTTP requests per replica before scaling out"
+  type        = string
+  default     = "50"
+}
+
+# ---------- Frontend / CORS ----------
+
+variable "frontend_url" {
+  description = "Frontend application URL (used for OAuth redirect and CORS)"
+  type        = string
+  default     = "https://cloudblocks.example.com"
+}
+
+variable "cors_origins" {
+  description = "List of allowed CORS origins for the API"
+  type        = list(string)
+  default     = ["https://cloudblocks.example.com"]
 }


### PR DESCRIPTION
## Summary

Closes #63

Enable multi-replica horizontal scaling for the CloudBlocks API on Azure Container Apps by provisioning Azure Cache for Redis, configuring auto-scaling rules, adding health probes, and enhancing the CI/CD pipeline.

## Changes

### Terraform (`infra/terraform/environments/dev/`)

- **Azure Cache for Redis** — Added `azurerm_redis_cache` resource (Basic C0, 250MB) with TLS 1.2 minimum and `allkeys-lru` eviction policy
- **Container App env vars** — Fixed `DATABASE_URL` → `CLOUDBLOCKS_DATABASE_URL` (asyncpg driver), added `CLOUDBLOCKS_SESSION_BACKEND`, `CLOUDBLOCKS_REDIS_URL`, `CLOUDBLOCKS_CORS_ORIGINS`, `CLOUDBLOCKS_FRONTEND_URL`, `CLOUDBLOCKS_TOKEN_ENCRYPTION_SALT`, `CLOUDBLOCKS_GITHUB_REDIRECT_URI`, `CLOUDBLOCKS_APP_ENV`, `CLOUDBLOCKS_APP_DEBUG`, `CLOUDBLOCKS_SESSION_COOKIE_SECURE`
- **Auto-scaling** — HTTP-based scaling rule: configurable concurrent requests threshold (default 50), min replicas 1, max replicas 3
- **Health probes** — Startup (`/health`, 5s interval, 50s budget), liveness (`/health`, 30s interval), readiness (`/health/ready`, 15s interval)
- **Parameterization** — New variables: `redis_sku`, `session_secret`, `container_cpu`, `container_memory`, `container_min_replicas`, `container_max_replicas`, `scaling_concurrent_requests`, `frontend_url`, `cors_origins`
- **Outputs** — Added `container_app_name`, `redis_hostname`, `redis_ssl_port`, `max_replicas`

### CI/CD (`.github/workflows/deploy.yml`)

- Added `CONTAINER_APP_NAME` secret reference (replaces hardcoded name)
- Post-deploy revision health check (polls for 5 min until healthy)
- Post-deploy `/health` endpoint verification via curl
- Added `IMAGE_NAME` env variable for DRY image naming

### Documentation

- Updated `docs/guides/DEPLOYMENT.md` with multi-replica architecture diagrams, Azure resource table, scaling configuration, health probes, CI/CD pipeline docs, and GitHub secrets reference
- Updated `infra/terraform/README.md` with resource table and quick start

## Scaling Prerequisites Checklist

All met since Phase 8:
- ✅ All persistent data in PostgreSQL (not SQLite) — #60
- ✅ Sessions in Redis (not SQLite) — #61
- ✅ OAuth state is stateless (cookie-based) — Phase 7
- ✅ No in-memory state in application code

## Testing

- `pnpm build` ✅
- `pnpm lint` ✅ (0 errors)
- `pytest` ✅ (202 passed, 93.10% coverage)
- Terraform changes are infrastructure-only (no application code modified)