### PR TITLE
style(docs): improve dark mode readability for documentation site

### DIFF
--- a/docs/stylesheets/lego-theme.css
+++ b/docs/stylesheets/lego-theme.css
@@ -97,44 +97,44 @@
    --------------------------------------------------------------------------- */
 
 [data-md-color-scheme="slate"] {
-  /* Tune the hue toward a warm tone */
-  --md-hue: 35;
+  /* Neutral hue — no warm/brown tint */
+  --md-hue: 220;
 
   /* Primary = Lego Blue (brighter for contrast on dark) */
   --md-primary-fg-color: var(--lego-blue-light);
   --md-primary-fg-color--light: #5599DD;
   --md-primary-fg-color--dark: var(--lego-blue);
-  --md-primary-bg-color: #1E1E1E;
-  --md-primary-bg-color--light: #2A2520;
+  --md-primary-bg-color: #1a1a2e;
+  --md-primary-bg-color--light: #22223a;
 
-  /* Accent = Lego Yellow */
-  --md-accent-fg-color: var(--lego-yellow);
-  --md-accent-fg-color--transparent: rgba(255, 213, 0, 0.1);
-  --md-accent-bg-color: var(--lego-yellow-dark);
+  /* Accent = Lego Blue-Light (subtle, not yellow) */
+  --md-accent-fg-color: var(--lego-blue-light);
+  --md-accent-fg-color--transparent: rgba(51, 133, 214, 0.1);
+  --md-accent-bg-color: var(--lego-blue);
 
-  /* Background = dark baseplate */
-  --md-default-bg-color: #1A1714;
-  --md-default-bg-color--light: #221E1A;
-  --md-default-bg-color--lighter: #2D2822;
-  --md-default-bg-color--lightest: #38322A;
+  /* Background = neutral dark (no brown) */
+  --md-default-bg-color: #1a1a2e;
+  --md-default-bg-color--light: #20203a;
+  --md-default-bg-color--lighter: #2a2a44;
+  --md-default-bg-color--lightest: #35354f;
 
-  /* Text */
-  --md-default-fg-color: #E8E0D4;
-  --md-default-fg-color--light: rgba(232, 224, 212, 0.7);
-  --md-default-fg-color--lighter: rgba(232, 224, 212, 0.42);
-  --md-default-fg-color--lightest: rgba(232, 224, 212, 0.12);
+  /* Text = high-contrast neutral white */
+  --md-default-fg-color: #e0e0e8;
+  --md-default-fg-color--light: rgba(224, 224, 232, 0.72);
+  --md-default-fg-color--lighter: rgba(224, 224, 232, 0.42);
+  --md-default-fg-color--lightest: rgba(224, 224, 232, 0.12);
 
   /* Footer */
-  --md-footer-bg-color: #0D0B08;
-  --md-footer-bg-color--dark: #060504;
+  --md-footer-bg-color: #12121f;
+  --md-footer-bg-color--dark: #0a0a14;
 
   /* Code */
-  --md-code-bg-color: #2D2822;
-  --md-code-fg-color: #E8E0D4;
-  --md-code-hl-color: rgba(255, 213, 0, 0.15);
+  --md-code-bg-color: #22223a;
+  --md-code-fg-color: #e0e0e8;
+  --md-code-hl-color: rgba(51, 133, 214, 0.2);
 
   /* Typeset links */
-  --md-typeset-a-color: var(--lego-blue-light);
+  --md-typeset-a-color: #6eaaef;
 }
 
 /* ---------------------------------------------------------------------------
@@ -161,8 +161,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset h1 {
-  color: var(--lego-yellow);
-  border-bottom-color: var(--lego-red);
+  color: #f0f0f5;
+  border-bottom-color: var(--lego-blue-light);
 }
 
 /* h2 — Stud accent divider */
@@ -188,12 +188,11 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset h2 {
-  border-bottom-color: var(--lego-yellow-dark);
+  border-bottom-color: rgba(224, 224, 232, 0.15);
 }
 
 [data-md-color-scheme="slate"] .md-typeset h2::after {
-  background-image:
-    radial-gradient(ellipse 8px 4px at 8px 2px, var(--lego-yellow-dark) 60%, transparent 60%);
+  display: none;
 }
 
 /* h3 — Lego green left accent */
