### PR TITLE
docs: M16 Documentation Architecture & Canonical Cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,11 @@ cd apps/web && pnpm dev
 
 Open [http://localhost:5173](http://localhost:5173) to verify the app is running.
 
+### Terminology
+
+- **Milestone** = official planning container (GitHub milestone). Use this term for all new planning work.
+- **Phase** = legacy label from early development. Keep it only when referencing completed historical work for traceability.
+
 ---
 
 ## Development Setup
@@ -200,11 +205,11 @@ Documentation issues may omit domain labels when the change is cross-cutting. If
 
 ### Roadmap Implementation Workflow
 
-Use the full workflow for any feature that spans multiple PRs, multiple domains, or a named roadmap phase.
+Use the full workflow for any feature that spans multiple PRs, multiple domains, or a named roadmap milestone.
 
 1. **Create or reuse a milestone**
-   - Create a milestone when the work is a named phase or release, spans multiple Epics, or needs shared tracking across multiple implementation issues.
-   - Milestone names use the format `Phase N - Name`.
+   - Create a milestone when the work is a named roadmap milestone or release, spans multiple Epics, or needs shared tracking across multiple implementation issues.
+   - Milestone names use the format `Milestone N - Name`.
    - Reuse an existing open milestone when the work clearly belongs to it.
 
 2. **Create an Epic issue**
@@ -389,6 +394,31 @@ When docs mix implemented behavior and future design, use these rules:
 5. **Canonical source wins on conflicts**
    - If two docs disagree, update the non-canonical doc to match the canonical source.
 
+### Documentation Lifecycle Policy
+
+Status labels and meanings must stay consistent with the Document Ownership table in `docs/README.md`.
+
+| Status | Meaning | Handling rule |
+|---|---|---|
+| **Canonical** | Source of truth for active behavior | Update in place when behavior changes; other docs must align to it |
+| **Canonical (v2.0 Target)** | Accepted target spec not yet fully implemented | Keep as forward-looking target; do not rewrite as implemented behavior |
+| **Supporting** | Reference material that explains canonical docs | Keep concise; update links and examples to match canonical docs |
+| **Historical** | Past decisions/specs kept for traceability | Do not evolve behavior here; keep read-only historical context |
+| **Superseded** | Replaced by a newer canonical source | Do not continue active edits; add/keep clear pointer to replacement |
+| **Accepted** (ADR) | Active architectural decision in effect | Keep immutable; create a new ADR if the decision changes |
+
+Decision rules for already-merged documentation:
+
+1. **Update in place** when the doc is Canonical and behavior has changed.
+2. **Demote to Supporting** when a doc duplicates canonical content and mainly adds explanation.
+3. **Archive as Historical/Superseded** when content reflects past behavior or is replaced by a newer source.
+4. **Merge duplicates** when two active docs cover the same canonical concept; keep one owner and convert the other to Supporting or Superseded.
+
+### Documentation Update Requirement
+
+All code changes that affect documented behavior **MUST** include corresponding documentation updates in the same PR.
+If no docs change is needed, the PR description must explicitly state why.
+
 ### Documentation PR Checklist
 
 - [ ] Field names match canonical types (`placementId` not `plateId`, `category` not `type`)
@@ -426,7 +456,7 @@ Brief description of what this PR does and why.
 - [ ] `tsc -b` passes
 - [ ] `vite build` succeeds
 - [ ] Linting clean
-- [ ] Docs updated (if applicable)
+- [ ] Docs updated for any behavior changes (REQUIRED for code changes)
 ```
 
 ### Review Process

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Most IaC tools work **code → diagram** (visualize existing infra). CloudBlocks
 - **Magnetic snap & tactile UX** — Grid snapping, dynamic shadows, bounce transitions on drag (Phase 2 UX)
 - **Lego minifigure** — DevOps engineer character with Azure provider branding (Phase 3)
 - **Architecture diff** — Compare local vs GitHub architecture with visual overlays (Milestone 7)
-- **Cloud resource blocks (8 categories)** — compute, database, storage, gateway, function, queue, event, timer (Milestone 6)
+- **Cloud resource blocks (10 categories)** — compute, database, storage, gateway, function, queue, event, analytics, identity, observability (Milestone 6)
 - **Block-to-block connections** — `dataflow`, `http`, `internal`, `data`, `async`
 - **Open source** — Apache 2.0 licensed, extend and contribute freely
 
@@ -100,7 +100,9 @@ cloudblocks/
 - **Function** — Serverless execution blocks
 - **Queue** — Messaging and buffering blocks
 - **Event** — Event routing blocks
-- **Timer** — Scheduled trigger blocks
+- **Analytics** — Log and telemetry analysis blocks
+- **Identity** — Identity and access management blocks
+- **Observability** — Monitoring workspace and signal aggregation blocks
 
 ### Connections (5 Types)
 - **dataflow** — Directional traffic flow between components
@@ -112,7 +114,7 @@ cloudblocks/
 ```
 Internet → Gateway (dataflow) → Compute (data) → Database
                              → Storage
-Timer (async) → Function (async) → Event
+Event (async) → Function (async) → Queue
 ```
 
 ## Tech Stack
@@ -166,7 +168,9 @@ cd apps/api && pip install -e ".[dev]" && uvicorn app.main:app --reload
 
 ## Roadmap
 
-| Phase | Description | Status |
+> Phases are historical development stage labels from early milestones. All new work uses Milestone numbering.
+
+| Milestone | Description | Status |
 |-------|-------------|--------|
 | Milestones 1–7 | Visual builder, code generation (Terraform/Bicep/Pulumi), templates, GitHub integration, learning mode, collaboration, architecture diff | ✅ Complete |
 | Phase 2 UX | Magnetic snap, dynamic shadows, bounce transitions | ✅ Complete |

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -4,7 +4,7 @@ The main frontend application for CloudBlocks — a 2.5D isometric visual archit
 
 ## What This Package Does
 
-This is the **visual editor** where users design cloud architectures by placing plates (networks, subnets) and blocks (compute, database, storage, gateway, function, queue, event, timer) on a 2D model that is rendered as 2.5D isometric SVG. Connections between blocks represent initiator-direction semantics across typed protocols.
+This is the **visual editor** where users design cloud architectures by placing plates (global, edge, region, zone, subnet) and blocks (compute, database, storage, gateway, function, queue, event, analytics, identity, observability) on a 2D model that is rendered as 2.5D isometric SVG. Connections between blocks represent initiator-direction semantics across typed protocols.
 
 ## Quick Start
 
@@ -115,7 +115,7 @@ src/
 - ✅ PR creation from UI (Milestone 5)
 - ✅ Typed API client with session auth (Milestone 5)
 - ✅ Multi-generator code export: Terraform, Bicep, Pulumi (Milestone 6)
-- ✅ Serverless blocks: Function, Queue, Event, Timer (Milestone 6)
+- ✅ Extended block set: Function, Queue, Event, Analytics, Identity, Observability (Milestone 6)
 - ✅ Drag-to-create block placement from palette (Milestone 6B)
 - ✅ First-screen onboarding and selection states (Milestone 6B)
 - ✅ Learning Mode with guided scenarios (Milestone 6C)

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,9 @@ High-level product vision and roadmap.
 | [ROADMAP.md](concept/ROADMAP.md) | Canonical | Milestone timeline & milestones |
 | [ARCHITECTURE.md](concept/ARCHITECTURE.md) | Supporting | System architecture overview |
 | [UI_FLOW.md](concept/UI_FLOW.md) | Supporting | User interaction flows |
+| [M16_DOCUMENTATION_ARCHITECTURE.md](concept/M16_DOCUMENTATION_ARCHITECTURE.md) | Supporting | Documentation architecture & cleanup plan |
+| [M17_PRODUCT_STRUCTURE.md](concept/M17_PRODUCT_STRUCTURE.md) | Supporting | Product structure & package extraction plan |
+| [M18_DEVOPS_UX.md](concept/M18_DEVOPS_UX.md) | Supporting | DevOps UX & deployment orchestration plan |
 
 ---
 
@@ -91,6 +94,8 @@ Detailed visual and interaction specifications.
 | [RELEASE_GATES.md](design/RELEASE_GATES.md) | Supporting | Release criteria |
 | [LEARNING_MODE_SPEC.md](design/LEARNING_MODE_SPEC.md) | **Canonical** | Learning Mode design spec — scenarios, validation, engine, UI |
 | [GRAPH_IR_SPEC.md](design/GRAPH_IR_SPEC.md) | Supporting | Graph IR specification — typed ports, protocol semantics, evolution plan |
+| [KPI_SCORECARD.md](design/KPI_SCORECARD.md) | Supporting | Product & engineering KPI metrics |
+| [BRICK_GUIDEBOOK.md](design/BRICK_GUIDEBOOK.md) | Historical (Superseded) | v1.x visual guidebook (Korean) — superseded by CLOUDBLOCKS_SPEC_V2.md |
 
 > **Historical**: BRICK_DESIGN_SPEC.md and VISUAL_DESIGN_SPEC.md describe the v1.x design system. For current specifications, see CLOUDBLOCKS_SPEC_V2.md (see [ADR-0008](adr/0008-v2-universal-architecture-specification.md)). The v2.0 spec is accepted but not yet fully implemented.
 > **UI Single Source of Truth**: All visual/interaction specs are in `CLOUDBLOCKS_SPEC_V2.md`. See that spec for the StarCraft-style Bottom Panel layout.
@@ -142,3 +147,4 @@ User and developer guides.
 | TypeScript types | `apps/web/src/shared/types/index.ts` |
 | Validation rules | `apps/web/src/entities/validation/` |
 | Milestone timeline | [ROADMAP.md](concept/ROADMAP.md) |
+| KPI metrics | [KPI_SCORECARD.md](design/KPI_SCORECARD.md) |

--- a/docs/concept/ACTION_PLAN_EXECUTION.md
+++ b/docs/concept/ACTION_PLAN_EXECUTION.md
@@ -1,0 +1,259 @@
+# CloudBlocks Action Plan — Validation + Execution Plan (English)
+
+**Date:** 2026-03-18  
+**Owner:** CloudBlocks Core Team  
+**Source Input:** User checklist (UX Core → DevOps UX → Brick System → Core Model → Provider → Terraform → AI)
+
+---
+
+## 1) Executive Validation
+
+Your plan is directionally correct and product-focused: **"Concept → usable product"**.
+
+It is also mostly aligned with the existing CloudBlocks architecture and roadmap, with one important adjustment:
+
+- Several items in your checklist are already partially/completely implemented in recent milestones.
+- The best approach is **not a fresh rewrite**, but a **gap-driven execution plan** with strict phases and exit criteria.
+
+This document converts your checklist into:
+1. **Validated scope** (what is already done vs missing)
+2. **Milestones + phases**
+3. **Execution order and acceptance gates**
+
+---
+
+## 2) Fit Check Against Existing Docs/Code
+
+Validated against:
+- `docs/concept/PRD.md`
+- `docs/concept/ROADMAP.md`
+- `docs/design/UI_IMPROVEMENT_GAP_ANALYSIS.md`
+- `docs/design/BRICK_DESIGN_SPEC.md`
+- `docs/design/MODULE_BOUNDARIES.md`
+
+### 2.1 Already in progress / partially delivered
+
+- Bottom-panel command model (selection → action pattern) is already present.
+- Drag UX foundations exist (dragging/reposition + DragGhost path in prior phases).
+- Connection mode + preview path exists.
+- Brick silhouette/tier systems exist (partially as visual system foundations).
+- Provider foundations exist (Azure-first + partial multi-provider structure).
+- Terraform generation exists and is integrated.
+- Templates and template gallery exist.
+
+### 2.2 Still missing / needs hardening
+
+- **Entry UX**: true first-screen guided start flow is still inconsistent.
+- **Action model consistency**: command semantics need stronger context-locking rules.
+- **Drag-to-create reliability**: drop validation/highlighting needs production-grade behavior and tests.
+- **DevOps actor model**: clear command executor flow is not fully normalized.
+- **Provider mode UX**: user-facing provider-mode behavior still incomplete.
+- **Core model standardization**: block/provider/config schema hardening and migration policy needed.
+- **AI roadmap**: needs staged technical prerequisites before feature promises.
+
+---
+
+## 3) Final Milestone Structure (Proposed)
+
+## Milestone A — UX Core Hardening (Priority 1)
+
+### Phase A1: Start Entry
+- Empty canvas CTA
+- `Create VNet`
+- `Start from Template`
+- `Create Subnet (public/private)`
+
+**Exit Criteria**
+- New users can create a valid starter architecture within 60 seconds without docs.
+
+### Phase A2: Selection → Action Contract
+- Standardize Command Panel semantics by selected entity type.
+- Lock invalid actions by context (no ambiguous commands).
+
+**Exit Criteria**
+- 100% deterministic action matrix (VNet/Subnet/Resource).
+
+### Phase A3: Drag & Drop + Connect Reliability
+- Drag ghost + valid target highlight + invalid drop feedback.
+- Connect mode target highlighting + preview + constraints.
+
+**Exit Criteria**
+- No orphan blocks, no invalid silent drops, no broken connection state.
+
+### Phase A4: Interaction State Machine
+- Finalize Zustand interaction states:
+  - `idle`, `selecting`, `dragging`, `placing`, `connecting`
+
+**Exit Criteria**
+- Every interaction transition is explicit, test-covered, and reversible.
+
+---
+
+## Milestone B — External Actors + DevOps UX (Priority 2)
+
+### Phase B1: Internet/External Actor Model
+- Internet selectable/connectable/off-canvas placement refinement.
+- Add `devops` external actor type.
+
+### Phase B2: DevOps Command Experience
+- Build/Connect/Deploy tabs
+- Action catalog:
+  - `create-vnet`, `create-subnet`, `deploy-vm`, `connect`, `generate-terraform`
+
+### Phase B3: Execution Engine
+- `executeDevOpsAction()` with auditable action result payload.
+
+**Exit Criteria**
+- DevOps actor can execute all P1 actions deterministically from UI state.
+
+---
+
+## Milestone C — Brick Design System Consolidation (Priority 3)
+
+### Phase C1: Taxonomy Freeze
+- `network`, `compute`, `data`, `messaging`, `security`, `edge`
+
+### Phase C2: Shape/Size/Height Canonicalization
+- Formal shape mapping by category.
+- Container > Subnet > Resource size hierarchy.
+- Height tiers (container low / data mid / compute high).
+
+### Phase C3: Design Tokens + Visual QA
+- Shape > Color > Label principle enforcement.
+
+**Exit Criteria**
+- Visual identity remains consistent across all resources/providers.
+
+---
+
+## Milestone D — Core Model + Provider System (Priority 4)
+
+### Phase D1: Core Model Hardening
+- Block schema formalization:
+  - `id`, `category`, `subtype`, `provider`, `config`
+- Connection model hardening.
+
+### Phase D2: Provider Modes
+- Neutral / Azure / AWS / GCP mode contracts.
+- Palette mapping and provider extension policy.
+
+### Phase D3: Adapter Contract
+- Provider adapter interface and validation contract.
+
+**Exit Criteria**
+- Same architecture model can be compiled under provider mode with deterministic differences.
+
+---
+
+## Milestone E — Terraform Pipeline Productization (Priority 5)
+
+### Phase E1: Mapping Accuracy
+- Block→Terraform mapping completeness matrix.
+
+### Phase E2: Generator Reliability
+- `architecture.json` → tf conversion hardened.
+
+### Phase E3: Output Workflow
+- Preview / Export / GitHub PR in one stable flow.
+
+**Exit Criteria**
+- Generated Terraform validates for all reference templates.
+
+---
+
+## Milestone F — AI Roadmap (Priority 6)
+
+### Phase F1: AI Architecture Drafting
+### Phase F2: AI Validation Assistant
+### Phase F3: Cost Optimization Suggestions
+### Phase F4: Recommendation Engine
+
+**Note:** AI work starts only after Milestones A–E pass release gates.
+
+---
+
+## 4) OSS/Private Repo Split (Validated)
+
+### OSS (keep)
+- `cloudblocks-core`
+- `cloudblocks-ui`
+- `cloudblocks-provider`
+
+### Private (later)
+- `cloudblocks-ai`
+- `cloudblocks-devops`
+- `cloudblocks-cloud`
+
+**Decision:** keep monorepo until Milestone D stable, then split by bounded context.
+
+---
+
+## 5) Non-Negotiable Product Rules (English)
+
+1. **Select → Action** (no floating global action ambiguity)
+2. **Drag → Feedback → Drop** (no blind placement)
+3. **Context-aware UI only**
+4. **Shape > Color > Label** visual hierarchy
+
+### Explicit "Do Not Do"
+- Do not show all resources all the time.
+- Do not allow drag without feedback.
+- Do not represent Internet as a normal internal resource.
+- Do not expose provider mode as top-level clutter before context selection.
+- Do not regress into text-first UX.
+
+---
+
+## 6) Execution Order (Short)
+
+1. **A (UX Core Hardening)**
+2. **B (External + DevOps UX)**
+3. **C (Brick System Consolidation)**
+4. **D (Core Model + Provider Modes)**
+5. **E (Terraform Productization)**
+6. **F (AI)**
+
+---
+
+## 7) Delivery Governance
+
+For each phase:
+- Issue breakdown (small, testable tasks)
+- One PR per issue
+- Required checks:
+  - Lint
+  - Typecheck/build
+  - Targeted tests
+  - Regression tests for touched domain
+
+Definition of Done:
+- Feature works in UI
+- Model invariant preserved
+- Tests and docs updated
+- No hidden behavior changes
+
+---
+
+## 8) Immediate Next Actions (recommended)
+
+1. Create milestone labels:
+   - `M-A-ux-core`
+   - `M-B-devops-ux`
+   - `M-C-brick-system`
+   - `M-D-core-provider`
+   - `M-E-terraform`
+   - `M-F-ai`
+
+2. Open execution epics for Milestone A (A1~A4).
+3. Start with A1 + A2 in parallel, then A3, then A4.
+
+---
+
+## Final Statement
+
+Your checklist is strategically correct.
+The highest leverage is to execute it as a **gap-driven, phase-gated program** instead of restarting architecture from scratch.
+
+CloudBlocks should now move as:
+
+**Usable UX foundation → deterministic model/provider contracts → reliable code generation → AI assistance.**

--- a/docs/concept/ARCHITECTURE.md
+++ b/docs/concept/ARCHITECTURE.md
@@ -99,7 +99,7 @@ No backend required. All state lives in the browser.
 │   React + TypeScript + SVG + CSS transforms + Zustand  │
 │   ┌──────────┐ ┌──────────┐ ┌────────────────────┐    │
 │   │ Isometric│ │ Rule     │ │ Local-First Store   │    │
-│   │ Builder  │ │ Engine   │ │ (IndexedDB/lS)      │    │
+│   │ Builder  │ │ Engine   │ │ (localStorage)      │    │
 │   └──────────┘ └──────────┘ └────────────────────┘    │
 └────────────────────┬───────────────────────────────────┘
                      │
@@ -147,7 +147,7 @@ The frontend is a SPA built with React and SVG + CSS transforms. In Milestone 1,
 - Drag and drop interaction
 - Code generation preview (client-side for simple cases)
 - GitHub sync UI (commit, branch, PR)
-- Local-first store (IndexedDB + localStorage)
+- Local-first store (localStorage)
 
 ### Technologies
 - React + TypeScript
@@ -305,16 +305,6 @@ GET  /api/v1/ai/keys                         → list stored key providers
 DELETE /api/v1/ai/keys/{provider}            → delete stored key
 ```
 
-Implemented auth/session routes:
-
-```
-POST /api/v1/auth/github                     -> returns { authorize_url }, sets cb_oauth cookie
-GET  /api/v1/auth/github/callback?code&state -> redirects, sets cb_session cookie
-GET  /api/v1/auth/session                    -> returns current user; clears stale cookie on 401
-POST /api/v1/auth/logout                     -> always 200; clears server session + cookie
-POST /api/v1/session/workspace               -> binds active workspace to session
-```
-
 ---
 
 # 3. Core Modeling Engine
@@ -358,7 +348,7 @@ The canonical model types are defined in `apps/web/src/shared/types/index.ts`. T
 
 ### Serialization Format
 
-- Serialization is versioned through `schemaVersion` and currently uses `"0.1.0"` (see `apps/web/src/shared/types/schema.ts`).
+- Serialization is versioned through `schemaVersion` and currently uses `"2.0.0"` (see `apps/web/src/shared/types/schema.ts`).
 - The persisted root payload shape is `{ schemaVersion, workspaces[] }`, where each workspace contains one `architecture: ArchitectureModel`.
 - For broader domain semantics and lifecycle rules, see [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md).
 
@@ -378,13 +368,18 @@ The validation engine is split into focused modules:
 apps/web/src/entities/validation/
 ├── engine.ts       # validateArchitecture(model): orchestration entrypoint
 ├── placement.ts    # validatePlacement(block, plate): placement rule checks
-└── connection.ts   # validateConnection(connection, blocks, externalActors): flow rule checks
+├── connection.ts   # validateConnection(connection, blocks, externalActors): flow rule checks
+├── providerValidation.ts # validateProviderRules(block, plate): provider warnings
+├── aggregation.ts  # validateAggregation(model, block): aggregation constraints
+└── role.ts         # validateBlockRoles(block): role constraints
 ```
 
 Validation flow in `engine.ts`:
-- Iterate all blocks and run placement rules from `placement.ts`
-- Iterate all connections and run connection rules from `connection.ts`
-- Aggregate errors/warnings into one `ValidationResult`
+- Placement validation (per block) via `placement.ts`
+- Aggregation validation (per block, v2.0 section 8) via `aggregation.ts`
+- Role validation (per block, v2.0 section 9) via `role.ts`
+- Connection validation (per connection) via `connection.ts`
+- Provider-specific validation (warnings) via `providerValidation.ts`
 
 > For the complete rule set (placement rules, connection rules, and connection semantics), see [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md) §7 (Rule Engine).
 
@@ -484,7 +479,7 @@ The Provider Adapter translates the generic CloudBlocks model into cloud provide
 # 8. GitHub Integration Architecture (Milestone 5+)
 
 > See also: PRD §16 (Future Roadmap — Milestone 5 GitHub Integration)
-> **Status**: Implemented for Milestone 5-7 with session auth migration completed in Phase 7.
+> **Status**: Implemented for Milestone 5-7, with session auth migration completed during historical Phase 7.
 
 ## Auth: GitHub OAuth + Session Cookie Model
 
@@ -541,16 +536,16 @@ The storage follows a **Git-native** design: GitHub repos serve as the primary d
 
 Milestone 1 uses browser localStorage for persistence. Storage key: `cloudblocks:workspaces`.
 
-The persisted format uses `schemaVersion: "0.1.0"` with a `workspaces[]` array, each containing a single `architecture: ArchitectureModel` object.
+The persisted format uses `schemaVersion: "2.0.0"` with a `workspaces[]` array, each containing a single `architecture: ArchitectureModel` object.
 
 > For the full workspace model and serialization format, see [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md) §13 (Workspace Model) and §14 (Implementation Schema).
 
 ### Milestone 3+ Storage (Local-First + GitHub Sync — Planned)
 
-IndexedDB for local state + optional GitHub sync:
+localStorage for local state + optional GitHub sync:
 
 ```
-Local (IndexedDB)     ←→    GitHub (via Backend API)
+Local (localStorage)  ←→    GitHub (via Backend API)
   architecture.json          cloudblocks/architecture.json
   draft changes              committed versions
   offline edits              synced on connect
@@ -582,8 +577,8 @@ The architecture supports horizontal scalability:
 |-----------|----------|
 | Frontend | Static hosting / CDN |
 | Backend API | Stateless containers (scale horizontally) |
-| Metadata DB | SQLite (dev), PostgreSQL (production — Phase 8 ✅) |
-| Job Queue | In-process/background (dev), Redis (production — Phase 8 planned) |
+| Metadata DB | SQLite (dev), PostgreSQL (production — Milestone 8 ✅) |
+| Job Queue | In-process/background (dev), Redis (production — Milestone 8 planned) |
 | Storage | GitHub (unlimited repos) + Blob storage |
 
 ---

--- a/docs/concept/M16_DOCUMENTATION_ARCHITECTURE.md
+++ b/docs/concept/M16_DOCUMENTATION_ARCHITECTURE.md
@@ -1,0 +1,198 @@
+# Milestone 16 — Documentation Architecture & Canonical Cleanup
+
+## Goal
+
+Restore documentation coherence across the CloudBlocks project. Establish clear canonical ownership, resolve runtime-vs-target architecture confusion, and verify code/document consistency after M15.
+
+This milestone promotes Epic #356 from a standalone cleanup task to a full milestone, acknowledging that documentation architecture is a first-class engineering concern — not a side task to be done between feature milestones.
+
+---
+
+## Background
+
+Documentation drift has accumulated across M1–M15. The docs currently mix:
+
+- **Runtime architecture vs target architecture** — readers cannot tell what CloudBlocks _is_ today vs what it _intends to become_
+- **Canonical vs superseded sources** — multiple documents claim authority over the same concern (e.g., validation contracts, design specs)
+- **v1.x historical patterns vs v2.0 target specs** — onboarding and education flows reference structures that no longer exist
+- **Inconsistent planning vocabulary** — "Milestone" and "Phase" are used interchangeably, making roadmap tracking ambiguous
+- **No lifecycle policy** — merged documents have no rules for when to update, demote, or archive
+
+Epic #356 ("Documentation Architecture and Canonical Source Cleanup") identified 12 sub-issues covering these problems. One sub-issue (#365) is already closed. Seven documentation PRs are open and awaiting review.
+
+With M15 now complete and the v2.0 specification implemented, this is the right time to reconcile documentation with the actual codebase state before any further structural work (M17) or feature work.
+
+---
+
+## Scope
+
+### Area A: Documentation Architecture Cleanup (Epic #356)
+
+All 12 sub-issues from Epic #356. These restore a coherent documentation architecture by establishing clear layering:
+
+| Layer | Purpose |
+|-------|---------|
+| System architecture | Current runtime topology, module boundaries, storage/auth/data flow |
+| Domain model | Current canonical types and serialization ownership |
+| Validation | One canonical contract for implemented rules and extension policy |
+| Design specs | Explicit split between current main-branch behavior and target v2.0 spec |
+| Guides/examples | Current usage conventions only; future paths labeled explicitly |
+| Planning vocabulary | Milestone and Phase assigned clear, non-overlapping meanings |
+| Lifecycle policy | Merged docs updated, demoted, or archived based on explicit rules |
+| Archive/Historical | Execution plans, audits, and superseded refs removed from active guidance |
+
+### Area B: Code/Document Consistency Verification
+
+A systematic check that all canonical documents accurately reflect the codebase as of `main` branch post-M15. This goes beyond Epic #356's documentation-internal reconciliation to verify documentation-to-code alignment.
+
+---
+
+## Sub-Issues (Epic #356)
+
+| # | Title | Size | Status |
+|---|-------|------|--------|
+| #346 | Refresh backend API and storage docs to match implemented route surface | M | Open |
+| #347 | Fix docs navigation, project structure, and contributor setup references | M | Open |
+| #348 | Align auth, security, and deployment docs with cookie-session implementation | M | Open |
+| #349 | Normalize roadmap, version, and implementation-status markers across docs | L | Open |
+| #350 | Reconcile canonical and superseded design spec declarations (v1.x/v2.0) | M | Open |
+| #355 | Archive or retire time-bound and superseded docs from active surface | M | Open |
+| #357 | Consolidate validation and rule-engine docs into one canonical contract | M | Open |
+| #358 | Realign system, model, and storage architecture docs with actual runtime | L | Open |
+| #364 | Reconcile Learning Mode spec with current domain model and scenarios | M | Open |
+| #365 | Align templates, examples, and tutorial packaging docs | M | **Closed** (PR #367 merged) |
+| #366 | Standardize Milestone vs Phase terminology across active docs | M | Open |
+| #368 | Define lifecycle rules for already-merged documentation | M | Open |
+
+---
+
+## Wave Plan
+
+### Wave 1 — Foundation (Set Conventions)
+
+Establish the conventions and policies that all subsequent documentation work must follow.
+
+| Issue | Title | Rationale |
+|-------|-------|-----------|
+| #349 | Normalize roadmap, version, and implementation-status markers | Defines how status markers work across all docs |
+| #366 | Standardize Milestone vs Phase terminology | Establishes planning vocabulary before other docs reference it |
+| #368 | Define lifecycle rules for merged documentation | Sets update/demote/archive policy before reconciliation begins |
+
+**Output**: Documented conventions for status markers, planning terminology, and document lifecycle. All subsequent waves follow these conventions.
+
+### Wave 2 — Reconciliation (Heavy Content Work)
+
+Reconcile the major canonical documents with the codebase and with each other.
+
+| Issue | Title | Rationale |
+|-------|-------|-----------|
+| #350 | Reconcile canonical vs superseded design spec declarations | Resolve v1.x/v2.0 authority conflicts |
+| #358 | Realign system, model, and storage architecture docs with runtime | Largest single issue — ensures architecture docs match code |
+| #357 | Consolidate validation/rule-engine docs into one canonical contract | Merge duplicate validation authority |
+| #364 | Reconcile Learning Mode spec with current domain model | Align education content with actual domain |
+
+**Output**: All major canonical documents reconciled. No conflicting authority claims remain.
+
+### Wave 3 — Alignment & Archive
+
+Align remaining supporting docs and archive superseded material.
+
+| Issue | Title | Rationale |
+|-------|-------|-----------|
+| #346 | Refresh backend API and storage docs | Match docs to implemented API surface |
+| #347 | Fix docs navigation, project structure, contributor setup | Update docs/README.md navigation and onboarding |
+| #348 | Align auth/security/deployment docs with cookie-session | Reflect actual auth implementation |
+| #355 | Archive/retire time-bound and superseded docs | Clean up active doc surface |
+
+**Output**: All supporting docs accurate. Historical/superseded docs archived with clear labels.
+
+**Note**: #365 (templates/examples alignment) is already closed via merged PR #367.
+
+---
+
+## New Sub-Issues (Code/Document Consistency)
+
+These issues extend beyond Epic #356's scope to cover code-to-document alignment.
+
+### New Issue 1: Post-M15 Code-Document Consistency Audit
+
+Systematic verification that every canonical document matches the post-M15 codebase state. Scope includes:
+
+- TypeScript types in `apps/web/src/shared/types/index.ts` vs DOMAIN_MODEL.md
+- Validation rules in `apps/web/src/entities/validation/` vs VALIDATION_CONTRACT.md
+- API routes in `apps/api/app/api/routes/` vs API_SPEC.md
+- Design tokens in `apps/web/src/shared/tokens/designTokens.ts` vs BRICK_DESIGN_SPEC.md
+- Rendering approach in code vs ARCHITECTURE.md and README.md
+
+**Size**: L
+
+### New Issue 2: README and docs/README.md Refresh
+
+Update the project's entry points to reflect current state:
+
+- Root README.md: update milestone status table, feature list, tech stack versions
+- docs/README.md: update document index, add/remove entries for new/archived docs
+- Verify all document links are valid (no broken references)
+
+**Size**: M
+
+### New Issue 3: Open PR Triage
+
+Review, merge, or close the 7 open documentation PRs from Epic #356:
+
+| PR | Title | Branch |
+|----|-------|--------|
+| #352 | Align auth/security/deployment docs | docs/auth-session-doc-alignment |
+| #353 | Normalize roadmap/version/status markers | docs/status-version-normalization |
+| #354 | Reconcile v1.x vs v2.0 spec declarations | docs/v1-v2-spec-taxonomy |
+| #359 | Refresh backend API/storage docs | docs/backend-api-storage-sync |
+| #361 | Archive superseded v1.x design specs | docs/archive-superseded-docs |
+| #362 | Consolidate validation/rule-engine docs | docs/runtime-architecture-realignment |
+| #363 | Realign architecture docs with runtime | docs/runtime-architecture-realignment-v2 |
+
+For each PR: review against Wave 1 conventions, request changes or approve, merge or close with explanation.
+
+**Size**: L (7 PRs to review)
+
+---
+
+## Exit Criteria
+
+- [ ] All 12 Epic #356 sub-issues closed
+- [ ] All 7 open documentation PRs resolved (merged or closed with documented reason)
+- [ ] Zero documents with incorrect canonical/superseded status
+- [ ] docs/README.md accurately reflects current project state with valid links
+- [ ] Code-document consistency audit passes with no critical gaps
+- [ ] Milestone vs Phase terminology standardized across all active docs
+- [ ] Document lifecycle policy documented and applied to existing docs
+- [ ] Root README.md feature list and milestone table match current state
+
+---
+
+## Dependencies
+
+- M15 complete (v2.0 Specification Implementation) — done
+
+---
+
+## Constraints
+
+- Do not hide current main-branch behavior in favor of target v2.0 design intent
+- Do not keep multiple active documents claiming canonical ownership for the same concern
+- If a document is retained for history, label it as historical and remove it from active source-of-truth navigation
+- Preserve ADR history — prefer reclassification, cross-linking, and archiving over destructive deletion
+- Do not introduce new architecture patterns — only document what currently exists
+- Follow existing document ownership model: Canonical / Supporting / Historical
+
+---
+
+## Estimated Effort
+
+- 11 remaining Epic #356 sub-issues: mostly size/M, two size/L
+- 3 new code/doc consistency issues: 1 size/L, 1 size/M, 1 size/L
+- 7 open PRs to triage
+- **Total**: ~2–3 weeks of focused documentation work
+- **Wave 1**: ~3–4 days
+- **Wave 2**: ~5–7 days
+- **Wave 3**: ~3–5 days
+- **New issues + PR triage**: ~3–4 days (can overlap with Wave 3)

--- a/docs/concept/M17_PRODUCT_STRUCTURE.md
+++ b/docs/concept/M17_PRODUCT_STRUCTURE.md
@@ -1,0 +1,225 @@
+# Milestone 17 — Product Structure
+
+## Goal
+
+Restructure the CloudBlocks monorepo from a scaffolded prototype into a modular, separation-ready architecture. Establish clear module boundaries, resolve rendering model ambiguity, extract shared packages, and redefine backend responsibilities.
+
+---
+
+## Background
+
+After M15 (v2.0 Specification Implementation) and M16 (Documentation Architecture), the codebase needs structural consolidation before further feature work. A codebase analysis revealed five structural issues:
+
+### 1. Rendering Model Ambiguity
+
+The README states "React + SVG frontend (FSD architecture)" and ADR-0005 established a "2D-first editor with 2.5D rendering" approach. However, `apps/web/package.json` includes `three.js`, `@react-three/fiber`, and `@react-three/drei` as dependencies. These are installed but their usage status is unclear. The project needs a definitive decision: SVG-only, Canvas/Three.js, or a defined hybrid boundary.
+
+### 2. Unused Package Scaffolding
+
+The `packages/` directory contains scaffolded but unused packages:
+
+| Package | State |
+|---------|-------|
+| `@cloudblocks/schema` | Exports only `SCHEMA_VERSION = '2.0.0'` — no actual consumers |
+| `@cloudblocks/domain` | Placeholder |
+| `@cloudblocks/ui` | Placeholder |
+| `@cloudblocks/terraform-templates` | Placeholder |
+| `@cloudblocks/scenario-library` | Placeholder |
+
+No `import` from `@cloudblocks/schema` (or any other package) exists anywhere in `apps/web` or `apps/api`.
+
+### 3. Backend Role Drift
+
+The README describes the backend as a "thin orchestration backend." The actual `apps/api` surface includes auth/session management, workspace CRUD, GitHub OAuth integration, code generation orchestration, AI-assisted architecture (keys, prompts, suggestions), and route-level business logic. This is broader than "thin orchestration" and needs an accurate role definition.
+
+### 4. Version Inconsistencies
+
+| Location | Version |
+|----------|---------|
+| Root `package.json` | 0.11.0 |
+| `apps/web/package.json` | 0.11.0 |
+| `apps/api/pyproject.toml` | 0.11.0 |
+| `packages/schema/package.json` | 0.1.0 |
+
+The schema package version is misaligned. No versioning policy exists for when packages should track root version vs version independently.
+
+### 5. Data Contract Coupling
+
+The `ArchitectureModel` JSON schema is the shared contract between the TypeScript frontend and Python backend. It is currently duplicated in both languages with no single source of truth. This is the strongest coupling point in the monorepo and the primary barrier to future repo separation.
+
+### Monorepo Decision
+
+A coupling analysis found:
+
+- **Code coupling**: WEAK — `apps/web` does not import from `packages/*`, `apps/api` is Python with no TypeScript dependencies
+- **Data contract coupling**: STRONG — ArchitectureModel JSON duplicated across languages
+- **Infrastructure coupling**: MEDIUM — Dockerfiles assume monorepo layout, but CI already has per-app jobs
+
+**Decision**: Keep the monorepo. Structure it as a "modular monorepo" where packages define clear boundaries, enabling future repo separation without code changes if that becomes necessary.
+
+---
+
+## Scope
+
+### Area A: Rendering Model Decision
+
+**Problem**: Ambiguity between SVG and Three.js rendering approaches.
+
+**Work**:
+- Audit current rendering code: which renderer is actually used for what
+- Write an ADR documenting the rendering model decision
+- If SVG-only: remove Three.js dependencies (`three`, `@react-three/fiber`, `@react-three/drei`) and any associated code
+- If hybrid: define the boundary (e.g., SVG for 2D editor, Three.js for 3D preview) and document in the ADR
+- Update README and ARCHITECTURE.md to reflect the decision
+
+**Options to evaluate** (decision made during implementation, not in this design doc):
+
+| Option | Pros | Cons |
+|--------|------|------|
+| SVG-only | Simpler, smaller bundle, matches current working code | Limits future 3D features |
+| Hybrid (SVG + Three.js) | Future flexibility, 3D preview possible | Complexity, larger bundle, dual rendering paths |
+| Three.js migration | Full 3D capability | Major rewrite, breaks working SVG code |
+
+### Area B: Package Extraction
+
+**Problem**: `packages/` contains empty scaffolding. Shared domain logic is duplicated.
+
+**Work**:
+- **`@cloudblocks/schema`**: Extract the ArchitectureModel JSON schema, TypeScript type definitions, and validation schemas. This becomes the single source of truth for the data contract.
+- **`@cloudblocks/domain`**: Extract shared domain logic (block categories, connection types, validation rule definitions) used by both frontend and backend.
+- **Remove unused packages**: Delete placeholder packages that have no planned consumers (`ui`, `terraform-templates`, `scenario-library`) or define concrete extraction plans for them.
+- **Import boundaries**: `apps/web` and `apps/api` consume `packages/*`, never the reverse. Packages do not import from each other unless an explicit dependency is declared.
+- **Version alignment**: All packages follow root version (currently 0.11.0).
+
+**Key constraint**: The Python backend cannot directly consume TypeScript packages. The schema package must produce a language-neutral artifact (JSON Schema file) that both TypeScript and Python can consume, with generated types for each language.
+
+### Area C: Backend Role Redefinition
+
+**Problem**: Documented role ("thin orchestration") does not match actual responsibilities.
+
+**Work**:
+- Document the actual backend responsibilities accurately:
+  - Authentication and session management (GitHub OAuth, cookie-based sessions)
+  - Workspace persistence (SQLite metadata)
+  - GitHub integration (repo sync, PR creation)
+  - Code generation orchestration (Terraform, Bicep, Pulumi)
+  - AI-assisted architecture (suggestions, prompts, natural language input)
+- Define the API surface contract explicitly, organized by domain
+- Create a shared data contract: ArchitectureModel JSON schema becomes the interface between frontend and backend (via the schema package from Area B)
+- Decide validation rule ownership: frontend-only, backend-only, or shared (via domain package from Area B)
+- Update README, ARCHITECTURE.md, and API_SPEC.md to reflect the actual role
+
+### Area D: Monorepo Structure Cleanup
+
+**Problem**: Build/test/lint configuration assumes a simpler structure than what exists.
+
+**Work**:
+- Consolidate workspace configuration (`pnpm-workspace.yaml`, `tsconfig` references)
+- Ensure `pnpm build`, `pnpm lint`, and `pnpm test` work from root for all apps and packages
+- Clean up unused entries in `scripts/`
+- Align CI pipeline (`.github/workflows/ci.yml`) with actual module structure — ensure extracted packages are built and tested
+- Verify Dockerfiles work with the restructured monorepo layout
+
+### Area E: Version Strategy
+
+**Problem**: No versioning policy. Schema package version misaligned.
+
+**Work**:
+- Define versioning policy: all packages track root version (single-version policy)
+- Align `packages/schema` version from 0.1.0 to current root version
+- Document the policy: pre-1.0 means no stability guarantees, version bumps are milestone-driven
+- Add version validation to CI (all package.json versions must match root)
+
+---
+
+## Epic Decomposition
+
+### [Epic] Rendering Model Resolution (Area A)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Audit current rendering code and Three.js usage | S |
+| 2 | Write ADR: Rendering model decision | M |
+| 3 | Implement rendering model decision (remove or boundary) | M |
+
+### [Epic] Package Extraction & Boundaries (Area B)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Design schema package: JSON Schema + TS types + Python codegen | M |
+| 2 | Extract `@cloudblocks/schema` with ArchitectureModel contract | L |
+| 3 | Extract `@cloudblocks/domain` with shared domain logic | L |
+| 4 | Migrate apps/web imports to use extracted packages | M |
+| 5 | Remove or plan unused placeholder packages | S |
+
+### [Epic] Backend Role & API Contract (Area C)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Document actual backend responsibilities and API surface | M |
+| 2 | Define shared ArchitectureModel contract (JSON Schema) | M |
+| 3 | Decide and implement validation rule ownership | M |
+| 4 | Update README, ARCHITECTURE.md, API_SPEC.md | M |
+
+### [Epic] Monorepo Infrastructure (Areas D + E)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Consolidate workspace and tsconfig configuration | M |
+| 2 | Ensure root-level build/test/lint for all modules | M |
+| 3 | Align CI pipeline with restructured modules | M |
+| 4 | Define and enforce version alignment policy | S |
+
+---
+
+## Exit Criteria
+
+- [ ] Rendering model documented in ADR; unused dependencies removed or justified with clear boundary
+- [ ] `packages/` contains real extracted code with actual consumers in `apps/web` and/or `apps/api`
+- [ ] `@cloudblocks/schema` is the single source of truth for the ArchitectureModel contract
+- [ ] Backend role accurately documented; API surface defined as explicit contract
+- [ ] All package versions aligned with root or independently versioned with explicit documented policy
+- [ ] `pnpm build`, `pnpm lint`, and tests pass from root for all apps and packages
+- [ ] CI pipeline builds and tests extracted packages
+- [ ] Monorepo structure supports future repo separation without code changes (verified by documentation, not by actually splitting)
+- [ ] Validation rule ownership decided and documented
+- [ ] No placeholder/empty packages remain in `packages/`
+
+---
+
+## Dependencies
+
+- M16 complete (documentation must be accurate before restructuring the codebase it describes)
+
+---
+
+## Constraints
+
+- No breaking changes to user-facing features — the builder must work identically before and after restructuring
+- Keep modular monorepo — do not split repos
+- Maintain test coverage >= 90%
+- Always design/document first, then implement
+- Pre-1.0: no stability guarantees, but version bumps should be intentional
+- Python backend cannot consume TypeScript directly — cross-language contracts must use language-neutral formats (JSON Schema)
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Package extraction breaks CI pipeline | Build failures, blocked PRs | Incremental extraction: one package at a time, verify CI after each |
+| Rendering model decision requires significant dependency removal | Large diff, potential regressions | Write ADR first, implement in isolated PR with thorough testing |
+| Backend redefinition surfaces API inconsistencies | API contract confusion | Contract-first approach: define schema before changing code |
+| Cross-language schema generation adds tooling complexity | Maintenance burden | Use established tools (e.g., `json-schema-to-typescript`, `datamodel-code-generator`) |
+
+---
+
+## Estimated Effort
+
+- **Area A** (Rendering Model): ~3–4 days
+- **Area B** (Package Extraction): ~2 weeks (largest area)
+- **Area C** (Backend Role): ~1 week
+- **Area D+E** (Monorepo + Versioning): ~1 week
+- **Total**: ~4–6 weeks
+- Design documents and ADRs are written first for each area before implementation begins

--- a/docs/concept/M18_DEVOPS_UX.md
+++ b/docs/concept/M18_DEVOPS_UX.md
@@ -1,0 +1,233 @@
+# Milestone 18 — DevOps UX
+
+## Goal
+
+Add operational control capabilities to CloudBlocks. Introduce an Ops Control Center, standardize deployment terminology, build environment promotion/rollback UX, and add a notification system. Transform CloudBlocks from "design and generate" into "design, deploy, and operate."
+
+---
+
+## Background
+
+CloudBlocks currently supports architecture design and code generation (Terraform, Bicep, Pulumi). It has basic CI/CD pipeline support through GitHub Actions workflows (`ci.yml`, `deploy.yml`, `promote.yml`). But there is no in-app operational visibility — users must leave CloudBlocks to monitor deployments, check environment status, or manage promotions.
+
+### Current State
+
+- **Code generation**: Working (Terraform, Bicep, Pulumi output)
+- **GitHub integration**: OAuth login, repo sync, PR creation
+- **CI/CD workflows**: Three GitHub Actions workflows exist but are triggered outside CloudBlocks
+- **Architecture diff**: M7 feature compares local vs GitHub architecture with visual overlays
+- **No ops dashboard**: Users must use GitHub Actions UI, Azure Portal, or CLI to check deployment status
+- **Inconsistent terminology**: "deploy," "promote," and "release" are used without clear definitions across docs and workflows
+
+### Infrastructure Context
+
+| Concern | Decision |
+|---------|----------|
+| Backend deployment target | Azure Container Apps (Consumption plan) |
+| Frontend deployment target | Azure Static Web Apps |
+| Environment names | `local`, `staging`, `production` (full names, no abbreviations) |
+| Dev environment | Local only — no cloud deployment |
+| CI/CD | GitHub Actions |
+| Backend runtime | Docker-based |
+| Cost visibility | Estimated costs must be shown before any deployment |
+
+### Relationship to Existing Milestones
+
+- **M10 (External Actors & DevOps UX)**: M10 focused on the minifigure/worker RTS interaction pattern (selectable DevOps character, build animations, CommandCard). M18 focuses on the operational control plane — deployment status, promotion, rollback. These are complementary, not overlapping.
+- **M7 (Architecture Diff)**: M18 extends the diff feature to compare architecture across environments (what is deployed to staging vs production), not just local vs GitHub.
+- **M13 (Terraform Pipeline)**: M18 builds on the validated code generation pipeline to add deployment orchestration and monitoring.
+
+---
+
+## Scope
+
+### Area A: Ops Control Center
+
+A dashboard within CloudBlocks showing deployment and environment status.
+
+**Features**:
+- Deployment status per environment (`local`, `staging`, `production`)
+- Real-time pipeline status via GitHub Actions integration (workflow runs, job status)
+- Environment health indicators (up / down / deploying / unknown)
+- Architecture diff between environments — what version is deployed where, and how they differ
+- Cost estimation panel — show estimated Azure costs before triggering a deployment
+- Deployment history — log of past deployments per environment with timestamps and outcomes
+
+**Key design decisions**:
+- Polling vs webhooks for GitHub Actions status (webhooks preferred for real-time, polling as fallback)
+- Cost estimation source: Azure Pricing API or static pricing tables with "estimated" labels
+- Dashboard placement: dedicated panel/page within CloudBlocks, not a separate app
+
+### Area B: Deploy Terminology Standardization
+
+**Problem**: "deploy," "promote," "release," and "rollback" are used inconsistently across docs, UI, and workflows.
+
+**Canonical vocabulary**:
+
+| Term | Definition |
+|------|-----------|
+| **Deploy** | Push code/infrastructure to a specific environment. Triggered by CI/CD pipeline. |
+| **Promote** | Move a tested version from `staging` to `production`. A controlled, deliberate action with pre-checks. |
+| **Rollback** | Revert an environment to a previous known-good version. Emergency or planned recovery. |
+| **Release** | Tag a version as a user-facing milestone. A labeling action, not a deployment action. |
+
+**Work**:
+- Update all documentation to use these terms consistently
+- Rename workflow files and UI labels if they use incorrect terms
+- Add a terminology section to the deployment guide
+
+### Area C: Promote/Rollback UX
+
+Visual promotion and rollback flows within CloudBlocks.
+
+**Promote flow**:
+1. User views staging environment in Ops Control Center
+2. User clicks "Promote to Production"
+3. Pre-promotion checklist displayed:
+   - Tests passed on staging
+   - Cost estimate reviewed
+   - Architecture diff reviewed (staging vs current production)
+4. User confirms promotion
+5. GitHub Actions `promote.yml` workflow triggered
+6. Real-time status shown in Ops Control Center
+7. Promotion recorded in deployment history
+
+**Rollback flow**:
+1. User views production environment in Ops Control Center
+2. User clicks "Rollback"
+3. List of previous successful deployments shown
+4. User selects target version
+5. Confirmation dialog with diff (current vs target)
+6. Rollback executed via workflow
+7. Status tracked in real-time
+
+**Promotion history**:
+- Log of all promotions and rollbacks with timestamps, user, source version, target version, outcome
+
+### Area D: Notification System
+
+In-app notifications for deployment lifecycle events.
+
+**Events**:
+- Deployment started (environment, triggered by, version)
+- Deployment succeeded (environment, duration)
+- Deployment failed (environment, error summary)
+- Promotion completed (staging version promoted to production)
+- Rollback completed (environment, rolled back to version)
+
+**Implementation**:
+- In-app notification center (bell icon with unread count)
+- Toast notifications for real-time events while user is active
+- Notification history (filterable by environment, event type, date)
+- Optional future extension: webhook integration for external services (Slack, Teams) — not in M18 scope, but the notification data model should support it
+
+---
+
+## User Stories
+
+| # | Story |
+|---|-------|
+| 1 | As an architect, I want to see which version is deployed to each environment without leaving CloudBlocks |
+| 2 | As an operator, I want to promote a staging-tested architecture to production with one click and pre-checks |
+| 3 | As a team lead, I want to rollback production to the last known-good state when a deployment fails |
+| 4 | As an architect, I want to see estimated Azure costs before triggering a deployment |
+| 5 | As a developer, I want consistent deploy terminology so I do not confuse "promote" with "deploy" |
+| 6 | As a user, I want to be notified when a deployment succeeds or fails without watching the pipeline |
+
+---
+
+## Epic Decomposition
+
+### [Epic] Ops Control Center (Area A)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Design Ops Control Center layout and information architecture | M |
+| 2 | Implement environment status dashboard (local/staging/production) | L |
+| 3 | Integrate GitHub Actions API for real-time pipeline status | M |
+| 4 | Build cross-environment architecture diff view | L |
+| 5 | Add cost estimation panel with Azure pricing integration | M |
+| 6 | Implement deployment history log | M |
+
+### [Epic] Deploy Terminology Cleanup (Area B)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Define canonical deploy vocabulary and add to deployment guide | S |
+| 2 | Audit and update all docs, workflows, and UI labels for terminology consistency | M |
+| 3 | Rename workflow files if needed (deploy.yml, promote.yml naming review) | S |
+
+### [Epic] Promote/Rollback UX (Area C)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Design promote flow with pre-promotion checklist | M |
+| 2 | Implement promote UI: staging to production with confirmation | L |
+| 3 | Design rollback flow with version selection | M |
+| 4 | Implement rollback UI with diff preview | L |
+| 5 | Build promotion/rollback history log | M |
+
+### [Epic] Notification System (Area D)
+
+| # | Title | Size |
+|---|-------|------|
+| 1 | Design notification data model and event taxonomy | M |
+| 2 | Implement in-app notification center (bell icon, unread count) | M |
+| 3 | Add toast notifications for real-time deployment events | M |
+| 4 | Build notification history with filtering | M |
+
+---
+
+## Exit Criteria
+
+- [ ] Ops Control Center shows real-time deployment status for `local`, `staging`, and `production` environments
+- [ ] Deploy/promote/rollback terminology is consistent across all docs, workflows, and UI
+- [ ] Promote flow works end-to-end: staging to production with pre-promotion checklist
+- [ ] Rollback to a previous version works from Ops Control Center
+- [ ] Cost estimation is displayed before deployment confirmation
+- [ ] Notification system shows deployment lifecycle events in-app
+- [ ] Deployment history log records all deploys, promotions, and rollbacks
+- [ ] Cross-environment architecture diff is viewable in Ops Control Center
+
+---
+
+## Dependencies
+
+- M17 complete (stable module structure required before adding new UI features and backend endpoints)
+- GitHub Actions workflows operational (`ci.yml`, `deploy.yml`, `promote.yml`)
+- Azure deployment target configured (Azure Container Apps + Azure Static Web Apps)
+
+---
+
+## Constraints
+
+- Environment names use full names: `local`, `staging`, `production` — never abbreviations
+- `local` (dev) is local only — no cloud deployment for this environment
+- Cost estimation must be shown before any deployment to `staging` or `production`
+- Backend must be Docker-based for deployment
+- CI/CD through GitHub Actions — no custom deployment scripts
+- Pre-1.0: no stability guarantees
+- Always design/document first, then implement
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| GitHub Actions API rate limits affect real-time status | Dashboard shows stale data | Use webhooks as primary mechanism; polling at longer intervals as fallback |
+| Azure cost estimation API does not cover all resource types | Inaccurate cost display | Use conservative estimates, label as "estimated," allow manual adjustment |
+| Promote/rollback complexity varies by IaC tool (Terraform state vs Bicep) | Inconsistent behavior across generators | Start with Terraform-first approach; add Bicep/Pulumi support incrementally |
+| Notification volume overwhelms users on active projects | Notification fatigue | Default to meaningful events only; allow per-event-type mute settings |
+| Cross-environment diff requires deployed architecture snapshots | Data availability gap | Store architecture snapshot on each successful deployment |
+
+---
+
+## Estimated Effort
+
+- **Area A** (Ops Control Center): ~2.5 weeks (largest area — dashboard, API integration, diff)
+- **Area B** (Terminology): ~2–3 days (docs and naming review)
+- **Area C** (Promote/Rollback): ~2 weeks (UI flows, workflow integration)
+- **Area D** (Notifications): ~1.5 weeks
+- **Total**: ~6–8 weeks
+- Design documents and wireframes are produced first for each area before implementation begins

--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -1,6 +1,10 @@
 # CloudBlocks Platform — Development Roadmap
 
-This document defines the staged development roadmap for the CloudBlocks Platform. Each milestone is a **Milestone** (development stage), independent of software release versions.
+This document defines the staged development roadmap for the CloudBlocks Platform. Official planning is tracked with GitHub milestones, independent of software release versions.
+
+> **Terminology**
+> - **Milestone** = official planning container (GitHub milestone) used for all new planning work.
+> - **Phase** = legacy label from early development, retained only in completed historical sections for traceability.
 
 CloudBlocks evolves from a **2.5D isometric cloud architecture builder** into a **full architecture-to-code platform** — generating Terraform, Bicep, and Pulumi from visual designs, with Git-native workflow integration.
 
@@ -312,6 +316,10 @@ Features:
 > **Note**: Azure Infrastructure Foundation (Phase 1, 6 commits) and Sound Effects (Phase 2, 12 commits) were completed alongside Milestone 6C — including audioService, CC0 sound assets, Terraform Azure modules, and Docker/CI configuration.
 
 ---
+
+## Historical Phase References (Completed)
+
+The sections below retain original Phase labels because they map to completed historical work in git history.
 
 ## Phase 3 — Lego Minifigure Character SVG ✅
 
@@ -852,8 +860,8 @@ Key principles:
 4. Keep backend **thin** — orchestration, not CRUD
 5. **Open-source first** — community drives templates and generators
 6. **Local-first UX** — works offline, syncs when connected
-7. **Phased UI/Engine Evolution** — systematic transition from Azure-first to multi-provider visual logic
-8. **Phased Documentation Updates** — keep canonical docs synchronized with delivered milestone/phase code changes
+7. **Milestone-aligned UI/Engine Evolution** — systematic transition from Azure-first to multi-provider visual logic
+8. **Milestone-aligned Documentation Updates** — keep canonical docs synchronized with delivered milestone work while preserving historical phase references
 
 ---
 

--- a/docs/design/DOC_CONSISTENCY_AUDIT_2026-03-19.md
+++ b/docs/design/DOC_CONSISTENCY_AUDIT_2026-03-19.md
@@ -1,0 +1,101 @@
+# Document Consistency Audit — 2026-03-19
+
+## Scope
+- `docs/concept/PRD.md`
+- `docs/concept/ROADMAP.md`
+- `docs/concept/ACTION_PLAN_EXECUTION.md`
+- `docs/design/UI_IMPROVEMENT_GAP_ANALYSIS.md`
+- Current merged issue/PR status through #210
+
+## Method
+1. Document-to-document consistency check
+2. Document-to-code consistency check (high-level, milestone gates)
+3. Logical consistency check (goal -> phase -> dependency -> execution)
+
+---
+
+## A. Document-to-Document Consistency
+
+### A1. PRD vs ROADMAP
+- **Status:** Consistent after roadmap note and historical positioning
+- **Observation:** PRD remains valid as product intent; ROADMAP is implementation timeline source.
+- **Action:** Keep PRD as vision/reference, ROADMAP as execution truth.
+
+### A2. ROADMAP vs ACTION_PLAN_EXECUTION
+- **Status:** Consistent
+- **Observation:** New milestones A–F are execution-oriented and compatible with existing roadmap phases.
+- **Action:** Link both directions in docs index later (minor).
+
+### A3. UI Gap Analysis vs Current Direction
+- **Status:** Partially historical but still useful
+- **Observation:** Some items already implemented; still useful for rationale and boundary decisions.
+- **Action:** Add explicit historical badge where needed (low priority).
+
+---
+
+## B. Document-to-Code Consistency
+
+### B1. Closed bug series (#199~#201)
+- **Status:** Consistent
+- **Evidence:** PR #208, #209, #210 merged.
+
+### B2. Milestone setup
+- **Status:** Consistent
+- **Evidence:** Milestones #7~#12 exist and match ACTION_PLAN_EXECUTION structure.
+
+### B3. KPI governance
+- **Status:** Added but not yet linked from roadmap/docs index
+- **Action:** Add cross-link from ROADMAP and docs/README in next doc-only PR.
+
+---
+
+## C. Logical Consistency (Critical)
+
+### C1. Required sequence
+- **Required:** Documentation -> Consistency review -> Milestone -> Issues -> Execution
+- **Current:** Sequence now aligned.
+
+### C2. Dependency discipline
+- **Required:** Every execution issue must declare `Priority` and `Depends on`.
+- **Current:** Not yet enforced via issue template.
+- **Action:** Add issue template fields and PR template dependency section.
+
+### C3. Release risk control
+- **Required:** One issue per PR + mandatory checks before merge.
+- **Current:** Being followed in recent issue cycle.
+
+---
+
+## D. Risk Register (Current)
+
+1. **Doc drift risk**
+   - Risk: Strategy docs and roadmap diverge over time.
+   - Mitigation: Add monthly doc consistency audit issue.
+
+2. **Dependency ambiguity risk**
+   - Risk: Issues executed out of order without explicit dependency metadata.
+   - Mitigation: Mandatory issue fields (`Priority`, `Depends on`, `Blocks`).
+
+3. **Operational noise risk**
+   - Risk: CI/merge queue delays misread as idle.
+   - Mitigation: Fixed progress report format with current stage + blocker.
+
+---
+
+## E. Decision (Audit Result)
+
+- **Decision:** Proceed with execution under milestones A–F.
+- **Gate passed:** Documentation baseline and consistency checks are sufficient to start milestone issue breakdown.
+- **Next immediate step:** Create M-A execution issues (A1~A4) with explicit priority/dependency metadata.
+
+---
+
+## F. Next Actions
+
+1. Create M-A issues:
+   - A1 Start Entry
+   - A2 Selection->Action contract
+   - A3 Drag/Drop + Connect reliability
+   - A4 Interaction state machine hardening
+2. Add issue template enforcing priority/dependency fields
+3. Add doc cross-links for KPI scorecard

--- a/docs/design/KPI_SCORECARD.md
+++ b/docs/design/KPI_SCORECARD.md
@@ -1,0 +1,121 @@
+# CloudBlocks KPI Scorecard (Objective Quality & Success Metrics)
+
+## Purpose
+Use a single objective scorecard to evaluate product success and engineering quality.
+
+---
+
+## 1) Product Value Metrics
+
+### 1.1 Time to First Value (TTFV)
+- Definition: Time from first open to first successful `architecture -> validate -> generate` completion.
+- Target: <= 10 minutes (new user median).
+
+### 1.2 Core Task Success Rate
+- Definition: Success ratio for key flow:
+  1) Create basic architecture
+  2) Pass validation
+  3) Generate IaC
+- Target: >= 90%.
+
+### 1.3 Funnel Drop-off
+- Definition: Drop-off by stage (Onboarding / Modeling / Validation / Generation).
+- Target: No single stage > 30% drop-off.
+
+---
+
+## 2) Engineering Stability Metrics
+
+### 2.1 Main Branch CI Green Rate
+- Definition: Successful CI runs / total CI runs on main.
+- Target: >= 95%.
+
+### 2.2 Regression Reopen Rate
+- Definition: Reopened bug issues / closed bug issues.
+- Target: < 10%.
+
+### 2.3 Deployment Reliability
+- Definition: Failed deployments / total deployments.
+- Target: < 5%.
+
+### 2.4 MTTR
+- Definition: Mean time to recover from production-impacting failures.
+- Target: <= 60 minutes.
+
+---
+
+## 3) Architecture & Maintainability Metrics
+
+### 3.1 Doc-Code Consistency Score
+- Definition: Percentage of "canonical" documented contracts that match implementation.
+- Scope:
+  - Architecture schema contract
+  - Rule engine contract
+  - Generator contract
+- Target: >= 95% consistency.
+
+### 3.2 Contract Test Pass Rate
+- Definition: Pass rate for schema/rule/generator contract tests.
+- Target: 100% on required gates.
+
+### 3.3 Change Blast Radius
+- Definition: Number of core modules impacted per PR (median).
+- Target: <= 3 modules/PR for normal work.
+
+---
+
+## 4) Open Core Business Metrics
+
+### 4.1 OSS Adoption
+- Signals:
+  - Weekly stars / forks / external PRs
+  - New contributor count
+- Target: Positive trend (4-week rolling average).
+
+### 4.2 Platform Demand Signals
+- Signals:
+  - Requests for RBAC / SSO / audit / policy packs
+  - Enterprise inquiry count
+- Target: Growing month-over-month.
+
+### 4.3 Retention Signals
+- Definition: Teams active across multiple weeks.
+- Target: Positive retention trend by cohort.
+
+---
+
+## Weekly Report Format (Required)
+
+## A. Completed This Week
+- (short bullet list)
+
+## B. In Progress
+- (issue/PR references)
+
+## C. Risks / Blockers
+- (technical + product risks)
+
+## D. KPI Snapshot
+- TTFV:
+- Core Task Success:
+- CI Green Rate:
+- Regression Reopen Rate:
+- Doc-Code Consistency:
+- Contract Test Pass:
+- OSS Adoption Trend:
+- Platform Demand Trend:
+
+## E. Next Week Plan
+- Ordered by priority + dependency
+
+---
+
+## Operating Rules
+- No implementation milestone starts without:
+  1) Documentation update
+  2) Document consistency review
+  3) Doc-code consistency review
+  4) Milestone confirmation
+  5) Issue breakdown with priority/dependency
+- One issue per PR.
+- Merge only after required checks pass.

