### PR TITLE
fix(ci): address Copilot review comments on CI/CD workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,34 @@
+# Deploy to Staging — triggers on push to main or manual dispatch
+#
+# Builds API image, pushes to shared ACR, deploys to staging Container App
+# and Static Web App. Uses GitHub Environment "staging" for scoped secrets.
+#
+# Required secrets (configure in GitHub → Settings → Environments → staging):
+#   AZURE_CLIENT_ID        — Azure AD app (service principal) client ID for OIDC
+#   AZURE_TENANT_ID        — Azure AD tenant ID
+#   AZURE_SUBSCRIPTION_ID  — Azure subscription ID
+#   ACR_NAME               — Azure Container Registry name (e.g. cloudblocksstagingacr)
+#   ACR_LOGIN_SERVER       — ACR login server URL (e.g. cloudblocksstagingacr.azurecr.io)
+#   AZURE_RESOURCE_GROUP   — Staging resource group name (e.g. rg-cloudblocks-staging)
+#   CONTAINER_APP_NAME     — Staging Container App name (e.g. ca-cloudblocks-api-staging)
+#   AZURE_SWA_TOKEN        — Staging Static Web Apps deployment token
+
 name: Deploy to Staging
 
 on:
-  push:
-    branches: [main]
-  workflow_dispatch:
+  workflow_dispatch: # Manual trigger for initial setup / reruns
+  # NOTE: Push trigger is intentionally disabled until Azure staging
+  # environment secrets are configured. Enable by uncommenting below:
+  # push:
+  #   branches: [main]
 
 concurrency:
-  group: deploy-staging
+  # Include ref so workflow_dispatch runs from different branches don't cancel each other
+  group: deploy-staging-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
-  id-token: write
+  id-token: write # Required for OIDC token exchange with Azure
   contents: read
 
 env:
@@ -59,7 +77,7 @@ jobs:
           az containerapp update \
             --name ${{ secrets.CONTAINER_APP_NAME }} \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --image ${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
 
       - name: Wait for revision to become active
         run: |
@@ -68,8 +86,8 @@ jobs:
             STATUS=$(az containerapp revision list \
               --name ${{ secrets.CONTAINER_APP_NAME }} \
               --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --query "[?properties.active==\`true\`].properties.healthState" \
-              --output tsv 2>/dev/null || echo "Unknown")
+              --query "[?properties.active==\`true\`].properties.healthState | [0]" \
+              --output tsv || echo "Unknown")
             echo "  Attempt $i/30: status=$STATUS"
             if [ "$STATUS" = "Healthy" ]; then
               echo "✅ Revision is healthy"
@@ -91,14 +109,15 @@ jobs:
           HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://${APP_URL}/health" --max-time 10 || echo "000")
           echo "  HTTP status: $HTTP_CODE"
           if [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Health check passed"
+            echo "✅ Staging health check passed"
           else
             echo "⚠️ Health check returned $HTTP_CODE (may still be warming up)"
           fi
 
   deploy-web:
-    name: Deploy Web to Staging
+    name: Deploy Web to Staging SWA
     runs-on: ubuntu-latest
+    needs: deploy-api # Ensure API is deployed first so frontend talks to latest API
     environment: staging
     steps:
       - name: Checkout

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,28 +1,88 @@
+# Promote to Production — manual workflow_dispatch with image tag from staging
+#
+# Deploys the SAME image that was validated in staging to production.
+# No rebuild — image tag promotion only. Uses GitHub Environment "production"
+# which should have required reviewers configured.
+#
+# Required secrets (configure in GitHub → Settings → Environments → production):
+#   AZURE_CLIENT_ID        — Azure AD app (service principal) client ID for OIDC
+#   AZURE_TENANT_ID        — Azure AD tenant ID
+#   AZURE_SUBSCRIPTION_ID  — Azure subscription ID
+#   ACR_NAME               — Azure Container Registry name (shared with staging)
+#   ACR_LOGIN_SERVER       — Shared ACR login server URL (same as staging)
+#   AZURE_RESOURCE_GROUP   — Production resource group name (e.g. rg-cloudblocks-production)
+#   CONTAINER_APP_NAME     — Production Container App name (e.g. ca-cloudblocks-api-production)
+#   AZURE_SWA_TOKEN        — Production Static Web Apps deployment token
+
 name: Promote to Production
 
 on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to deploy (e.g., commit SHA from staging)'
+        description: "Image tag to promote (git SHA from staging deploy)"
         required: true
         type: string
+      skip_web:
+        description: "Skip frontend deployment (API-only promotion)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-production
-  cancel-in-progress: false
+  cancel-in-progress: false # Never cancel in-progress production deploys
 
 permissions:
-  id-token: write
+  id-token: write # Required for OIDC token exchange with Azure
   contents: read
 
 env:
   IMAGE_NAME: cloudblocks-api
 
 jobs:
+  validate-tag:
+    name: Validate Image Tag
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Validate image tag format
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          if ! echo "$TAG" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "❌ Invalid image tag format: '$TAG'"
+            echo "   Expected a 40-character lowercase hex git SHA (e.g., a1b2c3d4...)."
+            echo "   Use the git commit SHA from a successful staging deploy."
+            exit 1
+          fi
+          echo "✅ Image tag format valid: $TAG"
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify image exists in ACR
+        run: |
+          TAG="${{ inputs.image_tag }}"
+          echo "Verifying ${{ env.IMAGE_NAME }}:${TAG} exists in ACR..."
+          TAGS=$(az acr repository show-tags \
+            --name ${{ secrets.ACR_NAME }} \
+            --repository ${{ env.IMAGE_NAME }} \
+            --output tsv)
+          if ! echo "$TAGS" | grep -qxF "$TAG"; then
+            echo "❌ Image tag '${TAG}' not found in ACR."
+            echo "   Deploy to staging first, then use the git SHA as the image tag."
+            exit 1
+          fi
+          echo "✅ Image tag verified: ${TAG}"
+
   deploy-api:
     name: Deploy API to Production
     runs-on: ubuntu-latest
+    needs: validate-tag
     environment: production
     steps:
       - name: Login to Azure
@@ -32,22 +92,24 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy image to production
+      - name: Deploy new revision
         run: |
+          TAG="${{ inputs.image_tag }}"
+          echo "🚀 Promoting ${{ env.IMAGE_NAME }}:${TAG} to production..."
           az containerapp update \
             --name ${{ secrets.CONTAINER_APP_NAME }} \
             --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --image ${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${{ inputs.image_tag }}
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }}:${TAG}"
 
       - name: Wait for revision to become active
         run: |
