### PR TITLE
docs: add README badges for version, tech stack, and live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CI](https://github.com/yeongseon/cloudblocks/actions/workflows/ci.yml/badge.svg)](https://github.com/yeongseon/cloudblocks/actions/workflows/ci.yml)
+[![Version](https://img.shields.io/github/v/release/yeongseon/cloudblocks?label=version)](https://github.com/yeongseon/cloudblocks/releases/latest)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev/)
+[![Python](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.110+-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
+[![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://yeongseon.github.io/cloudblocks/)
 
 <p align="center">
   <img src="docs/images/hero.png" alt="CloudBlocks — visual cloud architecture builder" width="720" />


### PR DESCRIPTION
## Summary
- Add 6 new badges: Version, TypeScript 5.9, React 19, Python 3.10+, FastAPI 0.110+, Live Demo
- Total badges: 2 → 8 (License, CI, Version, TypeScript, React, Python, FastAPI, Live Demo)
- Provides instant visibility into tech stack and project status