### PR TITLE
docs: add live demo link to README, update repo homepage to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 Design cloud infrastructure by placing blocks on plates, connect components, validate against real-world rules, and generate Terraform, Bicep, or Pulumi — all from the browser. No YAML. No HCL. Just place, connect, validate, generate.
 
+> **[▶ Try the Live Demo](https://yeongseon.github.io/cloudblocks/)** — Frontend-only playground. Visual builder, code generation, and templates work instantly. AI and GitHub features require the backend ([setup guide](docs/guides/TUTORIALS.md)).
+
 ## Why CloudBlocks?
 
 Most IaC tools work **code → diagram** (visualize existing infra). CloudBlocks works **architecture → code** (model visually, compile to infra).


### PR DESCRIPTION
## Summary

- Add "Try the Live Demo" blockquote link after hero image in README with frontend-only disclaimer
- Repo homepage (About section) updated from SPA root to docs site (`/cloudblocks/docs/`)
- Clarifies that AI and GitHub features require the backend, while visual builder, code generation, and templates work instantly

## Changes

| Item | Before | After |
|------|--------|-------|
| GitHub About link | `https://yeongseon.github.io/cloudblocks/` (SPA) | `https://yeongseon.github.io/cloudblocks/docs/` (docs) |
| README demo link | None | Blockquote with demo link + disclaimer |

## Why

Users clicking the repo homepage link land on the SPA demo with no context — they can't tell it's frontend-only and backend-dependent features (AI, GitHub) silently fail. Pointing homepage to docs gives first-time visitors proper context, while the README demo link lets interested users jump straight to the playground.