### PR TITLE
docs: fix 8 doc-code discrepancies from deep audit

### DIFF
--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -486,7 +486,7 @@ Status: ✅ Delivered as part of Phase 9 — Visual Builder Evolution
 
 Features:
 
-- **Category Taxonomy Expansion** — Future expansion beyond current 8 categories to include Network, Compute, Data, Messaging, Security, and Edge
+- **Category Taxonomy Expansion** — Future expansion beyond current 10 categories to include Network, Compute, Data, Messaging, Security, and Edge
 - **Shape System** — Unique geometries: Tower (compute), Heavy Block (database/storage), Shield (gateway), Module (function/queue/event)
 - **Height System** — Tiered side wall heights (low/mid/high) to indicate resource scale or tier
 - **Visual Tokens** — Formal extraction of radius, shadow, border, and surface design tokens

--- a/docs/concept/UI_FLOW.md
+++ b/docs/concept/UI_FLOW.md
@@ -46,7 +46,7 @@ Plates are placed via the Insert menu or by dragging from the CommandCard palett
 
 ### Blocks (Cloud Resources)
 
-8 resource categories, placed inside plates:
+10 resource categories, placed inside plates:
 
 | Category | Examples | Initiator? |
 |----------|----------|-----------|
@@ -57,7 +57,9 @@ Plates are placed via the Insert menu or by dragging from the CommandCard palett
 | **Function** | Azure Function, Lambda | Yes |
 | **Queue** | Service Bus, SQS | Yes |
 | **Event** | Event Grid, EventBridge | Yes |
-| **Timer** | Scheduled trigger | Yes |
+| **Analytics** | Log Analytics, CloudWatch | No (receiver-only) |
+| **Identity** | Entra ID, IAM | No (receiver-only) |
+| **Observability** | Azure Monitor, CloudWatch | No (receiver-only) |
 
 Blocks are created by dragging from the **CommandCard** palette in the Bottom Panel, or via `Insert` menu.
 

--- a/docs/design/GRAPH_IR_SPEC.md
+++ b/docs/design/GRAPH_IR_SPEC.md
@@ -258,7 +258,7 @@ Recommended derived ports:
 - `in:data` (protocols: `data`)
 - No outbound ports in Phase 1 (enforces receiver-only invariant)
 
-### 5.6 Serverless categories (Function/Queue/Event/Timer)
+### 5.6 Serverless categories (Function/Queue/Event)
 
 Recommended derived ports (Phase 1 compatibility, Phase 6+ usage):
 
@@ -267,7 +267,7 @@ Recommended derived ports (Phase 1 compatibility, Phase 6+ usage):
   - `in:async` (protocols: `async`)
   - `out:data` (protocols: `data`)
   - `out:async` (protocols: `async`)
-- Queue/Event/Timer:
+- Queue/Event:
   - Primarily `async` semantics
 
 Note: Phase 1 may derive only a conservative subset and leave protocol as `unknown` when not inferable from the legacy model.

--- a/docs/design/VALIDATION_CONTRACT.md
+++ b/docs/design/VALIDATION_CONTRACT.md
@@ -94,7 +94,20 @@ Connection rules validate dataflow between blocks. Connections follow **initiato
 
 ## 5. Aggregation Rules
 
