### PR TITLE
fix(#145): remove phantom multiSelect flags from ActionDefinition

### DIFF
--- a/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
@@ -327,13 +327,13 @@ describe('useTechTree constants', () => {
   it('defines all action entries with expected metadata', () => {
     const expectedActions: Record<
       ActionType,
-      Pick<ActionDefinition, 'id' | 'label' | 'icon' | 'multiSelect'> & { hotkey?: string }
+      Pick<ActionDefinition, 'id' | 'label' | 'icon'> & { hotkey?: string }
     > = {
-      link: { id: 'link', label: 'Link', icon: '🔗', hotkey: 'L', multiSelect: false },
-      edit: { id: 'edit', label: 'Edit', icon: '✏️', hotkey: 'E', multiSelect: false },
-      delete: { id: 'delete', label: 'Delete', icon: '🗑️', hotkey: 'Del', multiSelect: true },
-      copy: { id: 'copy', label: 'Copy', icon: '📋', hotkey: 'C', multiSelect: true },
-      rename: { id: 'rename', label: 'Rename', icon: '📝', hotkey: 'R', multiSelect: false },
+      link: { id: 'link', label: 'Link', icon: '🔗', hotkey: 'L' },
+      edit: { id: 'edit', label: 'Edit', icon: '✏️', hotkey: 'E' },
+      delete: { id: 'delete', label: 'Delete', icon: '🗑️', hotkey: 'Del' },
+      copy: { id: 'copy', label: 'Copy', icon: '📋', hotkey: 'C' },
+      rename: { id: 'rename', label: 'Rename', icon: '📝', hotkey: 'R' },
     };
 
     const actionTypes: ActionType[] = ['link', 'edit', 'delete', 'copy', 'rename'];

--- a/apps/web/src/widgets/bottom-panel/useTechTree.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.ts
@@ -306,16 +306,14 @@ export interface ActionDefinition {
   label: string;
   icon: string;
   hotkey?: string;
-  /** Whether this action applies to multi-selection */
-  multiSelect: boolean;
 }
 
 export const ACTION_DEFINITIONS: Record<ActionType, ActionDefinition> = {
-  link: { id: 'link', label: 'Link', icon: '🔗', hotkey: 'L', multiSelect: false },
-  edit: { id: 'edit', label: 'Edit', icon: '✏️', hotkey: 'E', multiSelect: false },
-  delete: { id: 'delete', label: 'Delete', icon: '🗑️', hotkey: 'Del', multiSelect: true },
-  copy: { id: 'copy', label: 'Copy', icon: '📋', hotkey: 'C', multiSelect: true },
-  rename: { id: 'rename', label: 'Rename', icon: '📝', hotkey: 'R', multiSelect: false },
+  link: { id: 'link', label: 'Link', icon: '🔗', hotkey: 'L' },
+  edit: { id: 'edit', label: 'Edit', icon: '✏️', hotkey: 'E' },
+  delete: { id: 'delete', label: 'Delete', icon: '🗑️', hotkey: 'Del' },
+  copy: { id: 'copy', label: 'Copy', icon: '📋', hotkey: 'C' },
+  rename: { id: 'rename', label: 'Rename', icon: '📝', hotkey: 'R' },
 };
 
 export const ACTION_GRID: (ActionType | null)[][] = [


### PR DESCRIPTION
## Summary
- Removes `multiSelect: boolean` property from `ActionDefinition` interface — it was never implemented (UI store only supports single `selectedId: string | null`)
- Removes `multiSelect` values from all `ACTION_DEFINITIONS` entries
- Updates tests to match new interface shape

## Changes
| File | Change |
|------|--------|
| `useTechTree.ts` | Removed `multiSelect` from `ActionDefinition` interface and all action entries |
| `useTechTree.test.ts` | Updated test expectations to exclude `multiSelect` |

## Testing
- 13 useTechTree tests — all passing
- LSP diagnostics clean

Closes #145