### PR TITLE
docs: apply unresolved review feedback from PR #367

### DIFF
--- a/docs/engine/templates.md
+++ b/docs/engine/templates.md
@@ -9,7 +9,7 @@ Templates are reusable architecture models that serve as starting points for new
 | Term | Definition |
 |------|-----------|
 | **Template** | A reusable, pre-built `ArchitectureModel` JSON that users can instantiate as a new workspace. Templates define the infrastructure topology (plates, blocks, connections). |
-| **Scenario** | A guided tutorial that walks users through building an architecture step-by-step, with validation checks at each stage. Scenarios are defined in `apps/web/src/features/learning/`. |
+| **Scenario** | A guided tutorial that walks users through building an architecture step-by-step, with validation checks at each stage. Scenarios are defined in `apps/web/src/features/learning/scenarios/`. |
 
 > Templates provide instant starting points; Scenarios provide learning experiences. Both use the same `ArchitectureModel` format internally.
 ---
@@ -19,7 +19,7 @@ Templates are reusable architecture models that serve as starting points for new
 ```
 apps/web/src/features/templates/
   builtin.ts          # Built-in template definitions (6 templates)
-  registry.ts         # Template registry (CRUD + marketplace manifest loader)
+  registry.ts         # Template registry (register/get/list/search + marketplace manifest helpers)
 ```
 
 ---

--- a/examples/three-tier-web-app/README.md
+++ b/examples/three-tier-web-app/README.md
@@ -29,8 +29,8 @@ Internet → Gateway (Application Gateway)
 ## How to Build in CloudBlocks
 
 1. Create a **Region Plate** (VNet)
-2. Add a **Public Subnet Plate** inside the Network
-3. Add a **Private Subnet Plate** inside the Network
+2. Add a **Public Subnet Plate** inside the Region Plate
+3. Add a **Private Subnet Plate** inside the Region Plate
 4. Place a **Gateway** block on the Public Subnet
 5. Place a **Compute** block on the Public Subnet
 6. Place a **Database** block on the Private Subnet


### PR DESCRIPTION
## Summary
- Fix scenario path reference: `learning/` -> `learning/scenarios/` (Copilot review comment)
- Fix registry.ts description: `CRUD + marketplace manifest loader` -> `register/get/list/search + marketplace manifest helpers` (no delete/update exists)
- Fix terminology: `inside the Network` -> `inside the Region Plate` in three-tier-web-app example

These three items were flagged by Copilot review on PR #367 but not applied before merge.

## Parent
Follow-up to #367 (closes no issue — purely fixes review feedback)