### PR TITLE
feat(provider): align GCP compute/gateway mappings for multi-cloud parity (#189)

### DIFF
--- a/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
+++ b/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
@@ -189,4 +189,74 @@ describe('provider adapters', () => {
     expect(mainTf?.content).toContain('provider "aws"');
     expect(mainTf?.content).toContain('resource "aws_ecs_service" "ecs_compute"');
   });
+
+  it('gcp adapter maps compute and gateway blocks to documented terraform resources', () => {
+    const architecture: ArchitectureModel = {
+      id: 'arch-adapter-gcp-1',
+      name: 'Provider Adapter GCP Terraform Test',
+      version: '1',
+      plates: [
+        {
+          id: 'net-1',
+          name: 'Network',
+          type: 'network',
+          parentId: null,
+          children: ['sub-1'],
+          position: { x: 0, y: 0, z: 0 },
+          size: { width: 12, height: 0.7, depth: 16 },
+          metadata: {},
+        },
+        {
+          id: 'sub-1',
+          name: 'Public Subnet',
+          type: 'subnet',
+          subnetAccess: 'public',
+          parentId: 'net-1',
+          children: ['app-1', 'gw-1'],
+          position: { x: 0, y: 0.7, z: 0 },
+          size: { width: 6, height: 0.5, depth: 8 },
+          metadata: {},
+        },
+      ] as Plate[],
+      blocks: [
+        {
+          id: 'app-1',
+          name: 'Compute',
+          category: 'compute',
+          placementId: 'sub-1',
+          position: { x: 1, y: 1.2, z: 1 },
+          metadata: {},
+          provider: 'gcp',
+        },
+        {
+          id: 'gw-1',
+          name: 'Gateway',
+          category: 'gateway',
+          placementId: 'sub-1',
+          position: { x: 2, y: 1.2, z: 1 },
+          metadata: {},
+          provider: 'gcp',
+        },
+      ] as Block[],
+      connections: [],
+      externalActors: [{ id: 'ext-1', name: 'Internet', type: 'internet' }],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+
+    const output = generateCode(architecture, {
+      provider: 'gcp',
+      mode: 'draft',
+      projectName: 'adapter-test',
+      region: 'eastus',
+      generator: 'terraform',
+    });
+
+    const mainTf = output.files.find((file) => file.path === 'main.tf');
+
+    expect(mainTf).toBeDefined();
+    expect(mainTf?.content).toContain('provider "google"');
+    expect(mainTf?.content).toContain('resource "google_cloud_run_v2_service" "run_compute"');
+    expect(mainTf?.content).toContain('resource "google_compute_backend_service" "backend_gateway"');
+  });
 });

--- a/apps/web/src/features/generate/provider.test.ts
+++ b/apps/web/src/features/generate/provider.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   awsProvider,
   awsProviderDefinition,
+  gcpProvider,
+  gcpProviderDefinition,
   azureProvider,
   azureProviderDefinition,
   getProvider,
@@ -97,6 +99,10 @@ describe('getProvider', () => {
   it('returns undefined for unknown name', () => {
     expect(getProvider('unknown')).toBeUndefined();
   });
+
+  it('returns gcp provider for gcp name', () => {
+    expect(getProvider('gcp')).toBe(gcpProvider);
+  });
 });
 
 describe('getProviderDefinition', () => {
@@ -106,6 +112,10 @@ describe('getProviderDefinition', () => {
 
   it('returns aws provider definition for aws name', () => {
     expect(getProviderDefinition('aws')).toBe(awsProviderDefinition);
+  });
+
+  it('returns gcp provider definition for gcp name', () => {
+    expect(getProviderDefinition('gcp')).toBe(gcpProviderDefinition);
   });
 
   it('returns undefined for unknown name', () => {
@@ -128,6 +138,30 @@ describe('awsProvider', () => {
     });
     expect(awsProvider.plateMappings.subnet).toEqual({
       resourceType: 'aws_subnet',
+      namePrefix: 'subnet',
+    });
+  });
+});
+
+describe('gcpProvider', () => {
+  it('uses Cloud Run and backend service mappings for compute and gateway', () => {
+    expect(gcpProvider.blockMappings.compute).toEqual({
+      resourceType: 'google_cloud_run_v2_service',
+      namePrefix: 'run',
+    });
+    expect(gcpProvider.blockMappings.gateway).toEqual({
+      resourceType: 'google_compute_backend_service',
+      namePrefix: 'backend',
+    });
+  });
+
+  it('keeps expected network and subnet plate mappings', () => {
+    expect(gcpProvider.plateMappings.network).toEqual({
+      resourceType: 'google_compute_network',
+      namePrefix: 'network',
+    });
+    expect(gcpProvider.plateMappings.subnet).toEqual({
+      resourceType: 'google_compute_subnetwork',
       namePrefix: 'subnet',
     });
   });

--- a/apps/web/src/features/generate/providers/gcp/index.ts
+++ b/apps/web/src/features/generate/providers/gcp/index.ts
@@ -5,8 +5,8 @@ export const gcpProviderDefinition: ProviderDefinition = {
   displayName: 'GCP',
   blockMappings: {
     compute: {
-      resourceType: 'google_compute_instance',
-      namePrefix: 'instance',
+      resourceType: 'google_cloud_run_v2_service',
+      namePrefix: 'run',
     },
     database: {
       resourceType: 'google_sql_database_instance',
@@ -17,8 +17,8 @@ export const gcpProviderDefinition: ProviderDefinition = {
       namePrefix: 'bucket',
     },
     gateway: {
-      resourceType: 'google_compute_url_map',
-      namePrefix: 'urlmap',
+      resourceType: 'google_compute_backend_service',
+      namePrefix: 'backend',
     },
     function: {
       resourceType: 'google_cloudfunctions_function',


### PR DESCRIPTION
## Summary
- Update GCP provider mapping for `compute` to `google_cloud_run_v2_service` (prefix `run`).
- Update GCP provider mapping for `gateway` to `google_compute_backend_service` (prefix `backend`).
- Add provider and adapter regression tests for GCP mapping parity in generated terraform output.

## Why
Milestone 8 requires adapter parity with documented provider mappings. Existing GCP mappings diverged from the current baseline in `docs/engine/provider.md`.

## Validation
- `pnpm --filter @cloudblocks/web test -- src/features/generate/provider.test.ts src/features/generate/__tests__/providerAdapters.test.ts`
- `pnpm lint`
- `pnpm build`

Closes #189