-Validation for block clusters and aggregations.
+Validation for block aggregation (scaling/clustering) configuration.
+
+| Rule ID | Severity | Condition | Message |
+|---------|----------|-----------|---------|
+| `rule-aggregation-count` | error | `block.aggregation.count < 1` or count is not an integer | Aggregation count must be a positive integer |
+
+### Implementation References
+
+- **Frontend**: `apps/web/src/entities/validation/aggregation.ts`
+- **Backend**: Not yet implemented (planned for Milestone 6)
+
+### 5.1 Application Placement Rules (Planned — Not Yet Implemented)
+
+> **Status: Planned.** The Application entity and its placement rules are designed but have no corresponding implementation. The rules below describe the intended behavior for a future milestone. See [DOMAIN_MODEL.md §4.5](../model/DOMAIN_MODEL.md#45-application) for the Application entity design.
 
 | Rule ID | Severity | Condition | Message |
 |---------|----------|-----------|---------|
@@ -123,7 +136,7 @@ Validation for block clusters and aggregations.
 | Managed Redis (ElastiCache) | `database` block alone | `database` + redis app ❌ |
 | Self-hosted Redis on VM | `compute` block + `redis` app | `database` + redis app ❌ |
 
-### Implementation References
+### Implementation References (Application)
 
 - **Frontend**: `apps/web/src/entities/validation/application.ts` (planned)
 - **Backend**: Not yet implemented (planned for Milestone 6)

--- a/docs/model/DOMAIN_MODEL.md
+++ b/docs/model/DOMAIN_MODEL.md
@@ -47,7 +47,7 @@ These invariants **must hold at all times** in a valid `ArchitectureModel`. Viol
 
 | Rule | Description |
 |------|-------------|
-| **Single Root** | An `ArchitectureModel` has exactly one root Network Plate (`parentId: null`). All other Plates and Blocks are descendants. |
+| **Root Plates** | An `ArchitectureModel` has one or more root Plates (`parentId: null`). Valid root plate types are `global` and `edge`. All other Plates and Blocks are descendants of root plates. |
 | **Containment Hierarchy** | Plates form a strict tree across plate layers (`global`/`edge` roots, then `region` → `zone` → `subnet`). No cycles in the containment tree. |
 | **Block Placement** | Every Block has a `placementId` referencing a Plate. `compute`, `database`, `storage`, `gateway`, `analytics`, `identity`, and `observability` are placed on Subnet Plates; `function`, `queue`, and `event` are placed on Region Plates. Blocks cannot exist outside the hierarchy. |
 | **Children Consistency** | A Plate's `children[]` must match the set of entities whose `parentId` or `placementId` references that Plate. |
@@ -59,7 +59,7 @@ These invariants **must hold at all times** in a valid `ArchitectureModel`. Viol
 | **No Self-Connections** | `connection.sourceId !== connection.targetId`. |
 | **No Duplicate Connections** | UI/domain store operations prevent adding duplicate ordered pairs `(sourceId, targetId)` during connection creation. |
 | **No Cycles (Planned Validation)** | The intended architecture constraint is a DAG-style flow, but explicit cycle detection is planned rather than fully enforced in validation rules today. |
-| **Receiver-Only Enforcement** | `database` and `storage` blocks never appear as `sourceId` in any connection. They are receiver-only. `queue` and `event` may appear as `sourceId` only when targeting `function`. |
+| **Receiver-Only Enforcement** | `database`, `storage`, `analytics`, `identity`, and `observability` blocks never appear as `sourceId` in any connection. They are receiver-only. `queue` and `event` may appear as `sourceId` only when targeting `function`. |
 
 ---
 
@@ -260,6 +260,10 @@ Block
   position      — position relative to parent plate {x, y, z}
   metadata      — additional properties
   provider?: ProviderType  — optional cloud provider
+  subtype?: string  — provider-specific resource subtype (e.g., 'vm', 'container-app')
+  config?: Record<string, unknown>  — provider-specific configuration
+  aggregation?: Aggregation  — cluster/scaling configuration (mode + count)
+  roles?: BlockRole[]  — identity and access management roles
 ```
 
 Example:

--- a/docs/model/STORAGE_ARCHITECTURE.md
+++ b/docs/model/STORAGE_ARCHITECTURE.md
@@ -113,7 +113,7 @@ my-cloud-project/
         "blocks": [],
         "connections": [],
         "externalActors": [
-          { "id": "ext-internet", "name": "Internet", "type": "internet" }
+          { "id": "ext-internet", "name": "Internet", "type": "internet", "position": { "x": -3, "y": 0, "z": 5 } }
         ],
         "createdAt": "2025-01-01T00:00:00Z",
         "updatedAt": "2025-01-01T00:00:00Z"


### PR DESCRIPTION
## Summary

Fixes #384 — Resolves 8 remaining doc-code discrepancies found during exhaustive line-by-line deep audit of all canonical documentation against source code.

## Changes (6 files, 8 fixes)

### UI_FLOW.md
- Block count "8 resource categories" → "10 resource categories"
- Removed stale `Timer` row from block table (not a valid `BlockCategory`)
- Added missing `analytics`, `identity`, `observability` rows

### GRAPH_IR_SPEC.md
- §5.6 heading: "Function/Queue/Event/Timer" → "Function/Queue/Event"
- §5.6 body: "Queue/Event/Timer" → "Queue/Event"

### DOMAIN_MODEL.md
- §5 Block Structure: added missing optional fields (`subtype?`, `config?`, `aggregation?`, `roles?`) to match `types/index.ts`
- §2.2: "Single Root" invariant → "Root Plates" — code allows both `global` and `edge` as root plates via `VALID_PARENTS`
- §2.3: receiver-only list expanded from "database and storage" to include `analytics`, `identity`, `observability` (matches §6 and code)

### VALIDATION_CONTRACT.md
- §5: Added actual implemented aggregation rule (`rule-aggregation-count`: count ≥ 1, integer)
- Separated planned Application placement rules into §5.1 with explicit "Planned — Not Yet Implemented" status marker

### ROADMAP.md
- Phase 4: "8 categories" → "10 categories"

### STORAGE_ARCHITECTURE.md
- ExternalActor JSON example: added missing `position` field required by `types/index.ts`

## Verification

All changes verified against source code:
- `apps/web/src/shared/types/index.ts` — BlockCategory (10 values), Block interface (5 optional fields), ExternalActor (position required)
- `apps/web/src/entities/validation/connection.ts` — ALLOWED_CONNECTIONS (receiver-only: database, storage, analytics, identity, observability)
- `apps/web/src/entities/validation/placement.ts` — VALID_PARENTS (global/edge both have `[]` = root)
- `apps/web/src/entities/validation/aggregation.ts` — `rule-aggregation-count` (count ≥ 1, integer)