### PR TITLE
feat(provider): align AWS compute mapping for multi-cloud parity (#187)

### DIFF
--- a/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
+++ b/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
@@ -129,4 +129,64 @@ describe('provider adapters', () => {
     expect(mainTf?.content.trim().length).toBeGreaterThan(0);
     expect(mainTf?.content).toContain('provider "azurerm"');
   });
+
+  it('aws adapter maps compute block to ecs service in terraform output', () => {
+    const architecture: ArchitectureModel = {
+      id: 'arch-adapter-aws-1',
+      name: 'Provider Adapter AWS Terraform Test',
+      version: '1',
+      plates: [
+        {
+          id: 'net-1',
+          name: 'Network',
+          type: 'network',
+          parentId: null,
+          children: ['sub-1'],
+          position: { x: 0, y: 0, z: 0 },
+          size: { width: 12, height: 0.7, depth: 16 },
+          metadata: {},
+        },
+        {
+          id: 'sub-1',
+          name: 'Public Subnet',
+          type: 'subnet',
+          subnetAccess: 'public',
+          parentId: 'net-1',
+          children: ['app-1'],
+          position: { x: 0, y: 0.7, z: 0 },
+          size: { width: 6, height: 0.5, depth: 8 },
+          metadata: {},
+        },
+      ] as Plate[],
+      blocks: [
+        {
+          id: 'app-1',
+          name: 'Compute',
+          category: 'compute',
+          placementId: 'sub-1',
+          position: { x: 1, y: 1.2, z: 1 },
+          metadata: {},
+          provider: 'aws',
+        },
+      ] as Block[],
+      connections: [],
+      externalActors: [{ id: 'ext-1', name: 'Internet', type: 'internet' }],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+
+    const output = generateCode(architecture, {
+      provider: 'aws',
+      mode: 'draft',
+      projectName: 'adapter-test',
+      region: 'eastus',
+      generator: 'terraform',
+    });
+
+    const mainTf = output.files.find((file) => file.path === 'main.tf');
+
+    expect(mainTf).toBeDefined();
+    expect(mainTf?.content).toContain('provider "aws"');
+    expect(mainTf?.content).toContain('resource "aws_ecs_service" "ecs_compute"');
+  });
 });

--- a/apps/web/src/features/generate/provider.test.ts
+++ b/apps/web/src/features/generate/provider.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  awsProvider,
+  awsProviderDefinition,
   azureProvider,
   azureProviderDefinition,
   getProvider,
@@ -88,6 +90,10 @@ describe('getProvider', () => {
     expect(getProvider('azure')).toBe(azureProvider);
   });
 
+  it('returns aws provider for aws name', () => {
+    expect(getProvider('aws')).toBe(awsProvider);
+  });
+
   it('returns undefined for unknown name', () => {
     expect(getProvider('unknown')).toBeUndefined();
   });
@@ -98,7 +104,31 @@ describe('getProviderDefinition', () => {
     expect(getProviderDefinition('azure')).toBe(azureProviderDefinition);
   });
 
+  it('returns aws provider definition for aws name', () => {
+    expect(getProviderDefinition('aws')).toBe(awsProviderDefinition);
+  });
+
   it('returns undefined for unknown name', () => {
     expect(getProviderDefinition('unknown' as 'azure')).toBeUndefined();
+  });
+});
+
+describe('awsProvider', () => {
+  it('uses ECS service mapping for compute category', () => {
+    expect(awsProvider.blockMappings.compute).toEqual({
+      resourceType: 'aws_ecs_service',
+      namePrefix: 'ecs',
+    });
+  });
+
+  it('keeps expected network and subnet plate mappings', () => {
+    expect(awsProvider.plateMappings.network).toEqual({
+      resourceType: 'aws_vpc',
+      namePrefix: 'vpc',
+    });
+    expect(awsProvider.plateMappings.subnet).toEqual({
+      resourceType: 'aws_subnet',
+      namePrefix: 'subnet',
+    });
   });
 });

--- a/apps/web/src/features/generate/providers/aws/index.ts
+++ b/apps/web/src/features/generate/providers/aws/index.ts
@@ -5,8 +5,8 @@ export const awsProviderDefinition: ProviderDefinition = {
   displayName: 'AWS',
   blockMappings: {
     compute: {
-      resourceType: 'aws_instance',
-      namePrefix: 'instance',
+      resourceType: 'aws_ecs_service',
+      namePrefix: 'ecs',
     },
     database: {
       resourceType: 'aws_db_instance',


### PR DESCRIPTION
## Summary
- Update AWS provider definition to map `compute` blocks to `aws_ecs_service` (prefix `ecs`) to match provider parity baseline.
- Add provider tests for AWS adapter and definition resolution.
- Add regression coverage proving terraform output uses `aws_ecs_service` for AWS compute blocks.

## Why
Milestone 8 requires provider adapter parity with documented mappings. AWS compute previously mapped to `aws_instance`, which diverged from the current provider adapter baseline in `docs/engine/provider.md`.

## Validation
- `pnpm --filter @cloudblocks/web test -- src/features/generate/provider.test.ts src/features/generate/__tests__/providerAdapters.test.ts`
- `pnpm lint`
- `pnpm build`

Closes #187