### PR TITLE
feat(providers): add subtypeBlockMappings to AWS, GCP, and Azure definitions

### DIFF
--- a/apps/web/src/features/generate/providers/aws/index.ts
+++ b/apps/web/src/features/generate/providers/aws/index.ts
@@ -1,4 +1,23 @@
-import type { ProviderAdapter, ProviderDefinition } from '../../types';
+import type { ProviderAdapter, ProviderDefinition, SubtypeResourceMap } from '../../types';
+
+const awsSubtypeBlockMappings: SubtypeResourceMap = {
+  compute: {
+    ec2: { resourceType: 'aws_instance', namePrefix: 'ec2' },
+    ecs: { resourceType: 'aws_ecs_service', namePrefix: 'ecs' },
+    lambda: { resourceType: 'aws_lambda_function', namePrefix: 'fn' },
+  },
+  database: {
+    'rds-postgres': { resourceType: 'aws_db_instance', namePrefix: 'rds' },
+    dynamodb: { resourceType: 'aws_dynamodb_table', namePrefix: 'ddb' },
+  },
+  storage: {
+    s3: { resourceType: 'aws_s3_bucket', namePrefix: 's3' },
+  },
+  gateway: {
+    alb: { resourceType: 'aws_lb', namePrefix: 'alb' },
+    'api-gateway': { resourceType: 'aws_apigatewayv2_api', namePrefix: 'apigw' },
+  },
+};
 
 export const awsProviderDefinition: ProviderDefinition = {
   name: 'aws',
@@ -75,6 +94,7 @@ export const awsProviderDefinition: ProviderDefinition = {
       runtime: 'nodejs',
     },
   },
+  subtypeBlockMappings: awsSubtypeBlockMappings,
 };
 
 export const awsProvider: ProviderAdapter = {

--- a/apps/web/src/features/generate/providers/azure/index.ts
+++ b/apps/web/src/features/generate/providers/azure/index.ts
@@ -1,4 +1,23 @@
-import type { ProviderAdapter, ProviderDefinition } from '../../types';
+import type { ProviderAdapter, ProviderDefinition, SubtypeResourceMap } from '../../types';
+
+const azureSubtypeBlockMappings: SubtypeResourceMap = {
+  compute: {
+    vm: { resourceType: 'azurerm_linux_virtual_machine', namePrefix: 'vm' },
+    'container-instances': { resourceType: 'azurerm_container_group', namePrefix: 'aci' },
+    functions: { resourceType: 'azurerm_linux_function_app', namePrefix: 'func' },
+  },
+  database: {
+    'sql-database': { resourceType: 'azurerm_mssql_database', namePrefix: 'sqldb' },
+    'cosmos-db': { resourceType: 'azurerm_cosmosdb_account', namePrefix: 'cosmos' },
+  },
+  storage: {
+    'blob-storage': { resourceType: 'azurerm_storage_account', namePrefix: 'st' },
+  },
+  gateway: {
+    'application-gateway': { resourceType: 'azurerm_application_gateway', namePrefix: 'appgw' },
+    'api-management': { resourceType: 'azurerm_api_management', namePrefix: 'apim' },
+  },
+};
 
 /**
  * Azure Provider Definitions (v1.0)
@@ -100,6 +119,7 @@ export const azureProviderDefinition: ProviderDefinition = {
       runtime: 'nodejs',
     },
   },
+  subtypeBlockMappings: azureSubtypeBlockMappings,
 };
 
 /**

--- a/apps/web/src/features/generate/providers/gcp/index.ts
+++ b/apps/web/src/features/generate/providers/gcp/index.ts
@@ -1,4 +1,23 @@
-import type { ProviderAdapter, ProviderDefinition } from '../../types';
+import type { ProviderAdapter, ProviderDefinition, SubtypeResourceMap } from '../../types';
+
+const gcpSubtypeBlockMappings: SubtypeResourceMap = {
+  compute: {
+    'compute-engine': { resourceType: 'google_compute_instance', namePrefix: 'gce' },
+    'cloud-run': { resourceType: 'google_cloud_run_v2_service', namePrefix: 'run' },
+    'cloud-functions': { resourceType: 'google_cloudfunctions2_function', namePrefix: 'gcf' },
+  },
+  database: {
+    'cloud-sql-postgres': { resourceType: 'google_sql_database_instance', namePrefix: 'sql' },
+    firestore: { resourceType: 'google_firestore_database', namePrefix: 'fdb' },
+  },
+  storage: {
+    'cloud-storage': { resourceType: 'google_storage_bucket', namePrefix: 'gcs' },
+  },
+  gateway: {
+    'cloud-load-balancing': { resourceType: 'google_compute_url_map', namePrefix: 'lb' },
+    'api-gateway': { resourceType: 'google_api_gateway_api', namePrefix: 'apigw' },
+  },
+};
 
 export const gcpProviderDefinition: ProviderDefinition = {
   name: 'gcp',
@@ -75,6 +94,7 @@ export const gcpProviderDefinition: ProviderDefinition = {
       runtime: 'nodejs',
     },
   },
+  subtypeBlockMappings: gcpSubtypeBlockMappings,
 };
 
 export const gcpProvider: ProviderAdapter = {

--- a/apps/web/src/features/generate/types.ts
+++ b/apps/web/src/features/generate/types.ts
@@ -149,6 +149,7 @@ export interface ProviderDefinition {
     bicep: BicepProviderConfig;
     pulumi: PulumiProviderConfig;
   };
+  subtypeBlockMappings?: SubtypeResourceMap;
 }
 
 // ─── Generator Plugin Interface (v1.0) ──────────────────────


### PR DESCRIPTION
## Summary
- add optional `subtypeBlockMappings` to `ProviderDefinition`
- populate subtype-to-resource mappings for AWS, GCP, and Azure providers
- keep existing `blockMappings` and `plateMappings` unchanged

Closes #271