### PR TITLE
feat(#144): implement CommandCard actions and remove non-functional buttons

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -294,6 +294,70 @@ describe('architectureStore', () => {
     });
   });
 
+  describe('duplicateBlock', () => {
+    it('duplicates a block with a new id, copy suffix, and +1/+1 position offset', () => {
+      getState().addPlate('network', 'VNet', null);
+      const netId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Sub', netId, 'public');
+      const subId = getArch().plates[1].id;
+
+      getState().addBlock('compute', 'VM', subId, 'azure');
+      const source = getArch().blocks[0];
+
+      getState().duplicateBlock(source.id);
+
+      const blocks = getArch().blocks;
+      expect(blocks).toHaveLength(2);
+
+      const duplicate = blocks[1];
+      expect(duplicate.id).not.toBe(source.id);
+      expect(duplicate.name).toBe('VM (copy)');
+      expect(duplicate.category).toBe(source.category);
+      expect(duplicate.placementId).toBe(source.placementId);
+      expect(duplicate.provider).toBe(source.provider);
+      expect(duplicate.position).toEqual({
+        x: source.position.x + 1,
+        y: source.position.y,
+        z: source.position.z + 1,
+      });
+    });
+
+    it('no-ops on non-existent block id', () => {
+      getState().addPlate('network', 'VNet', null);
+      const before = getState().workspace.architecture;
+
+      getState().duplicateBlock('missing-block');
+
+      expect(getState().workspace.architecture).toBe(before);
+    });
+  });
+
+  describe('renameBlock', () => {
+    it('renames a block', () => {
+      getState().addPlate('network', 'VNet', null);
+      const netId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Sub', netId, 'public');
+      const subId = getArch().plates[1].id;
+      getState().addBlock('compute', 'Old Name', subId);
+      const blockId = getArch().blocks[0].id;
+
+      getState().renameBlock(blockId, 'New Name');
+
+      expect(getArch().blocks[0].name).toBe('New Name');
+    });
+  });
+
+  describe('renamePlate', () => {
+    it('renames a plate', () => {
+      getState().addPlate('network', 'Old Plate', null);
+      const plateId = getArch().plates[0].id;
+
+      getState().renamePlate(plateId, 'New Plate');
+
+      expect(getArch().plates[0].name).toBe('New Plate');
+    });
+  });
+
   describe('removeBlock', () => {
     it('removes a block and its connections', () => {
       getState().addPlate('network', 'VNet', null);

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -14,7 +14,10 @@ type DomainSlice = Pick<
   | 'addPlate'
   | 'removePlate'
   | 'addBlock'
+  | 'duplicateBlock'
   | 'removeBlock'
+  | 'renameBlock'
+  | 'renamePlate'
   | 'moveBlock'
   | 'setPlateProfile'
   | 'movePlatePosition'
@@ -180,6 +183,33 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set) => ({
     });
   },
 
+  duplicateBlock: (blockId) => {
+    set((state) => {
+      const arch = state.workspace.architecture;
+      const sourceBlock = arch.blocks.find((candidate) => candidate.id === blockId);
+
+      if (!sourceBlock) {
+        return state;
+      }
+
+      const newBlock: Block = {
+        ...sourceBlock,
+        id: generateId('block'),
+        name: `${sourceBlock.name} (copy)`,
+        position: {
+          x: sourceBlock.position.x + 1,
+          y: sourceBlock.position.y,
+          z: sourceBlock.position.z + 1,
+        },
+      };
+
+      return withHistory(state, {
+        ...arch,
+        blocks: [...arch.blocks, newBlock],
+      });
+    });
+  },
+
   removeBlock: (id) => {
     set((state) => {
       const arch = state.workspace.architecture;
@@ -202,6 +232,32 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set) => ({
         ),
         connections: arch.connections.filter(
           (connection) => connection.sourceId !== id && connection.targetId !== id
+        ),
+      });
+    });
+  },
+
+  renameBlock: (blockId, newName) => {
+    set((state) => {
+      const arch = state.workspace.architecture;
+
+      return withHistory(state, {
+        ...arch,
+        blocks: arch.blocks.map((candidate) =>
+          candidate.id === blockId ? { ...candidate, name: newName } : candidate
+        ),
+      });
+    });
+  },
+
+  renamePlate: (plateId, newName) => {
+    set((state) => {
+      const arch = state.workspace.architecture;
+
+      return withHistory(state, {
+        ...arch,
+        plates: arch.plates.map((candidate) =>
+          candidate.id === plateId ? { ...candidate, name: newName } : candidate
         ),
       });
     });

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -38,7 +38,10 @@ export interface ArchitectureState {
     placementId: string,
     provider?: ProviderType,
   ) => void;
+  duplicateBlock: (blockId: string) => void;
   removeBlock: (id: string) => void;
+  renameBlock: (blockId: string, newName: string) => void;
+  renamePlate: (plateId: string, newName: string) => void;
   moveBlock: (blockId: string, newPlacementId: string) => void;
   setPlateProfile: (plateId: string, profileId: PlateProfileId) => void;
   movePlatePosition: (id: string, deltaX: number, deltaZ: number) => void;

--- a/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
@@ -85,8 +85,12 @@ const computeBlock: Block = {
 describe('CommandCard', () => {
   const addPlateMock = vi.fn();
   const addBlockMock = vi.fn();
+  const duplicateBlockMock = vi.fn();
+  const renameBlockMock = vi.fn();
+  const renamePlateMock = vi.fn();
   const removeBlockMock = vi.fn();
   const removePlateMock = vi.fn();
+  const togglePropertiesMock = vi.fn();
   const setSelectedIdMock = vi.fn<(id: string | null) => void>();
   const setToolModeMock = vi.fn<(mode: ToolMode) => void>();
 
@@ -97,6 +101,8 @@ describe('CommandCard', () => {
       selectedId: null,
       setSelectedId: setSelectedIdMock,
       setToolMode: setToolModeMock,
+      toggleProperties: togglePropertiesMock,
+      showProperties: true,
       toolMode: 'select',
       activeProvider: 'azure',
     });
@@ -104,6 +110,9 @@ describe('CommandCard', () => {
     useArchitectureStore.setState({
       addPlate: addPlateMock,
       addBlock: addBlockMock,
+      duplicateBlock: duplicateBlockMock,
+      renameBlock: renameBlockMock,
+      renamePlate: renamePlateMock,
       removeBlock: removeBlockMock,
       removePlate: removePlateMock,
       workspace: {
@@ -319,7 +328,62 @@ describe('CommandCard', () => {
     expect(setToolModeMock).toHaveBeenCalledWith('connect');
   });
 
-  it('handles non-destructive action buttons without errors', async () => {
+  it('shows only implemented block action buttons', () => {
+    useUIStore.setState({ selectedId: 'block-1' });
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        architecture: {
+          ...baseArchitecture,
+          plates: [networkPlate, publicSubnet],
+          blocks: [computeBlock],
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+
+    render(<CommandCard />);
+
+    expect(screen.getByRole('button', { name: /Link/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Edit/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Copy/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rename/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete/ })).toBeInTheDocument();
+
+    expect(screen.queryByRole('button', { name: /Config/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Add App/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Move/ })).not.toBeInTheDocument();
+  });
+
+  it('opens properties panel when edit is clicked and properties are hidden', async () => {
+    const user = userEvent.setup();
+
+    useUIStore.setState({ selectedId: 'block-1' });
+    useUIStore.setState({ showProperties: false });
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        architecture: {
+          ...baseArchitecture,
+          plates: [networkPlate, publicSubnet],
+          blocks: [computeBlock],
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+
+    render(<CommandCard />);
+
+    await user.click(screen.getByRole('button', { name: /Edit/ }));
+
+    expect(togglePropertiesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('duplicates selected block when copy is clicked', async () => {
     const user = userEvent.setup();
 
     useUIStore.setState({ selectedId: 'block-1' });
@@ -339,14 +403,37 @@ describe('CommandCard', () => {
 
     render(<CommandCard />);
 
-    await user.click(screen.getByRole('button', { name: /Edit/ }));
     await user.click(screen.getByRole('button', { name: /Copy/ }));
-    await user.click(screen.getByRole('button', { name: /Config/ }));
-    await user.click(screen.getByRole('button', { name: /Add App/ }));
-    await user.click(screen.getByRole('button', { name: /Move/ }));
+
+    expect(duplicateBlockMock).toHaveBeenCalledWith('block-1');
+  });
+
+  it('renames selected block when rename is clicked and prompt has value', async () => {
+    const user = userEvent.setup();
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('  New Block Name  ');
+
+    useUIStore.setState({ selectedId: 'block-1' });
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        architecture: {
+          ...baseArchitecture,
+          plates: [networkPlate, publicSubnet],
+          blocks: [computeBlock],
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+
+    render(<CommandCard />);
+
     await user.click(screen.getByRole('button', { name: /Rename/ }));
 
-    expect(useUIStore.getState().selectedId).toBe('block-1');
+    expect(promptSpy).toHaveBeenCalledWith('Rename block:', 'App VM');
+    expect(renameBlockMock).toHaveBeenCalledWith('block-1', 'New Block Name');
+    promptSpy.mockRestore();
   });
 
   // ─── PlateActionMode Tests ──────────────────────────────
@@ -374,10 +461,10 @@ describe('CommandCard', () => {
 
     // Should have plate action buttons
     expect(screen.getByRole('button', { name: /Deploy/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Config/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Delete/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Move/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Rename/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Delete/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Config/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Move/ })).not.toBeInTheDocument();
   });
 
   it('updates header text across none, block, plate, and deploy states', async () => {
@@ -707,8 +794,9 @@ describe('CommandCard', () => {
     expect(setSelectedIdMock).toHaveBeenCalledWith(null);
   });
 
-  it('handles plate move, rename, config actions without errors', async () => {
+  it('renames selected plate when rename is clicked and prompt has value', async () => {
     const user = userEvent.setup();
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('  Renamed Plate  ');
 
     useUIStore.setState({ selectedId: 'net-1' });
     useArchitectureStore.setState({
@@ -726,11 +814,11 @@ describe('CommandCard', () => {
 
     render(<CommandCard />);
 
-    await user.click(screen.getByRole('button', { name: /Move/ }));
     await user.click(screen.getByRole('button', { name: /Rename/ }));
-    await user.click(screen.getByRole('button', { name: /Config/ }));
 
-    expect(useUIStore.getState().selectedId).toBe('net-1');
+    expect(promptSpy).toHaveBeenCalledWith('Rename plate:', 'VNet');
+    expect(renamePlateMock).toHaveBeenCalledWith('net-1', 'Renamed Plate');
+    promptSpy.mockRestore();
   });
 
   it('transitions to PlateCreationMode for public subnet deploy and creates VM', async () => {

--- a/apps/web/src/widgets/bottom-panel/CommandCard.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.tsx
@@ -215,6 +215,7 @@ export function CommandCard({ className = '' }: CommandCardProps) {
 function PlateActionMode({ selectedPlate, onDeploy }: { selectedPlate: Plate; onDeploy: () => void }) {
   const setSelectedId = useUIStore((s) => s.setSelectedId);
   const removePlate = useArchitectureStore((s) => s.removePlate);
+  const renamePlate = useArchitectureStore((s) => s.renamePlate);
   const isSoundMuted = useUIStore((s) => s.isSoundMuted);
   const playSound = useCallback((name: SoundName) => { if (!isSoundMuted) audioService.playSound(name); }, [isSoundMuted]);
 
@@ -223,19 +224,22 @@ function PlateActionMode({ selectedPlate, onDeploy }: { selectedPlate: Plate; on
       case 'deploy':
         onDeploy();
         break;
+      case 'rename': {
+        const newName = window.prompt('Rename plate:', selectedPlate.name);
+        if (newName !== null && newName.trim() !== '') {
+          renamePlate(selectedPlate.id, newName.trim());
+        }
+        break;
+      }
       case 'delete':
         removePlate(selectedPlate.id);
         setSelectedId(null);
         playSound('delete');
         break;
-      case 'move':
-      case 'rename':
-      case 'config':
-        break;
       default:
         break;
     }
-  }, [onDeploy, removePlate, selectedPlate.id, setSelectedId, playSound]);
+  }, [onDeploy, removePlate, renamePlate, selectedPlate.id, selectedPlate.name, setSelectedId, playSound]);
 
   return (
     <>
@@ -608,6 +612,9 @@ function BlockActionMode() {
   const selectedId = useUIStore((s) => s.selectedId);
   const setSelectedId = useUIStore((s) => s.setSelectedId);
   const setToolMode = useUIStore((s) => s.setToolMode);
+  const toggleProperties = useUIStore((s) => s.toggleProperties);
+  const duplicateBlock = useArchitectureStore((s) => s.duplicateBlock);
+  const renameBlock = useArchitectureStore((s) => s.renameBlock);
   const removeBlock = useArchitectureStore((s) => s.removeBlock);
   const removePlate = useArchitectureStore((s) => s.removePlate);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
@@ -621,6 +628,28 @@ function BlockActionMode() {
       case 'link':
         setToolMode('connect');
         break;
+
+      case 'edit':
+        if (!useUIStore.getState().showProperties) {
+          toggleProperties();
+        }
+        break;
+
+      case 'copy':
+        duplicateBlock(selectedId);
+        playSound('block-snap');
+        break;
+
+      case 'rename': {
+        const block = architecture.blocks.find((candidate) => candidate.id === selectedId);
+        if (block) {
+          const newName = window.prompt('Rename block:', block.name);
+          if (newName !== null && newName.trim() !== '') {
+            renameBlock(selectedId, newName.trim());
+          }
+        }
+        break;
+      }
 
       case 'delete': {
         const isBlock = architecture.blocks.some((b) => b.id === selectedId);
@@ -636,18 +665,10 @@ function BlockActionMode() {
         break;
       }
 
-      case 'edit':
-      case 'copy':
-      case 'config':
-      case 'add-app':
-      case 'move':
-      case 'rename':
-        break;
-
       default:
         break;
     }
-  }, [selectedId, setSelectedId, setToolMode, removeBlock, removePlate, architecture, playSound]);
+  }, [selectedId, setSelectedId, setToolMode, toggleProperties, duplicateBlock, renameBlock, removeBlock, removePlate, architecture, playSound]);
 
   return (
     <>

--- a/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
@@ -333,14 +333,11 @@ describe('useTechTree constants', () => {
       edit: { id: 'edit', label: 'Edit', icon: '✏️', hotkey: 'E', multiSelect: false },
       delete: { id: 'delete', label: 'Delete', icon: '🗑️', hotkey: 'Del', multiSelect: true },
       copy: { id: 'copy', label: 'Copy', icon: '📋', hotkey: 'C', multiSelect: true },
-      config: { id: 'config', label: 'Config', icon: '⚙️', multiSelect: false },
-      'add-app': { id: 'add-app', label: 'Add App', icon: '➕', multiSelect: false },
-      move: { id: 'move', label: 'Move', icon: '↔️', hotkey: 'M', multiSelect: true },
       rename: { id: 'rename', label: 'Rename', icon: '📝', hotkey: 'R', multiSelect: false },
     };
 
-    const actionTypes: ActionType[] = ['link', 'edit', 'delete', 'copy', 'config', 'add-app', 'move', 'rename'];
-    expect(actionTypes).toHaveLength(8);
+    const actionTypes: ActionType[] = ['link', 'edit', 'delete', 'copy', 'rename'];
+    expect(actionTypes).toHaveLength(5);
 
     for (const actionType of actionTypes) {
       const actual = ACTION_DEFINITIONS[actionType];
@@ -355,9 +352,9 @@ describe('useTechTree constants', () => {
       expect(row).toHaveLength(3);
     }
     expect(ACTION_GRID).toEqual([
-      ['link', 'edit', 'config'],
-      ['move', 'copy', 'rename'],
-      ['add-app', null, 'delete'],
+      ['link', 'edit', 'copy'],
+      ['rename', null, 'delete'],
+      [null, null, null],
     ]);
   });
 });

--- a/apps/web/src/widgets/bottom-panel/useTechTree.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.ts
@@ -299,7 +299,7 @@ export const CREATION_GRID: ResourceType[][] = [
 
 // ─── Action Definitions ────────────────────────────────────
 
-export type ActionType = 'link' | 'edit' | 'delete' | 'copy' | 'config' | 'add-app' | 'move' | 'rename';
+export type ActionType = 'link' | 'edit' | 'delete' | 'copy' | 'rename';
 
 export interface ActionDefinition {
   id: ActionType;
@@ -315,19 +315,16 @@ export const ACTION_DEFINITIONS: Record<ActionType, ActionDefinition> = {
   edit: { id: 'edit', label: 'Edit', icon: '✏️', hotkey: 'E', multiSelect: false },
   delete: { id: 'delete', label: 'Delete', icon: '🗑️', hotkey: 'Del', multiSelect: true },
   copy: { id: 'copy', label: 'Copy', icon: '📋', hotkey: 'C', multiSelect: true },
-  config: { id: 'config', label: 'Config', icon: '⚙️', multiSelect: false },
-  'add-app': { id: 'add-app', label: 'Add App', icon: '➕', multiSelect: false },
-  move: { id: 'move', label: 'Move', icon: '↔️', hotkey: 'M', multiSelect: true },
   rename: { id: 'rename', label: 'Rename', icon: '📝', hotkey: 'R', multiSelect: false },
 };
 
 export const ACTION_GRID: (ActionType | null)[][] = [
-  ['link', 'edit', 'config'],
-  ['move', 'copy', 'rename'],
-  ['add-app', null, 'delete'],
+  ['link', 'edit', 'copy'],
+  ['rename', null, 'delete'],
+  [null, null, null],
 ];
 
-export type PlateActionType = 'deploy' | 'config' | 'delete' | 'move' | 'rename';
+export type PlateActionType = 'deploy' | 'delete' | 'rename';
 
 export interface PlateActionDefinition {
   id: PlateActionType;
@@ -338,15 +335,13 @@ export interface PlateActionDefinition {
 
 export const PLATE_ACTION_DEFINITIONS: Record<PlateActionType, PlateActionDefinition> = {
   deploy: { id: 'deploy', label: 'Deploy', icon: '🚀', hotkey: 'Q' },
-  config: { id: 'config', label: 'Config', icon: '⚙️', hotkey: 'W' },
   delete: { id: 'delete', label: 'Delete', icon: '🗑️', hotkey: 'E' },
-  move: { id: 'move', label: 'Move', icon: '↔️', hotkey: 'A' },
   rename: { id: 'rename', label: 'Rename', icon: '📝', hotkey: 'S' },
 };
 
 export const PLATE_ACTION_GRID: (PlateActionType | null)[][] = [
-  ['deploy', 'config', 'delete'],
-  ['move', 'rename', null],
+  ['deploy', 'rename', 'delete'],
+  [null, null, null],
   [null, null, null],
 ];
 


### PR DESCRIPTION
## Summary
- Removes non-functional CommandCard actions (`config`, `add-app`, `move` for blocks; `config`, `move` for plates)
- Implements working handlers for `edit` (opens Properties panel), `copy` (duplicates block with offset + "(copy)" suffix), and `rename` (prompt-based rename via store)
- Adds `duplicateBlock`, `renameBlock`, `renamePlate` to architecture store with full undo/redo support via `withHistory`
- Updates `ACTION_GRID` and `PLATE_ACTION_GRID` layouts for the reduced action set
- Adds comprehensive tests for all new store methods and CommandCard behaviors

## Changes
| File | Change |
|------|--------|
| `useTechTree.ts` | Removed unused action types, updated grid layouts |
| `CommandCard.tsx` | Implemented edit/copy/rename handlers, removed empty switch cases |
| `slices/types.ts` | Added `duplicateBlock`, `renameBlock`, `renamePlate` to state interface |
| `slices/domainSlice.ts` | Implemented 3 new store methods with `withHistory` |
| `architectureStore.test.ts` | Tests for duplicateBlock, renameBlock, renamePlate |
| `CommandCard.test.tsx` | Updated for removed buttons, added behavior tests |
| `useTechTree.test.ts` | Updated action/grid expectations |

## Testing
- 71 test files, 1104 tests — all passing
- `pnpm lint`: 0 errors
- `pnpm build`: passes

Closes #144