### PR TITLE
docs: add size labels to issue labeling guidelines (#237)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,7 @@ zundo        — Zustand undo/redo middleware
   - Non-Epic implementation issues use exactly one type label: `enhancement`, `bug`, or `testing`.
   - Documentation issues use `documentation`; domain labels are recommended and optional when the docs are cross-cutting.
   - Domain labels include `frontend`, `backend`, `security`, `auth`, `infrastructure`, `ux`, `design-system`, `domain-model`, and `cloud-provider`.
+  - Every non-Epic issue must have exactly one size label: `size/S`, `size/M`, `size/L`, or `size/XL`. Assign it at creation time.
 - Use one branch per sub-issue and one PR per branch. Each PR should reference and close its issue.
 
 ## Validation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,12 @@ Apply labels before starting work.
 #### 1) Size / tracking labels
 
 - `epic` — required for Epic tracking issues only
+- `size/S` — Small: 1–2 files, < 1 hour
+- `size/M` — Medium: 3–5 files, 1–3 hours
+- `size/L` — Large: 6–10 files, 3–8 hours
+- `size/XL` — Extra Large: 10+ files, 8+ hours
+
+Every non-Epic issue should have exactly one `size/*` label. Assign it when the issue is created.
 
 #### 2) Type labels
 


### PR DESCRIPTION
## Summary

- Add `size/S`, `size/M`, `size/L`, `size/XL` label definitions to CONTRIBUTING.md labeling rules
- Add mandatory size label requirement to AGENTS.md

Closes #237