### PR TITLE
feat(api): add architecture suggestion engine with LLM-based analysis (#310)

### DIFF
--- a/apps/api/app/engines/suggestions.py
+++ b/apps/api/app/engines/suggestions.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from app.domain.models.ai_entities import AISuggestionsResponse
+from app.infrastructure.llm.client import LLMClient, LLMError
+
+logger = logging.getLogger(__name__)
+
+RESPONSE_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "required": ["suggestions", "score"],
+    "properties": {
+        "suggestions": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "category",
+                    "severity",
+                    "message",
+                    "action_description",
+                ],
+                "properties": {
+                    "category": {
+                        "type": "string",
+                        "enum": ["security", "reliability", "best_practice"],
+                    },
+                    "severity": {
+                        "type": "string",
+                        "enum": ["critical", "warning", "info"],
+                    },
+                    "message": {"type": "string"},
+                    "action_description": {"type": "string"},
+                },
+            },
+        },
+        "score": {
+            "type": "object",
+            "required": ["security", "reliability", "best_practice"],
+            "properties": {
+                "security": {"type": "number", "minimum": 0, "maximum": 100},
+                "reliability": {"type": "number", "minimum": 0, "maximum": 100},
+                "best_practice": {"type": "number", "minimum": 0, "maximum": 100},
+            },
+        },
+    },
+}
+
+SUGGESTION_SYSTEM_PROMPT = """You are a cloud architecture reviewer.
+
+Analyze the provided cloud architecture JSON and identify security, reliability,
+and best-practice issues.
+
+Focus on these checks:
+- Missing encryption at rest or in transit
+- Public exposure of sensitive resources
+- Single points of failure and missing redundancy
+- Missing WAF or firewall protections
+- Improper subnet placement (public/private)
+- Missing backup or disaster recovery strategy
+- Naming and structural best-practice violations
+
+Return ONLY valid JSON with this exact structure:
+{
+  "suggestions": [
+    {
+      "category": "security|reliability|best_practice",
+      "severity": "critical|warning|info",
+      "message": "Human-readable description",
+      "action_description": "What to do to fix it"
+    }
+  ],
+  "score": {
+    "security": 0-100,
+    "reliability": 0-100,
+    "best_practice": 0-100
+  }
+}
+
+Rules:
+- Output must be a JSON object, no markdown.
+- Include all score keys even if there are no suggestions.
+- Use empty suggestions list when no issues are found.
+- Keep suggestions concise and actionable.
+"""
+
+
+class SuggestionEngine:
+    def __init__(self, llm_client: LLMClient) -> None:
+        self._client: LLMClient = llm_client
+
+    async def analyze(
+        self,
+        architecture: dict[str, object],
+        provider: str = "aws",
+    ) -> AISuggestionsResponse:
+        architecture_json = json.dumps(architecture, separators=(",", ":"))
+        user_prompt = f"Analyze this {provider} architecture:\n{architecture_json}"
+
+        try:
+            response = await self._client.generate(
+                SUGGESTION_SYSTEM_PROMPT,
+                user_prompt,
+                response_schema=RESPONSE_SCHEMA,
+            )
+        except LLMError:
+            logger.exception("Failed to generate architecture suggestions")
+            return AISuggestionsResponse()
+
+        try:
+            return AISuggestionsResponse.model_validate(response)
+        except Exception:
+            logger.warning("Malformed suggestion response payload", exc_info=True)
+            return AISuggestionsResponse()

