### PR TITLE
Fix docs navigation, project structure, and contributor setup references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ This project follows the [Contributor Covenant Code of Conduct](https://www.cont
 
 - **Node.js** >= 20.0.0
 - **pnpm** >= 9.0.0 (enforced — npm/yarn will be rejected)
-- **Python** >= 3.11 (for backend)
+- **Python** >= 3.10 (for backend)
 - **Git**
 
 ### Quick Setup
@@ -110,8 +110,9 @@ cloudblocks/
 │   ├── concept/          # PRD, Architecture, Roadmap
 │   ├── model/            # Domain model, schema specs
 │   ├── engine/           # Generator, rules, templates, provider
-│   ├── guides/           # Tutorials, deployment, API spec
-│   ├── system/           # Versioning, architecture review
+│   ├── design/           # Visual specs, security, release gates
+│   ├── api/              # API specification
+│   ├── guides/           # Tutorials, deployment
 │   └── adr/              # Architecture Decision Records
 ├── examples/             # Example architecture READMEs
 ├── infra/                # Deployment scaffolds

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,13 +47,14 @@ Immutable records of key decisions.
 
 | ADR | Status | Decision |
 |-----|--------|----------|
-| [0001](adr/0001-architecture-model-as-source-of-truth.md) | Historical | Architecture model as source of truth |
-| [0002](adr/0002-git-native-storage.md) | Historical | Git-native storage |
-| [0003](adr/0003-lego-style-composition-model.md) | Historical | Lego-style composition model |
-| [0004](adr/0004-rule-engine-architecture.md) | Historical | Rule engine architecture |
-| [0005](adr/0005-2d-first-editor-with-25d-rendering.md) | Historical | 2D-first with 2.5D rendering |
+| [0001](adr/0001-architecture-model-as-source-of-truth.md) | Accepted | Architecture model as source of truth |
+| [0002](adr/0002-git-native-storage.md) | Accepted | Git-native storage |
+| [0003](adr/0003-lego-style-composition-model.md) | Partially Superseded | Lego-style composition model |
+| [0004](adr/0004-rule-engine-architecture.md) | Accepted | Rule engine architecture |
+| [0005](adr/0005-2d-first-editor-with-25d-rendering.md) | Accepted | 2D-first with 2.5D rendering |
 | [0006](adr/0006-graph-ir-evolution-approach.md) | Accepted | Graph IR evolution approach |
 | [0007](adr/0007-multi-environment-deployment-strategy.md) | Accepted | Multi-environment deployment strategy |
+| [0008](adr/0008-v2-universal-architecture-specification.md) | Accepted | v2.0 Universal Architecture Specification |
 
 ---
 


### PR DESCRIPTION
## Summary
Fixes documentation inconsistencies in CONTRIBUTING.md and docs/README.md.

## Changes
- **CONTRIBUTING.md**: Fix Python version requirement from `>= 3.11` to `>= 3.10` (matches `pyproject.toml`, CI, README badge)
- **CONTRIBUTING.md**: Replace non-existent `docs/system/` directory with actual directories (`design/`, `api/`)
- **docs/README.md**: Add missing ADR-0008 (v2.0 Universal Architecture Specification) to the ADR table
- **docs/README.md**: Align ADR statuses (0001-0005) with `docs/adr/README.md` source of truth

Closes #347