### PR TITLE
feat: Lego-themed docs site with 3-column layout

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,5 @@
+{# Extends the Material for MkDocs base template #}
+{% extends "base.html" %}
+
+{# Empty overrides file — reserves the custom_dir for future branding #}
+{# Add partial overrides (header, footer, etc.) in partials/ as needed #}

--- a/docs/stylesheets/lego-theme.css
+++ b/docs/stylesheets/lego-theme.css
@@ -1,0 +1,510 @@
+/* =============================================================================
+   CloudBlocks Lego Documentation Theme
+   "Subtle Lego" — brand-consistent colors, playful typography, warm backgrounds
+   Overrides MkDocs Material CSS variables with CloudBlocks Lego design tokens
+   ============================================================================= */
+
+/* ---------------------------------------------------------------------------
+   0. Lego Design Tokens (matching apps/web/src/app/index.css)
+   --------------------------------------------------------------------------- */
+
+:root {
+  /* Lego Primary Palette */
+  --lego-red: #E3000B;
+  --lego-red-dark: #B80009;
+  --lego-red-light: #FF3333;
+  --lego-yellow: #FFD500;
+  --lego-yellow-dark: #D4B200;
+  --lego-yellow-light: #FFE44D;
+  --lego-blue: #0055BF;
+  --lego-blue-dark: #003D8A;
+  --lego-blue-light: #3385D6;
+  --lego-green: #00852B;
+  --lego-green-dark: #006622;
+  --lego-green-light: #00A63E;
+  --lego-orange: #FE8A18;
+  --lego-orange-dark: #D97200;
+  --lego-white: #FFFFFF;
+  --lego-black: #1B1B1B;
+
+  /* Baseplate & Panel */
+  --lego-baseplate: #D2B48C;
+  --lego-baseplate-dark: #C4A67A;
+  --lego-baseplate-light: #E0C9A6;
+  --lego-panel-bg: #FFF8E7;
+  --lego-panel-border: #FFD500;
+
+  /* Lego Shadows (chunky depth) */
+  --lego-shadow-panel: 0 4px 0 0 rgba(0, 0, 0, 0.12), 0 6px 16px rgba(0, 0, 0, 0.08);
+  --lego-shadow-btn: 0 3px 0 0 rgba(0, 0, 0, 0.18);
+  --lego-shadow-stud: inset 0 -2px 4px rgba(0, 0, 0, 0.15), 0 1px 2px rgba(255, 255, 255, 0.5);
+
+  /* Lego Radii (chunky, rounded) */
+  --lego-radius-lg: 16px;
+  --lego-radius-md: 10px;
+  --lego-radius-sm: 6px;
+  --lego-radius-pill: 20px;
+}
+
+/* ---------------------------------------------------------------------------
+   1. Light Mode — MkDocs Material CSS Variable Overrides
+   --------------------------------------------------------------------------- */
+
+[data-md-color-scheme="default"] {
+  /* Primary = Lego Blue */
+  --md-primary-fg-color: var(--lego-blue);
+  --md-primary-fg-color--light: var(--lego-blue-light);
+  --md-primary-fg-color--dark: var(--lego-blue-dark);
+  --md-primary-bg-color: var(--lego-white);
+  --md-primary-bg-color--light: var(--lego-panel-bg);
+
+  /* Accent = Lego Yellow */
+  --md-accent-fg-color: var(--lego-orange);
+  --md-accent-fg-color--transparent: rgba(254, 138, 24, 0.1);
+  --md-accent-bg-color: var(--lego-yellow);
+  --md-accent-bg-color--light: var(--lego-yellow-light);
+
+  /* Background = warm panel */
+  --md-default-bg-color: var(--lego-panel-bg);
+  --md-default-bg-color--light: #FFF4D6;
+  --md-default-bg-color--lighter: #FFFCF0;
+  --md-default-bg-color--lightest: var(--lego-white);
+
+  /* Text */
+  --md-default-fg-color: var(--lego-black);
+  --md-default-fg-color--light: rgba(27, 27, 27, 0.7);
+  --md-default-fg-color--lighter: rgba(27, 27, 27, 0.42);
+  --md-default-fg-color--lightest: rgba(27, 27, 27, 0.12);
+
+  /* Footer */
+  --md-footer-bg-color: var(--lego-blue-dark);
+  --md-footer-bg-color--dark: #002A5F;
+  --md-footer-fg-color: var(--lego-white);
+  --md-footer-fg-color--light: rgba(255, 255, 255, 0.7);
+  --md-footer-fg-color--lighter: rgba(255, 255, 255, 0.5);
+
+  /* Code */
+  --md-code-bg-color: #FFF4D6;
+  --md-code-fg-color: var(--lego-black);
+  --md-code-hl-color: rgba(255, 213, 0, 0.3);
+
+  /* Typeset links */
+  --md-typeset-a-color: var(--lego-blue);
+}
+
+/* ---------------------------------------------------------------------------
+   2. Dark Mode — Lego Dark Palette
+   --------------------------------------------------------------------------- */
+
+[data-md-color-scheme="slate"] {
+  /* Tune the hue toward a warm tone */
+  --md-hue: 35;
+
+  /* Primary = Lego Blue (brighter for contrast on dark) */
+  --md-primary-fg-color: var(--lego-blue-light);
+  --md-primary-fg-color--light: #5599DD;
+  --md-primary-fg-color--dark: var(--lego-blue);
+  --md-primary-bg-color: #1E1E1E;
+  --md-primary-bg-color--light: #2A2520;
+
+  /* Accent = Lego Yellow */
+  --md-accent-fg-color: var(--lego-yellow);
+  --md-accent-fg-color--transparent: rgba(255, 213, 0, 0.1);
+  --md-accent-bg-color: var(--lego-yellow-dark);
+
+  /* Background = dark baseplate */
+  --md-default-bg-color: #1A1714;
+  --md-default-bg-color--light: #221E1A;
+  --md-default-bg-color--lighter: #2D2822;
+  --md-default-bg-color--lightest: #38322A;
+
+  /* Text */
+  --md-default-fg-color: #E8E0D4;
+  --md-default-fg-color--light: rgba(232, 224, 212, 0.7);
+  --md-default-fg-color--lighter: rgba(232, 224, 212, 0.42);
+  --md-default-fg-color--lightest: rgba(232, 224, 212, 0.12);
+
+  /* Footer */
+  --md-footer-bg-color: #0D0B08;
+  --md-footer-bg-color--dark: #060504;
+
+  /* Code */
+  --md-code-bg-color: #2D2822;
+  --md-code-fg-color: #E8E0D4;
+  --md-code-hl-color: rgba(255, 213, 0, 0.15);
+
+  /* Typeset links */
+  --md-typeset-a-color: var(--lego-blue-light);
+}
+
+/* ---------------------------------------------------------------------------
+   3. Typography — Lego Headings
+   --------------------------------------------------------------------------- */
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-typeset h5,
+.md-typeset h6 {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+/* h1 — Lego Red accent underline */
+.md-typeset h1 {
+  font-weight: 700;
+  color: var(--lego-blue-dark);
+  border-bottom: 3px solid var(--lego-red);
+  padding-bottom: 0.3em;
+  margin-bottom: 0.8em;
+}
+
+[data-md-color-scheme="slate"] .md-typeset h1 {
+  color: var(--lego-yellow);
+  border-bottom-color: var(--lego-red);
+}
+
+/* h2 — Stud accent divider */
+.md-typeset h2 {
+  position: relative;
+  padding-bottom: 0.4em;
+  margin-top: 1.6em;
+  border-bottom: 2px solid var(--lego-yellow);
+}
+
+.md-typeset h2::after {
+  content: "";
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  background-image:
+    radial-gradient(ellipse 8px 4px at 8px 2px, var(--lego-yellow) 60%, transparent 60%);
+  background-size: 20px 4px;
+  background-repeat: repeat-x;
+  opacity: 0.5;
+}
+
+[data-md-color-scheme="slate"] .md-typeset h2 {
+  border-bottom-color: var(--lego-yellow-dark);
+}
+
+[data-md-color-scheme="slate"] .md-typeset h2::after {
+  background-image:
+    radial-gradient(ellipse 8px 4px at 8px 2px, var(--lego-yellow-dark) 60%, transparent 60%);
+}
+
+/* h3 — Lego green left accent */
+.md-typeset h3 {
+  border-left: 4px solid var(--lego-green);
+  padding-left: 0.6em;
+}
+
+[data-md-color-scheme="slate"] .md-typeset h3 {
+  border-left-color: var(--lego-green-light);
+}
+
+/* ---------------------------------------------------------------------------
+   4. Header — Lego Blue with Chunky Style
+   --------------------------------------------------------------------------- */
+
+.md-header {
+  background-color: var(--lego-blue);
+  box-shadow: 0 4px 0 0 var(--lego-blue-dark), 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+[data-md-color-scheme="slate"] .md-header {
+  background-color: #1A1714;
+  box-shadow: 0 4px 0 0 #0D0B08, 0 6px 12px rgba(0, 0, 0, 0.3);
+}
+
+.md-header__title {
+  font-weight: 700;
+}
+
+/* ---------------------------------------------------------------------------
+   5. Navigation Sidebar — Warm Panel
+   --------------------------------------------------------------------------- */
+
+.md-sidebar {
+  border-radius: 0;
+}
+
+/* Left nav styling */
+.md-sidebar--primary .md-sidebar__inner {
+  border-right: 2px solid var(--md-default-fg-color--lightest);
+}
+
+.md-nav__link {
+  border-radius: var(--lego-radius-sm);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.md-nav__link:hover {
+  background-color: var(--md-accent-fg-color--transparent);
+}
+
+.md-nav__item--active > .md-nav__link {
+  font-weight: 600;
+  color: var(--lego-blue);
+}
+
+[data-md-color-scheme="slate"] .md-nav__item--active > .md-nav__link {
+  color: var(--lego-yellow);
+}
+
+/* Section labels */
+.md-nav--primary .md-nav__title {
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+}
+
+/* ---------------------------------------------------------------------------
+   6. Content Area — Readable with Subtle Lego Accents
+   --------------------------------------------------------------------------- */
+
+/* Tables — rounded with Lego borders */
+.md-typeset table:not([class]) {
+  border: 2px solid var(--md-default-fg-color--lightest);
+  border-radius: var(--lego-radius-md);
+  overflow: hidden;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.md-typeset table:not([class]) th {
+  background-color: var(--lego-blue);
+  color: var(--lego-white);
+  font-weight: 600;
+  border-bottom: 3px solid var(--lego-blue-dark);
+}
+
+[data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
+  background-color: var(--lego-blue-dark);
+  border-bottom-color: #001F4D;
+}
+
+.md-typeset table:not([class]) td {
+  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+}
+
+.md-typeset table:not([class]) tr:last-child td {
+  border-bottom: none;
+}
+
+.md-typeset table:not([class]) tr:hover td {
+  background-color: var(--md-accent-fg-color--transparent);
+}
+
+/* Code blocks — warm background */
+.md-typeset pre > code {
+  border-radius: var(--lego-radius-md);
+  border: 1px solid var(--md-default-fg-color--lightest);
+}
+
+/* Inline code */
+.md-typeset code {
+  border-radius: var(--lego-radius-sm);
+  background-color: var(--md-code-bg-color);
+  padding: 0.1em 0.4em;
+  font-size: 0.85em;
+}
+
+/* ---------------------------------------------------------------------------
+   7. Admonitions — Lego-Themed
+   --------------------------------------------------------------------------- */
+
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: var(--lego-radius-md);
+  border-width: 2px;
+  box-shadow: 0 2px 0 0 rgba(0, 0, 0, 0.08);
+}
+
+.md-typeset .admonition-title,
+.md-typeset summary {
+  font-weight: 600;
+  border-radius: var(--lego-radius-md) var(--lego-radius-md) 0 0;
+}
+
+/* Note → Lego Blue */
+.md-typeset .admonition.note,
+.md-typeset details.note {
+  border-color: var(--lego-blue);
+}
+
+/* Tip → Lego Green */
+.md-typeset .admonition.tip,
+.md-typeset details.tip {
+  border-color: var(--lego-green);
+}
+
+/* Warning → Lego Orange */
+.md-typeset .admonition.warning,
+.md-typeset details.warning {
+  border-color: var(--lego-orange);
+}
+
+/* Danger → Lego Red */
+.md-typeset .admonition.danger,
+.md-typeset details.danger {
+  border-color: var(--lego-red);
+}
+
+/* Info → lighter Blue */
+.md-typeset .admonition.info,
+.md-typeset details.info {
+  border-color: var(--lego-blue-light);
+}
+
+/* ---------------------------------------------------------------------------
+   8. Buttons & Search — Chunky Lego Style
+   --------------------------------------------------------------------------- */
+
+/* Search bar */
+.md-search__input {
+  border-radius: var(--lego-radius-pill);
+  background-color: rgba(255, 255, 255, 0.15);
+}
+
+.md-search__input:focus {
+  background-color: var(--lego-white);
+  color: var(--lego-black);
+}
+
+/* Header tabs (if enabled) */
+.md-tabs {
+  background-color: var(--lego-blue-dark);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
+.md-tabs__link--active {
+  font-weight: 600;
+}
+
+/* ---------------------------------------------------------------------------
+   9. Footer — Lego Dark Blue
+   --------------------------------------------------------------------------- */
+
+.md-footer {
+  border-top: 4px solid var(--lego-yellow);
+}
+
+.md-footer-meta {
+  background-color: var(--md-footer-bg-color--dark);
+}
+
+/* ---------------------------------------------------------------------------
+   10. Stud Pattern Decorative Accent (subtle)
+   --------------------------------------------------------------------------- */
+
+/* Stud row below header — subtle brick-top texture */
+.md-header::after {
+  content: "";
+  display: block;
+  height: 6px;
+  background-image:
+    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 255, 255, 0.15) 50%, transparent 50%);
+  background-size: 16px 6px;
+  background-repeat: repeat-x;
+  background-position: 0 0;
+}
+
+/* Stud row above footer */
+.md-footer::before {
+  content: "";
+  display: block;
+  height: 6px;
+  background-image:
+    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 213, 0, 0.3) 50%, transparent 50%);
+  background-size: 16px 6px;
+  background-repeat: repeat-x;
+  background-position: 0 0;
+}
+
+/* ---------------------------------------------------------------------------
+   11. Scrollbar — Lego Themed (optional, Webkit)
+   --------------------------------------------------------------------------- */
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--md-default-bg-color--light);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--lego-baseplate);
+  border-radius: var(--lego-radius-sm);
+  border: 2px solid var(--md-default-bg-color--light);
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: var(--lego-baseplate-dark);
+}
+
+/* ---------------------------------------------------------------------------
+   12. Selection & Focus — Lego Yellow Highlight
+   --------------------------------------------------------------------------- */
+
+::selection {
+  background-color: rgba(255, 213, 0, 0.35);
+  color: var(--lego-black);
+}
+
+.md-typeset a:focus,
+.md-nav__link:focus-visible {
+  outline: 2px solid var(--lego-yellow);
+  outline-offset: 2px;
+  border-radius: var(--lego-radius-sm);
+}
+
+/* ---------------------------------------------------------------------------
+   13. 3-Column Layout Polish
+   --------------------------------------------------------------------------- */
+
+/* Ensure right ToC sidebar has visual separation */
+.md-sidebar--secondary .md-sidebar__inner {
+  border-left: 2px solid var(--md-default-fg-color--lightest);
+  padding-left: 0.8rem;
+}
+
+/* ToC active item highlight */
+.md-nav--secondary .md-nav__link--active {
+  color: var(--lego-blue);
+  font-weight: 600;
+  border-left: 3px solid var(--lego-yellow);
+  padding-left: 0.6em;
+  margin-left: -3px;
+}
+
+[data-md-color-scheme="slate"] .md-nav--secondary .md-nav__link--active {
+  color: var(--lego-yellow);
+  border-left-color: var(--lego-orange);
+}
+
+/* ---------------------------------------------------------------------------
+   14. Print Styles — Clean output
+   --------------------------------------------------------------------------- */
+
+@media print {
+  .md-header,
+  .md-footer,
+  .md-sidebar {
+    display: none !important;
+  }
+
+  .md-typeset h1 {
+    border-bottom-color: #000;
+  }
+
+  .md-typeset h2::after {
+    display: none;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,18 +15,22 @@ validation:
 theme:
   name: material
   language: en
+  custom_dir: docs/overrides
+  font:
+    text: Fredoka
+    code: Roboto Mono
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: blue
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
@@ -36,6 +40,7 @@ theme:
     - navigation.sections
     - navigation.expand
     - navigation.top
+    - navigation.indexes
     - search.suggest
     - search.highlight
     - content.code.copy
@@ -45,6 +50,9 @@ theme:
 
 plugins:
   - search
+
+extra_css:
+  - stylesheets/lego-theme.css
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

- Apply "Subtle Lego" design language to MkDocs Material documentation site — Lego color tokens, Fredoka font, warm cream/baseplate backgrounds, stud-pattern accents on headers and dividers
- Enable and style 3-column layout (left nav + content + right ToC sidebar) with proper borders and active-item highlighting  
- Full light/dark mode support with themed tables, admonitions, code blocks, and blockquotes

## Changes

| File | Description |
|------|-------------|
| `docs/stylesheets/lego-theme.css` | 510-line custom CSS — design tokens, light/dark schemes, typography, tables, admonitions, stud accents, 3-column polish |
| `mkdocs.yml` | Updated theme config — Fredoka font, custom palette, `custom_dir`, `navigation.indexes`, extra_css |
| `docs/overrides/main.html` | Jinja template override placeholder for future header branding |

## Visual Verification

Tested locally with `mkdocs serve` — verified on both light and dark modes:
- ✅ 3-column layout (left nav, content, right ToC)
- ✅ Lego Blue header with stud-pattern border
- ✅ Fredoka font on headings
- ✅ Warm cream background (light) / dark baseplate (dark)
- ✅ Red h1 underline, yellow stud-pattern h2 dividers
- ✅ Blue table headers with rounded corners
- ✅ Active nav item yellow highlight (dark mode)
- ✅ `mkdocs build --strict` passes

## Related Issues

- Epic: #398
- Closes #399 — Create Lego theme custom CSS
- Closes #400 — Update mkdocs.yml for Lego theme and 3-column layout  
- Closes #401 — Add docs theme overrides for Lego header branding

## Milestone

Milestone 16 — Documentation Architecture & Canonical Cleanup