### PR TITLE
fix(ui): allow ExternalActor as connect source for block target states (#175)

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -5,7 +5,7 @@ import interact from 'interactjs';
 import { BlockSprite } from './BlockSprite';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
-import type { Block, BlockCategory, Plate } from '../../shared/types/index';
+import type { Block, BlockCategory, ExternalActor, Plate } from '../../shared/types/index';
 import * as isometric from '../../shared/utils/isometric';
 import { audioService } from '../../shared/utils/audioService';
 import type { SoundName } from '../../shared/utils/audioService';
@@ -53,6 +53,12 @@ const makeBlock = (id: string, category: BlockCategory): Block => ({
   position: { x: 1, y: 0, z: 2 },
   metadata: {},
 });
+
+const internetActor: ExternalActor = {
+  id: 'actor-internet',
+  type: 'internet',
+  name: 'Internet',
+};
 
 describe('BlockSprite', () => {
   const addConnectionMock = vi.fn();
@@ -567,6 +573,52 @@ describe('BlockSprite', () => {
     );
 
     expect(container.firstElementChild).toHaveClass('is-connected');
+  });
+
+  it('adds is-valid-target class when connect source is external actor and target is gateway', () => {
+    const gatewayBlock = makeBlock('block-gateway', 'gateway');
+
+    useUIStore.setState({ toolMode: 'connect', connectionSource: internetActor.id });
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        architecture: {
+          ...useArchitectureStore.getState().workspace.architecture,
+          blocks: [gatewayBlock],
+          externalActors: [internetActor],
+          connections: [],
+        },
+      },
+    });
+
+    const { container } = render(
+      <BlockSprite block={gatewayBlock} parentPlate={parentPlate} screenX={0} screenY={0} zIndex={1} />,
+    );
+
+    expect(container.firstElementChild).toHaveClass('is-valid-target');
+  });
+
+  it('adds is-invalid-target class when connect source is external actor and target is compute', () => {
+    const computeBlock = makeBlock('block-compute', 'compute');
+
+    useUIStore.setState({ toolMode: 'connect', connectionSource: internetActor.id });
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        architecture: {
+          ...useArchitectureStore.getState().workspace.architecture,
+          blocks: [computeBlock],
+          externalActors: [internetActor],
+          connections: [],
+        },
+      },
+    });
+
+    const { container } = render(
+      <BlockSprite block={computeBlock} parentPlate={parentPlate} screenX={0} screenY={0} zIndex={1} />,
+    );
+
+    expect(container.firstElementChild).toHaveClass('is-invalid-target');
   });
 
   it('adds is-warning class when block has placement validation error (gateway on private subnet)', () => {

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -55,6 +55,7 @@ export const BlockSprite = memo(function BlockSprite({
   const removeBlock = useArchitectureStore((s) => s.removeBlock);
   const moveBlockPosition = useArchitectureStore((s) => s.moveBlockPosition);
   const blocks = useArchitectureStore((s) => s.workspace.architecture.blocks);
+  const externalActors = useArchitectureStore((s) => s.workspace.architecture.externalActors);
   const connections = useArchitectureStore((s) => s.workspace.architecture.connections);
   const diffMode = useUIStore((s) => s.diffMode);
   const diffDelta: DiffDelta | null = useUIStore((s) => s.diffDelta);
@@ -72,9 +73,13 @@ export const BlockSprite = memo(function BlockSprite({
   const sourceBlock = isConnectMode && connectionSource
     ? blocks.find((b) => b.id === connectionSource)
     : null;
-  const isValidConnectTarget = sourceBlock !== null && sourceBlock !== undefined
+  const sourceActor = isConnectMode && connectionSource
+    ? externalActors.find((actor) => actor.id === connectionSource)
+    : null;
+  const sourceType = sourceBlock?.category ?? sourceActor?.type ?? null;
+  const isValidConnectTarget = sourceType !== null
     && block.id !== connectionSource
-    && canConnect(sourceBlock.category, block.category);
+    && canConnect(sourceType, block.category);
   const isInvalidConnectTarget = isConnectMode && connectionSource !== null
     && block.id !== connectionSource
     && !isValidConnectTarget;


### PR DESCRIPTION
## Summary
- Update `BlockSprite` connect-mode target-state logic to support both block and ExternalActor sources.
- When the source is the Internet actor, valid targets (for example, Gateway) now render as valid instead of invalid.
- Add tests covering external-actor source behavior for both valid and invalid block targets.

## Why
Connection creation already accepts `internet -> gateway`, but target highlighting only looked up source blocks. That made the UI signal incorrect state during actor-origin connect flow.

## Validation
- `pnpm --filter @cloudblocks/web test -- src/entities/block/BlockSprite.test.tsx`
- `pnpm lint`
- `pnpm build`

Closes #175