### PR TITLE
fix: correct VITE_API_URL to prevent double /api path segment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ CLOUDBLOCKS_APP_PORT=8000
 CLOUDBLOCKS_APP_DEBUG=true
 
 # Frontend (Vite — no CLOUDBLOCKS_ prefix)
-VITE_API_URL=http://localhost:8000/api
+VITE_API_URL=http://localhost:8000
 
 # GitHub OAuth
 CLOUDBLOCKS_GITHUB_CLIENT_ID=

--- a/apps/web/src/shared/api/client.test.ts
+++ b/apps/web/src/shared/api/client.test.ts
@@ -131,3 +131,59 @@ describe('api client', () => {
     expect(requestInit.credentials).toBe('include');
   });
 });
+
+describe('API_BASE_URL normalization', () => {
+  const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>();
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('strips trailing slash from VITE_API_URL', async () => {
+    vi.stubEnv('VITE_API_URL', 'http://localhost:8000/');
+    const { apiGet } = await import('./client');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await apiGet('/api/v1/test');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/api/v1/test');
+  });
+
+  it('works correctly when VITE_API_URL has no trailing slash', async () => {
+    vi.stubEnv('VITE_API_URL', 'http://localhost:8000');
+    const { apiGet } = await import('./client');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await apiGet('/api/v1/test');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/api/v1/test');
+  });
+
+  it('produces correct URL when VITE_API_URL is empty', async () => {
+    vi.stubEnv('VITE_API_URL', '');
+    const { apiGet } = await import('./client');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await apiGet('/api/v1/test');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/test');
+  });
+
+  it('strips multiple trailing slashes from VITE_API_URL', async () => {
+    vi.stubEnv('VITE_API_URL', 'http://localhost:8000///');
+    const { apiGet } = await import('./client');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await apiGet('/api/v1/test');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/api/v1/test');
+  });
+});

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -1,4 +1,6 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
+const RAW_API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
+/** Strip trailing slashes so `${base}${path}` never produces `//`. */
+const API_BASE_URL = RAW_API_BASE_URL.replace(/\/+$/, '');
 
 export class ApiError extends Error {
   status: number;


### PR DESCRIPTION
## Summary

- **Fix `.env.example`**: Changed `VITE_API_URL=http://localhost:8000/api` → `VITE_API_URL=http://localhost:8000` to prevent double `/api` prefix when the frontend API client already prepends `/api/v1/` to all paths
- **Add trailing-slash normalization**: `API_BASE_URL` now strips trailing slashes defensively, so `http://localhost:8000/` + `/api/v1/test` produces `http://localhost:8000/api/v1/test` instead of `http://localhost:8000//api/v1/test`
- **Add 4 new tests**: URL normalization tests covering trailing slash, no trailing slash, empty URL, and multiple trailing slashes

## Bug

With `.env.example` set to `VITE_API_URL=http://localhost:8000/api`, the frontend would produce URLs like `http://localhost:8000/api/api/v1/auth/session` — double `/api` segment causing 404s on all API calls.

## Files Changed

| File | Change |
|------|--------|
| `.env.example` | Fixed `VITE_API_URL` value |
| `apps/web/src/shared/api/client.ts` | Added trailing-slash normalization |
| `apps/web/src/shared/api/client.test.ts` | Added 4 URL normalization tests |

## Verification

- ✅ All 13 tests pass
- ✅ Build passes (`pnpm build`)
- ✅ Lint clean (0 errors)
- ✅ No LSP diagnostics

Closes #141