### PR TITLE
fix: use dynamic plate-type colors for Portrait panel background (#439)

### DIFF
--- a/apps/web/src/widgets/bottom-panel/Portrait.css
+++ b/apps/web/src/widgets/bottom-panel/Portrait.css
@@ -116,12 +116,10 @@
   filter: drop-shadow(0 2px 0 rgba(0,0,0,0.4));
 }
 
-/* Plate state */
+/* Plate state — background-color and border-color set via inline style per plate type */
 .portrait-panel--plate {
-  background-color: #00852B;
-  border-color: #00591D;
   background-image: 
-    radial-gradient(circle at 6px 6px, #00A636 2.5px, transparent 3px),
+    radial-gradient(circle at 6px 6px, rgba(255,255,255,0.18) 2.5px, transparent 3px),
     radial-gradient(circle at 6px 7px, rgba(0,0,0,0.15) 3px, transparent 3.5px);
   background-size: 12px 12px;
 }

--- a/apps/web/src/widgets/bottom-panel/Portrait.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/Portrait.test.tsx
@@ -119,6 +119,27 @@ describe('Portrait', () => {
     expect(subnetImage).toBeInTheDocument();
     expect(subnetImage).toHaveAttribute('src', 'subnet.svg');
   });
+  it('renders region plate portrait with correct plate-type background color', () => {
+    useUIStore.setState({ selectedId: 'net-1' });
+
+    const { container } = render(<Portrait />);
+
+    const panel = container.querySelector('.portrait-panel--plate');
+    expect(panel).toBeInTheDocument();
+    // Region plate uses leftSideColor=#64B5F6, rightSideColor=#42A5F5 from getPlateFaceColors
+    expect(panel).toHaveStyle({ backgroundColor: '#64B5F6', borderColor: '#42A5F5' });
+  });
+
+  it('renders subnet plate portrait with correct subnet-type background color', () => {
+    useUIStore.setState({ selectedId: 'subnet-1' });
+
+    const { container } = render(<Portrait />);
+
+    const panel = container.querySelector('.portrait-panel--plate');
+    expect(panel).toBeInTheDocument();
+    // Public subnet uses leftSideColor=#16A34A, rightSideColor=#15803D from getPlateFaceColors
+    expect(panel).toHaveStyle({ backgroundColor: '#16A34A', borderColor: '#15803D' });
+  });
 
   it('renders connection portrait with link icon', () => {
     useUIStore.setState({ selectedId: 'conn-1' });

--- a/apps/web/src/widgets/bottom-panel/Portrait.tsx
+++ b/apps/web/src/widgets/bottom-panel/Portrait.tsx
@@ -10,6 +10,7 @@
 
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { getPlateFaceColors } from '../../entities/plate/plateFaceColors';
 import {
   BLOCK_FRIENDLY_NAMES,
   BLOCK_COLORS,
@@ -95,6 +96,8 @@ export function Portrait({ className = '' }: PortraitProps) {
       ? SUBNET_ACCESS_COLORS[selectedPlate.subnetAccess]
       : PLATE_COLORS[selectedPlate.type];
 
+    const faceColors = getPlateFaceColors(selectedPlate);
+
     const plateIcon = selectedPlate.type === 'subnet'
       ? PLATE_ICONS.subnet[selectedPlate.subnetAccess ?? 'private']
       : PLATE_ICONS[selectedPlate.type].default;
@@ -105,8 +108,13 @@ export function Portrait({ className = '' }: PortraitProps) {
         ? 'Region'
         : selectedPlate.type.charAt(0).toUpperCase() + selectedPlate.type.slice(1);
 
+    const plateStyle: React.CSSProperties = {
+      backgroundColor: faceColors.leftSideColor,
+      borderColor: faceColors.rightSideColor,
+    };
+
     return (
-      <div className={`portrait-panel portrait-panel--plate ${className}`}>
+      <div className={`portrait-panel portrait-panel--plate ${className}`} style={plateStyle}>
         <div className="portrait-content">
           <img src={plateIcon} alt={altText} className="portrait-icon-img" />
           <span className="portrait-label">{selectedPlate.name}</span>


### PR DESCRIPTION
## Summary
- Portrait panel always showed hardcoded green (`#00852B`) regardless of plate type
- Now uses `getPlateFaceColors()` to apply `leftSideColor`/`rightSideColor` as background/border per plate type
- Region→Blue, Global→Purple, Edge→Teal, Zone→Green, Subnet(public)→Green, Subnet(private)→Indigo
- CSS stud highlight changed from hardcoded color to semi-transparent white overlay (`rgba(255,255,255,0.18)`) that adapts to any base color

## Changes
| File | Change |
|------|--------|
| `apps/web/src/widgets/bottom-panel/Portrait.tsx` | Import `getPlateFaceColors`, compute dynamic `plateStyle`, apply as inline style |
| `apps/web/src/widgets/bottom-panel/Portrait.css` | Remove hardcoded `background-color`/`border-color`, use adaptive stud overlay |
| `apps/web/src/widgets/bottom-panel/Portrait.test.tsx` | Add 2 tests verifying region and subnet plate background colors |

## Verification
- [x] `pnpm build` passes
- [x] `pnpm lint` clean
- [x] All 1515 tests pass (1513 existing + 2 new)

Closes #439