### PR TITLE
feat: create WorkerStore for build queue state (#227)

### DIFF
--- a/apps/web/src/entities/store/workerStore.test.ts
+++ b/apps/web/src/entities/store/workerStore.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useWorkerStore } from './workerStore';
+
+const resetStore = () => {
+  useWorkerStore.setState({
+    workerId: 'worker-default',
+    workerState: 'idle',
+    workerPosition: [0, 0, 0],
+    buildQueue: [],
+    activeBuild: null,
+  });
+};
+
+describe('workerStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it('has expected initial state', () => {
+    const state = useWorkerStore.getState();
+
+    expect(state.workerId).toBe('worker-default');
+    expect(state.workerState).toBe('idle');
+    expect(state.workerPosition).toEqual([0, 0, 0]);
+    expect(state.buildQueue).toEqual([]);
+    expect(state.activeBuild).toBeNull();
+  });
+
+  it('startBuild sets active build and moving state when no active build exists', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    useWorkerStore.getState().startBuild('block-1', [1, 2, 3]);
+    const state = useWorkerStore.getState();
+
+    expect(state.workerState).toBe('moving');
+    expect(state.activeBuild).toEqual({
+      blockId: 'block-1',
+      targetPosition: [1, 2, 3],
+      progress: 0,
+      startedAt: 1700000000000,
+    });
+    expect(state.buildQueue).toEqual([]);
+
+    nowSpy.mockRestore();
+  });
+
+  it('startBuild enqueues task when active build exists', () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1700000000000);
+
+    const store = useWorkerStore.getState();
+    store.startBuild('block-1', [1, 2, 3]);
+    store.startBuild('block-2', [4, 5, 6]);
+    const state = useWorkerStore.getState();
+
+    expect(state.activeBuild?.blockId).toBe('block-1');
+    expect(state.buildQueue).toHaveLength(1);
+    expect(state.buildQueue[0]).toEqual({
+      blockId: 'block-2',
+      targetPosition: [4, 5, 6],
+      progress: 0,
+      startedAt: 1700000000000,
+    });
+
+    nowSpy.mockRestore();
+  });
+
+  it('tickBuildProgress increments active build progress', () => {
+    const store = useWorkerStore.getState();
+
+    store.startBuild('block-1', [1, 1, 1]);
+    store.setWorkerState('building');
+    store.tickBuildProgress(0.25);
+
+    expect(useWorkerStore.getState().activeBuild?.progress).toBe(0.25);
+  });
+
+  it('tickBuildProgress auto-completes when progress reaches one or more', () => {
+    const store = useWorkerStore.getState();
+
+    store.startBuild('block-1', [1, 1, 1]);
+    store.setWorkerState('building');
+    store.tickBuildProgress(1);
+
+    const state = useWorkerStore.getState();
+    expect(state.activeBuild).toBeNull();
+    expect(state.workerState).toBe('idle');
+  });
+
+  it('tickBuildProgress is a no-op when worker is not building', () => {
+    const store = useWorkerStore.getState();
+
+    store.startBuild('block-1', [1, 1, 1]);
+    store.tickBuildProgress(0.5);
+
+    expect(useWorkerStore.getState().activeBuild?.progress).toBe(0);
+  });
+
+  it('completeBuild dequeues next task and sets moving state', () => {
+    const store = useWorkerStore.getState();
+
+    store.startBuild('block-1', [1, 1, 1]);
+    store.startBuild('block-2', [2, 2, 2]);
+    store.completeBuild();
+
+    const state = useWorkerStore.getState();
+    expect(state.activeBuild?.blockId).toBe('block-2');
+    expect(state.buildQueue).toEqual([]);
+    expect(state.workerState).toBe('moving');
+  });
+
+  it('completeBuild sets idle when queue is empty', () => {
+    const store = useWorkerStore.getState();
+
+    store.startBuild('block-1', [1, 1, 1]);
+    store.completeBuild();
+
+    const state = useWorkerStore.getState();
+    expect(state.activeBuild).toBeNull();
+    expect(state.workerState).toBe('idle');
+  });
+
+  it('cancelBuild clears active build and does not dequeue next task', () => {
+    const store = useWorkerStore.getState();
+
+    store.startBuild('block-1', [1, 1, 1]);
+    store.startBuild('block-2', [2, 2, 2]);
+    store.cancelBuild();
+
+    const state = useWorkerStore.getState();
+    expect(state.activeBuild).toBeNull();
+    expect(state.workerState).toBe('idle');
+    expect(state.buildQueue).toHaveLength(1);
+    expect(state.buildQueue[0].blockId).toBe('block-2');
+  });
+
+  it('clearQueue resets queue and worker state', () => {
+    const store = useWorkerStore.getState();
+
+    store.startBuild('block-1', [1, 1, 1]);
+    store.startBuild('block-2', [2, 2, 2]);
+    store.setWorkerState('building');
+    store.clearQueue();
+
+    const state = useWorkerStore.getState();
+    expect(state.activeBuild).toBeNull();
+    expect(state.buildQueue).toEqual([]);
+    expect(state.workerState).toBe('idle');
+  });
+
+  it('setWorkerPosition updates worker position', () => {
+    const store = useWorkerStore.getState();
+
+    store.setWorkerPosition([9, 8, 7]);
+
+    expect(useWorkerStore.getState().workerPosition).toEqual([9, 8, 7]);
+  });
+
+  it('setWorkerState updates worker state', () => {
+    const store = useWorkerStore.getState();
+
+    store.setWorkerState('moving');
+
+    expect(useWorkerStore.getState().workerState).toBe('moving');
+  });
+});

