### PR TITLE
feat(generate): add SubtypeResourceMap and resolveBlockMapping

### DIFF
--- a/apps/web/src/features/generate/__tests__/resolveMapping.test.ts
+++ b/apps/web/src/features/generate/__tests__/resolveMapping.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { BlockResourceMap, SubtypeResourceMap } from '../types';
+import { resolveBlockMapping } from '../types';
+
+const baseBlockMappings: BlockResourceMap = {
+  compute: { resourceType: 'aws_ecs_service', namePrefix: 'ecs' },
+  database: { resourceType: 'aws_db_instance', namePrefix: 'db' },
+  storage: { resourceType: 'aws_s3_bucket', namePrefix: 'bucket' },
+  gateway: { resourceType: 'aws_lb', namePrefix: 'lb' },
+  function: { resourceType: 'aws_lambda_function', namePrefix: 'lambda' },
+  queue: { resourceType: 'aws_sqs_queue', namePrefix: 'queue' },
+  event: { resourceType: 'aws_sns_topic', namePrefix: 'topic' },
+  timer: { resourceType: 'aws_cloudwatch_event_rule', namePrefix: 'schedule' },
+};
+
+const subtypeMappings: SubtypeResourceMap = {
+  compute: {
+    ec2: { resourceType: 'aws_instance', namePrefix: 'ec2' },
+    ecs: { resourceType: 'aws_ecs_service', namePrefix: 'ecs' },
+    lambda: { resourceType: 'aws_lambda_function', namePrefix: 'fn' },
+  },
+  database: {
+    'rds-postgres': { resourceType: 'aws_db_instance', namePrefix: 'rds' },
+    dynamodb: { resourceType: 'aws_dynamodb_table', namePrefix: 'ddb' },
+  },
+};
+
+describe('resolveBlockMapping', () => {
+  it('returns subtype mapping when subtype is found', () => {
+    const result = resolveBlockMapping(baseBlockMappings, subtypeMappings, 'compute', 'ec2');
+    expect(result).toEqual({ resourceType: 'aws_instance', namePrefix: 'ec2' });
+  });
+
+  it('falls back to category mapping when subtype is unknown', () => {
+    const result = resolveBlockMapping(baseBlockMappings, subtypeMappings, 'compute', 'unknown-subtype');
+    expect(result).toEqual({ resourceType: 'aws_ecs_service', namePrefix: 'ecs' });
+  });
+
+  it('falls back to category mapping when subtype is undefined', () => {
+    const result = resolveBlockMapping(baseBlockMappings, subtypeMappings, 'compute', undefined);
+    expect(result).toEqual({ resourceType: 'aws_ecs_service', namePrefix: 'ecs' });
+  });
+
+  it('falls back to category mapping when subtypeMappings is undefined', () => {
+    const result = resolveBlockMapping(baseBlockMappings, undefined, 'compute', 'ec2');
+    expect(result).toEqual({ resourceType: 'aws_ecs_service', namePrefix: 'ecs' });
+  });
+
+  it('falls back to category mapping when category has no subtypes defined', () => {
+    const result = resolveBlockMapping(baseBlockMappings, subtypeMappings, 'storage', 's3');
+    expect(result).toEqual({ resourceType: 'aws_s3_bucket', namePrefix: 'bucket' });
+  });
+
+  it('returns category mapping for categories without any subtype entries', () => {
+    const result = resolveBlockMapping(baseBlockMappings, subtypeMappings, 'gateway');
+    expect(result).toEqual({ resourceType: 'aws_lb', namePrefix: 'lb' });
+  });
+
+  it('returns subtype mapping for database subtypes', () => {
+    const result = resolveBlockMapping(baseBlockMappings, subtypeMappings, 'database', 'dynamodb');
+    expect(result).toEqual({ resourceType: 'aws_dynamodb_table', namePrefix: 'ddb' });
+  });
+
+  it('returns category mapping with empty subtypeMappings object', () => {
+    const result = resolveBlockMapping(baseBlockMappings, {}, 'compute', 'ec2');
+    expect(result).toEqual({ resourceType: 'aws_ecs_service', namePrefix: 'ecs' });
+  });
+});

--- a/apps/web/src/features/generate/types.ts
+++ b/apps/web/src/features/generate/types.ts
@@ -80,6 +80,37 @@ export interface ResourceMapping {
 export type BlockResourceMap = Record<BlockCategory, ResourceMapping>;
 export type PlateResourceMap = Record<PlateType, ResourceMapping>;
 
+// ─── Subtype-Aware Mapping ───────────────────────────────────
+
+/**
+ * Maps BlockCategory → subtype string → ResourceMapping.
+ * Used alongside BlockResourceMap for subtype-specific resource resolution.
+ */
+export type SubtypeResourceMap = Partial<Record<BlockCategory, Record<string, ResourceMapping>>>;
+
+/**
+ * Resolve the correct ResourceMapping for a block based on category and optional subtype.
+ * Resolution order:
+ *   1. If subtype provided AND subtypeMappings has entry → return subtype mapping
+ *   2. Otherwise → fallback to blockMappings[category]
+ *   3. If neither found → return undefined
+ */
+export function resolveBlockMapping(
+  blockMappings: BlockResourceMap,
+  subtypeMappings: SubtypeResourceMap | undefined,
+  category: BlockCategory,
+  subtype?: string,
+): ResourceMapping | undefined {
+  if (subtype && subtypeMappings) {
+    const categorySubtypes = subtypeMappings[category];
+    if (categorySubtypes && categorySubtypes[subtype]) {
+      return categorySubtypes[subtype];
+    }
+  }
+
+  return blockMappings[category];
+}
+
 /** @deprecated Use ProviderDefinition instead. Kept for backward compat with terraform.ts */
 export interface ProviderAdapter {
   name: ProviderName;


### PR DESCRIPTION
## Summary
- Add `SubtypeResourceMap` to support optional subtype-aware provider mapping via `Partial<Record<BlockCategory, ...>>`.
- Add pure `resolveBlockMapping()` with deterministic fallback order: subtype mapping first, then category mapping.
- Add TDD coverage in `resolveMapping.test.ts` for subtype hit, unknown subtype fallback, undefined subtype, undefined/empty subtype maps, and categories without subtype entries.

## Validation
- `pnpm --filter web exec vitest run --reporter=verbose`
- `pnpm build`
- `pnpm lint`

Closes #270