### PR TITLE
feat(validation): add provider-specific validation rules

### DIFF
--- a/apps/web/src/entities/validation/__tests__/providerValidation.test.ts
+++ b/apps/web/src/entities/validation/__tests__/providerValidation.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest';
+import type { ArchitectureModel, Block, Plate } from '../../../shared/types/index';
+import { validateProviderRules } from '../providerValidation';
+
+function makePlate(overrides: Partial<Plate> = {}): Plate {
+  return {
+    id: 'subnet-private-1',
+    name: 'Private Subnet',
+    type: 'subnet',
+    subnetAccess: 'private',
+    parentId: 'network-1',
+    children: [],
+    position: { x: 0, y: 0, z: 0 },
+    size: { width: 8, height: 1, depth: 8 },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeBlock(overrides: Partial<Block> = {}): Block {
+  return {
+    id: 'block-1',
+    name: 'Block One',
+    category: 'compute',
+    placementId: 'subnet-private-1',
+    position: { x: 0, y: 0, z: 0 },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeModel(
+  overrides: Partial<ArchitectureModel> = {}
+): ArchitectureModel {
+  return {
+    id: 'arch-1',
+    name: 'Architecture',
+    version: '1.0.0',
+    plates: [makePlate()],
+    blocks: [],
+    connections: [],
+    externalActors: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('validateProviderRules', () => {
+  it('returns warning for AWS Lambda on subnet', () => {
+    const model = makeModel({
+      blocks: [
+        makeBlock({
+          id: 'lambda-1',
+          name: 'Lambda Handler',
+          provider: 'aws',
+          subtype: 'lambda',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      ruleId: 'rule-provider-aws-lambda-subnet',
+      severity: 'warning',
+      targetId: 'lambda-1',
+    });
+  });
+
+  it('returns no warning for AWS EC2 on subnet', () => {
+    const model = makeModel({
+      blocks: [
+        makeBlock({
+          id: 'ec2-1',
+          name: 'EC2 App',
+          provider: 'aws',
+          subtype: 'ec2',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns warning for GCP Cloud SQL on public subnet', () => {
+    const model = makeModel({
+      plates: [makePlate({ id: 'subnet-public-1', subnetAccess: 'public' })],
+      blocks: [
+        makeBlock({
+          id: 'sql-1',
+          name: 'Cloud SQL',
+          category: 'database',
+          provider: 'gcp',
+          subtype: 'cloud-sql-postgres',
+          placementId: 'subnet-public-1',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      ruleId: 'rule-provider-gcp-sql-public',
+      severity: 'warning',
+      targetId: 'sql-1',
+    });
+  });
+
+  it('returns no warning for GCP Cloud SQL on private subnet', () => {
+    const model = makeModel({
+      plates: [makePlate({ id: 'subnet-private-2', subnetAccess: 'private' })],
+      blocks: [
+        makeBlock({
+          id: 'sql-2',
+          name: 'Cloud SQL Private',
+          category: 'database',
+          provider: 'gcp',
+          subtype: 'cloud-sql-postgres',
+          placementId: 'subnet-private-2',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns warning for unknown subtype', () => {
+    const model = makeModel({
+      blocks: [
+        makeBlock({
+          id: 'unknown-1',
+          name: 'Mystery Compute',
+          provider: 'aws',
+          category: 'compute',
+          subtype: 'mystery-instance',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({
+      ruleId: 'rule-provider-unknown-subtype',
+      severity: 'warning',
+      targetId: 'unknown-1',
+    });
+  });
+
+  it('returns no warning for known subtype', () => {
+    const model = makeModel({
+      blocks: [
+        makeBlock({
+          id: 'known-1',
+          name: 'Cloud Run Service',
+          provider: 'gcp',
+          category: 'compute',
+          subtype: 'cloud-run',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns no warnings for block without provider', () => {
+    const model = makeModel({
+      blocks: [
+        makeBlock({
+          id: 'no-provider-1',
+          name: 'Generic Compute',
+          subtype: 'ec2',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns no warnings for block without subtype', () => {
+    const model = makeModel({
+      blocks: [
+        makeBlock({
+          id: 'no-subtype-1',
+          name: 'Provider Block',
+          provider: 'aws',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('collects multiple warnings across architecture', () => {
+    const model = makeModel({
+      plates: [
+        makePlate({ id: 'subnet-public-1', subnetAccess: 'public' }),
+        makePlate({ id: 'subnet-private-1', subnetAccess: 'private' }),
+      ],
+      blocks: [
+        makeBlock({
+          id: 'lambda-1',
+          name: 'Lambda Worker',
+          provider: 'aws',
+          category: 'compute',
+          subtype: 'lambda',
+          placementId: 'subnet-private-1',
+        }),
+        makeBlock({
+          id: 'sql-public-1',
+          name: 'Cloud SQL Public',
+          provider: 'gcp',
+          category: 'database',
+          subtype: 'cloud-sql-postgres',
+          placementId: 'subnet-public-1',
+        }),
+        makeBlock({
+          id: 'unknown-2',
+          name: 'Unknown Gateway',
+          provider: 'azure',
+          category: 'gateway',
+          subtype: 'unknown-gateway',
+        }),
+      ],
+    });
+
+    const warnings = validateProviderRules(model);
+
+    expect(warnings).toHaveLength(3);
+    expect(warnings.map((warning) => warning.ruleId).sort()).toEqual([
+      'rule-provider-aws-lambda-subnet',
+      'rule-provider-gcp-sql-public',
+      'rule-provider-unknown-subtype',
+    ]);
+    for (const warning of warnings) {
+      expect(warning.severity).toBe('warning');
+    }
+  });
+});

--- a/apps/web/src/entities/validation/engine.ts
+++ b/apps/web/src/entities/validation/engine.ts
@@ -4,6 +4,7 @@ import type {
 } from '../../shared/types/index';
 import { validatePlacement } from './placement';
 import { validateConnection } from './connection';
+import { validateProviderRules } from './providerValidation';
 
 /**
  * Rule Engine — validates an entire ArchitectureModel.
@@ -46,6 +47,9 @@ export function validateArchitecture(
       }
     }
   }
+
+  const providerWarnings = validateProviderRules(model);
+  warnings.push(...providerWarnings);
 
   return {
     valid: errors.length === 0,

--- a/apps/web/src/entities/validation/providerValidation.ts
+++ b/apps/web/src/entities/validation/providerValidation.ts
@@ -1,0 +1,92 @@
+import type {
+  ArchitectureModel,
+  Block,
+  Plate,
+  ValidationError,
+} from '../../shared/types/index';
+
+const KNOWN_SUBTYPES: Record<string, Record<string, string[]>> = {
+  aws: {
+    compute: ['ec2', 'ecs', 'lambda'],
+    database: ['rds-postgres', 'dynamodb'],
+    storage: ['s3'],
+    gateway: ['alb', 'api-gateway'],
+  },
+  gcp: {
+    compute: ['compute-engine', 'cloud-run', 'cloud-functions'],
+    database: ['cloud-sql-postgres', 'firestore'],
+    storage: ['cloud-storage'],
+    gateway: ['cloud-load-balancing', 'api-gateway'],
+  },
+  azure: {
+    compute: ['vm', 'container-instances', 'functions'],
+    database: ['sql-database', 'cosmos-db'],
+    storage: ['blob-storage'],
+    gateway: ['application-gateway', 'api-management'],
+  },
+};
+
+function validateBlockProviderRules(
+  block: Block,
+  plate: Plate | undefined
+): ValidationError[] {
+  const warnings: ValidationError[] = [];
+
+  if (
+    block.provider === 'aws' &&
+    block.subtype === 'lambda' &&
+    plate?.type === 'subnet'
+  ) {
+    warnings.push({
+      ruleId: 'rule-provider-aws-lambda-subnet',
+      severity: 'warning',
+      message: `AWS Lambda "${block.name}" is placed on a subnet. Lambda functions are serverless and typically don't require VPC placement unless accessing private resources.`,
+      suggestion:
+        'Consider whether VPC placement is intentional for private resource access.',
+      targetId: block.id,
+    });
+  }
+
+  if (
+    block.provider === 'gcp' &&
+    block.subtype === 'cloud-sql-postgres' &&
+    plate?.type === 'subnet' &&
+    plate.subnetAccess === 'public'
+  ) {
+    warnings.push({
+      ruleId: 'rule-provider-gcp-sql-public',
+      severity: 'warning',
+      message: `GCP Cloud SQL "${block.name}" is on a public subnet. Database instances should typically be on private subnets for security.`,
+      suggestion: 'Move the database block to a private subnet.',
+      targetId: block.id,
+    });
+  }
+
+  if (block.provider && block.subtype) {
+    const providerSubtypes = KNOWN_SUBTYPES[block.provider];
+    const categorySubtypes = providerSubtypes?.[block.category];
+
+    if (categorySubtypes && !categorySubtypes.includes(block.subtype)) {
+      warnings.push({
+        ruleId: 'rule-provider-unknown-subtype',
+        severity: 'warning',
+        message: `Block "${block.name}" has unknown subtype "${block.subtype}" for ${block.provider} ${block.category}.`,
+        suggestion: `Check available subtypes for ${block.provider} ${block.category} resources.`,
+        targetId: block.id,
+      });
+    }
+  }
+
+  return warnings;
+}
+
+export function validateProviderRules(model: ArchitectureModel): ValidationError[] {
+  const warnings: ValidationError[] = [];
+
+  for (const block of model.blocks) {
+    const plate = model.plates.find((p) => p.id === block.placementId);
+    warnings.push(...validateBlockProviderRules(block, plate));
+  }
+
+  return warnings;
+}


### PR DESCRIPTION
## Summary
- Create `providerValidation.ts` with three warning-level validation rules
- Integrate into validation engine as additive rules (existing rules unchanged)
- Include 9 comprehensive test cases

## Validation Rules
1. **AWS Lambda on subnet**: Warns when Lambda is placed on a subnet (serverless, typically no VPC needed)
2. **GCP Cloud SQL on public subnet**: Warns about security concern for database on public subnet
3. **Unknown subtype**: Warns when block has an unrecognized subtype for its provider/category combination

## Changes
- `providerValidation.ts` (NEW): Pure validation functions with `KNOWN_SUBTYPES` registry
- `engine.ts`: Add `validateProviderRules()` integration (3 lines)
- `__tests__/providerValidation.test.ts` (NEW): 9 test cases covering all scenarios

## Testing
- All 1282 existing tests pass
- 9 new tests for provider validation
- Rules produce warnings only — never block placement

Closes #273