### PR TITLE
fix(infra): address Copilot review comments on Terraform module and docs

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -2,25 +2,35 @@
 
 Terraform configurations for deploying CloudBlocks to Azure.
 
-## Environments
+> **Strategy**: See [Environment Strategy](../../docs/guides/ENVIRONMENT_STRATEGY.md) for the full deployment model and [ADR-0007](../../docs/adr/0007-multi-environment-deployment-strategy.md) for the decision record.
 
-- `environments/dev/` — Development environment
-
-> Note: `environments/dev/` is the current implementation baseline and is considered legacy for cloud deployment strategy. New multi-environment wrappers are planned for staging and production.
-
-## Planned Structure
-
-The Terraform layout will evolve to a shared module plus thin environment wrappers:
+## Structure
 
 ```text
 infra/terraform/
-|- modules/cloudblocks-stack/    <- Shared stack module (planned)
-|- environments/staging/         <- Staging wrapper (planned)
-|- environments/production/      <- Production wrapper (planned)
-`- environments/dev/             <- Current legacy environment
+├── modules/
+│   └── cloudblocks-stack/          # Shared module (all Azure resources)
+│       ├── main.tf
+│       ├── variables.tf
+│       ├── outputs.tf
+│       └── versions.tf
+└── environments/
+    ├── dev/                        # Legacy — original monolithic config
+    ├── staging/                    # Staging environment wrapper
+    │   └── main.tf                 # module "stack" { source = "../../modules/cloudblocks-stack" }
+    └── production/                 # Production environment wrapper
+        └── main.tf                 # module "stack" { source = "../../modules/cloudblocks-stack" }
 ```
 
-This documentation-only phase defines strategy. Module extraction and wrapper implementation are tracked separately.
+## Environments
+
+| Environment | Directory | Purpose | Terraform `var.environment` |
+|---|---|---|---|
+| Staging | `environments/staging/` | Pre-production validation, UAT | `staging` |
+| Production | `environments/production/` | Live service | `production` |
+| Dev (legacy) | `environments/dev/` | Original monolithic config (deprecated) | — |
+
+> **Note**: `environments/dev/` is the original monolithic Terraform configuration. Use `staging/` or `production/` for new cloud deployments.
 
 ## Resources Provisioned
 
@@ -29,16 +39,25 @@ This documentation-only phase defines strategy. Module extraction and wrapper im
 | Resource Group | `azurerm_resource_group` | Logical grouping for all resources |
 | Log Analytics | `azurerm_log_analytics_workspace` | Container logs and metrics |
 | Container App Environment | `azurerm_container_app_environment` | Hosting environment for Container Apps |
-| Container Registry | `azurerm_container_registry` | Docker image storage (Basic SKU) |
-| PostgreSQL | `azurerm_postgresql_flexible_server` | Relational metadata (B_Standard_B1ms) |
-| Redis | `azurerm_redis_cache` | Session cache (Basic C0, 250MB) |
+| Container Registry | `azurerm_container_registry` | Docker image storage (shared, created by staging) |
+| PostgreSQL | `azurerm_postgresql_flexible_server` | Relational metadata |
+| Redis | `azurerm_redis_cache` | Session cache |
 | Container App | `azurerm_container_app` | Backend API with auto-scaling |
-| Static Web App | `azurerm_static_web_app` | Frontend SPA hosting (Free tier) |
+| Static Web App | `azurerm_static_web_app` | Frontend SPA hosting |
+
+### Environment-Specific SKUs
+
+| Resource | Staging | Production |
+|----------|---------|------------|
+| PostgreSQL | B_Standard_B1ms | GP_Standard_D2s_v3 |
+| Redis | Basic C0 (250MB) | Standard C1 |
+| Static Web App | Free | Standard |
+| Container Registry | Basic (shared, created by staging) | — (references staging ACR) |
 
 ## Quick Start
 
 ```bash
-cd environments/dev
+cd environments/staging  # or environments/production
 
 # Copy and configure variables
 cp terraform.tfvars.example terraform.tfvars
@@ -50,16 +69,40 @@ terraform plan -var-file="terraform.tfvars"
 terraform apply -var-file="terraform.tfvars"
 ```
 
+> **Important (remote state)**: Each environment should use a separate Terraform backend (e.g., Azure Storage Account). Storage account names must be globally unique across all of Azure — choose a name that includes your project and environment, e.g., `tfstatecloudblocksstg`.
+
 ## Scaling
 
-The Container App scales horizontally based on HTTP concurrent requests. Configure via `terraform.tfvars`:
+The Container App scales horizontally based on HTTP concurrent requests. Configure per environment via `terraform.tfvars`:
 
 ```hcl
