### PR TITLE
fix: bind minifigure provider to activeProvider (#225)

### DIFF
--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -219,7 +219,7 @@ export function SceneCanvas() {
                   zIndex,
                 }}
               >
-                <MinifigureSvg provider="azure" />
+                <MinifigureSvg provider={activeProvider} />
               </div>
             );
           })()}


### PR DESCRIPTION
## Summary
- Fixes hardcoded 'azure' provider in MinifigureSvg component
- Now reads activeProvider from uiStore instead of hardcoded value
- Allows minifigure to match the currently selected provider

Closes #225