### PR TITLE
fix(ui): add bottom padding to empty canvas overlay to clear BottomPanel

### DIFF
--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.css
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.css
@@ -6,6 +6,7 @@
   justify-content: center;
   z-index: 100;
   pointer-events: none;
+  padding-bottom: 260px; /* clear BottomPanel height */
 }
 
 .empty-canvas-content {


### PR DESCRIPTION
## Summary
- Add `padding-bottom: 260px` to `.empty-canvas-overlay` so the centered card clears the 260px BottomPanel

## Problem
The "Learn How" button at the bottom of the overlay card was hidden behind the BottomPanel (same z-index level, 260px tall).

## Fix
Single CSS property addition — pushes the flexbox-centered card upward.

Closes #247