@@ -216,8 +215,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-header {
-  background-color: #1A1714;
-  box-shadow: 0 4px 0 0 #0D0B08, 0 6px 12px rgba(0, 0, 0, 0.3);
+  background-color: #12121f;
+  box-shadow: 0 4px 0 0 #0a0a14, 0 6px 12px rgba(0, 0, 0, 0.3);
 }
 
 .md-header__title {
@@ -252,7 +251,7 @@
 }
 
 [data-md-color-scheme="slate"] .md-nav__item--active > .md-nav__link {
-  color: var(--lego-yellow);
+  color: var(--lego-blue-light);
 }
 
 /* Section labels */
@@ -284,8 +283,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset table:not([class]) th {
-  background-color: var(--lego-blue-dark);
-  border-bottom-color: #001F4D;
+  background-color: var(--lego-blue);
+  border-bottom-color: var(--lego-blue-dark);
 }
 
 .md-typeset table:not([class]) td {
@@ -439,7 +438,7 @@
    --------------------------------------------------------------------------- */
 
 .md-footer {
-  border-top: 4px solid var(--lego-yellow);
+  border-top: 2px solid var(--lego-yellow);
 }
 
 .md-footer-meta {
@@ -454,10 +453,10 @@
 .md-header::after {
   content: "";
   display: block;
-  height: 6px;
+  height: 4px;
   background-image:
-    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 255, 255, 0.15) 50%, transparent 50%);
-  background-size: 16px 6px;
+    radial-gradient(ellipse 5px 2px at 5px 2px, rgba(255, 255, 255, 0.1) 50%, transparent 50%);
+  background-size: 14px 4px;
   background-repeat: repeat-x;
   background-position: 0 0;
 }
@@ -466,10 +465,10 @@
 .md-footer::before {
   content: "";
   display: block;
-  height: 6px;
+  height: 4px;
   background-image:
-    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 213, 0, 0.3) 50%, transparent 50%);
-  background-size: 16px 6px;
+    radial-gradient(ellipse 5px 2px at 5px 2px, rgba(255, 213, 0, 0.15) 50%, transparent 50%);
+  background-size: 14px 4px;
   background-repeat: repeat-x;
   background-position: 0 0;
 }
@@ -513,6 +512,11 @@
   border-radius: var(--lego-radius-sm);
 }
 
+[data-md-color-scheme="slate"] .md-typeset a:focus,
+[data-md-color-scheme="slate"] .md-nav__link:focus-visible {
+  outline-color: var(--lego-blue-light);
+}
+
 /* ---------------------------------------------------------------------------
    13. 3-Column Layout Polish
    --------------------------------------------------------------------------- */
@@ -533,8 +537,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-nav--secondary .md-nav__link--active {
-  color: var(--lego-yellow);
-  border-left-color: var(--lego-orange);
+  color: var(--lego-blue-light);
+  border-left-color: var(--lego-blue);
 }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace harsh yellow headings and stud decorations with clean neutral tones in dark mode
- Improve text contrast and background colors for better readability
- Keep subtle Lego hints (blue accents, green h3 border, stud texture at reduced opacity)

## Changes

| Element | Before | After |
|---------|--------|-------|
| h1 color | `--lego-yellow` (gold) | `#f0f0f5` (bright white) |
| h1 underline | `--lego-red` | `--lego-blue-light` (subtle blue) |
| h2 underline | Yellow + stud dot pattern | Thin gray line, no stud pattern |
| Background | `#1A1714` (warm brown) | `#1a1a2e` (neutral dark blue) |
| Body text | `#E8E0D4` (warm) | `#e0e0e8` (neutral white) |
| Accent color | Yellow (`--lego-yellow`) | Blue (`--lego-blue-light`) |
| Nav active | Yellow | Blue |
| Table header | `--lego-blue-dark` | `--lego-blue` (slightly brighter) |
| Stud decorations | 6px, 15-30% opacity | 4px, 10-15% opacity |
| Footer border | 4px yellow | 2px yellow |

## Why

The dark mode was optimized for Lego brand identity (gold headings, stud patterns, warm brown) at the cost of readability. Documentation should prioritize scanability — the Lego identity is preserved via subtle blue accents and reduced stud textures.