### PR TITLE
fix: remove unused oauth state from github login start

### DIFF
--- a/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
@@ -55,14 +55,13 @@ describe('GitHubLogin', () => {
     const user = userEvent.setup();
     mockApiPost.mockResolvedValueOnce({
       authorize_url: `${window.location.origin}/#oauth-callback`,
-      state: 'state-123',
     });
 
     render(<GitHubLogin />);
     await user.click(screen.getByRole('button', { name: 'Sign in with GitHub' }));
 
     expect(mockApiPost).toHaveBeenCalledWith('/api/v1/auth/github');
-    expect(sessionStorage.getItem('github_oauth_state')).toBe('state-123');
+    expect(sessionStorage.getItem('github_oauth_state')).toBeNull();
     expect(window.location.href).toContain('#oauth-callback');
   });
 
@@ -160,7 +159,7 @@ describe('GitHubLogin', () => {
     await user.click(screen.getByRole('button', { name: 'Sign in with GitHub' }));
 
     expect(screen.getByText('Loading...')).toBeInTheDocument();
-    resolvePost({ authorize_url: 'https://github.com', state: 's' });
+    resolvePost({ authorize_url: 'https://github.com' });
   });
 
   it('displays authError from store', () => {

--- a/apps/web/src/widgets/github-login/GitHubLogin.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.tsx
@@ -6,7 +6,6 @@ import './GitHubLogin.css';
 
 interface GitHubAuthStartResponse {
   authorize_url: string;
-  state: string;
 }
 
 export function GitHubLogin() {
@@ -31,7 +30,6 @@ export function GitHubLogin() {
 
     try {
       const response = await apiPost<GitHubAuthStartResponse>('/api/v1/auth/github');
-      sessionStorage.setItem('github_oauth_state', response.state);
       window.location.href = response.authorize_url;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to start GitHub login.';


### PR DESCRIPTION
## Summary
- update `GitHubAuthStartResponse` to match backend payload (`authorize_url` only)
- stop writing undefined OAuth state to `sessionStorage`
- adjust GitHubLogin tests to validate cookie-based state flow contract

## Validation
- pnpm --filter @cloudblocks/web test -- src/widgets/github-login/GitHubLogin.test.tsx

Closes #201