-container_min_replicas      = 1    # Minimum replicas
-container_max_replicas      = 5    # Maximum replicas
-scaling_concurrent_requests = "50" # Requests/replica threshold
+# Staging
+container_min_replicas      = 0    # Scale to zero allowed
+container_max_replicas      = 3
+scaling_concurrent_requests = "50"
+
+# Production
+container_min_replicas      = 2    # Always warm
+container_max_replicas      = 5
+scaling_concurrent_requests = "50"
 ```
 
 ## Required Variables
 
-See `environments/dev/terraform.tfvars.example` for all variables with descriptions. Sensitive values (passwords, secrets) should use a `.tfvars` file excluded from version control or be passed via environment variables (`TF_VAR_*`).
+See `environments/staging/terraform.tfvars.example` for all variables with descriptions. For production, see `environments/production/terraform.tfvars.example` — ACR values must reference staging outputs.
+
+Sensitive values (passwords, secrets) should use a `.tfvars` file excluded from version control or be passed via environment variables (`TF_VAR_*`).
+
+## Resource Naming
+
+All resources follow the pattern `{type}-cloudblocks-{env}`:
+
+| Pattern | Staging Example | Production Example |
+|---------|----------------|-------------------|
+| `rg-cloudblocks-{env}` | `rg-cloudblocks-staging` | `rg-cloudblocks-production` |
+| `psql-cloudblocks-{env}` | `psql-cloudblocks-staging` | `psql-cloudblocks-production` |
+| `redis-cloudblocks-{env}` | `redis-cloudblocks-staging` | `redis-cloudblocks-production` |
+| `ca-cloudblocks-api-{env}` | `ca-cloudblocks-api-staging` | `ca-cloudblocks-api-production` |
+| `swa-cloudblocks-{env}` | `swa-cloudblocks-staging` | `swa-cloudblocks-production` |
+
+Container Registry uses the pattern `{project}{env}acr` (no hyphens — ACR does not allow them).

--- a/infra/terraform/environments/production/terraform.tfvars.example
+++ b/infra/terraform/environments/production/terraform.tfvars.example
@@ -5,14 +5,18 @@ location = "koreacentral"
 project_name = "cloudblocks"
 
 # ---------- Shared ACR ----------
+# All ACR values below come from staging Terraform outputs.
+# Run in staging directory: terraform output -raw acr_login_server
 
 # Shared ACR login server from staging output.
 acr_login_server = "cloudblocksstagingacr.azurecr.io"
 
 # Shared ACR admin username from staging output.
+# Run: cd ../staging && terraform output -raw acr_admin_username
 acr_admin_username = "replace-with-staging-acr-admin-username"
 
 # Shared ACR admin password from secure secret storage.
+# Run: cd ../staging && terraform output -raw acr_admin_password
 acr_admin_password = "replace-with-staging-acr-admin-password"
 
 # ---------- PostgreSQL ----------

--- a/infra/terraform/environments/staging/outputs.tf
+++ b/infra/terraform/environments/staging/outputs.tf
@@ -8,6 +8,18 @@ output "acr_login_server" {
   value       = module.cloudblocks.acr_login_server
 }
 
+output "acr_admin_username" {
+  description = "ACR admin username (needed by production environment)"
+  value       = module.cloudblocks.acr_admin_username
+  sensitive   = true
+}
+
+output "acr_admin_password" {
+  description = "ACR admin password (needed by production environment)"
+  value       = module.cloudblocks.acr_admin_password
+  sensitive   = true
+}
+
 output "container_app_url" {
   description = "Public URL for the API container app"
   value       = module.cloudblocks.container_app_url

--- a/infra/terraform/modules/cloudblocks-stack/outputs.tf
+++ b/infra/terraform/modules/cloudblocks-stack/outputs.tf
@@ -8,6 +8,18 @@ output "acr_login_server" {
   value       = var.create_acr ? azurerm_container_registry.this[0].login_server : var.acr_login_server
 }
 
+output "acr_admin_username" {
+  description = "ACR admin username (needed by production to reference staging ACR)"
+  value       = var.create_acr ? azurerm_container_registry.this[0].admin_username : var.acr_admin_username
+  sensitive   = true
+}
+
+output "acr_admin_password" {
+  description = "ACR admin password (needed by production to reference staging ACR)"
+  value       = var.create_acr ? azurerm_container_registry.this[0].admin_password : var.acr_admin_password
+  sensitive   = true
+}
+
 output "container_app_url" {
   description = "Public URL for the API container app"
   value       = "https://${azurerm_container_app.api.ingress[0].fqdn}"

--- a/infra/terraform/modules/cloudblocks-stack/variables.tf
+++ b/infra/terraform/modules/cloudblocks-stack/variables.tf
@@ -24,12 +24,22 @@ variable "acr_login_server" {
   description = "External ACR login server when create_acr is false"
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.create_acr || length(var.acr_login_server) > 0
+    error_message = "acr_login_server is required when create_acr is false."
+  }
 }
 
 variable "acr_admin_username" {
   description = "External ACR admin username when create_acr is false"
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.create_acr || length(var.acr_admin_username) > 0
+    error_message = "acr_admin_username is required when create_acr is false."
+  }
 }
 
 variable "acr_admin_password" {
@@ -37,6 +47,11 @@ variable "acr_admin_password" {
   type        = string
   sensitive   = true
   default     = ""
+
+  validation {
+    condition     = var.create_acr || length(var.acr_admin_password) > 0
+    error_message = "acr_admin_password is required when create_acr is false."
+  }
 }
 
 variable "postgres_admin_username" {


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PRs #265/#276/#290/#291 on the infrastructure code and documentation.

### Changes

- **Terraform module `variables.tf`**: Add `validation` blocks for `acr_login_server`, `acr_admin_username`, and `acr_admin_password` — required when `create_acr = false` (production)
- **Module `outputs.tf`**: Export `acr_admin_username` and `acr_admin_password` so production can reference staging ACR
- **Staging `outputs.tf`**: Re-export ACR admin credentials for production consumption
- **Production `terraform.tfvars.example`**: Add explicit `terraform output` commands showing how to retrieve ACR values from staging
- **Terraform `README.md`**: Rewrite to reflect actual state (modules and environment wrappers now exist), add resource naming table with full `production` names, add storage account uniqueness note for remote state

### Review Comments Addressed

- ACR variable validation when `create_acr = false` (PR #276)
- Missing ACR admin outputs in staging (PR #276)
- Storage account uniqueness warning (PR #276)
- README accuracy — structure diagram and environment table now match actual repo state (PR #276, #265)
- Resource naming: all examples use `production` (not `prod`) per naming standard (PR #265)

Closes review threads from #265, #276.