### PR TITLE
feat(#143): Replace alert/confirm with toast notifications

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "interactjs": "^1.10.27",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-hot-toast": "^2.6.0",
     "uuid": "^13.0.0",
     "zundo": "^2.3.0",
     "zustand": "^5.0.12"
@@ -41,7 +42,7 @@
     "jsdom": "^29.0.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-"vite": "^8.0.0",
+    "vite": "^8.0.0",
     "vitest": "^4.1.0"
   }
 }

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -3,6 +3,9 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { useArchitectureStore } from '../entities/store/architectureStore';
 import { useUIStore } from '../entities/store/uiStore';
 import { useAuthStore } from '../entities/store/authStore';
+vi.mock('react-hot-toast', () => ({
+  Toaster: () => <div data-testid="app-toaster" />,
+}));
 
 // Mock all child widgets and SceneCanvas
 vi.mock('../widgets/scene-canvas/SceneCanvas', () => ({
@@ -118,6 +121,7 @@ describe('App', () => {
     expect(await screen.findByTestId('github-repos')).toBeInTheDocument();
     expect(await screen.findByTestId('github-sync')).toBeInTheDocument();
     expect(await screen.findByTestId('github-pr')).toBeInTheDocument();
+    expect(screen.getByTestId('app-toaster')).toBeInTheDocument();
   });
 
   it('calls registerBuiltinTemplates and loadFromStorage on mount', () => {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,4 +1,5 @@
 import { lazy, Suspense, useEffect } from 'react';
+import { Toaster } from 'react-hot-toast';
 import { SceneCanvas } from '../widgets/scene-canvas/SceneCanvas';
 import { MenuBar } from '../widgets/menu-bar/MenuBar';
 
@@ -148,6 +149,17 @@ function App() {
           </Suspense>
         </div>
       </div>
+      <Toaster
+        position="bottom-center"
+        toastOptions={{
+          duration: 3000,
+          style: {
+            background: '#1a1a2e',
+            color: '#e0e0e0',
+            border: '1px solid rgba(255,255,255,0.1)',
+          },
+        }}
+      />
     </div>
   );
 }

--- a/apps/web/src/shared/ui/ConfirmDialog.css
+++ b/apps/web/src/shared/ui/ConfirmDialog.css
@@ -1,0 +1,63 @@
+.confirm-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.65);
+  z-index: 3000;
+  padding: 16px;
+}
+
+.confirm-dialog {
+  width: min(420px, 100%);
+  background: #121326;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.45);
+  color: #e0e0e0;
+  padding: 18px;
+}
+
+.confirm-dialog-title {
+  margin: 0 0 10px;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.confirm-dialog-message {
+  margin: 0;
+  color: rgba(224, 224, 224, 0.88);
+  line-height: 1.5;
+}
+
+.confirm-dialog-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.confirm-dialog-btn {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  color: #e0e0e0;
+  padding: 8px 14px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.confirm-dialog-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.confirm-dialog-btn-confirm {
+  border-color: rgba(122, 209, 255, 0.45);
+  background: rgba(65, 148, 255, 0.22);
+}
+
+.confirm-dialog-btn-confirm:hover {
+  background: rgba(65, 148, 255, 0.35);
+}

--- a/apps/web/src/shared/ui/ConfirmDialog.test.tsx
+++ b/apps/web/src/shared/ui/ConfirmDialog.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { confirmDialog } from './ConfirmDialog';
+
+describe('confirmDialog', () => {
+  it('renders the dialog with title and message, then resolves true on confirm', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const promise = confirmDialog('All unsaved changes will be lost.', 'Reset Workspace?');
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Reset Workspace?')).toBeInTheDocument();
+    expect(screen.getByText('All unsaved changes will be lost.')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await expect(promise).resolves.toBe(true);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('resolves false when Cancel is clicked', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const promise = confirmDialog('This cannot be undone.', 'Delete this workspace?');
+    await screen.findByRole('dialog');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('resolves false when overlay is clicked', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const promise = confirmDialog('Continue?', 'Confirm Action');
+    await screen.findByRole('dialog');
+
+    const overlay = document.querySelector('.confirm-dialog-overlay');
+    if (!(overlay instanceof HTMLElement)) {
+      throw new Error('Expected confirm dialog overlay to exist');
+    }
+
+    await user.click(overlay);
+
+    await expect(promise).resolves.toBe(false);
+  });
+});

--- a/apps/web/src/shared/ui/ConfirmDialog.tsx
+++ b/apps/web/src/shared/ui/ConfirmDialog.tsx
@@ -1,0 +1,95 @@
+import { createPortal } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import './ConfirmDialog.css';
+
+interface ConfirmDialogProps {
+  title: string;
+  message: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDialogProps) {
+  return createPortal(
+    <div className="confirm-dialog-overlay" role="presentation" onClick={onCancel}>
+      <div
+        className="confirm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        aria-describedby="confirm-dialog-message"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h3 id="confirm-dialog-title" className="confirm-dialog-title">
+          {title}
+        </h3>
+        <p id="confirm-dialog-message" className="confirm-dialog-message">
+          {message}
+        </p>
+        <div className="confirm-dialog-actions">
+          <button type="button" className="confirm-dialog-btn" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="confirm-dialog-btn confirm-dialog-btn-confirm"
+            onClick={onConfirm}
+          >
+            Confirm
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+let dialogRoot: Root | null = null;
+let dialogHost: HTMLDivElement | null = null;
+let resolver: ((value: boolean) => void) | null = null;
+
+function ensureHost(): void {
+  if (typeof document === 'undefined' || dialogHost) return;
+  dialogHost = document.createElement('div');
+  dialogHost.setAttribute('data-confirm-dialog-host', 'true');
+  document.body.appendChild(dialogHost);
+  dialogRoot = createRoot(dialogHost);
+}
+
+function unmountDialog(): void {
+  if (!dialogRoot) return;
+  dialogRoot.render(null);
+}
+
+function settle(value: boolean): void {
+  if (resolver) {
+    resolver(value);
+    resolver = null;
+  }
+  unmountDialog();
+}
+
+export function confirmDialog(message: string, title = 'Confirm'): Promise<boolean> {
+  ensureHost();
+
+  if (!dialogRoot) {
+    return Promise.resolve(false);
+  }
+
+  if (resolver) {
+    resolver(false);
+  }
+
+  return new Promise<boolean>((resolve) => {
+    resolver = resolve;
+    dialogRoot?.render(
+      renderDialogPortal({
+        title,
+        message,
+        onCancel: () => settle(false),
+        onConfirm: () => settle(true),
+      }),
+    );
+  });
+}

--- a/apps/web/src/widgets/bottom-panel/CommandCard.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useRef, useCallback, useEffect, useState, type CSSProperties } from 'react';
+import { toast } from 'react-hot-toast';
 import interact from 'interactjs';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
@@ -384,7 +385,7 @@ function CreationMode({ activeTab }: { activeTab: TabId }) {
     if (def.blockCategory) {
       const targetId = techTree.getTargetPlateId(type);
       if (!targetId) {
-        alert('Please create a Network first.');
+        toast.error('Please create a Network first.');
         return;
       }
 

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock('../../shared/ui/ConfirmDialog', () => ({
+  confirmDialog: vi.fn(),
+}));
 vi.mock('../../shared/api/client', () => ({
   apiPost: vi.fn(),
 }));
@@ -10,6 +19,8 @@ import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import type { ArchitectureModel, Block, Connection, Plate } from '../../shared/types/index';
 import { apiPost } from '../../shared/api/client';
+import { toast } from 'react-hot-toast';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import { audioService } from '../../shared/utils/audioService';
 
 const emptyArch: ArchitectureModel = {
@@ -219,8 +230,7 @@ describe('MenuBar', () => {
 
   it('handles File menu save, load, import trigger, export, and reset(confirm=true)', async () => {
     const user = userEvent.setup();
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
-    const confirmMock = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(confirmDialog).mockResolvedValue(true);
     const createObjectURLMock = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:test');
     const revokeObjectURLMock = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
     const anchorClickMock = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
@@ -237,7 +247,7 @@ describe('MenuBar', () => {
 
     await user.click(within(fileDropdown).getByRole('button', { name: /Save Workspace/ }));
     expect(saveToStorageMock).toHaveBeenCalledOnce();
-    expect(alertMock).toHaveBeenCalledWith('Workspace saved!');
+    expect(toast.success).toHaveBeenCalledWith('Workspace saved!');
 
     await openMenu(user, 'File');
     await user.click(within(getMenuDropdown('File')).getByRole('button', { name: /Load Workspace/ }));
@@ -255,19 +265,23 @@ describe('MenuBar', () => {
 
     await openMenu(user, 'File');
     await user.click(within(getMenuDropdown('File')).getByRole('button', { name: /Reset Workspace/ }));
-    expect(confirmMock).toHaveBeenCalledWith('Reset workspace? All unsaved changes will be lost.');
-    expect(resetWorkspaceMock).toHaveBeenCalledOnce();
+    expect(confirmDialog).toHaveBeenCalledWith('All unsaved changes will be lost.', 'Reset Workspace?');
+    await waitFor(() => {
+      expect(resetWorkspaceMock).toHaveBeenCalledOnce();
+    });
   }, 30000);
 
   it('does not reset workspace when reset confirmation is false', async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    vi.mocked(confirmDialog).mockResolvedValue(false);
     render(<MenuBar />);
 
     const fileDropdown = await openMenu(user, 'File');
     await user.click(within(fileDropdown).getByRole('button', { name: /Reset Workspace/ }));
 
-    expect(resetWorkspaceMock).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(resetWorkspaceMock).not.toHaveBeenCalled();
+    });
   });
 
   it('imports selected JSON file with FileReader and closes open menu', async () => {
@@ -406,7 +420,6 @@ describe('MenuBar', () => {
 
   it('handles Insert menu network and subnet actions', async () => {
     const user = userEvent.setup();
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
     render(<MenuBar />);
 
     let insertDropdown = await openMenu(user, 'Insert');
@@ -415,11 +428,11 @@ describe('MenuBar', () => {
 
     insertDropdown = await openMenu(user, 'Insert');
     await user.click(within(insertDropdown).getByRole('button', { name: /Public Subnet/ }));
-    expect(alertMock).toHaveBeenCalledWith('Please create a Network Plate first.');
+    expect(toast.error).toHaveBeenCalledWith('Please create a Network Plate first.');
 
     insertDropdown = await openMenu(user, 'Insert');
     await user.click(within(insertDropdown).getByRole('button', { name: /Private Subnet/ }));
-    expect(alertMock).toHaveBeenCalledWith('Please create a Network Plate first.');
+    expect(toast.error).toHaveBeenCalledWith('Please create a Network Plate first.');
 
     setArchitectureState({ plates: [networkPlate] });
 
@@ -637,7 +650,6 @@ describe('MenuBar', () => {
 
   it('quick action buttons call undo, redo, and save', async () => {
     const user = userEvent.setup();
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
     useArchitectureStore.setState({ canUndo: true, canRedo: true });
     render(<MenuBar />);
 
@@ -649,7 +661,7 @@ describe('MenuBar', () => {
 
     await user.click(screen.getByTitle('Save Workspace (Ctrl+S)'));
     expect(saveToStorageMock).toHaveBeenCalledOnce();
-    expect(alertMock).toHaveBeenCalledWith('Workspace saved!');
+    expect(toast.success).toHaveBeenCalledWith('Workspace saved!');
   });
 
   it('toggles sound and updates audio service mute state', async () => {
@@ -665,9 +677,8 @@ describe('MenuBar', () => {
     setMutedSpy.mockRestore();
   });
 
-  it('shows alert when compare with GitHub fails', async () => {
+  it('shows toast error when compare with GitHub fails', async () => {
     const user = userEvent.setup();
-    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
     vi.mocked(apiPost).mockRejectedValue(new Error('pull failed'));
     useAuthStore.setState({
       status: 'authenticated',
@@ -685,7 +696,6 @@ describe('MenuBar', () => {
     const githubDropdown = getMenuDropdown(/octocat/);
     await user.click(within(githubDropdown).getByRole('button', { name: /Compare with GitHub/ }));
 
-    expect(alertSpy).toHaveBeenCalledWith('pull failed');
-    alertSpy.mockRestore();
+    expect(toast.error).toHaveBeenCalledWith('pull failed');
   });
 });

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -1,9 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
+import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { computeArchitectureDiff } from '../../features/diff/engine';
 import { apiPost } from '../../shared/api/client';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import type { PullResponse } from '../../shared/types/api';
 import type { ArchitectureModel } from '../../shared/types';
 import { audioService } from '../../shared/utils/audioService';
@@ -84,8 +86,8 @@ export function MenuBar() {
     setOpenMenu((prev) => (prev === menu ? null : menu));
   };
 
-  const handleAction = (action: () => void) => {
-    action();
+  const handleAction = (action: () => void | Promise<void>) => {
+    void action();
     setOpenMenu(null);
   };
 
@@ -97,7 +99,7 @@ export function MenuBar() {
   const handleAddPublicSubnet = () => {
     const network = architecture.plates.find((p) => p.type === 'network');
     if (!network) {
-      alert('Please create a Network Plate first.');
+      toast.error('Please create a Network Plate first.');
       return;
     }
     addPlate('subnet', 'Public Subnet', network.id, 'public');
@@ -107,7 +109,7 @@ export function MenuBar() {
   const handleAddPrivateSubnet = () => {
     const network = architecture.plates.find((p) => p.type === 'network');
     if (!network) {
-      alert('Please create a Network Plate first.');
+      toast.error('Please create a Network Plate first.');
       return;
     }
     addPlate('subnet', 'Private Subnet', network.id, 'private');
@@ -136,7 +138,7 @@ export function MenuBar() {
 
   const handleSave = () => {
     saveToStorage();
-    alert('Workspace saved!');
+    toast.success('Workspace saved!');
   };
 
   const handleLoad = () => {
@@ -173,8 +175,9 @@ export function MenuBar() {
     setOpenMenu(null);
   };
 
-  const handleReset = () => {
-    if (confirm('Reset workspace? All unsaved changes will be lost.')) {
+  const handleReset = async () => {
+    const confirmed = await confirmDialog('All unsaved changes will be lost.', 'Reset Workspace?');
+    if (confirmed) {
       resetWorkspace();
     }
   };
@@ -196,7 +199,7 @@ export function MenuBar() {
       const delta = computeArchitectureDiff(remoteArch, localArch);
       useUIStore.getState().setDiffMode(true, delta, remoteArch);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to fetch remote architecture');
+      toast.error(err instanceof Error ? err.message : 'Failed to fetch remote architecture');
     }
   };
 

--- a/apps/web/src/widgets/toolbar/Toolbar.test.tsx
+++ b/apps/web/src/widgets/toolbar/Toolbar.test.tsx
@@ -1,11 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock('../../shared/ui/ConfirmDialog', () => ({
+  confirmDialog: vi.fn(),
+}));
 import { Toolbar } from './Toolbar';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import type { ArchitectureModel, Plate } from '../../shared/types/index';
+import { toast } from 'react-hot-toast';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 
 const emptyArch: ArchitectureModel = {
   id: 'arch-1', name: 'Test', version: '1.0.0',
@@ -180,14 +191,12 @@ describe('Toolbar', () => {
     expect(addPlateMock).toHaveBeenCalledWith('subnet', 'Public Subnet', 'net-1', 'public');
   });
 
-  it('alerts when adding public subnet without network', async () => {
+  it('shows toast error when adding public subnet without network', async () => {
     const user = userEvent.setup();
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
     render(<Toolbar />);
     await user.click(screen.getByTitle('Add Public Subnet'));
-    expect(alertMock).toHaveBeenCalledWith('Please create a Network Plate first.');
+    expect(toast.error).toHaveBeenCalledWith('Please create a Network Plate first.');
     expect(addPlateMock).not.toHaveBeenCalled();
-    alertMock.mockRestore();
   });
 
   it('adds private subnet when network exists', async () => {
@@ -215,13 +224,11 @@ describe('Toolbar', () => {
     expect(addPlateMock).toHaveBeenCalledWith('subnet', 'Private Subnet', 'net-1', 'private');
   });
 
-  it('alerts when adding private subnet without network', async () => {
+  it('shows toast error when adding private subnet without network', async () => {
     const user = userEvent.setup();
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
     render(<Toolbar />);
     await user.click(screen.getByTitle('Add Private Subnet'));
-    expect(alertMock).toHaveBeenCalledWith('Please create a Network Plate first.');
-    alertMock.mockRestore();
+    expect(toast.error).toHaveBeenCalledWith('Please create a Network Plate first.');
   });
 
   // --- Tool modes ---
@@ -325,14 +332,12 @@ describe('Toolbar', () => {
 
   // --- Save / Load / Reset ---
 
-  it('saves workspace on click and shows alert', async () => {
+  it('saves workspace on click and shows toast success', async () => {
     const user = userEvent.setup();
-    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {});
     render(<Toolbar />);
     await user.click(screen.getByTitle('Save Workspace'));
     expect(saveToStorageMock).toHaveBeenCalledOnce();
-    expect(alertMock).toHaveBeenCalledWith('Workspace saved!');
-    alertMock.mockRestore();
+    expect(toast.success).toHaveBeenCalledWith('Workspace saved!');
   });
 
   it('loads workspace on click', async () => {
@@ -344,20 +349,23 @@ describe('Toolbar', () => {
 
   it('resets workspace after confirmation', async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(confirmDialog).mockResolvedValue(true);
     render(<Toolbar />);
     await user.click(screen.getByTitle('Reset Workspace'));
-    expect(resetWorkspaceMock).toHaveBeenCalledOnce();
-    vi.restoreAllMocks();
+    expect(confirmDialog).toHaveBeenCalledWith('All unsaved changes will be lost.', 'Reset Workspace?');
+    await waitFor(() => {
+      expect(resetWorkspaceMock).toHaveBeenCalledOnce();
+    });
   });
 
   it('does not reset workspace when confirmation cancelled', async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    vi.mocked(confirmDialog).mockResolvedValue(false);
     render(<Toolbar />);
     await user.click(screen.getByTitle('Reset Workspace'));
-    expect(resetWorkspaceMock).not.toHaveBeenCalled();
-    vi.restoreAllMocks();
+    await waitFor(() => {
+      expect(resetWorkspaceMock).not.toHaveBeenCalled();
+    });
   });
 
   // --- Undo / Redo ---

--- a/apps/web/src/widgets/toolbar/Toolbar.tsx
+++ b/apps/web/src/widgets/toolbar/Toolbar.tsx
@@ -1,8 +1,10 @@
 import { useRef } from 'react';
+import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import type { ToolMode } from '../../entities/store/uiStore';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import { ProviderToggle } from './ProviderToggle';
 import './Toolbar.css';
 
@@ -46,7 +48,7 @@ export function Toolbar() {
   const handleAddPublicSubnet = () => {
     const network = architecture.plates.find((p) => p.type === 'network');
     if (!network) {
-      alert('Please create a Network Plate first.');
+      toast.error('Please create a Network Plate first.');
       return;
     }
     addPlate('subnet', 'Public Subnet', network.id, 'public');
@@ -55,7 +57,7 @@ export function Toolbar() {
   const handleAddPrivateSubnet = () => {
     const network = architecture.plates.find((p) => p.type === 'network');
     if (!network) {
-      alert('Please create a Network Plate first.');
+      toast.error('Please create a Network Plate first.');
       return;
     }
     addPlate('subnet', 'Private Subnet', network.id, 'private');
@@ -71,7 +73,7 @@ export function Toolbar() {
 
   const handleSave = () => {
     saveToStorage();
-    alert('Workspace saved!');
+    toast.success('Workspace saved!');
   };
 
   const handleLoad = () => {
@@ -108,8 +110,9 @@ export function Toolbar() {
     e.target.value = '';
   };
 
-  const handleReset = () => {
-    if (confirm('Reset workspace? All unsaved changes will be lost.')) {
+  const handleReset = async () => {
+    const confirmed = await confirmDialog('All unsaved changes will be lost.', 'Reset Workspace?');
+    if (confirmed) {
       resetWorkspace();
     }
   };

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
@@ -1,10 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+vi.mock('../../shared/ui/ConfirmDialog', () => ({
+  confirmDialog: vi.fn(),
+}));
 import { WorkspaceManager } from './WorkspaceManager';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import type { Workspace } from '../../shared/types/index';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 
 const makeWorkspace = (id: string, name: string, blocks = 0, plates = 0): Workspace => ({
   id,
@@ -202,7 +206,7 @@ describe('WorkspaceManager', () => {
 
   it('deletes workspace after confirmation', async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.mocked(confirmDialog).mockResolvedValue(true);
     const ws2 = makeWorkspace('ws-2', 'Second');
     useArchitectureStore.setState({
       workspace: makeWorkspace('ws-1', 'Default'),
@@ -218,13 +222,15 @@ describe('WorkspaceManager', () => {
     const deleteBtns = screen.getAllByTitle('Delete workspace');
     // Click delete on the second workspace
     await user.click(deleteBtns[1]);
-    expect(deleteWorkspaceMock).toHaveBeenCalledWith('ws-2');
-    vi.restoreAllMocks();
+    expect(confirmDialog).toHaveBeenCalledWith('This cannot be undone.', 'Delete this workspace?');
+    await waitFor(() => {
+      expect(deleteWorkspaceMock).toHaveBeenCalledWith('ws-2');
+    });
   });
 
   it('does not delete workspace when confirmation is cancelled', async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    vi.mocked(confirmDialog).mockResolvedValue(false);
     const ws2 = makeWorkspace('ws-2', 'Second');
     useArchitectureStore.setState({
       workspace: makeWorkspace('ws-1', 'Default'),
@@ -239,8 +245,9 @@ describe('WorkspaceManager', () => {
     render(<WorkspaceManager />);
     const deleteBtns = screen.getAllByTitle('Delete workspace');
     await user.click(deleteBtns[1]);
-    expect(deleteWorkspaceMock).not.toHaveBeenCalled();
-    vi.restoreAllMocks();
+    await waitFor(() => {
+      expect(deleteWorkspaceMock).not.toHaveBeenCalled();
+    });
   });
 
   it('includes current workspace in list even if not in workspaces array', () => {

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import './WorkspaceManager.css';
 
 export function WorkspaceManager() {
@@ -31,9 +32,10 @@ export function WorkspaceManager() {
     setNewName('');
   };
 
-  const handleDelete = (id: string) => {
+  const handleDelete = async (id: string) => {
     if (allWorkspaces.length <= 1) return;
-    if (confirm('Delete this workspace? This cannot be undone.')) {
+    const confirmed = await confirmDialog('This cannot be undone.', 'Delete this workspace?');
+    if (confirmed) {
       deleteWorkspace(id);
     }
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-hot-toast:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
@@ -848,6 +851,11 @@ packages:
     resolution: {integrity: sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==}
     engines: {node: '>=18'}
 
+  goober@2.1.18:
+    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1127,6 +1135,13 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-hot-toast@2.6.0:
+    resolution: {integrity: sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -2182,6 +2197,10 @@ snapshots:
 
   globals@17.4.0: {}
 
+  goober@2.1.18(csstype@3.2.3):
+    dependencies:
+      csstype: 3.2.3
+
   has-flag@4.0.0: {}
 
   hermes-estree@0.25.1: {}
@@ -2426,6 +2445,13 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-hot-toast@2.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      csstype: 3.2.3
+      goober: 2.1.18(csstype@3.2.3)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react-is@17.0.2: {}
 


### PR DESCRIPTION
## Summary
- Install `react-hot-toast` and replace all browser `alert()` calls with non-blocking toast notifications
- Replace all browser `confirm()` calls with a custom async `ConfirmDialog` component
- Zero remaining `alert()`/`confirm()` calls in the codebase

## Changes
- **App.tsx**: Mount `<Toaster />` with dark theme styling, bottom-center position
- **ConfirmDialog.tsx/css**: New Promise-based confirmation dialog with React portal, dark theme
- **Toolbar.tsx**: Replace 2 alert + 1 confirm → toast.error + confirmDialog
- **MenuBar.tsx**: Replace 3 alert + 1 confirm → toast.error/success + confirmDialog
- **CommandCard.tsx**: Replace 1 alert → toast.error
- **WorkspaceManager.tsx**: Replace 1 confirm → confirmDialog
- **Tests**: New ConfirmDialog tests + updated Toolbar, MenuBar, WorkspaceManager tests

## Validation
- ✅ All 1097 tests pass (70+ test files)
- ✅ `pnpm lint`: 0 errors
- ✅ `pnpm build`: passes
- ✅ Zero `alert()`/`confirm()` calls remaining in src/**/*.tsx

Closes #143