### PR TITLE
feat(ui): add provider comparison view in CodePreview (#188)

### DIFF
--- a/apps/web/src/widgets/code-preview/CodePreview.css
+++ b/apps/web/src/widgets/code-preview/CodePreview.css
@@ -61,6 +61,18 @@
   min-width: 80px;
 }
 
+.code-preview-field-checkbox {
+  min-width: 140px;
+}
+
+.code-preview-checkbox-label {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  font-size: 11px;
+  color: #d0d0d0;
+}
+
 .code-preview-field-label {
   font-size: 10px;
   color: #999;
@@ -182,4 +194,32 @@
   font-size: 10px;
   color: #666;
   text-align: right;
+}
+
+.code-preview-compare-grid {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.code-preview-compare-card {
+  border: 1px solid #2d2d4d;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+}
+
+.code-preview-compare-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 11px;
+  color: #c9d3ff;
+  padding: 6px 8px;
+  background: rgba(67, 83, 176, 0.25);
+}
+
+.code-preview-code-compare {
+  margin: 0;
+  max-height: 180px;
 }

--- a/apps/web/src/widgets/code-preview/CodePreview.test.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.test.tsx
@@ -338,4 +338,44 @@ describe('CodePreview', () => {
     const codeElement = container.querySelector('.code-preview-code code');
     expect(codeElement?.textContent).toBe('');
   });
+
+  it('generates comparison outputs for azure, aws, and gcp when compare mode is enabled', async () => {
+    const user = userEvent.setup();
+    vi.mocked(generateCode).mockImplementation((_, options) => ({
+      files: [{ path: 'main.tf', content: `provider=${options.provider}`, language: 'hcl' as const }],
+      metadata: {
+        generator: 'terraform',
+        version: '0.3.0',
+        provider: options.provider,
+        generatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    }));
+
+    useUIStore.setState({ showCodePreview: true });
+    render(<CodePreview />);
+
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByText('🚀 Compare Providers'));
+
+    expect(vi.mocked(generateCode)).toHaveBeenCalledTimes(3);
+    expect(screen.getByText('AZURE')).toBeInTheDocument();
+    expect(screen.getByText('AWS')).toBeInTheDocument();
+    expect(screen.getByText('GCP')).toBeInTheDocument();
+    expect(screen.getByText('provider=azure')).toBeInTheDocument();
+    expect(screen.getByText('provider=aws')).toBeInTheDocument();
+    expect(screen.getByText('provider=gcp')).toBeInTheDocument();
+  });
+
+  it('shows compare-mode restriction error for non-terraform generators', async () => {
+    const user = userEvent.setup();
+    useUIStore.setState({ showCodePreview: true });
+    render(<CodePreview />);
+
+    const select = screen.getByRole('combobox');
+    await user.selectOptions(select, 'bicep');
+    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByText('🚀 Compare Providers'));
+
+    expect(screen.getByText('Provider comparison is currently available for Terraform only.')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/widgets/code-preview/CodePreview.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.tsx
@@ -3,6 +3,7 @@ import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { generateCode, GenerationError } from '../../features/generate/pipeline';
 import type { GeneratedOutput, GenerationOptions, GeneratorId } from '../../features/generate/types';
+import type { ProviderType } from '../../shared/types/index';
 import './CodePreview.css';
 
 const GENERATORS: { id: GeneratorId; label: string }[] = [
@@ -14,13 +15,16 @@ const GENERATORS: { id: GeneratorId; label: string }[] = [
 export function CodePreview() {
   const show = useUIStore((s) => s.showCodePreview);
   const toggleCodePreview = useUIStore((s) => s.toggleCodePreview);
+  const activeProvider = useUIStore((s) => s.activeProvider);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
 
   const [activeTab, setActiveTab] = useState(0);
   const [projectName, setProjectName] = useState('myproject');
   const [region, setRegion] = useState('eastus');
   const [generator, setGenerator] = useState<GeneratorId>('terraform');
+  const [compareProviders, setCompareProviders] = useState(false);
   const [output, setOutput] = useState<GeneratedOutput | null>(null);
+  const [comparisonOutputs, setComparisonOutputs] = useState<Record<ProviderType, GeneratedOutput> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   if (!show) return null;
@@ -28,16 +32,40 @@ export function CodePreview() {
   const handleGenerate = () => {
     setError(null);
     setOutput(null);
+    setComparisonOutputs(null);
+
     try {
-      const options: GenerationOptions = {
-        provider: 'azure',
+      const baseOptions = {
         mode: 'draft',
         projectName,
         region,
         generator,
-      };
-      const result = generateCode(architecture, options);
-      setOutput(result);
+      } as const;
+
+      if (compareProviders) {
+        if (generator !== 'terraform') {
+          setError('Provider comparison is currently available for Terraform only.');
+          return;
+        }
+
+        const providers: ProviderType[] = ['azure', 'aws', 'gcp'];
+        const generated = Object.fromEntries(
+          providers.map((provider) => {
+            const options: GenerationOptions = { ...baseOptions, provider };
+            return [provider, generateCode(architecture, options)];
+          }),
+        ) as Record<ProviderType, GeneratedOutput>;
+
+        setComparisonOutputs(generated);
+      } else {
+        const options: GenerationOptions = {
+          ...baseOptions,
+          provider: activeProvider,
+        };
+        const result = generateCode(architecture, options);
+        setOutput(result);
+      }
+
       setActiveTab(0);
     } catch (err) {
       if (err instanceof GenerationError) {
@@ -77,7 +105,7 @@ export function CodePreview() {
     <div className="code-preview">
       <div className="code-preview-header">
         <h3 className="code-preview-title">⚡ Code Generation</h3>
-        <button className="code-preview-close" onClick={toggleCodePreview}>
+        <button type="button" className="code-preview-close" onClick={toggleCodePreview}>
           ✕
         </button>
       </div>
@@ -113,8 +141,19 @@ export function CodePreview() {
             onChange={(e) => setRegion(e.target.value)}
           />
         </label>
-        <button className="code-preview-generate-btn" onClick={handleGenerate}>
-          🚀 Generate {selectedGenerator?.label ?? 'Code'}
+        <label className="code-preview-field code-preview-field-checkbox">
+          <span className="code-preview-field-label">Compare</span>
+          <label className="code-preview-checkbox-label">
+            <input
+              type="checkbox"
+              checked={compareProviders}
+              onChange={(e) => setCompareProviders(e.target.checked)}
+            />
+            Azure / AWS / GCP
+          </label>
+        </label>
+        <button type="button" className="code-preview-generate-btn" onClick={handleGenerate}>
+          🚀 {compareProviders ? 'Compare Providers' : `Generate ${selectedGenerator?.label ?? 'Code'}`}
         </button>
       </div>
 
@@ -124,21 +163,22 @@ export function CodePreview() {
         <>
           <div className="code-preview-tabs">
             {output.files.map((file, i) => (
-              <button
-                key={file.path}
-                className={`code-preview-tab ${i === activeTab ? 'code-preview-tab-active' : ''}`}
-                onClick={() => setActiveTab(i)}
-              >
+                <button
+                  type="button"
+                  key={file.path}
+                  className={`code-preview-tab ${i === activeTab ? 'code-preview-tab-active' : ''}`}
+                  onClick={() => setActiveTab(i)}
+                >
                 {file.path}
               </button>
             ))}
           </div>
 
           <div className="code-preview-actions">
-            <button className="code-preview-action-btn" onClick={handleCopyFile}>
+            <button type="button" className="code-preview-action-btn" onClick={handleCopyFile}>
               📋 Copy
             </button>
-            <button className="code-preview-action-btn" onClick={handleDownloadAll}>
+            <button type="button" className="code-preview-action-btn" onClick={handleDownloadAll}>
               💾 Download All
             </button>
           </div>
@@ -152,6 +192,27 @@ export function CodePreview() {
             {new Date(output.metadata.generatedAt).toLocaleTimeString()}
           </div>
         </>
+      )}
+
+      {comparisonOutputs && (
+        <div className="code-preview-compare-grid">
+          {(['azure', 'aws', 'gcp'] as ProviderType[]).map((provider) => {
+            const providerOutput = comparisonOutputs[provider];
+            const activeFile = providerOutput.files[activeTab] ?? providerOutput.files[0];
+
+            return (
+              <section key={provider} className="code-preview-compare-card">
+                <header className="code-preview-compare-header">
+                  <strong>{provider.toUpperCase()}</strong>
+                  <span>{providerOutput.files.length} files</span>
+                </header>
+                <pre className="code-preview-code code-preview-code-compare">
+                  <code>{activeFile?.content ?? ''}</code>
+                </pre>
+              </section>
+            );
+          })}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add a compare mode in `CodePreview` to generate and display Azure/AWS/GCP outputs in one workflow.
- Keep single-provider generation path aligned with active provider selection.
- Add test coverage for compare-mode behavior and non-terraform guardrails.

## Why
Milestone 8 requires a provider comparison surface so users can inspect provider-specific output differences before generation/deployment decisions.

## Validation
- `pnpm --filter @cloudblocks/web test -- src/widgets/code-preview/CodePreview.test.tsx`
- `pnpm lint`
- `pnpm build`

Closes #188