--- a/docs/design/VALIDATION_CONTRACT.md
+++ b/docs/design/VALIDATION_CONTRACT.md
@@ -44,11 +44,10 @@ Placement rules validate that blocks are placed on appropriate plates.
 | `rule-db-private` | error | Database block not on a `subnet` plate with `subnetAccess: "private"` | Database block must be placed on a private Subnet Plate |
 | `rule-gw-public` | error | Gateway block not on a `subnet` plate with `subnetAccess: "public"` | Gateway block must be placed on a public Subnet Plate |
 | `rule-storage-subnet` | error | Storage block not on a `subnet` plate | Storage block must be placed on a Subnet Plate |
+| `rule-analytics-subnet` | error | Analytics block not on a `subnet` plate | Analytics block must be placed on a Subnet Plate |
+| `rule-identity-subnet` | error | Identity block not on a `subnet` plate | Identity block must be placed on a Subnet Plate |
+| `rule-observability-subnet` | error | Observability block not on a `subnet` plate | Observability block must be placed on a Subnet Plate |
 | `rule-serverless-network` | error | `function`, `queue`, or `event` block not on a `region` plate | Serverless blocks (function/queue/event) must be placed on a Region Plate |
-
-> **Note on timer-like triggers**: The current model does not define a separate `timer` block category. Timer-based behavior is represented as a subtype/configuration of existing `event` blocks (for example, a timer-triggered event), and such blocks are validated by `rule-serverless-network` like other `event` blocks.
-
-> **Note on Timer blocks**: `timer` blocks are not currently validated by `rule-serverless-network` and fall through to the default (unvalidated) state in the current implementation.
 
 ### 3.1 v2.0 Layer Hierarchy Rules
 
