### PR TITLE
docs: user-centric restructure with Lego baseplate dark theme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,152 +1,141 @@
-# CloudBlocks Documentation Index
+# Welcome to CloudBlocks
 
-> **Reading Order**: concept → adr → model/design → engine → guides
+**CloudBlocks** is an architecture compiler — a visual IDE for cloud infrastructure that turns designs into infrastructure-as-code. Place blocks, connect resources, validate constraints, and generate Terraform, Bicep, or Pulumi — all from the browser.
 
----
+<div class="grid cards" markdown>
 
-## Getting Started Journey
+-   :material-rocket-launch:{ .lg .middle } **Quick Start**
 
-New to CloudBlocks? Follow this path:
+    ---
 
-| Step | What to Do | Link |
-|------|-----------|------|
-| 1. Try it | Open the builder and use a template | [Quick Start](../README.md#quick-start) |
-| 2. Learn | Follow a guided scenario in Learning Mode | [Tutorials](guides/TUTORIALS.md) |
-| 3. Build | Design your own architecture from scratch | [UI Flow](concept/UI_FLOW.md) |
-| 4. Generate | Export to Terraform, Bicep, or Pulumi | [Generator](engine/generator.md) |
-| 5. Deploy | Push to GitHub and trigger CI/CD | [Deployment](guides/DEPLOYMENT.md) |
+    Clone the repo, run `pnpm dev`, and open the builder in under 2 minutes.
 
----
+    [:octicons-arrow-right-24: Get started](guides/TUTORIALS.md)
 
-## Document Ownership
+-   :material-puzzle:{ .lg .middle } **Templates**
 
-| Status | Meaning |
-|--------|---------|
-| **Canonical** | Source of truth — code must conform |
-| **Canonical (v2.0 Target)** | Accepted v2.0 specification — not yet fully implemented |
-| **Superseded** | v1.x spec replaced by v2.0 — retained for reference |
-| **Supporting** | Reference material — links to canonical |
-| **Accepted** | Active decision — currently in effect |
-| **Historical** | Past decisions — do not update |
+    ---
 
----
+    Start from a pre-built architecture — three-tier web app, serverless API, or event pipeline.
 
-## 1. Concept (Start Here)
+    [:octicons-arrow-right-24: Browse templates](engine/templates.md)
 
-High-level product vision and roadmap.
+-   :material-code-braces:{ .lg .middle } **Code Generation**
 
-| Document | Status | Description |
-|----------|--------|-------------|
-| [PRD.md](concept/PRD.md) | Canonical | Product requirements |
-| [ROADMAP.md](concept/ROADMAP.md) | Canonical | Milestone timeline & milestones |
-| [ARCHITECTURE.md](concept/ARCHITECTURE.md) | Supporting | System architecture overview |
-| [UI_FLOW.md](concept/UI_FLOW.md) | Supporting | User interaction flows |
-| [M16_DOCUMENTATION_ARCHITECTURE.md](concept/M16_DOCUMENTATION_ARCHITECTURE.md) | Supporting | Documentation architecture & cleanup plan |
-| [M17_PRODUCT_STRUCTURE.md](concept/M17_PRODUCT_STRUCTURE.md) | Supporting | Product structure & package extraction plan |
-| [M18_DEVOPS_UX.md](concept/M18_DEVOPS_UX.md) | Supporting | DevOps UX & deployment orchestration plan |
+    ---
+
+    Export your design to Terraform, Bicep, or Pulumi with one click.
+
+    [:octicons-arrow-right-24: Learn how](engine/generator.md)
+
+-   :material-shield-check:{ .lg .middle } **Validation Rules**
+
+    ---
+
+    Real-time constraint checking ensures your architecture is valid before you export.
+
+    [:octicons-arrow-right-24: View rules](engine/rules.md)
+
+</div>
 
 ---
 
-## 2. Architecture Decision Records (ADR)
+## Your First Architecture in 5 Steps
 
-Immutable records of key decisions.
-
-| ADR | Status | Decision |
-|-----|--------|----------|
-| [0001](adr/0001-architecture-model-as-source-of-truth.md) | Accepted | Architecture model as source of truth |
-| [0002](adr/0002-git-native-storage.md) | Accepted | Git-native storage |
-| [0003](adr/0003-lego-style-composition-model.md) | Partially Superseded | Lego-style composition model |
-| [0004](adr/0004-rule-engine-architecture.md) | Accepted | Rule engine architecture |
-| [0005](adr/0005-2d-first-editor-with-25d-rendering.md) | Accepted | 2D-first with 2.5D rendering |
-| [0006](adr/0006-graph-ir-evolution-approach.md) | Accepted | Graph IR evolution approach |
-| [0007](adr/0007-multi-environment-deployment-strategy.md) | Accepted | Multi-environment deployment strategy |
-| [0008](adr/0008-v2-universal-architecture-specification.md) | Accepted | v2.0 Universal Architecture Specification |
-| [0009](adr/0009-ai-assisted-architecture.md) | Accepted | AI-assisted architecture |
+| Step | What You Do | Guide |
+|:----:|-------------|-------|
+| **1** | Install and launch the builder | [Installation](guides/DEPLOYMENT.md#quick-start) |
+| **2** | Follow a guided tutorial in Learning Mode | [Tutorials](guides/TUTORIALS.md) |
+| **3** | Design your own architecture | [Using the Editor](concept/UI_FLOW.md) |
+| **4** | Generate infrastructure code | [Code Generator](engine/generator.md) |
+| **5** | Deploy to your cloud environment | [Deployment](guides/DEPLOYMENT.md) |
 
 ---
 
-## 3. Domain Model
+## Key Concepts
 
-Core domain entities and rules.
+CloudBlocks uses a **Lego-style composition model** where everything snaps together:
 
-| Document | Status | Description |
-|----------|--------|-------------|
-| [DOMAIN_MODEL.md](model/DOMAIN_MODEL.md) | **Canonical** | Entities, invariants, type specs |
-| [STORAGE_ARCHITECTURE.md](model/STORAGE_ARCHITECTURE.md) | Canonical | Git-native storage design |
-| [ARCHITECTURE_MODEL_OVERVIEW.md](model/ARCHITECTURE_MODEL_OVERVIEW.md) | Supporting | DSL & pipeline overview |
+- **Plates** — Logical boundaries (VPC, resource group, subnet). Plates hold blocks.
+- **Blocks** — Cloud resources (VM, database, storage, function). Blocks sit on plates.
+- **Connections** — Typed links between blocks (network, data, event, IAM).
+- **Templates** — Pre-built architecture patterns you can load and customize.
 
-> **Code source of truth**: `apps/web/src/shared/types/index.ts`
-
----
-
-## 4. Design Specs
-
-Detailed visual and interaction specifications.
-
-| Document | Status | Description |
-|----------|--------|-------------|
-| [CLOUDBLOCKS_SPEC_V2.md](design/CLOUDBLOCKS_SPEC_V2.md) | **Canonical (v2.0 Target)** | v2.0 universal architecture specification — unified geometry, provider system, visual tokens |
-| [BRICK_DESIGN_SPEC.md](design/BRICK_DESIGN_SPEC.md) | Historical (Superseded) | v1.x merged brick design system (superseded by CLOUDBLOCKS_SPEC_V2.md) |
-| [VISUAL_DESIGN_SPEC.md](design/VISUAL_DESIGN_SPEC.md) | Historical (Superseded) | v1.x colors, geometry, materials (superseded by CLOUDBLOCKS_SPEC_V2.md) |
-| [VALIDATION_CONTRACT.md](design/VALIDATION_CONTRACT.md) | Canonical | Validation rule contracts |
-| [MODULE_BOUNDARIES.md](design/MODULE_BOUNDARIES.md) | Supporting | FSD module structure |
-| [NFR_TARGETS.md](design/NFR_TARGETS.md) | Supporting | Non-functional requirements |
-| [SECURITY_BOUNDARIES.md](design/SECURITY_BOUNDARIES.md) | Supporting | Security constraints |
-| [RELEASE_GATES.md](design/RELEASE_GATES.md) | Supporting | Release criteria |
-| [LEARNING_MODE_SPEC.md](design/LEARNING_MODE_SPEC.md) | **Canonical** | Learning Mode design spec — scenarios, validation, engine, UI |
-| [GRAPH_IR_SPEC.md](design/GRAPH_IR_SPEC.md) | Supporting | Graph IR specification — typed ports, protocol semantics, evolution plan |
-| [KPI_SCORECARD.md](design/KPI_SCORECARD.md) | Supporting | Product & engineering KPI metrics |
-| [BRICK_GUIDEBOOK.md](design/BRICK_GUIDEBOOK.md) | Historical (Superseded) | v1.x visual guidebook (Korean) — superseded by CLOUDBLOCKS_SPEC_V2.md |
-
-> **Historical**: BRICK_DESIGN_SPEC.md and VISUAL_DESIGN_SPEC.md describe the v1.x design system. For current specifications, see CLOUDBLOCKS_SPEC_V2.md (see [ADR-0008](adr/0008-v2-universal-architecture-specification.md)). The v2.0 spec is accepted but not yet fully implemented.
-> **UI Single Source of Truth**: All visual/interaction specs are in `CLOUDBLOCKS_SPEC_V2.md`. See that spec for the StarCraft-style Bottom Panel layout.
+> New to cloud architecture? Start with the [Tutorials](guides/TUTORIALS.md) — they walk you through real-world patterns step by step.
 
 ---
 
-## 5. Engine (Code Generation & AI)
+## What Can You Build?
 
-Infrastructure code generation pipeline and AI-assisted architecture.
-
-| Document | Status | Description |
-|----------|--------|-------------|
-| [generator.md](engine/generator.md) | Canonical | Generation pipeline |
-| [ai.md](engine/ai.md) | Canonical | AI-assisted architecture (NL→architecture, suggestions, cost) |
-| [provider.md](engine/provider.md) | Canonical | Provider adapters (Azure) |
-| [rules.md](engine/rules.md) | Supporting | Validation overview (see VALIDATION_CONTRACT.md for canonical rules) |
-| [templates.md](engine/templates.md) | Canonical | Architecture templates |
+| Pattern | Description | Template |
+|---------|-------------|----------|
+| Three-Tier Web App | Frontend + API + database with networking | Built-in |
+| Serverless API | Functions + API gateway + storage | Built-in |
+| Event-Driven Pipeline | Queues + event hubs + processing | Built-in |
+| Custom Architecture | Start from scratch — any cloud pattern | Blank canvas |
 
 ---
 
-## 6. API
+## Features at a Glance
 
-REST API specification.
-
-| Document | Status | Description |
-|----------|--------|-------------|
-| [API_SPEC.md](api/API_SPEC.md) | Canonical | REST API endpoints |
-
----
-
-## 7. Guides
-
-User and developer guides.
-
-| Document | Status | Description |
-|----------|--------|-------------|
-| [DEPLOYMENT.md](guides/DEPLOYMENT.md) | Supporting | Deployment instructions |
-| [ENVIRONMENT_STRATEGY.md](guides/ENVIRONMENT_STRATEGY.md) | Canonical | Local/staging/production deployment strategy |
-| [TUTORIALS.md](guides/TUTORIALS.md) | Supporting | Getting started tutorials |
+| Feature | Description |
+|---------|-------------|
+| **Visual Builder** | Drag-and-drop editor with grid snapping and auto-layout |
+| **10 Resource Categories** | Compute, database, storage, gateway, function, queue, event, analytics, identity, observability |
+| **Multi-Cloud Output** | Generate Terraform (HCL — HashiCorp Configuration Language), Bicep (Azure Resource Manager), or Pulumi (TypeScript) |
+| **Validation Engine** | Real-time rule checking for placement, connections, and constraints |
+| **AI Assistant** | Natural language to architecture, smart suggestions, cost estimation (requires backend) |
+| **GitHub Integration** | OAuth login, repo sync, PR creation, architecture diff |
+| **Learning Mode** | Guided scenarios to learn cloud architecture patterns |
+| **Multi-Environment** | Design for dev, staging, and production in one project |
 
 ---
 
-## Key Reference Documents
+## Learn More
 
-| Concern | Reference Document |
-|---------|-------------------|
-| Domain entities & types | [DOMAIN_MODEL.md](model/DOMAIN_MODEL.md) |
-| Visual sizing & layout | [CLOUDBLOCKS_SPEC_V2.md](design/CLOUDBLOCKS_SPEC_V2.md) |
-| Colors & materials | [CLOUDBLOCKS_SPEC_V2.md](design/CLOUDBLOCKS_SPEC_V2.md) |
-| TypeScript types | `apps/web/src/shared/types/index.ts` |
-| Validation rules | `apps/web/src/entities/validation/` |
-| Milestone timeline | [ROADMAP.md](concept/ROADMAP.md) |
-| KPI metrics | [KPI_SCORECARD.md](design/KPI_SCORECARD.md) |
+<div class="grid cards" markdown>
+
+-   :material-book-open-variant:{ .lg .middle } **Guides**
+
+    ---
+
+    Environment setup, deployment strategies, and workspace configuration.
+
+    [:octicons-arrow-right-24: Guides](guides/ENVIRONMENT_STRATEGY.md)
+
+-   :material-robot:{ .lg .middle } **AI Engine**
+
+    ---
+
+    Use natural language to generate architectures, get suggestions, and estimate costs.
+
+    [:octicons-arrow-right-24: AI docs](engine/ai.md)
+
+-   :material-file-document:{ .lg .middle } **Spec Reference**
+
+    ---
+
+    Full CloudBlocks v2.0 specification — geometry, providers, visual tokens.
+
+    [:octicons-arrow-right-24: Spec v2.0](design/CLOUDBLOCKS_SPEC_V2.md)
+
+-   :material-api:{ .lg .middle } **REST API**
+
+    ---
+
+    Backend API endpoints for architectures, templates, AI, and GitHub integration.
+
+    [:octicons-arrow-right-24: API spec](api/API_SPEC.md)
+
+</div>
+
+---
+
+## For Developers
+
+Building or contributing to CloudBlocks? Head to the **[Developer](concept/ARCHITECTURE.md)** section for architecture docs, ADRs, module boundaries, and milestone plans.
+
+- [Architecture Overview](concept/ARCHITECTURE.md)
+- [Domain Model](model/DOMAIN_MODEL.md)
+- [Decision Records (ADRs)](adr/README.md)
+- [Contributing Guide](https://github.com/yeongseon/cloudblocks/blob/main/CONTRIBUTING.md)

--- a/docs/guides/TUTORIALS.md
+++ b/docs/guides/TUTORIALS.md
@@ -43,7 +43,7 @@ Each tutorial includes:
 Internet → [Public Subnet: Gateway] → [Private Subnet: Compute → Database]
 ```
 
-**Generated Terraform** (Milestone 3+):
+**Generated Terraform**:
 ```hcl
 resource "azurerm_virtual_network" "main" {
   name                = "vnet-main"
@@ -113,12 +113,12 @@ Internet → Gateway → [Compute-A, Compute-B] → Database
 
 **Result**:
 ```
-Internet → Gateway → Compute → Storage → (event-driven processing planned for Milestone 6)
+Internet → Gateway → Compute → Storage → (event-driven processing coming soon)
 ```
 
-> **Note (Milestone 1)**: In the MVP, Storage and Database are receiver-only. The `Storage → Compute` event-driven pattern requires the `EventFlow` connection type planned for Milestone 6. In Milestone 1, model this as `Compute → Storage` (polling pattern).
+> **Note**: Storage and Database are currently receiver-only. The `Storage → Compute` event-driven pattern requires the `EventFlow` connection type (coming soon). For now, model this as `Compute → Storage` (polling pattern).
 
-**Revised Milestone 1-compatible architecture:**
+**Alternative architecture using current features:**
 ```
 Internet → Gateway → Compute → Storage
                       ↓
@@ -140,19 +140,16 @@ Internet → Gateway → Compute → Storage
 
 ---
 
-### Tutorial 6: Serverless API (Milestone 6+)
-
-> **⚠️ This tutorial requires block types and connection types planned for Milestone 6+.**
-> FunctionBlock, QueueBlock, and EventFlow connections are not available in Milestone 1.
+### Tutorial 6: Serverless API
 
 **Objective**: Build a serverless API with functions and queues.
 
 **You'll learn**:
-- FunctionBlock usage (Milestone 6)
-- QueueBlock for async processing (Milestone 6)
-- EventFlow connection type (Milestone 6)
+- Function block usage
+- Queue block for async processing
+- EventFlow connection type
 
-**Result** (Milestone 6+):
+**Result**:
 ```
 HTTP → Function → Queue → Function → Database
 ```
@@ -198,7 +195,7 @@ Tutorials are defined as JSON files for programmatic use:
 
 ## Adding Community Tutorials
 
-> **Note**: The tutorial scenario library is planned for Milestone 6+. The directory structure below shows the intended organization.
+> **Note**: Community tutorial contributions are planned for a future release. The directory structure below shows the intended organization.
 
 Tutorial scenarios will live in a dedicated package:
 

--- a/docs/stylesheets/lego-theme.css
+++ b/docs/stylesheets/lego-theme.css
@@ -97,44 +97,70 @@
    --------------------------------------------------------------------------- */
 
 [data-md-color-scheme="slate"] {
-  /* Neutral hue — no warm/brown tint */
-  --md-hue: 220;
+  --md-hue: 0;
 
-  /* Primary = Lego Blue (brighter for contrast on dark) */
-  --md-primary-fg-color: var(--lego-blue-light);
-  --md-primary-fg-color--light: #5599DD;
-  --md-primary-fg-color--dark: var(--lego-blue);
-  --md-primary-bg-color: #1a1a2e;
-  --md-primary-bg-color--light: #22223a;
+  --md-primary-fg-color: var(--lego-blue);
+  --md-primary-fg-color--light: var(--lego-blue-light);
+  --md-primary-fg-color--dark: var(--lego-blue-dark);
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
 
-  /* Accent = Lego Blue-Light (subtle, not yellow) */
-  --md-accent-fg-color: var(--lego-blue-light);
-  --md-accent-fg-color--transparent: rgba(51, 133, 214, 0.1);
-  --md-accent-bg-color: var(--lego-blue);
+  --md-accent-fg-color: var(--lego-yellow);
+  --md-accent-fg-color--transparent: rgba(255, 213, 0, 0.15);
+  --md-accent-bg-color: var(--lego-yellow-dark);
+  --md-accent-bg-color--light: rgba(255, 213, 0, 0.2);
 
-  /* Background = neutral dark (no brown) */
-  --md-default-bg-color: #1a1a2e;
-  --md-default-bg-color--light: #20203a;
-  --md-default-bg-color--lighter: #2a2a44;
-  --md-default-bg-color--lightest: #35354f;
+  --md-default-bg-color: #2d2d2d;
+  --md-default-bg-color--light: #353535;
+  --md-default-bg-color--lighter: #3e3e3e;
+  --md-default-bg-color--lightest: #4a4a4a;
 
-  /* Text = high-contrast neutral white */
-  --md-default-fg-color: #e0e0e8;
-  --md-default-fg-color--light: rgba(224, 224, 232, 0.72);
-  --md-default-fg-color--lighter: rgba(224, 224, 232, 0.42);
-  --md-default-fg-color--lightest: rgba(224, 224, 232, 0.12);
+  --md-default-fg-color: rgba(255, 255, 255, 0.92);
+  --md-default-fg-color--light: rgba(255, 255, 255, 0.72);
+  --md-default-fg-color--lighter: rgba(255, 255, 255, 0.48);
+  --md-default-fg-color--lightest: rgba(255, 255, 255, 0.18);
 
-  /* Footer */
-  --md-footer-bg-color: #12121f;
-  --md-footer-bg-color--dark: #0a0a14;
-
-  /* Code */
-  --md-code-bg-color: #22223a;
-  --md-code-fg-color: #e0e0e8;
-  --md-code-hl-color: rgba(51, 133, 214, 0.2);
-
-  /* Typeset links */
+  --md-typeset-color: rgba(255, 255, 255, 0.92);
   --md-typeset-a-color: #6eaaef;
+
+  --md-footer-bg-color: #1a1a1a;
+  --md-footer-bg-color--dark: #111111;
+  --md-footer-fg-color: rgba(255, 255, 255, 0.7);
+  --md-footer-fg-color--light: rgba(255, 255, 255, 0.5);
+  --md-footer-fg-color--lighter: rgba(255, 255, 255, 0.3);
+
+  --md-code-bg-color: #242424;
+  --md-code-fg-color: rgba(255, 255, 255, 0.88);
+  --md-code-hl-color: rgba(51, 133, 214, 0.25);
+  --md-code-hl-color--light: rgba(51, 133, 214, 0.08);
+  --md-code-hl-number-color: #e6695b;
+  --md-code-hl-special-color: #f06090;
+  --md-code-hl-function-color: #c973d9;
+  --md-code-hl-constant-color: #9383e2;
+  --md-code-hl-keyword-color: #6791e0;
+  --md-code-hl-string-color: #2fb170;
+  --md-code-hl-name-color: var(--md-code-fg-color);
+  --md-code-hl-operator-color: var(--md-default-fg-color--light);
+  --md-code-hl-punctuation-color: var(--md-default-fg-color--light);
+  --md-code-hl-comment-color: var(--md-default-fg-color--lighter);
+  --md-code-hl-generic-color: var(--md-default-fg-color--light);
+  --md-code-hl-variable-color: var(--md-default-fg-color--light);
+
+  --md-admonition-fg-color: var(--md-default-fg-color);
+  --md-admonition-bg-color: var(--md-default-bg-color--light);
+
+  --md-typeset-kbd-color: rgba(255, 255, 255, 0.12);
+  --md-typeset-kbd-accent-color: rgba(255, 255, 255, 0.2);
+  --md-typeset-kbd-border-color: #2d2d2d;
+  --md-typeset-mark-color: rgba(255, 213, 0, 0.30);
+  --md-typeset-table-color: rgba(255, 255, 255, 0.12);
+  --md-typeset-table-color--light: rgba(255, 255, 255, 0.04);
+
+  --md-shadow-z1: 0 0.2rem 0.5rem rgba(0,0,0,0.25), 0 0 0.05rem rgba(0,0,0,0.35);
+  --md-shadow-z2: 0 0.2rem 0.5rem rgba(0,0,0,0.45), 0 0 0.05rem rgba(0,0,0,0.55);
+  --md-shadow-z3: 0 0.2rem 0.5rem rgba(0,0,0,0.65), 0 0 0.05rem rgba(0,0,0,0.75);
+
+  color-scheme: dark;
 }
 
 /* ---------------------------------------------------------------------------
@@ -161,8 +187,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset h1 {
-  color: #f0f0f5;
-  border-bottom-color: rgba(224, 224, 232, 0.3);
+  color: #ffffff;
+  border-bottom-color: var(--lego-red);
 }
 
 /* h2 — Stud accent divider */
@@ -188,11 +214,13 @@
 }
 
 [data-md-color-scheme="slate"] .md-typeset h2 {
-  border-bottom-color: rgba(224, 224, 232, 0.2);
+  border-bottom-color: var(--lego-yellow-dark);
 }
 
 [data-md-color-scheme="slate"] .md-typeset h2::after {
-  display: none;
+  background-image:
+    radial-gradient(ellipse 8px 4px at 8px 2px, var(--lego-yellow-dark) 60%, transparent 60%);
+  opacity: 0.4;
 }
 
 /* h3 — Lego green left accent */
@@ -215,8 +243,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-header {
-  background-color: #12121f;
-  box-shadow: 0 4px 0 0 #0a0a14, 0 6px 12px rgba(0, 0, 0, 0.3);
+  background-color: var(--lego-blue-dark);
+  box-shadow: 0 4px 0 0 #001f4d, 0 6px 12px rgba(0, 0, 0, 0.4);
 }
 
 .md-header__title {
@@ -251,7 +279,7 @@
 }
 
 [data-md-color-scheme="slate"] .md-nav__item--active > .md-nav__link {
-  color: var(--lego-blue-light);
+  color: var(--lego-yellow);
 }
 
 /* Section labels */
@@ -413,24 +441,25 @@
   box-shadow: inset 0 -3px 0 0 var(--lego-red);
 }
 
-/* Dark mode tabs — muted gold banner */
 [data-md-color-scheme="slate"] .md-tabs {
-  background-color: #20203a;
-  border-bottom-color: #2a2a44;
+  background-color: var(--lego-yellow-dark);
+  border-bottom-color: #b89800;
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link {
-  color: rgba(224, 224, 232, 0.7);
+  color: rgba(0, 30, 80, 0.75);
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link:hover {
-  color: #e0e0e8;
-  background-color: rgba(255, 255, 255, 0.06);
+  color: var(--lego-blue-dark);
+  background-color: rgba(255, 255, 255, 0.3);
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link--active {
-  color: #e0e0e8;
-  box-shadow: inset 0 -2px 0 0 var(--lego-blue-light);
+  color: var(--lego-blue-dark);
+  font-weight: 700;
+  background-color: rgba(255, 255, 255, 0.25);
+  box-shadow: inset 0 -3px 0 0 var(--lego-red);
 }
 
 /* ---------------------------------------------------------------------------
@@ -453,24 +482,34 @@
 .md-header::after {
   content: "";
   display: block;
-  height: 4px;
+  height: 6px;
   background-image:
-    radial-gradient(ellipse 5px 2px at 5px 2px, rgba(255, 255, 255, 0.1) 50%, transparent 50%);
-  background-size: 14px 4px;
+    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 255, 255, 0.15) 50%, transparent 50%);
+  background-size: 16px 6px;
   background-repeat: repeat-x;
   background-position: 0 0;
+}
+
+[data-md-color-scheme="slate"] .md-header::after {
+  background-image:
+    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 255, 255, 0.25) 50%, transparent 50%);
 }
 
 /* Stud row above footer */
 .md-footer::before {
   content: "";
   display: block;
-  height: 4px;
+  height: 6px;
   background-image:
-    radial-gradient(ellipse 5px 2px at 5px 2px, rgba(255, 213, 0, 0.15) 50%, transparent 50%);
-  background-size: 14px 4px;
+    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 213, 0, 0.25) 50%, transparent 50%);
+  background-size: 16px 6px;
   background-repeat: repeat-x;
   background-position: 0 0;
+}
+
+[data-md-color-scheme="slate"] .md-footer::before {
+  background-image:
+    radial-gradient(ellipse 6px 3px at 6px 3px, rgba(255, 213, 0, 0.35) 50%, transparent 50%);
 }
 
 /* ---------------------------------------------------------------------------
@@ -514,7 +553,7 @@
 
 [data-md-color-scheme="slate"] .md-typeset a:focus,
 [data-md-color-scheme="slate"] .md-nav__link:focus-visible {
-  outline-color: var(--lego-blue-light);
+  outline-color: var(--lego-yellow);
 }
 
 /* ---------------------------------------------------------------------------
@@ -537,8 +576,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-nav--secondary .md-nav__link--active {
-  color: var(--lego-blue-light);
-  border-left-color: var(--lego-blue);
+  color: var(--lego-yellow);
+  border-left-color: var(--lego-red);
 }
 
 /* ---------------------------------------------------------------------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,15 +20,13 @@ theme:
     text: Fredoka
     code: Roboto Mono
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
+    - scheme: default
       primary: custom
       accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
+    - scheme: slate
       primary: custom
       accent: custom
       toggle:
@@ -76,33 +74,38 @@ nav:
   - Getting Started:
       - Tutorials (Start Here): guides/TUTORIALS.md
       - Environment & Workspaces: guides/ENVIRONMENT_STRATEGY.md
+      - Deployment: guides/DEPLOYMENT.md
 
-  - Build Architectures:
+  - Build & Design:
       - Using the Editor (UI Flow): concept/UI_FLOW.md
       - Templates: engine/templates.md
-      - Architecture Model Overview: model/ARCHITECTURE_MODEL_OVERVIEW.md
+      - Validation Rules: engine/rules.md
+      - Learning Mode Spec: design/LEARNING_MODE_SPEC.md
 
-  - Generate & Deploy:
+  - Generate & Export:
       - Code Generator: engine/generator.md
       - AI Engine: engine/ai.md
-      - Validation Rules: engine/rules.md
-      - Validation Contract: design/VALIDATION_CONTRACT.md
       - Provider Adapters: engine/provider.md
-      - Deployment: guides/DEPLOYMENT.md
-      - REST API Spec: api/API_SPEC.md
 
   - Reference:
       - CloudBlocks Spec v2.0: design/CLOUDBLOCKS_SPEC_V2.md
       - Domain Model: model/DOMAIN_MODEL.md
-      - Storage Architecture: model/STORAGE_ARCHITECTURE.md
-      - Security Boundaries: design/SECURITY_BOUNDARIES.md
-      - Learning Mode Spec: design/LEARNING_MODE_SPEC.md
+      - Validation Contract: design/VALIDATION_CONTRACT.md
+      - REST API Spec: api/API_SPEC.md
 
-  - Contributing:
+  - Developer:
+      - Architecture: concept/ARCHITECTURE.md
+      - Storage Architecture: model/STORAGE_ARCHITECTURE.md
+      - Architecture Model Overview: model/ARCHITECTURE_MODEL_OVERVIEW.md
+      - Security Boundaries: design/SECURITY_BOUNDARIES.md
+      - Module Boundaries: design/MODULE_BOUNDARIES.md
+      - NFR Targets: design/NFR_TARGETS.md
+      - Release Gates: design/RELEASE_GATES.md
+      - KPI Scorecard: design/KPI_SCORECARD.md
+      - Graph IR Spec: design/GRAPH_IR_SPEC.md
       - Product & Planning:
           - Product Requirements: concept/PRD.md
           - Roadmap: concept/ROADMAP.md
-          - Architecture (Internal): concept/ARCHITECTURE.md
           - Milestone Plans:
               - M16 — Documentation Architecture: concept/M16_DOCUMENTATION_ARCHITECTURE.md
               - M17 — Product Structure: concept/M17_PRODUCT_STRUCTURE.md
@@ -119,12 +122,6 @@ nav:
           - ADR-0007 Multi-Environment Deployment: adr/0007-multi-environment-deployment-strategy.md
           - ADR-0008 v2.0 Universal Architecture Spec: adr/0008-v2-universal-architecture-specification.md
           - ADR-0009 AI-Assisted Architecture: adr/0009-ai-assisted-architecture.md
-      - Engineering Specs:
-          - Module Boundaries: design/MODULE_BOUNDARIES.md
-          - NFR Targets: design/NFR_TARGETS.md
-          - Release Gates: design/RELEASE_GATES.md
-          - KPI Scorecard: design/KPI_SCORECARD.md
-          - Graph IR Spec: design/GRAPH_IR_SPEC.md
       - Historical / Audits:
           - Brick Design Spec (v1.x): design/BRICK_DESIGN_SPEC.md
           - Visual Design Spec (v1.x): design/VISUAL_DESIGN_SPEC.md


### PR DESCRIPTION
## Summary
- Rewrite docs homepage (`docs/README.md`) as a user-welcoming landing page with Material card grids, 5-step onboarding journey, key concepts glossary, and features overview
- Restructure `mkdocs.yml` nav to be user-centric: Getting Started → Build & Design → Generate & Export → Reference → Developer (internal docs hidden)
- Apply Lego baseplate dark theme with full Material CSS variable coverage
- Default to light mode (remove `prefers-color-scheme` media queries)
- Clean up internal milestone references in `TUTORIALS.md` for user-facing language

## Changes
| File | What Changed |
|------|-------------|
| `docs/README.md` | Full rewrite — card grids, 5-step table, key concepts, features, learn more cards, developer section |
| `mkdocs.yml` | Nav restructured (6 tabs), Learning Mode Spec moved to Build & Design, light mode default |
| `docs/stylesheets/lego-theme.css` | Dark mode: gray baseplate `#2d2d2d`, Lego color accents, all Material slate variables overridden |
| `docs/guides/TUTORIALS.md` | Replaced "Milestone N" references with "coming soon" / "current features" |

## Review Checklist
- [x] `mkdocs build --strict` passes with no errors
- [x] Light mode is default (no system preference detection)
- [x] Dark mode toggle still works
- [x] All nav links resolve correctly
- [x] No internal milestone jargon in user-facing docs