### PR TITLE
fix(ui): render EmptyCanvasOverlay after scene-world to fix z-index overlap

### DIFF
--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -128,7 +128,6 @@ export function SceneCanvas() {
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
     >
-      <EmptyCanvasOverlay />
       <div 
         className="scene-world"
         style={{
@@ -242,6 +241,7 @@ export function SceneCanvas() {
           })}
         </div>
       </div>
+      <EmptyCanvasOverlay />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Move `<EmptyCanvasOverlay />` after `.scene-world` in SceneCanvas.tsx DOM order so it paints on top of minifigure and external actor sprites

## Problem
The "Build Your Architecture" overlay was rendering behind the minifigure and Internet actor on the empty canvas because `.scene-world` (with `will-change: transform`) creates a stacking context that painted on top of the overlay despite `z-index: 100`.

## Fix
Single-line DOM reorder: render the overlay AFTER `.scene-world` instead of before it.

Closes #245