### PR TITLE
fix(ui): show passive IdleState in DetailPanel when empty canvas overlay is visible

### DIFF
--- a/apps/web/src/widgets/bottom-panel/DetailPanel.css
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.css
@@ -270,3 +270,29 @@
 .detail-panel--connection .detail-header-icon {
   color: #FFFFFF;
 }
+
+/* Idle state (empty canvas — overlay is visible) */
+.detail-panel--idle {
+  justify-content: center;
+  align-items: center;
+  padding: 16px;
+  opacity: 0.6;
+}
+.detail-idle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 6px;
+}
+.detail-idle-icon {
+  font-size: 20px;
+}
+.detail-idle-text {
+  margin: 0;
+  font-size: 12px;
+  color: #665500;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
@@ -301,4 +301,60 @@ describe('DetailPanel', () => {
 
     expect(screen.getByText('None')).toBeInTheDocument();
   });
+
+  it("renders idle state when architecture is empty (overlay is visible)", () => {
+    useArchitectureStore.setState({
+      workspace: {
+        id: "ws-1",
+        name: "Test Workspace",
+        architecture: {
+          id: "arch-1",
+          name: "Empty Architecture",
+          version: "1.0.0",
+          plates: [],
+          blocks: [],
+          connections: [],
+          externalActors: [],
+          createdAt: "",
+          updatedAt: "",
+        },
+        createdAt: "",
+        updatedAt: "",
+      },
+    });
+    useUIStore.setState({ selectedId: null, showTemplateGallery: false });
+
+    render(<DetailPanel />);
+
+    expect(screen.getByText("No selection")).toBeInTheDocument();
+    expect(screen.queryByText("Welcome to CloudBlocks!")).not.toBeInTheDocument();
+  });
+
+  it("renders welcome state when template gallery is open even on empty canvas", () => {
+    useArchitectureStore.setState({
+      workspace: {
+        id: "ws-1",
+        name: "Test Workspace",
+        architecture: {
+          id: "arch-1",
+          name: "Empty Architecture",
+          version: "1.0.0",
+          plates: [],
+          blocks: [],
+          connections: [],
+          externalActors: [],
+          createdAt: "",
+          updatedAt: "",
+        },
+        createdAt: "",
+        updatedAt: "",
+      },
+    });
+    useUIStore.setState({ selectedId: null, showTemplateGallery: true });
+
+    render(<DetailPanel />);
+
+    expect(screen.getByText("Welcome to CloudBlocks!")).toBeInTheDocument();
+    expect(screen.queryByText("No selection")).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -33,6 +33,7 @@ interface DetailPanelProps {
 
 export function DetailPanel({ className = '' }: DetailPanelProps) {
   const selectedId = useUIStore((s) => s.selectedId);
+  const showTemplateGallery = useUIStore((s) => s.showTemplateGallery);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
 
   // Find selected item
@@ -41,6 +42,10 @@ export function DetailPanel({ className = '' }: DetailPanelProps) {
   const selectedConnection = architecture.connections.find((c) => c.id === selectedId);
 
   if (!selectedId) {
+    const isEmptyOnboarding = architecture.plates.length === 0 && !showTemplateGallery;
+    if (isEmptyOnboarding) {
+      return <IdleState className={className} />;
+    }
     return <WelcomeState className={className} />;
   }
 
@@ -57,6 +62,19 @@ export function DetailPanel({ className = '' }: DetailPanelProps) {
   }
 
   return <WelcomeState className={className} />;
+}
+
+// ─── Idle State ────────────────────────────────────────────
+
+function IdleState({ className }: { className: string }) {
+  return (
+    <div className={`detail-panel detail-panel--idle ${className}`}>
+      <div className="detail-idle">
+        <span className="detail-idle-icon">📋</span>
+        <p className="detail-idle-text">No selection</p>
+      </div>
+    </div>
+  );
 }
 
 // ─── Welcome State ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Adds `IdleState` component to `DetailPanel` that renders when the empty canvas onboarding overlay is visible (`plates.length === 0 && !showTemplateGallery`)
- Eliminates UI redundancy between the center overlay CTA and the bottom panel's competing `WelcomeState` CTAs
- `WelcomeState` is preserved for normal idle state (plates exist, nothing selected)

## Changes
| File | Change |
|------|--------|
| `DetailPanel.tsx` | Add `IdleState` component, `showTemplateGallery` selector, routing logic |
| `DetailPanel.css` | Idle state styles (muted, centered, no CTA) |
| `DetailPanel.test.tsx` | 2 new tests: idle on empty canvas, welcome on gallery open |

## Verification
- ✅ 1243 tests pass (77 files)
- ✅ Lint clean
- ✅ Build clean

Closes #262