@@ -223,6 +222,6 @@ When backend validation is introduced:
 
 ## 10. Migration Notes
 
-- Serverless block categories (`FunctionBlock`, `QueueBlock`, `EventBlock`) are implemented and reflected in the placement rules above. `TimerBlock` is planned but not yet supported in the TypeScript domain model (`BlockCategory`) or placement rules.
+- Serverless block categories (`FunctionBlock`, `QueueBlock`, `EventBlock`) are implemented and reflected in the placement rules above.
 - When adding new connection types (e.g., `EventFlow`), update the allowed connection map here first.
 - Breaking rule changes (removing a rule, changing severity) require a version bump to this document's Current version field.

--- a/docs/engine/generator.md
+++ b/docs/engine/generator.md
@@ -149,8 +149,11 @@ interface GeneratedOutput {
 interface GeneratedFile {
   path: string;      // e.g., "main.tf"
   content: string;   // file content
-  language: 'hcl' | 'json';
+  language: FileLanguage;
 }
+
+type KnownLanguage = 'hcl' | 'json' | 'bicep' | 'typescript';
+type FileLanguage = KnownLanguage | (string & {});
 
 interface GenerationMetadata {
   generator: string;

--- a/docs/engine/provider.md
+++ b/docs/engine/provider.md
@@ -27,6 +27,12 @@ Examples of generic categories:
 - database
 - storage
 - gateway
+- function
+- queue
+- event
+- analytics
+- identity
+- observability
 
 Examples of provider-specific resources:
 
@@ -62,6 +68,12 @@ Example:
 | database | azurerm_postgresql_flexible_server | aws_db_instance | google_sql_database_instance |
 | storage | azurerm_storage_account | aws_s3_bucket | google_storage_bucket |
 | gateway | azurerm_application_gateway | aws_lb | google_compute_backend_service |
+| function | azurerm_linux_function_app | - | - |
+| queue | azurerm_storage_queue | - | - |
+| event | azurerm_eventgrid_topic | - | - |
+| analytics | azurerm_log_analytics_workspace | - | - |
+| identity | azurerm_user_assigned_identity | - | - |
+| observability | azurerm_monitor_workspace | - | - |
 
 ---
 

--- a/docs/model/ARCHITECTURE_MODEL_OVERVIEW.md
+++ b/docs/model/ARCHITECTURE_MODEL_OVERVIEW.md
@@ -32,7 +32,7 @@ The architecture model provides a **provider-agnostic** representation of infras
 | **Workspace** | Top-level container for architecture projects | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §13 |
 | **Architecture** | Deployable infrastructure topology | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §14 |
 | **Plate** | Infrastructure boundary (Network / Subnet) | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §3 |
-| **Block** | Infrastructure resource (compute, database, storage, gateway) | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §4-5 |
+| **Block** | Infrastructure resource (compute, database, storage, gateway, function, queue, event, analytics, identity, observability) | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §4-5 |
 | **Application** | Software on hostable resources (nginx, nodejs, postgres) | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §4.5 |
 | **Connection** | Communication flow between blocks (initiator model) | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §6 |
 | **External Actor** | External endpoint (e.g., Internet) | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) §6.1 |
@@ -130,7 +130,7 @@ IaC Generation (Terraform, Bicep, Pulumi)
 | Topic | Document |
 |-------|----------|
 | Domain model (canonical) | [DOMAIN_MODEL.md](./DOMAIN_MODEL.md) |
-| Visual sizing | [BRICK_DESIGN_SPEC.md](../design/BRICK_DESIGN_SPEC.md) |
+| Visual sizing | [CLOUDBLOCKS_SPEC_V2.md](../design/CLOUDBLOCKS_SPEC_V2.md) |
 | Rule engine | [rules.md](../engine/rules.md) |
 | Code generation | [generator.md](../engine/generator.md) |
 | Provider mapping | [provider.md](../engine/provider.md) |

--- a/docs/model/STORAGE_ARCHITECTURE.md
+++ b/docs/model/STORAGE_ARCHITECTURE.md
@@ -68,7 +68,7 @@ This is NOT a traditional database-heavy architecture. The design principle: **D
 my-cloud-project/
 ├── cloudblocks/
 │   ├── architecture.json       # Architecture model (source of truth)
-│   ├── schemaVersion           # "0.1.0"
+│   ├── schemaVersion           # "2.0.0"
 │   └── generator.lock          # Pinned generator versions
 ├── infra/
 │   ├── terraform/
@@ -89,31 +89,37 @@ my-cloud-project/
 
 ```json
 {
-  "schemaVersion": "0.1.0",
-  "architecture": {
-    "id": "arch-abc123",
-    "name": "3-Tier Web App",
-    "version": "1",
-    "plates": [
-      {
-        "id": "plate-vnet01",
-        "name": "Main Network",
-        "type": "network",
-        "parentId": null,
-        "children": ["plate-subnet-pub", "plate-subnet-priv"],
-        "position": { "x": 0, "y": 0, "z": 0 },
-        "size": { "width": 10, "height": 0.3, "depth": 10 },
-        "metadata": {}
+  "schemaVersion": "2.0.0",
+  "workspaces": [
+    {
+      "id": "workspace-main",
+      "name": "3-Tier Web App",
+      "architecture": {
+        "id": "arch-abc123",
+        "name": "3-Tier Web App",
+        "version": "1",
+        "plates": [
+          {
+            "id": "plate-region01",
+            "name": "Main Region",
+            "type": "region",
+            "parentId": null,
+            "children": ["plate-subnet-pub", "plate-subnet-priv"],
+            "position": { "x": 0, "y": 0, "z": 0 },
+            "size": { "width": 10, "height": 0.3, "depth": 10 },
+            "metadata": {}
+          }
+        ],
+        "blocks": [],
+        "connections": [],
+        "externalActors": [
+          { "id": "ext-internet", "name": "Internet", "type": "internet" }
+        ],
+        "createdAt": "2025-01-01T00:00:00Z",
+        "updatedAt": "2025-01-01T00:00:00Z"
       }
-    ],
-    "blocks": [],
-    "connections": [],
-    "externalActors": [
-      { "id": "ext-internet", "name": "Internet", "type": "internet" }
-    ],
-    "createdAt": "2025-01-01T00:00:00Z",
-    "updatedAt": "2025-01-01T00:00:00Z"
-  }
+    }
+  ]
 }
 ```
 
@@ -123,7 +129,7 @@ Stable key ordering is enforced to keep Git diffs readable.
 
 ## Metadata DB Schema
 
-> **Current schema** defined inline in `apps/api/app/infrastructure/db/connection.py` (`_MIGRATIONS` list). Reference `.sql` copies exist in `migrations/` but are not executed at runtime. Migrations: 001 users + identities, 002 workspaces + generation\_runs, 003 ALTER TABLE identities (encrypted token), 004 sessions + indexes. The `ai_api_keys` table is created on-demand by `SQLiteAIApiKeyRepository._ensure_table()`. Phase 8 extends this with PostgreSQL/Redis deployment topology.
+> **Current schema** is tracked in SQL migrations under `apps/api/app/infrastructure/db/migrations/`: `001_create_users.sql`, `002_create_workspaces.sql`, and `003_create_ai_api_keys.sql`.
 
 ```sql
 -- Migration 001: User identity (linked to GitHub / Google OAuth)
@@ -145,6 +151,7 @@ CREATE TABLE IF NOT EXISTS identities (
     provider        TEXT NOT NULL,   -- 'github', 'google'
     provider_id     TEXT NOT NULL,
     access_token_hash TEXT,          -- hashed, not plaintext
+    refresh_token_hash TEXT,
     created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(provider, provider_id)
 );
@@ -174,9 +181,6 @@ CREATE TABLE IF NOT EXISTS generation_runs (
     created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
--- Migration 003: Add encrypted token storage for GitHub OAuth
-ALTER TABLE identities ADD COLUMN encrypted_access_token TEXT;
-
 -- Migration 004: Session auth storage (cookie-based, no token hash)
 CREATE TABLE IF NOT EXISTS sessions (
     id                     TEXT PRIMARY KEY,
@@ -197,7 +201,7 @@ CREATE TABLE IF NOT EXISTS ai_api_keys (
     user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     provider        TEXT NOT NULL,
     encrypted_key   TEXT NOT NULL,
-    created_at      TEXT NOT NULL DEFAULT (datetime("now")),
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(user_id, provider)
 );
 ```
@@ -265,7 +269,7 @@ cache:workspace:{workspace_id}    → JSON workspace metadata (TTL: 5m)
 ### Local-First Principle
 
 CloudBlocks is **local-first**:
-- Works fully offline with localStorage/IndexedDB
+- Works fully offline with localStorage
 - GitHub sync is optional (but recommended for teams)
 - No data loss if GitHub is down
 - Graceful degradation: edit locally → sync when online


### PR DESCRIPTION
## Summary

Completes **Milestone 16 — Documentation Architecture & Canonical Cleanup** by addressing all remaining open issues.

### Changes

**Fix 22 doc-vs-code discrepancies (#375)**
- Schema version `0.1.0` → `2.0.0` across ARCHITECTURE.md, STORAGE_ARCHITECTURE.md
- Block categories: 8 (with timer) → 10 (compute, database, storage, gateway, function, queue, event, analytics, identity, observability) across README.md, apps/web/README.md, ARCHITECTURE_MODEL_OVERVIEW.md, provider.md
- Validation modules: 3 → 6 (added providerValidation.ts, aggregation.ts, role.ts) in ARCHITECTURE.md
- Validation flow: 2 steps → 5 steps (placement → aggregation → role → connection → provider)
- Storage: IndexedDB → localStorage across ARCHITECTURE.md, STORAGE_ARCHITECTURE.md
- Plate type: `network` → `region` in STORAGE_ARCHITECTURE.md example
- Added analytics/identity/observability placement rules to VALIDATION_CONTRACT.md
- Removed timer references from VALIDATION_CONTRACT.md
- Fixed duplicate route block in ARCHITECTURE.md
- Updated STORAGE_ARCHITECTURE.md table schemas to match actual migrations
- Updated provider.md with all 10 Azure block mappings
- Updated generator.md with correct FileLanguage type
- Fixed ARCHITECTURE_MODEL_OVERVIEW.md spec reference (BRICK_DESIGN_SPEC → CLOUDBLOCKS_SPEC_V2)

**Standardize Milestone vs Phase terminology (#366)**
- Added terminology policy: Milestone = official planning container, Phase = historical label
- Updated README.md roadmap table header from `Phase` → `Milestone` with explanatory note
- Added Terminology section to CONTRIBUTING.md
- Fixed milestone naming guidance in CONTRIBUTING.md (`Phase N` → `Milestone N`)
- Added terminology block and historical guardrail to ROADMAP.md
- Updated ARCHITECTURE.md deployment table references (Phase 8 → Milestone 8)

**Documentation lifecycle policy (#368)**
- Added Documentation Lifecycle Policy table to CONTRIBUTING.md (status labels, handling rules)
- Added Documentation Update Requirement: code changes MUST include doc updates
- Updated PR template checklist to enforce doc updates for code changes

**New documentation files**
- `docs/concept/M16_DOCUMENTATION_ARCHITECTURE.md` — M16 milestone design doc
- `docs/concept/M17_PRODUCT_STRUCTURE.md` — M17 milestone design doc
- `docs/concept/M18_DEVOPS_UX.md` — M18 milestone design doc
- `docs/concept/ACTION_PLAN_EXECUTION.md` — Execution tracking
- `docs/design/DOC_CONSISTENCY_AUDIT_2026-03-19.md` — Audit report
- `docs/design/KPI_SCORECARD.md` — Product & engineering KPI metrics
- Updated `docs/README.md` index with all new documents

### Verification
- All 22 discrepancies verified against source code before editing
- No file conflicts between concurrent agent edits (different sections)
- Docs-only changes — no code or build impact

Closes #375
Closes #368
Closes #366
Part of Epic #370