### PR TITLE
docs: remove stale refs and dead code (post-M16 audit)

### DIFF
--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -6,7 +6,6 @@
 // ─── Layer Hierarchy (v2.0) ────────────────────────────────
 export type LayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet' | 'resource';
 
-export const LAYER_HIERARCHY: LayerType[] = ['global', 'edge', 'region', 'zone', 'subnet', 'resource'];
 
 export const VALID_PARENTS: Record<LayerType, LayerType[]> = {
   global: [],           // root level

--- a/docs/concept/ACTION_PLAN_EXECUTION.md
+++ b/docs/concept/ACTION_PLAN_EXECUTION.md
@@ -28,7 +28,7 @@ Validated against:
 - `docs/concept/PRD.md`
 - `docs/concept/ROADMAP.md`
 - `docs/design/UI_IMPROVEMENT_GAP_ANALYSIS.md`
-- `docs/design/BRICK_DESIGN_SPEC.md`
+- `docs/design/CLOUDBLOCKS_SPEC_V2.md`
 - `docs/design/MODULE_BOUNDARIES.md`
 
 ### 2.1 Already in progress / partially delivered

--- a/docs/concept/M16_DOCUMENTATION_ARCHITECTURE.md
+++ b/docs/concept/M16_DOCUMENTATION_ARCHITECTURE.md
@@ -121,7 +121,7 @@ Systematic verification that every canonical document matches the post-M15 codeb
 - TypeScript types in `apps/web/src/shared/types/index.ts` vs DOMAIN_MODEL.md
 - Validation rules in `apps/web/src/entities/validation/` vs VALIDATION_CONTRACT.md
 - API routes in `apps/api/app/api/routes/` vs API_SPEC.md
-- Design tokens in `apps/web/src/shared/tokens/designTokens.ts` vs BRICK_DESIGN_SPEC.md
+- Design tokens in `apps/web/src/shared/tokens/designTokens.ts` vs CLOUDBLOCKS_SPEC_V2.md
 - Rendering approach in code vs ARCHITECTURE.md and README.md
 
 **Size**: L

--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -215,7 +215,7 @@ New block types:
 - FunctionBlock (Serverless compute)
 - QueueBlock (Messaging services)
 - EventBlock (Event triggers)
-- TimerBlock (Scheduled triggers)
+
 
 Example:
 
@@ -326,7 +326,7 @@ The sections below retain original Phase labels because they map to completed hi
 Goal:
 Create a DevOps Engineer Lego minifigure character as an inline SVG component with cloud provider branding.
 
-> **Reference**: [VISUAL_DESIGN_SPEC.md §11](../design/VISUAL_DESIGN_SPEC.md#11-lego-minifigure-character)
+> **Reference**: [CLOUDBLOCKS_SPEC_V2.md](../design/CLOUDBLOCKS_SPEC_V2.md)
 
 Features:
 
@@ -473,7 +473,7 @@ Features:
 - [x] Connect mode shows line from source to cursor/target
 - [x] All UI interactions are driven by explicit `InteractionState` transitions in `uiStore.ts` (`'idle' | 'selecting' | 'dragging' | 'placing' | 'connecting'`)
 
-> **Reference**: [BRICK_DESIGN_SPEC.md](../design/BRICK_DESIGN_SPEC.md) §10 UX State Machine
+> **Reference**: [CLOUDBLOCKS_SPEC_V2.md](../design/CLOUDBLOCKS_SPEC_V2.md)
 
 ---
 
@@ -487,7 +487,7 @@ Status: ✅ Delivered as part of Phase 9 — Visual Builder Evolution
 Features:
 
 - **Category Taxonomy Expansion** — Future expansion beyond current 8 categories to include Network, Compute, Data, Messaging, Security, and Edge
-- **Shape System** — Unique geometries: Tower (compute), Heavy Block (database/storage), Shield (gateway), Module (function/queue/event/timer)
+- **Shape System** — Unique geometries: Tower (compute), Heavy Block (database/storage), Shield (gateway), Module (function/queue/event)
 - **Height System** — Tiered side wall heights (low/mid/high) to indicate resource scale or tier
 - **Visual Tokens** — Formal extraction of radius, shadow, border, and surface design tokens
 
@@ -508,7 +508,7 @@ Features:
 
 Follow-up (outside delivered exit criteria): full design token extraction and expanded taxonomy mapping.
 
-> **Reference**: [BRICK_DESIGN_SPEC.md](../design/BRICK_DESIGN_SPEC.md) §3.7 Shape System, §6.9 Design Tokens
+> **Reference**: [CLOUDBLOCKS_SPEC_V2.md](../design/CLOUDBLOCKS_SPEC_V2.md)
 
 ---
 
@@ -541,7 +541,7 @@ Features:
 - [x] Provider logic is isolated behind provider-oriented typing and model boundaries
 - [x] Existing Azure-first workflows remain backward compatible
 
-> **Reference**: [BRICK_DESIGN_SPEC.md](../design/BRICK_DESIGN_SPEC.md) §6.7 Planned Multi-Cloud, §9.6 Planned Connection Types
+> **Reference**: [CLOUDBLOCKS_SPEC_V2.md](../design/CLOUDBLOCKS_SPEC_V2.md)
 
 ---
 
@@ -572,7 +572,7 @@ Features:
 - [ ] Full multi-provider brick palettes are implemented across all provider/resource combinations
 - [ ] Provider-specific metadata is fully handled end-to-end in IaC generation
 
-> **Reference**: [BRICK_DESIGN_SPEC.md](../design/BRICK_DESIGN_SPEC.md) §6.6 Provider Accent Palette
+> **Reference**: [CLOUDBLOCKS_SPEC_V2.md](../design/CLOUDBLOCKS_SPEC_V2.md)
 
 ---
 

--- a/docs/concept/UI_FLOW.md
+++ b/docs/concept/UI_FLOW.md
@@ -87,8 +87,8 @@ Connections represent communication flows between blocks.
 
 ### Connection Rules
 
-- **Initiator model**: Source block must have `initiator: true` (compute, gateway, function, queue, event, timer)
-- **Receiver-only**: Database and storage blocks cannot initiate connections
+- **Initiator model**: Source block must have `initiator: true` (compute, gateway, function, queue, event)
+- **Receiver-only**: Database, storage, analytics, identity, and observability blocks cannot initiate connections
 - Connections are created by clicking a source block's port, then clicking the target block
 
 ### Example Topology
@@ -96,7 +96,7 @@ Connections represent communication flows between blocks.
 ```
 Internet → Gateway (dataflow) → Compute (data) → Database
                               → Storage
-Timer (async) → Function (async) → Event
+Event (async) → Function (async) → Queue
 ```
 
 ---

--- a/docs/design/GRAPH_IR_SPEC.md
+++ b/docs/design/GRAPH_IR_SPEC.md
@@ -28,7 +28,7 @@ Graph IR exists to:
 
 ## 3. Terminology
 
-- **Containment layer**: plates and placements (NetworkPlate/SubnetPlate containment).
+- **Containment layer**: plates and placements (plate containment hierarchy: global → edge/region → zone → subnet).
 - **Flow layer**: nodes/ports/edges representing directed communication or dependency flow.
 - **Protocol semantics**: `http | internal | data | async` (Phase 5), plus legacy `dataflow` (current model).
 - **Port**: a typed ingress/egress interface on a node. Edges connect ports.
@@ -83,7 +83,7 @@ export interface GraphIR {
 export interface GraphPlate {
   id: string; // same ID as Plate.id
   name: string;
-  type: 'network' | 'subnet';
+  type: 'global' | 'edge' | 'region' | 'zone' | 'subnet';
   subnetAccess?: 'public' | 'private';
   parentId: string | null;
   children: string[]; // IDs of child plates or blocks (mirrors current model)
@@ -133,7 +133,9 @@ export interface GraphNode {
           | 'function'
           | 'queue'
           | 'event'
-          | 'timer';
+          | 'analytics'
+          | 'identity'
+          | 'observability';
         provider?: 'azure' | 'aws' | 'gcp';
         name: string;
         properties: Record<string, unknown>; // derived from Block.metadata


### PR DESCRIPTION
## Summary

Closes #382

Post-M16 audit cleanup: removes stale document references and one dead code export.

## Changes

### Documentation (5 files)
- **ROADMAP.md** — Removed `TimerBlock` reference, removed `timer` from shape system list, updated 5 `BRICK_DESIGN_SPEC.md` / `VISUAL_DESIGN_SPEC.md` references → `CLOUDBLOCKS_SPEC_V2.md`
- **UI_FLOW.md** — Removed `timer` from initiator list, added `analytics/identity/observability` to receiver-only list, fixed example topology
- **GRAPH_IR_SPEC.md** — Updated PlateType from `network|subnet` → `global|edge|region|zone|subnet`, updated BlockCategory (removed `timer`, added `analytics|identity|observability`)
- **ACTION_PLAN_EXECUTION.md** — Updated `BRICK_DESIGN_SPEC.md` ref → `CLOUDBLOCKS_SPEC_V2.md`
- **M16_DOCUMENTATION_ARCHITECTURE.md** — Updated `BRICK_DESIGN_SPEC.md` ref → `CLOUDBLOCKS_SPEC_V2.md`

### Dead code (1 file)
- **`apps/web/src/shared/types/index.ts`** — Removed unused `LAYER_HIERARCHY` constant (0 references outside definition; `LayerType` kept — still used in `placement.ts`)

## Verification
- `LAYER_HIERARCHY` grep: 0 matches in codebase
- Remaining `BRICK_DESIGN_SPEC` mentions are all in Historical/Superseded docs or immutable ADRs (correct)
- `tsc` diagnostics: 0 errors