### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/docs/concept/PRD.md
+++ b/docs/concept/PRD.md
@@ -426,7 +426,7 @@ Reasons:
 
 The system internally uses a 2D coordinate model.
 
-> See also: ARCHITECTURE.md §6 (Rendering Layer), §14 (Technical Constraints)
+> See also: ARCHITECTURE.md §6 (Rendering Layer Architecture)
 
 ---
 

--- a/docs/engine/templates.md
+++ b/docs/engine/templates.md
@@ -72,7 +72,7 @@ CloudBlocks ships these built-in templates (Milestone 4):
 - **Data Storage Backend** — Compute connected to database and blob storage in a private subnet
 
 > **Note (Milestone 6+):** Additional templates (Serverless API, Event-driven pipeline, Microservices) require FunctionBlock and QueueBlock, which are planned for Milestone 6. See `features/templates/builtin.ts` for the current implementations.
-> **Note:** Example architectures are available in the [`examples/`](../examples/) directory.
+> **Note:** Example architectures are available in the [`examples/`](../../examples/) directory.
 
 ---
 

--- a/docs/guides/TUTORIALS.md
+++ b/docs/guides/TUTORIALS.md
@@ -217,4 +217,4 @@ packages/scenario-library/
 └── index.ts
 ```
 
-Community contributions are welcome! See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines on adding new tutorials.
+Community contributions are welcome! See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines on adding new tutorials.


### PR DESCRIPTION
## Summary
- Fix `docs/guides/TUTORIALS.md` CONTRIBUTING link path (`../../CONTRIBUTING.md`).
- Fix `docs/engine/templates.md` examples directory link path (`../../examples/`).
- Remove stale non-existent `ARCHITECTURE.md §14` reference from `docs/concept/PRD.md` by keeping the valid rendering-layer cross-reference.

Closes #131.

## Validation
- pnpm lint
- pnpm build