### PR TITLE
style(docs): fix dark mode tabs bar and heading borders

### DIFF
--- a/docs/stylesheets/lego-theme.css
+++ b/docs/stylesheets/lego-theme.css
@@ -162,7 +162,7 @@
 
 [data-md-color-scheme="slate"] .md-typeset h1 {
   color: #f0f0f5;
-  border-bottom-color: var(--lego-blue-light);
+  border-bottom-color: rgba(224, 224, 232, 0.3);
 }
 
 /* h2 — Stud accent divider */
@@ -188,7 +188,7 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset h2 {
-  border-bottom-color: rgba(224, 224, 232, 0.15);
+  border-bottom-color: rgba(224, 224, 232, 0.2);
 }
 
 [data-md-color-scheme="slate"] .md-typeset h2::after {
@@ -415,22 +415,22 @@
 
 /* Dark mode tabs — muted gold banner */
 [data-md-color-scheme="slate"] .md-tabs {
-  background-color: var(--lego-yellow-dark);
-  border-bottom-color: #B89800;
+  background-color: #20203a;
+  border-bottom-color: #2a2a44;
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link {
-  color: #1A1A2E;
+  color: rgba(224, 224, 232, 0.7);
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link:hover {
-  color: #1A1A2E;
-  background-color: rgba(255, 255, 255, 0.2);
+  color: #e0e0e8;
+  background-color: rgba(255, 255, 255, 0.06);
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link--active {
-  color: var(--lego-white);
-  box-shadow: inset 0 -3px 0 0 var(--lego-red-dark);
+  color: #e0e0e8;
+  box-shadow: inset 0 -2px 0 0 var(--lego-blue-light);
 }
 
 /* ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replace yellow/gold tabs bar with neutral dark background in dark mode
- Fix h1/h2 heading borders that were invisible against the dark background
- Active tab indicator changed from red-on-gold to blue underline

## Changes

| Element | Before | After |
|---------|--------|-------|
| Tabs bar bg | `--lego-yellow-dark` (gold) | `#20203a` (matches page bg) |
| Tab text | Dark text on gold | Light text on dark |
| Active tab | White text + red underline on gold | White text + blue underline |
| h1 border | `--lego-blue-light` (invisible) | `rgba(224,224,232,0.3)` (visible) |
| h2 border | `0.15` opacity | `0.2` opacity |

## Follow-up to
PR #412 — dark mode readability improvements