### PR TITLE
fix(api): remove unreachable except LLMError in suggest route

### DIFF
--- a/apps/api/app/api/routes/ai.py
+++ b/apps/api/app/api/routes/ai.py
@@ -101,11 +101,7 @@ async def suggest_improvements(
         timeout=settings.llm_request_timeout,
     )
     engine = SuggestionEngine(client)
-
-    try:
-        return await engine.analyze(request.architecture, request.provider)
-    except LLMError as exc:
-        raise GenerationError(f"AI suggestion failed: {exc}") from exc
+    return await engine.analyze(request.architecture, request.provider)
 
 
 SUBTYPE_TO_TF_RESOURCE: dict[str, str] = {


### PR DESCRIPTION
## Summary

- Remove dead code in `/api/v1/ai/suggest` route: the `try/except LLMError` wrapper around `engine.analyze()` was unreachable because `SuggestionEngine.analyze()` already catches `LLMError` internally and returns an empty `AISuggestionsResponse()`

## Details

**Before** (ai.py L103-108):
```python
engine = SuggestionEngine(client)
try:
    return await engine.analyze(request.architecture, request.provider)
except LLMError as exc:  # ← unreachable
    raise GenerationError(f"AI suggestion failed: {exc}") from exc
```

**After**:
```python
engine = SuggestionEngine(client)
return await engine.analyze(request.architecture, request.provider)
```

The `LLMError` import is retained because the `generate` route still uses it.

## Verification

- All 14 E2E tests pass ✅
- All 10 AI route tests pass ✅
- `ruff check` clean ✅
- No behavior change — the removed code was never reachable

## Context

Found during deep review of PR #407.

Closes #408