### PR TITLE
fix: keep workspace identity when pulling from GitHub (#195)

### DIFF
--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -29,7 +29,7 @@ describe('GitHubSync', () => {
   const mockApiGet = vi.mocked(apiGet);
   const mockApiPost = vi.mocked(apiPost);
   const mockApiPut = vi.mocked(apiPut);
-  const importArchitectureMock = vi.fn();
+  const replaceArchitectureMock = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -41,7 +41,7 @@ describe('GitHubSync', () => {
       error: null,
     });
     useArchitectureStore.setState({
-      importArchitecture: importArchitectureMock,
+      replaceArchitecture: replaceArchitectureMock,
       workspace: {
         id: 'ws-1',
         name: 'My Workspace',
@@ -143,7 +143,7 @@ describe('GitHubSync', () => {
     expect(screen.queryByRole('button', { name: 'Pull from GitHub' })).not.toBeInTheDocument();
   });
 
-  it('pull button calls API and imports architecture', async () => {
+  it('pull button calls API and replaces architecture in-place', async () => {
     const user = userEvent.setup();
     const archPayload = { id: 'pulled', name: 'Pulled', version: '1.0.0', plates: [], blocks: [], connections: [], externalActors: [], createdAt: '', updatedAt: '' };
     mockApiPost.mockResolvedValue({ architecture: archPayload });
@@ -157,7 +157,7 @@ describe('GitHubSync', () => {
     await waitFor(() => {
       expect(mockApiPost).toHaveBeenCalledWith('/api/v1/workspaces/ws-1/pull');
     });
-    expect(importArchitectureMock).toHaveBeenCalledWith(JSON.stringify(archPayload));
+    expect(replaceArchitectureMock).toHaveBeenCalledWith(archPayload);
   });
 
   it('sync shows error when API call fails', async () => {

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { apiGet, apiPost, apiPut } from '../../shared/api/client';
 import type { GitHubCommit, PullResponse, SyncResponse } from '../../shared/types/api';
+import type { ArchitectureSnapshot } from '../../shared/types/learning';
 import './GitHubSync.css';
 
 export function GitHubSync() {
@@ -12,7 +13,7 @@ export function GitHubSync() {
   const toggleGitHubRepos = useUIStore((s) => s.toggleGitHubRepos);
 
   const workspace = useArchitectureStore((s) => s.workspace);
-  const importArchitecture = useArchitectureStore((s) => s.importArchitecture);
+  const replaceArchitecture = useArchitectureStore((s) => s.replaceArchitecture);
   const setStoreBackendWorkspaceId = useArchitectureStore((s) => s.setBackendWorkspaceId);
 
   const isAuthenticated = useAuthStore((s) => s.status) === 'authenticated';
@@ -108,7 +109,7 @@ export function GitHubSync() {
       const response = await apiPost<PullResponse>(
         `/api/v1/workspaces/${encodeURIComponent(effectiveWorkspaceId)}/pull`
       );
-      importArchitecture(JSON.stringify(response.architecture));
+      replaceArchitecture(response.architecture as ArchitectureSnapshot);
       await loadCommits();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to pull from GitHub.');


### PR DESCRIPTION
## Summary
- stop using importArchitecture during pull (it creates a new local workspace)
- use replaceArchitecture to update the current workspace in place
- update GitHub Sync test expectations accordingly

## Validation
- pnpm --filter @cloudblocks/web test -- --run src/widgets/github-sync/GitHubSync.test.tsx

Closes #195