### PR TITLE
feat(#148): guard addConnection() against invalid connections

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -17,8 +17,18 @@ const interactMocks = vi.hoisted(() => ({
   unsetFn: vi.fn(),
 }));
 
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
 vi.mock('interactjs', () => ({
   default: interactMocks.interactFn,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    error: toastMocks.error,
+  },
 }));
 
 vi.mock('./BlockSprite.css', () => ({}));
@@ -51,6 +61,7 @@ describe('BlockSprite', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    addConnectionMock.mockReturnValue(true);
     interactMocks.draggableFn.mockReturnValue({ unset: interactMocks.unsetFn });
     interactMocks.interactFn.mockReturnValue({ draggable: interactMocks.draggableFn });
     useUIStore.setState({ selectedId: null, toolMode: 'select', connectionSource: null });
@@ -149,6 +160,29 @@ describe('BlockSprite', () => {
 
     expect(useUIStore.getState().connectionSource).toBe('block-same');
     expect(addConnectionMock).not.toHaveBeenCalled();
+  });
+
+  it('shows error toast when connect mode rejects an invalid connection', async () => {
+    const user = userEvent.setup();
+    addConnectionMock.mockReturnValue(false);
+    useUIStore.setState({ toolMode: 'connect' });
+
+    const sourceBlock = makeBlock('block-source', 'database');
+    const targetBlock = makeBlock('block-target', 'compute');
+
+    render(
+      <>
+        <BlockSprite block={sourceBlock} parentPlate={parentPlate} screenX={0} screenY={0} zIndex={1} />
+        <BlockSprite block={targetBlock} parentPlate={parentPlate} screenX={10} screenY={20} zIndex={2} />
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Block: database-block' }));
+    await user.click(screen.getByRole('button', { name: 'Block: compute-block' }));
+
+    expect(addConnectionMock).toHaveBeenCalledWith('block-source', 'block-target');
+    expect(toastMocks.error).toHaveBeenCalledWith('Invalid connection: check allowed connection rules');
+    expect(useUIStore.getState().connectionSource).toBeNull();
   });
 
   it('adds is-selected class when selected', () => {

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useRef } from 'react';
 import interact from 'interactjs';
+import { toast } from 'react-hot-toast';
 import type { Block, Plate } from '../../shared/types/index';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
@@ -197,7 +198,10 @@ export const BlockSprite = memo(function BlockSprite({
       if (!connectionSource) {
         startConnecting(block.id);
       } else if (connectionSource !== block.id) {
-        addConnection(connectionSource, block.id);
+        const success = addConnection(connectionSource, block.id);
+        if (!success) {
+          toast.error('Invalid connection: check allowed connection rules');
+        }
         completeInteraction();
       }
       return;

--- a/apps/web/src/entities/connection/ExternalActorSprite.tsx
+++ b/apps/web/src/entities/connection/ExternalActorSprite.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../store/architectureStore';
 import { useUIStore } from '../store/uiStore';
 import { canConnect } from '../validation/connection';
@@ -58,7 +59,10 @@ export const ExternalActorSprite = memo(function ExternalActorSprite({
       if (!connectionSource) {
         startConnecting(actor.id);
       } else if (connectionSource !== actor.id) {
-        addConnection(connectionSource, actor.id);
+        const success = addConnection(connectionSource, actor.id);
+        if (!success) {
+          toast.error('Invalid connection: check allowed connection rules');
+        }
         completeInteraction();
       }
       return;

--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -176,11 +176,13 @@ describe('architectureStore', () => {
       const subId = getArch().plates[1].id;
 
       getState().addBlock('compute', 'VM', subId);
-      const blockId = getArch().blocks[0].id;
+      getState().addBlock('database', 'DB', subId);
+      const sourceId = getArch().blocks[0].id;
+      const targetId = getArch().blocks[1].id;
 
-      getState().addConnection(blockId, 'some-target');
+      getState().addConnection(sourceId, targetId);
 
-      expect(getArch().blocks).toHaveLength(1);
+      expect(getArch().blocks).toHaveLength(2);
       expect(getArch().connections).toHaveLength(1);
 
       getState().removePlate(subId);
@@ -365,13 +367,15 @@ describe('architectureStore', () => {
       getState().addPlate('subnet', 'Sub', netId, 'public');
       const subId = getArch().plates[1].id;
 
+      getState().addBlock('gateway', 'Gateway', subId);
       getState().addBlock('compute', 'VM', subId);
-      const blockId = getArch().blocks[0].id;
-      getState().addConnection('ext-src', blockId);
+      const gatewayId = getArch().blocks[0].id;
+      const blockId = getArch().blocks[1].id;
+      getState().addConnection(gatewayId, blockId);
 
       getState().removeBlock(blockId);
 
-      expect(getArch().blocks).toHaveLength(0);
+      expect(getArch().blocks).toHaveLength(1);
       expect(getArch().connections).toHaveLength(0);
     });
 
@@ -646,25 +650,104 @@ describe('architectureStore', () => {
   // ── Connection actions ──
 
   describe('addConnection', () => {
+    const createConnectionFixture = () => {
+      getState().addPlate('network', 'VNet', null);
+      const networkId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Subnet', networkId, 'public');
+      const subnetId = getArch().plates[1].id;
+
+      getState().addBlock('gateway', 'Gateway', subnetId);
+      getState().addBlock('compute', 'Compute', subnetId);
+      getState().addBlock('database', 'Database', subnetId);
+      getState().addBlock('storage', 'Storage', subnetId);
+
+      const [gatewayId, computeId, databaseId, storageId] = getArch().blocks.map((block) => block.id);
+      return { gatewayId, computeId, databaseId, storageId };
+    };
+
     it('creates a dataflow connection', () => {
-      getState().addConnection('source-1', 'target-1');
+      const { gatewayId, computeId } = createConnectionFixture();
+      const success = getState().addConnection(gatewayId, computeId);
+
+      expect(success).toBe(true);
       const conns = getArch().connections;
       expect(conns).toHaveLength(1);
-      expect(conns[0].sourceId).toBe('source-1');
-      expect(conns[0].targetId).toBe('target-1');
+      expect(conns[0].sourceId).toBe(gatewayId);
+      expect(conns[0].targetId).toBe(computeId);
       expect(conns[0].type).toBe('dataflow');
     });
 
     it('prevents duplicate connections', () => {
-      getState().addConnection('source-1', 'target-1');
-      getState().addConnection('source-1', 'target-1');
+      const { gatewayId, computeId } = createConnectionFixture();
+      getState().addConnection(gatewayId, computeId);
+      const success = getState().addConnection(gatewayId, computeId);
+
+      expect(success).toBe(false);
       expect(getArch().connections).toHaveLength(1);
+    });
+
+    it('rejects self-connections', () => {
+      const { computeId } = createConnectionFixture();
+
+      const success = getState().addConnection(computeId, computeId);
+
+      expect(success).toBe(false);
+      expect(getArch().connections).toHaveLength(0);
+    });
+
+    it('rejects invalid category pairs', () => {
+      const { databaseId, computeId, storageId, gatewayId } = createConnectionFixture();
+
+      const dbToCompute = getState().addConnection(databaseId, computeId);
+      const storageToGateway = getState().addConnection(storageId, gatewayId);
+
+      expect(dbToCompute).toBe(false);
+      expect(storageToGateway).toBe(false);
+      expect(getArch().connections).toHaveLength(0);
+    });
+
+    it('accepts valid category pairs', () => {
+      const { gatewayId, computeId, databaseId } = createConnectionFixture();
+
+      const gatewayToCompute = getState().addConnection(gatewayId, computeId);
+      const computeToDatabase = getState().addConnection(computeId, databaseId);
+
+      expect(gatewayToCompute).toBe(true);
+      expect(computeToDatabase).toBe(true);
+      expect(getArch().connections).toHaveLength(2);
+    });
+
+    it('returns false when source block does not exist', () => {
+      const { computeId } = createConnectionFixture();
+
+      const success = getState().addConnection('missing-source', computeId);
+
+      expect(success).toBe(false);
+      expect(getArch().connections).toHaveLength(0);
+    });
+
+    it('returns false when target block does not exist', () => {
+      const { gatewayId } = createConnectionFixture();
+
+      const success = getState().addConnection(gatewayId, 'missing-target');
+
+      expect(success).toBe(false);
+      expect(getArch().connections).toHaveLength(0);
     });
   });
 
   describe('removeConnection', () => {
     it('removes a connection by ID', () => {
-      getState().addConnection('source-1', 'target-1');
+      getState().addPlate('network', 'VNet', null);
+      const networkId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Subnet', networkId, 'public');
+      const subnetId = getArch().plates[1].id;
+      getState().addBlock('gateway', 'Gateway', subnetId);
+      getState().addBlock('compute', 'Compute', subnetId);
+      const sourceId = getArch().blocks[0].id;
+      const targetId = getArch().blocks[1].id;
+
+      getState().addConnection(sourceId, targetId);
       const connId = getArch().connections[0].id;
       getState().removeConnection(connId);
       expect(getArch().connections).toHaveLength(0);

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -2,6 +2,8 @@ import type { Block, Connection, Plate, PlateProfileId } from '../../../shared/t
 import { buildPlateSizeFromProfileId, DEFAULT_BLOCK_SIZE } from '../../../shared/types/index';
 import { generateId } from '../../../shared/utils/id';
 import type { ArchitectureSlice, ArchitectureState } from './types';
+import { canConnect } from '../../validation/connection';
+import type { EndpointType } from '../../validation/connection';
 import {
   clampWithinParent,
   DEFAULT_PLATE_SIZE,
@@ -26,7 +28,7 @@ type DomainSlice = Pick<
   | 'removeConnection'
 >;
 
-export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set) => ({
+export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => ({
   addPlate: (type, name, parentId, subnetAccess, profileId?: PlateProfileId) => {
     set((state) => {
       const arch = state.workspace.architecture;
@@ -480,17 +482,34 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set) => ({
   },
 
   addConnection: (sourceId, targetId) => {
+    const arch = get().workspace.architecture;
+    const exists = arch.connections.some(
+      (connection) =>
+        connection.sourceId === sourceId && connection.targetId === targetId
+    );
+
+    if (exists) {
+      return false;
+    }
+
+    const sourceBlock = arch.blocks.find((block) => block.id === sourceId);
+    const sourceActor = arch.externalActors.find((actor) => actor.id === sourceId);
+    const sourceType: EndpointType | null = sourceBlock?.category ?? sourceActor?.type ?? null;
+
+    const targetBlock = arch.blocks.find((block) => block.id === targetId);
+    const targetActor = arch.externalActors.find((actor) => actor.id === targetId);
+    const targetType: EndpointType | null = targetBlock?.category ?? targetActor?.type ?? null;
+
+    if (!sourceType || !targetType) {
+      return false;
+    }
+
+    if (!canConnect(sourceType, targetType)) {
+      return false;
+    }
+
     set((state) => {
-      const arch = state.workspace.architecture;
-      const exists = arch.connections.some(
-        (connection) =>
-          connection.sourceId === sourceId && connection.targetId === targetId
-      );
-
-      if (exists) {
-        return state;
-      }
-
+      const nextArch = state.workspace.architecture;
       const connection: Connection = {
         id: generateId('conn'),
         sourceId,
@@ -500,10 +519,11 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set) => ({
       };
 
       return withHistory(state, {
-        ...arch,
-        connections: [...arch.connections, connection],
+        ...nextArch,
+        connections: [...nextArch.connections, connection],
       });
     });
+    return true;
   },
 
   removeConnection: (id) => {

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -47,7 +47,7 @@ export interface ArchitectureState {
   movePlatePosition: (id: string, deltaX: number, deltaZ: number) => void;
   moveBlockPosition: (id: string, deltaX: number, deltaZ: number) => void;
 
-  addConnection: (sourceId: string, targetId: string) => void;
+  addConnection: (sourceId: string, targetId: string) => boolean;
   removeConnection: (id: string) => void;
 
   validate: () => ValidationResult;


### PR DESCRIPTION
## Summary
- Guards `addConnection()` at store level with `canConnect()` validation before adding connections
- Returns `boolean` from `addConnection()` indicating success/failure
- Shows toast error in BlockSprite and ExternalActorSprite when connection is rejected
- Adds 6 new tests for invalid/valid connection rejection and toast feedback

## Changes
- `domainSlice.ts` — Added `canConnect()` check in `addConnection()`, resolves endpoint types from blocks and externalActors, rejects invalid pairs, uses `get` parameter
- `types.ts` — Updated `addConnection` return type from `void` to `boolean`
- `BlockSprite.tsx` — Shows toast error on rejected connection attempt
- `ExternalActorSprite.tsx` — Shows toast error on rejected connection attempt
- `architectureStore.test.ts` — Tests for self-connection rejection, invalid category pairs, valid pairs, boolean returns, missing endpoints
- `BlockSprite.test.tsx` — Tests for toast feedback on rejected connection

## Validation
- 72 test files, 1124 tests pass (+6 new)
- Coverage: Statements 97.08%, Branches 90.19%, Functions 98.61%, Lines 97.55%
- pnpm lint: clean
- pnpm build: passes

Closes #148