### PR TITLE
perf(ui): cache plate drag zoom and remove per-move transform parsing (#179)

### DIFF
--- a/apps/web/src/entities/plate/PlateSprite.test.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.test.tsx
@@ -183,6 +183,33 @@ describe('PlateSprite', () => {
     expect(movePlatePositionMock).toHaveBeenCalledWith(plate.id, 0, 0);
   });
 
+  it('caches zoom value at drag start and reuses it during move', () => {
+    const plate = makeNetworkPlate();
+    const { container } = render(
+      <div className="scene-world" style={{ transform: 'scale(2)' }}>
+        <PlateSprite plate={plate} screenX={0} screenY={0} zIndex={1} />
+      </div>,
+    );
+
+    const draggableConfig = interactMocks.draggableFn.mock.calls[0]?.[0] as {
+      listeners: {
+        start: () => void;
+        move: (event: { dx: number; dy: number; target: HTMLElement }) => void;
+      };
+    };
+
+    const target = container.querySelector('.plate-sprite') as HTMLElement;
+    draggableConfig.listeners.start();
+
+    const sceneWorld = container.querySelector('.scene-world') as HTMLElement;
+    sceneWorld.style.transform = 'scale(4)';
+
+    draggableConfig.listeners.move({ dx: 20, dy: 12, target });
+
+    expect(vi.mocked(screenDeltaToWorld)).toHaveBeenCalledWith(10, 6);
+    expect(movePlatePositionMock).toHaveBeenCalledWith(plate.id, 0, 0);
+  });
+
   it('ignores click while dragging', async () => {
     const user = userEvent.setup();
     const plate = makeNetworkPlate();

--- a/apps/web/src/entities/plate/PlateSprite.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.tsx
@@ -44,6 +44,7 @@ export const PlateSprite = memo(function PlateSprite({
   const plateRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const dragResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dragZoomRef = useRef(1);
 
   useEffect(() => {
     const el = plateRef.current;
@@ -55,6 +56,19 @@ export const PlateSprite = memo(function PlateSprite({
       listeners: {
         start() {
           isDragging.current = false;
+
+          dragZoomRef.current = 1;
+          const sceneWorld = plateRef.current?.closest('.scene-world') as HTMLElement | null;
+          if (sceneWorld) {
+            const transform = sceneWorld.style.transform;
+            const scaleMatch = transform.match(/scale\(([\d.]+)\)/);
+            if (scaleMatch?.[1]) {
+              const parsedZoom = Number.parseFloat(scaleMatch[1]);
+              if (Number.isFinite(parsedZoom) && parsedZoom > 0) {
+                dragZoomRef.current = parsedZoom;
+              }
+            }
+          }
         },
         move(event) {
           isDragging.current = true;
@@ -62,18 +76,8 @@ export const PlateSprite = memo(function PlateSprite({
           const imgEl = plateRef.current?.querySelector('.plate-img') as HTMLElement | null;
           if (imgEl) imgEl.classList.add('is-dragging');
 
-          const sceneWorld = event.target.closest('.scene-world') as HTMLElement | null;
-          let zoom = 1;
-          if (sceneWorld) {
-            const transform = sceneWorld.style.transform;
-            const scaleMatch = transform.match(/scale\(([\d.]+)\)/);
-            if (scaleMatch?.[1]) {
-              zoom = Number.parseFloat(scaleMatch[1]);
-            }
-          }
-
-          const dxScreen = event.dx / zoom;
-          const dyScreen = event.dy / zoom;
+          const dxScreen = event.dx / dragZoomRef.current;
+          const dyScreen = event.dy / dragZoomRef.current;
           const { dWorldX, dWorldZ } = screenDeltaToWorld(dxScreen, dyScreen);
 
           movePlatePosition(plate.id, dWorldX, dWorldZ);


### PR DESCRIPTION
## Summary
- Cache scene zoom once at plate drag start and reuse it during drag move events.
- Remove repeated transform regex parsing from plate drag move hot-path.
- Add a regression test proving move uses the cached zoom value after drag starts.

## Why
Drag interactions are high-frequency pointer paths. Parsing transform scale on every move adds avoidable overhead; caching the value at drag start aligns plate behavior with existing block drag optimization.

## Validation
- `pnpm --filter @cloudblocks/web test -- src/entities/plate/PlateSprite.test.tsx`
- `pnpm lint`
- `pnpm build`

Closes #179