### PR TITLE
fix(api): normalize legacy VITE_API_URL values (#174)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ CLOUDBLOCKS_APP_PORT=8000
 CLOUDBLOCKS_APP_DEBUG=true
 
 # Frontend (Vite — no CLOUDBLOCKS_ prefix)
+# Use API origin only (no /api suffix)
 VITE_API_URL=http://localhost:8000
 
 # GitHub OAuth

--- a/apps/web/src/shared/api/client.test.ts
+++ b/apps/web/src/shared/api/client.test.ts
@@ -186,4 +186,24 @@ describe('API_BASE_URL normalization', () => {
 
     expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/api/v1/test');
   });
+
+  it('strips legacy /api suffix from VITE_API_URL', async () => {
+    vi.stubEnv('VITE_API_URL', 'http://localhost:8000/api');
+    const { apiGet } = await import('./client');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await apiGet('/api/v1/test');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/api/v1/test');
+  });
+
+  it('strips legacy /api suffix with trailing slash from VITE_API_URL', async () => {
+    vi.stubEnv('VITE_API_URL', 'http://localhost:8000/api/');
+    const { apiGet } = await import('./client');
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }));
+    await apiGet('/api/v1/test');
+
+    expect(fetchMock.mock.calls[0][0]).toBe('http://localhost:8000/api/v1/test');
+  });
 });

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -1,6 +1,15 @@
 const RAW_API_BASE_URL = import.meta.env.VITE_API_URL ?? '';
-/** Strip trailing slashes so `${base}${path}` never produces `//`. */
-const API_BASE_URL = RAW_API_BASE_URL.replace(/\/+$/, '');
+
+function normalizeApiBaseUrl(rawBaseUrl: string): string {
+  const withoutTrailingSlashes = rawBaseUrl.replace(/\/+$/, '');
+  if (withoutTrailingSlashes.endsWith('/api')) {
+    return withoutTrailingSlashes.slice(0, -4);
+  }
+
+  return withoutTrailingSlashes;
+}
+
+const API_BASE_URL = normalizeApiBaseUrl(RAW_API_BASE_URL);
 
 export class ApiError extends Error {
   status: number;


### PR DESCRIPTION
## Summary
- Normalize `VITE_API_URL` in the web API client so legacy values ending in `/api` do not produce duplicated API path segments.
- Add regression tests covering `/api` and `/api/` base URL variants.
- Clarify `.env.example` frontend API URL contract to use origin-only value.

## Why
Some local setups still use `VITE_API_URL=http://localhost:8000/api`, which combines with request paths like `/api/v1/...` and produces broken URLs. This change keeps request resolution stable for both current and legacy env values.

## Validation
- `pnpm --filter @cloudblocks/web test -- src/shared/api/client.test.ts`
- `pnpm lint`
- `pnpm build`

Closes #174