-          echo "Waiting for production revision to become active..."
+          echo "Waiting for new revision to become active..."
           for i in $(seq 1 30); do
             STATUS=$(az containerapp revision list \
               --name ${{ secrets.CONTAINER_APP_NAME }} \
               --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-              --query "[?properties.active==\`true\`].properties.healthState" \
-              --output tsv 2>/dev/null || echo "Unknown")
+              --query "[?properties.active==\`true\`].properties.healthState | [0]" \
+              --output tsv || echo "Unknown")
             echo "  Attempt $i/30: status=$STATUS"
             if [ "$STATUS" = "Healthy" ]; then
               echo "✅ Production revision is healthy"
@@ -55,7 +117,7 @@ jobs:
             fi
             sleep 10
           done
-          echo "⚠️ Production revision health check timed out. Check Azure Portal."
+          echo "⚠️ Revision health check timed out (5 min). Check Azure Portal."
           exit 1
 
       - name: Verify health endpoint
@@ -71,16 +133,21 @@ jobs:
           if [ "$HTTP_CODE" = "200" ]; then
             echo "✅ Production health check passed"
           else
-            echo "⚠️ Production health check returned $HTTP_CODE"
+            echo "❌ Health check returned $HTTP_CODE — investigate immediately"
+            exit 1
           fi
 
   deploy-web:
-    name: Deploy Web to Production
+    name: Deploy Web to Production SWA
     runs-on: ubuntu-latest
+    needs: [validate-tag, deploy-api] # Atomic: web deploys only after API succeeds
+    if: ${{ !inputs.skip_web }}
     environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.image_tag }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

Addresses all 10 Copilot review comments from PR #279 on the CI/CD deployment and promotion workflows. Supersedes #279 (which has unresolvable merge conflicts with main).

## Changes

### deploy.yml (Deploy to Staging)
- **Concurrency group**: Include `github.ref` so `workflow_dispatch` runs from different branches don't cancel each other
- **Job ordering**: `deploy-web` now `needs: deploy-api` to ensure API is deployed before frontend
- **Push trigger**: Clarified with explicit NOTE comment that it's intentionally disabled until Azure secrets are configured
- **Shell safety**: Quoted `--image` argument to prevent shell injection
- **Health check**: Select first active revision (`| [0]`) to handle multi-revision scenarios
- **Error visibility**: Removed `2>/dev/null` stderr suppression from `az` commands
- **Documentation**: Added header comments listing all required secrets

### promote.yml (Promote to Production)
- **Tag validation**: New `validate-tag` job with strict SHA-40 hex regex (`^[0-9a-f]{40}$`)
- **ACR lookup**: Uses `ACR_NAME` secret directly instead of brittle `cut -d. -f1` parsing of login server
- **Exact tag match**: Uses `grep -qxF` for exact match instead of JMESPath `contains()` which accepted partial matches
- **Error visibility**: Removed `2>/dev/null` stderr suppression — let `az` errors surface
- **Shell safety**: Store tag in variable, quote `--image` argument
- **Health check**: Select first active revision to handle multi-revision scenarios
- **Atomic promotion**: `deploy-web` now `needs: [validate-tag, deploy-api]` — web only deploys after API succeeds
- **API-only promotions**: Added `skip_web` boolean input
- **Hard failure**: Production health check now `exit 1` on non-200 response
- **Documentation**: Added header comments listing all required secrets

## Review Comment Mapping

| # | Comment | Fix |
|---|---------|-----|
| 1 | Include `github.ref` in concurrency group | `deploy-staging-${{ github.ref }}` |
| 2 | deploy-web needs deploy-api (deploy.yml) | `needs: deploy-api` |
| 3 | Clarify push trigger commented out | Explicit NOTE comment |
| 4 | Validate image_tag with SHA regex | `^[0-9a-f]{40}$` validation step |
| 5 | Replace `cut -d. -f1` with ACR_NAME secret | `${{ secrets.ACR_NAME }}` |
| 6 | Exact tag match instead of `contains()` | `grep -qxF` |
| 7 | Remove `2>/dev/null` suppression | Removed |
| 8 | Quote `--image` argument | Quoted with `"..."` |
| 9 | Multi-revision health check | `\| [0]` JMESPath selector |
| 10 | Atomic promotion (deploy-web needs deploy-api) | `needs: [validate-tag, deploy-api]` |

Closes #277. Supersedes #279.