--- a/apps/api/app/tests/unit/test_suggestions_engine.py
+++ b/apps/api/app/tests/unit/test_suggestions_engine.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.domain.models.ai_entities import AISuggestionsResponse
+from app.engines.suggestions import SuggestionEngine
+from app.infrastructure.llm.client import LLMClient, LLMError
+
+MOCK_RESPONSE: dict[str, object] = {
+    "suggestions": [
+        {
+            "category": "security",
+            "severity": "critical",
+            "message": "Database is in public subnet",
+            "action_description": "Move database to private subnet",
+        },
+        {
+            "category": "reliability",
+            "severity": "warning",
+            "message": "Single AZ deployment",
+            "action_description": "Deploy across multiple availability zones",
+        },
+    ],
+    "score": {"security": 40, "reliability": 60, "best_practice": 75},
+}
+
+
+def _mock_llm_client() -> tuple[LLMClient, AsyncMock]:
+    raw_client = AsyncMock(spec=LLMClient)
+    client = cast(LLMClient, raw_client)
+    generate = cast(AsyncMock, raw_client.generate)
+    return client, generate
+
+
+@pytest.mark.asyncio
+async def test_analyze_returns_suggestions() -> None:
+    llm_client, generate = _mock_llm_client()
+    generate.return_value = MOCK_RESPONSE
+    engine = SuggestionEngine(llm_client)
+
+    result = await engine.analyze(
+        architecture={"blocks": [{"id": "db-1", "category": "database"}]},
+    )
+
+    assert isinstance(result, AISuggestionsResponse)
+    assert len(result.suggestions) == 2
+    assert result.suggestions[0].category == "security"
+    assert result.suggestions[0].severity == "critical"
+    assert result.score["security"] == 40
+
+
+@pytest.mark.asyncio
+async def test_analyze_empty_architecture() -> None:
+    llm_client, generate = _mock_llm_client()
+    generate.return_value = MOCK_RESPONSE
+    engine = SuggestionEngine(llm_client)
+
+    result = await engine.analyze(architecture={})
+
+    assert isinstance(result, AISuggestionsResponse)
+    assert len(result.suggestions) == 2
+
+
+@pytest.mark.asyncio
+async def test_analyze_malformed_llm_response() -> None:
+    llm_client, generate = _mock_llm_client()
+    generate.return_value = {
+        "suggestions": "bad-shape",
+        "score": "invalid",
+    }
+    engine = SuggestionEngine(llm_client)
+
+    result = await engine.analyze(architecture={"plates": []})
+
+    assert result.suggestions == []
+    assert result.score == {}
+
+
+@pytest.mark.asyncio
+async def test_analyze_llm_error() -> None:
+    llm_client, generate = _mock_llm_client()
+    generate.side_effect = LLMError("provider unavailable")
+    engine = SuggestionEngine(llm_client)
+
+    result = await engine.analyze(architecture={"blocks": []})
+
+    assert result.suggestions == []
+    assert result.score == {}
+
+
+@pytest.mark.asyncio
+async def test_analyze_score_values() -> None:
+    llm_client, generate = _mock_llm_client()
+    generate.return_value = MOCK_RESPONSE
+    engine = SuggestionEngine(llm_client)
+
+    result = await engine.analyze(architecture={"connections": []})
+
+    assert "security" in result.score
+    assert "reliability" in result.score
+    assert "best_practice" in result.score
+
+
+@pytest.mark.asyncio
+async def test_suggestions_have_required_fields() -> None:
+    llm_client, generate = _mock_llm_client()
+    generate.return_value = MOCK_RESPONSE
+    engine = SuggestionEngine(llm_client)
+
+    result = await engine.analyze(architecture={"externalActors": []})
+
+    for suggestion in result.suggestions:
+        assert suggestion.category
+        assert suggestion.severity
+        assert suggestion.message


### PR DESCRIPTION
## Summary
- Adds `SuggestionEngine` that uses `LLMClient` to analyze cloud architectures for security, reliability, and best-practice issues
- Returns structured `AISuggestionsResponse` with categorized suggestions and quality scores
- Graceful error handling: returns empty response on LLM failures or malformed output

## Changes
- `apps/api/app/engines/suggestions.py` — `SuggestionEngine` with `analyze()` method, system prompt, and JSON response schema
- `apps/api/app/tests/unit/test_suggestions_engine.py` — 6 tests covering success, empty input, malformed responses, LLM errors, and field validation

## Testing
- All 6 new unit tests pass
- Ruff lint clean

Closes #310