--- a/apps/web/src/entities/store/workerStore.ts
+++ b/apps/web/src/entities/store/workerStore.ts
@@ -1,0 +1,123 @@
+import { create } from 'zustand';
+
+export type WorkerState = 'idle' | 'moving' | 'building';
+
+export interface BuildTask {
+  blockId: string;
+  targetPosition: [number, number, number];
+  progress: number;
+  startedAt: number;
+}
+
+interface WorkerStoreState {
+  workerId: string;
+  workerState: WorkerState;
+  workerPosition: [number, number, number];
+  buildQueue: BuildTask[];
+  activeBuild: BuildTask | null;
+  startBuild: (blockId: string, targetPosition: [number, number, number]) => void;
+  tickBuildProgress: (deltaProgress: number) => void;
+  completeBuild: () => void;
+  cancelBuild: () => void;
+  setWorkerPosition: (pos: [number, number, number]) => void;
+  setWorkerState: (state: WorkerState) => void;
+  clearQueue: () => void;
+}
+
+const createBuildTask = (
+  blockId: string,
+  targetPosition: [number, number, number]
+): BuildTask => ({
+  blockId,
+  targetPosition,
+  progress: 0,
+  startedAt: Date.now(),
+});
+
+export const useWorkerStore = create<WorkerStoreState>((set, get) => ({
+  workerId: 'worker-default',
+  workerState: 'idle',
+  workerPosition: [0, 0, 0],
+  buildQueue: [],
+  activeBuild: null,
+
+  startBuild: (blockId, targetPosition) => {
+    const nextTask = createBuildTask(blockId, targetPosition);
+    const { activeBuild } = get();
+
+    if (activeBuild) {
+      set((state) => ({ buildQueue: [...state.buildQueue, nextTask] }));
+      return;
+    }
+
+    set({
+      activeBuild: nextTask,
+      workerState: 'moving',
+    });
+  },
+
+  tickBuildProgress: (deltaProgress) => {
+    const { workerState, activeBuild } = get();
+
+    if (workerState !== 'building' || !activeBuild) {
+      return;
+    }
+
+    const nextProgress = Math.min(1, Math.max(0, activeBuild.progress + deltaProgress));
+
+    if (nextProgress >= 1) {
+      get().completeBuild();
+      return;
+    }
+
+    set({
+      activeBuild: {
+        ...activeBuild,
+        progress: nextProgress,
+      },
+    });
+  },
+
+  completeBuild: () => {
+    const { buildQueue } = get();
+
+    if (buildQueue.length === 0) {
+      set({
+        activeBuild: null,
+        workerState: 'idle',
+      });
+      return;
+    }
+
+    const [nextTask, ...remainingQueue] = buildQueue;
+
+    set({
+      activeBuild: nextTask,
+      buildQueue: remainingQueue,
+      workerState: 'moving',
+    });
+  },
+
+  cancelBuild: () => {
+    set({
+      activeBuild: null,
+      workerState: 'idle',
+    });
+  },
+
+  setWorkerPosition: (pos) => {
+    set({ workerPosition: pos });
+  },
+
+  setWorkerState: (state) => {
+    set({ workerState: state });
+  },
+
+  clearQueue: () => {
+    set({
+      buildQueue: [],
+      activeBuild: null,
+      workerState: 'idle',
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- add a dedicated `workerStore` Zustand store for worker build queue, worker position, and worker state machine
- implement queueing/completion/cancel/clear behaviors with no integration to undo/redo state
- add full TDD coverage with 12 tests for initial state, transitions, queue behavior, and action no-op logic

## Validation
- `pnpm --filter web exec vitest run --reporter=verbose`
- `pnpm --filter web exec vitest run src/entities/store/workerStore.test.ts --reporter=verbose`
- `pnpm lint` *(currently fails on existing unrelated error in `apps/web/src/shared/types/schema.ts:68`)*
- `pnpm build` *(currently fails on existing unrelated ExternalActor typing errors across existing test files)*

Closes #227