### PR TITLE
refactor(web): migrate imports to @cloudblocks/schema and @cloudblocks/domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build shared packages
+        run: pnpm --filter @cloudblocks/schema build && pnpm --filter @cloudblocks/domain build
+
       - name: Lint
         run: pnpm lint
 
@@ -81,6 +84,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build shared packages
+        run: pnpm --filter @cloudblocks/schema build && pnpm --filter @cloudblocks/domain build
 
       - name: Run tests with coverage
         run: npx vitest run --coverage

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,10 @@ docker-compose.override.yml
 *.tgz
 .turbo/
 apps/web/coverage/
+
+# ─── Stale artifacts ──────────────────────────────────────────
+*.png
+!docs/**/*.png
+apps/api/*.db
+apps/api/*.db-shm
+apps/api/*.db-wal

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,8 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@cloudblocks/domain": "workspace:*",
+    "@cloudblocks/schema": "workspace:*",
     "interactjs": "^1.10.27",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/apps/web/src/__tests__/milestone10.integration.test.tsx
+++ b/apps/web/src/__tests__/milestone10.integration.test.tsx
@@ -6,7 +6,7 @@ import { CommandCard } from '../widgets/bottom-panel/CommandCard';
 import { useArchitectureStore } from '../entities/store/architectureStore';
 import { useUIStore } from '../entities/store/uiStore';
 import { useWorkerStore } from '../entities/store/workerStore';
-import type { ArchitectureModel, ExternalActor, Plate } from '../shared/types/index';
+import type { ArchitectureModel, ExternalActor, Plate } from '@cloudblocks/schema';
 
 type DragListeners = {
   start?: (event: { target: HTMLElement }) => void;

--- a/apps/web/src/__tests__/milestone12.integration.test.ts
+++ b/apps/web/src/__tests__/milestone12.integration.test.ts
@@ -10,7 +10,8 @@ import { gcpProviderDefinition } from '../features/generate/providers/gcp';
 import { gcpSubtypeRegistry } from '../features/generate/providers/gcp/subtypes';
 import { resolveBlockMapping } from '../features/generate/types';
 import type { ProviderDefinition } from '../features/generate/types';
-import type { ArchitectureModel, Block, Plate, Workspace } from '../shared/types';
+import type { Workspace } from '../shared/types';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 import { deserialize, serialize } from '../shared/types/schema';
 
 function makePlate(overrides: Partial<Plate> = {}): Plate {

--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -6,7 +6,7 @@ import { BlockSprite } from './BlockSprite';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 import { useWorkerStore } from '../store/workerStore';
-import type { Block, BlockCategory, ExternalActor, Plate } from '../../shared/types/index';
+import type { Block, BlockCategory, ExternalActor, Plate } from '@cloudblocks/schema';
 import * as isometric from '../../shared/utils/isometric';
 import { audioService } from '../../shared/utils/audioService';
 import type { SoundName } from '../../shared/utils/audioService';

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef } from 'react';
 import interact from 'interactjs';
 import { toast } from 'react-hot-toast';
-import type { Block, BlockCategory, Plate, ProviderType } from '../../shared/types/index';
+import type { Block, BlockCategory, Plate, ProviderType } from '@cloudblocks/schema';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 import { useWorkerStore } from '../store/workerStore';

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -1,5 +1,5 @@
 import { memo, useId, useMemo } from 'react';
-import type { BlockCategory, BlockRole, ProviderType } from '../../shared/types/index';
+import type { BlockCategory, BlockRole, ProviderType } from '@cloudblocks/schema';
 import { BLOCK_SHORT_NAMES, BLOCK_ICONS, ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
 import { getBlockDimensions, getBlockVisualProfile } from '../../shared/types/visualProfile';
 import { StudDefs, StudGrid } from '../../shared/components/IsometricStud';

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { BlockSvg } from '../BlockSvg';
 import { getBlockFaceColors } from '../blockFaceColors';
 import { getBlockDimensions, CATEGORY_TIER_MAP, TIER_DIMENSIONS } from '../../../shared/types/visualProfile';
-import type { BlockCategory, BlockRole, ProviderType } from '../../../shared/types/index';
+import type { BlockCategory, BlockRole, ProviderType } from '@cloudblocks/schema';
 import { BLOCK_PADDING, TILE_H, TILE_W, TILE_Z } from '../../../shared/tokens/designTokens';
 
 // ─── Test Helpers ─────────────────────────────────────────────

--- a/apps/web/src/entities/block/__tests__/blockFaceColors.test.ts
+++ b/apps/web/src/entities/block/__tests__/blockFaceColors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import type { BlockCategory, ProviderType, StudColorSpec } from '../../../shared/types/index';
+import type { StudColorSpec } from '../../../shared/types/index';
+import type { BlockCategory, ProviderType } from '@cloudblocks/schema';
 import {
   darken,
   deriveFaceColors,

--- a/apps/web/src/entities/block/__tests__/silhouettes.test.ts
+++ b/apps/web/src/entities/block/__tests__/silhouettes.test.ts
@@ -5,12 +5,9 @@ import {
   getSilhouetteFromCU,
   SILHOUETTE_GENERATORS,
 } from '../silhouettes';
-import {
-  BLOCK_VISUAL_PROFILES,
-  type BlockCategory,
-  type BrickSilhouette,
-  type BlockTier,
-} from '../../../shared/types/index';
+import { BLOCK_VISUAL_PROFILES } from '../../../shared/types/index';
+import type { BrickSilhouette, BlockTier } from '../../../shared/types/index';
+import type { BlockCategory } from '@cloudblocks/schema';
 import type { BlockDimensionsCU } from '../../../shared/types/visualProfile';
 import {
   CATEGORY_TIER_MAP,

--- a/apps/web/src/entities/block/blockFaceColors.ts
+++ b/apps/web/src/entities/block/blockFaceColors.ts
@@ -1,4 +1,5 @@
-import type { BlockCategory, ProviderType, StudColorSpec } from '../../shared/types/index';
+import type { StudColorSpec } from '../../shared/types/index';
+import type { BlockCategory, ProviderType } from '@cloudblocks/schema';
 
 // ═══════════════════════════════════════════════════════════════
 // Block Face Color System — v2.0

--- a/apps/web/src/entities/connection/ConnectionPath.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionPath.test.tsx
@@ -6,7 +6,7 @@ import { useArchitectureStore } from '../store/architectureStore';
 import { getEndpointWorldPosition } from '../../shared/utils/position';
 import { worldToScreen } from '../../shared/utils/isometric';
 import { getDiffState } from '../../features/diff/engine';
-import type { Connection } from '../../shared/types/index';
+import type { Connection } from '@cloudblocks/schema';
 import type { DiffDelta } from '../../shared/types/diff';
 
 vi.mock('../../shared/utils/position', () => ({

--- a/apps/web/src/entities/connection/ConnectionPath.tsx
+++ b/apps/web/src/entities/connection/ConnectionPath.tsx
@@ -1,5 +1,5 @@
 import { memo, useState } from 'react';
-import type { Connection, Block, Plate, ExternalActor } from '../../shared/types/index';
+import type { Connection, Block, Plate, ExternalActor } from '@cloudblocks/schema';
 import { getDiffState } from '../../features/diff/engine';
 import { getEndpointWorldPosition } from '../../shared/utils/position';
 import { worldToScreen } from '../../shared/utils/isometric';

--- a/apps/web/src/entities/connection/ExternalActorSprite.test.tsx
+++ b/apps/web/src/entities/connection/ExternalActorSprite.test.tsx
@@ -6,7 +6,7 @@ import { toast } from 'react-hot-toast';
 import { ExternalActorSprite } from './ExternalActorSprite';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
-import type { ExternalActor } from '../../shared/types/index';
+import type { ExternalActor } from '@cloudblocks/schema';
 import * as connectionValidation from '../validation/connection';
 import * as isometric from '../../shared/utils/isometric';
 import { audioService } from '../../shared/utils/audioService';

--- a/apps/web/src/entities/connection/ExternalActorSprite.tsx
+++ b/apps/web/src/entities/connection/ExternalActorSprite.tsx
@@ -4,7 +4,7 @@ import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../store/architectureStore';
 import { useUIStore } from '../store/uiStore';
 import { canConnect } from '../validation/connection';
-import type { ExternalActor } from '../../shared/types/index';
+import type { ExternalActor } from '@cloudblocks/schema';
 import { screenDeltaToWorld, snapToGrid } from '../../shared/utils/isometric';
 import { audioService } from '../../shared/utils/audioService';
 import internetSprite from '../../shared/assets/actor-sprites/internet.svg';

--- a/apps/web/src/entities/plate/PlateSprite.test.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.test.tsx
@@ -6,7 +6,7 @@ import { PlateSprite } from './PlateSprite';
 import { useUIStore } from '../store/uiStore';
 import { screenDeltaToWorld, worldSizeToScreen, snapToGrid } from '../../shared/utils/isometric';
 import { useArchitectureStore } from '../store/architectureStore';
-import type { Plate } from '../../shared/types/index';
+import type { Plate } from '@cloudblocks/schema';
 import { audioService } from '../../shared/utils/audioService';
 import type { SoundName } from '../../shared/utils/audioService';
 import type { DiffDelta } from '../../shared/types/diff';

--- a/apps/web/src/entities/plate/PlateSprite.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.tsx
@@ -1,11 +1,7 @@
 import { memo, useEffect, useRef } from 'react';
 import interact from 'interactjs';
-import {
-  DEFAULT_PLATE_PROFILE,
-  getPlateProfile,
-  getPlateStudColors,
-  type Plate,
-} from '../../shared/types/index';
+import { DEFAULT_PLATE_PROFILE, getPlateProfile, getPlateStudColors, isPlateProfileId } from '../../shared/types/index';
+import type { Plate } from '@cloudblocks/schema';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 import { getDiffState } from '../../features/diff/engine';
@@ -153,7 +149,7 @@ export const PlateSprite = memo(function PlateSprite({
 
   const sizeClass = plate.type === 'subnet' ? 'plate-subnet' : 'plate-network';
 
-  const profile = plate.profileId
+  const profile = plate.profileId && isPlateProfileId(plate.profileId)
     ? getPlateProfile(plate.profileId)
     : getPlateProfile(DEFAULT_PLATE_PROFILE[plate.type]);
   const studColors = getPlateStudColors(plate);

--- a/apps/web/src/entities/plate/PlateSvg.test.tsx
+++ b/apps/web/src/entities/plate/PlateSvg.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { PlateSvg } from './PlateSvg';
-import type { PlateType, StudColorSpec } from '../../shared/types/index';
+import type { StudColorSpec } from '../../shared/types/index';
+import type { PlateType } from '@cloudblocks/schema';
 import { TILE_W, TILE_H, TILE_Z, BLOCK_PADDING } from '../../shared/tokens/designTokens';
 
 const studColors: StudColorSpec = {

--- a/apps/web/src/entities/plate/PlateSvg.tsx
+++ b/apps/web/src/entities/plate/PlateSvg.tsx
@@ -1,8 +1,6 @@
 import { memo, useId, useMemo } from 'react';
-import type {
-  PlateType,
-  StudColorSpec,
-} from '../../shared/types/index';
+import type { StudColorSpec } from '../../shared/types/index';
+import type { PlateType } from '@cloudblocks/schema';
 import { StudDefs, StudGrid } from '../../shared/components/IsometricStud';
 import { TILE_W, TILE_H, TILE_Z, BLOCK_MARGIN, BLOCK_PADDING } from '../../shared/tokens/designTokens';
 

--- a/apps/web/src/entities/plate/plateFaceColors.ts
+++ b/apps/web/src/entities/plate/plateFaceColors.ts
@@ -1,7 +1,4 @@
-import type {
-  PlateType,
-  SubnetAccess,
-} from '../../shared/types/index';
+import type { PlateType, SubnetAccess } from '@cloudblocks/schema';
 
 export interface PlateFaceColors {
   topFaceColor: string;

--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type { ArchitectureSnapshot } from '../../shared/types/learning';
 import type { ArchitectureTemplate } from '../../shared/types/template';
 

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -1,4 +1,5 @@
-import type { Block, Connection, ExternalActor, Plate, PlateProfileId } from '../../../shared/types/index';
+import type { PlateProfileId } from '../../../shared/types/index';
+import type { Block, Connection, ExternalActor, Plate } from '@cloudblocks/schema';
 import { buildPlateSizeFromProfileId, DEFAULT_BLOCK_SIZE } from '../../../shared/types/index';
 import { generateId } from '../../../shared/utils/id';
 import type { ArchitectureSlice, ArchitectureState } from './types';

--- a/apps/web/src/entities/store/slices/helpers.ts
+++ b/apps/web/src/entities/store/slices/helpers.ts
@@ -1,4 +1,5 @@
-import type { ArchitectureModel, Block, Position, Workspace } from '../../../shared/types/index';
+import type { Workspace } from '../../../shared/types/index';
+import type { ArchitectureModel, Block, Position } from '@cloudblocks/schema';
 import { DEFAULT_BLOCK_SIZE, DEFAULT_PLATE_SIZE } from '../../../shared/types/index';
 import { createBlankArchitecture } from '../../../shared/types/schema';
 import {

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -1,9 +1,5 @@
-import type {
-  ArchitectureModel,
-  BlockCategory,
-  PlateType,
-  Workspace,
-} from '../../../shared/types/index';
+import type { Workspace } from '../../../shared/types/index';
+import type { ArchitectureModel, BlockCategory, PlateType } from '@cloudblocks/schema';
 import type { ArchitectureSnapshot } from '../../../shared/types/learning';
 import { saveWorkspaces, loadWorkspaces } from '../../../shared/utils/storage';
 import { generateId } from '../../../shared/utils/id';

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -1,14 +1,7 @@
 import type { StateCreator } from 'zustand';
-import type {
-  ArchitectureModel,
-  BlockCategory,
-  ProviderType,
-  PlateProfileId,
-  PlateType,
-  SubnetAccess,
-  ValidationResult,
-  Workspace,
-} from '../../../shared/types/index';
+import type { PlateProfileId, Workspace } from '../../../shared/types/index';
+import type { ArchitectureModel, BlockCategory, ProviderType, PlateType, SubnetAccess } from '@cloudblocks/schema';
+import type { ValidationResult } from '@cloudblocks/domain';
 import type { ArchitectureSnapshot } from '../../../shared/types/learning';
 import type { ArchitectureTemplate } from '../../../shared/types/template';
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
-import type { BlockCategory, ProviderType } from '../../shared/types/index';
+import type { BlockCategory, ProviderType } from '@cloudblocks/schema';
 import type { EditorMode } from '../../shared/types/learning';
 import type { DiffDelta } from '../../shared/types/diff';
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 
 export type ToolMode = 'select' | 'connect' | 'delete';
 export type InteractionState = 'idle' | 'selecting' | 'dragging' | 'placing' | 'connecting';

--- a/apps/web/src/entities/validation/__tests__/providerValidation.test.ts
+++ b/apps/web/src/entities/validation/__tests__/providerValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ArchitectureModel, Block, Plate } from '../../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 import { validateProviderRules } from '../providerValidation';
 
 function makePlate(overrides: Partial<Plate> = {}): Plate {

--- a/apps/web/src/entities/validation/aggregation.test.ts
+++ b/apps/web/src/entities/validation/aggregation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Block } from '../../shared/types/index';
+import type { Block } from '@cloudblocks/schema';
 import { validateAggregation } from './aggregation';
 
 function makeBlock(overrides: Partial<Block> = {}): Block {

--- a/apps/web/src/entities/validation/aggregation.ts
+++ b/apps/web/src/entities/validation/aggregation.ts
@@ -1,7 +1,5 @@
-import type {
-  Block,
-  ValidationError,
-} from '../../shared/types/index';
+import type { Block } from '@cloudblocks/schema';
+import type { ValidationError } from '@cloudblocks/domain';
 
 /**
  * Aggregation Validation (v2.0 — CLOUDBLOCKS_SPEC_V2.md §8, §15):

--- a/apps/web/src/entities/validation/connection.test.ts
+++ b/apps/web/src/entities/validation/connection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Block, Connection, ExternalActor, ConnectionType } from '../../shared/types/index';
+import type { Block, Connection, ExternalActor, ConnectionType } from '@cloudblocks/schema';
 import { validateConnection, canConnect, CONNECTION_VISUAL_STYLES } from './connection';
 
 function makeBlock(

--- a/apps/web/src/entities/validation/connection.ts
+++ b/apps/web/src/entities/validation/connection.ts
@@ -1,11 +1,5 @@
-import type {
-  Block,
-  Connection,
-  ConnectionType,
-  ExternalActor,
-  BlockCategory,
-  ValidationError,
-} from '../../shared/types/index';
+import type { Block, Connection, ConnectionType, ExternalActor, BlockCategory } from '@cloudblocks/schema';
+import type { ValidationError } from '@cloudblocks/domain';
 
 /**
  * Connection Rules (from DOMAIN_MODEL.md §6):

--- a/apps/web/src/entities/validation/engine.test.ts
+++ b/apps/web/src/entities/validation/engine.test.ts
@@ -1,11 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type {
-  ArchitectureModel,
-  Block,
-  Connection,
-  ExternalActor,
-  Plate,
-} from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, ExternalActor, Plate } from '@cloudblocks/schema';
 import { validateArchitecture } from './engine';
 import * as placementModule from './placement';
 import * as connectionModule from './connection';

--- a/apps/web/src/entities/validation/engine.ts
+++ b/apps/web/src/entities/validation/engine.ts
@@ -1,7 +1,5 @@
-import type {
-  ArchitectureModel,
-  ValidationResult,
-} from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
+import type { ValidationResult } from '@cloudblocks/domain';
 import { validatePlacement } from './placement';
 import { validateConnection } from './connection';
 import { validateProviderRules } from './providerValidation';

--- a/apps/web/src/entities/validation/placement.test.ts
+++ b/apps/web/src/entities/validation/placement.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { Block, Plate } from '../../shared/types/index';
+import type { Block, Plate } from '@cloudblocks/schema';
 import { validatePlacement, canPlaceBlock, validateLayerPlacement, validateGridAlignment, validateNoOverlap } from './placement';
 
 function makeBlock(

--- a/apps/web/src/entities/validation/placement.ts
+++ b/apps/web/src/entities/validation/placement.ts
@@ -1,12 +1,7 @@
-import type {
-  Block,
-  BlockCategory,
-  Plate,
-  Size,
-  ValidationError,
-} from '../../shared/types/index';
-import { VALID_PARENTS } from '../../shared/types/index';
-import type { LayerType } from '../../shared/types/index';
+import type { Block, BlockCategory, Plate, Size } from '@cloudblocks/schema';
+import type { ValidationError } from '@cloudblocks/domain';
+import { VALID_PARENTS } from '@cloudblocks/domain';
+import type { LayerType } from '@cloudblocks/schema';
 
 /**
  * Placement Rules (v2.0 — CLOUDBLOCKS_SPEC_V2.md §10, §15):

--- a/apps/web/src/entities/validation/providerValidation.ts
+++ b/apps/web/src/entities/validation/providerValidation.ts
@@ -1,9 +1,5 @@
-import type {
-  ArchitectureModel,
-  Block,
-  Plate,
-  ValidationError,
-} from '../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
+import type { ValidationError } from '@cloudblocks/domain';
 
 const KNOWN_SUBTYPES: Record<string, Record<string, string[]>> = {
   aws: {

--- a/apps/web/src/entities/validation/role.test.ts
+++ b/apps/web/src/entities/validation/role.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import type { Block, BlockRole } from '../../shared/types/index';
-import { BLOCK_ROLES } from '../../shared/types/index';
+import type { Block, BlockRole } from '@cloudblocks/schema';
+import { BLOCK_ROLES } from '@cloudblocks/domain';
 import { validateRoles } from './role';
 
 function makeBlock(overrides: Partial<Block> = {}): Block {

--- a/apps/web/src/entities/validation/role.ts
+++ b/apps/web/src/entities/validation/role.ts
@@ -1,8 +1,6 @@
-import type {
-  Block,
-  ValidationError,
-} from '../../shared/types/index';
-import { BLOCK_ROLES } from '../../shared/types/index';
+import type { Block } from '@cloudblocks/schema';
+import type { ValidationError } from '@cloudblocks/domain';
+import { BLOCK_ROLES } from '@cloudblocks/domain';
 
 /**
  * Role Validation (v2.0 — CLOUDBLOCKS_SPEC_V2.md §9):

--- a/apps/web/src/features/diff/engine.test.ts
+++ b/apps/web/src/features/diff/engine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ArchitectureModel } from '../../shared/types';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type { ModifiedEntity, PropertyChange } from '../../shared/types/diff';
 import { computeArchitectureDiff, getDiffState, normalizeArchitecture } from './engine';
 

--- a/apps/web/src/features/diff/engine.ts
+++ b/apps/web/src/features/diff/engine.ts
@@ -1,10 +1,4 @@
-import type {
-  ArchitectureModel,
-  Block,
-  Connection,
-  ExternalActor,
-  Plate,
-} from '../../shared/types';
+import type { ArchitectureModel, Block, Connection, ExternalActor, Plate } from '@cloudblocks/schema';
 import type { DiffDelta, DiffState, EntityDiff, PropertyChange } from '../../shared/types/diff';
 
 const ROOT_VOLATILE_PATHS = new Set(['createdAt', 'updatedAt']);

--- a/apps/web/src/features/generate/__tests__/generatorSubtype.test.ts
+++ b/apps/web/src/features/generate/__tests__/generatorSubtype.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ArchitectureModel } from '../../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import { normalizeBicep } from '../bicep';
 import { normalizePulumi } from '../pulumi';
 import { awsProvider, awsProviderDefinition } from '../providers/aws';

--- a/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
+++ b/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ArchitectureModel, Block, Plate } from '../../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 import type { ProviderName } from '../types';
 import { generateCode } from '../pipeline';
 import { getProvider } from '../provider';

--- a/apps/web/src/features/generate/bicep.test.ts
+++ b/apps/web/src/features/generate/bicep.test.ts
@@ -7,7 +7,7 @@ import {
   bicepPlugin,
 } from './bicep';
 import { azureProviderDefinition } from './provider';
-import type { ArchitectureModel, Block, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 import type { GenerationOptions } from './types';
 
 const basePosition = { x: 0, y: 0, z: 0 };

--- a/apps/web/src/features/generate/bicep.ts
+++ b/apps/web/src/features/generate/bicep.ts
@@ -1,4 +1,4 @@
-import type { ArchitectureModel, Block, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 import type {
   GenerationOptions,
   GeneratorPlugin,

--- a/apps/web/src/features/generate/pipeline.test.ts
+++ b/apps/web/src/features/generate/pipeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ArchitectureModel, Plate, Block } from '../../shared/types/index';
+import type { ArchitectureModel, Plate, Block } from '@cloudblocks/schema';
 import type { GeneratedOutput, GeneratedFile, GenerationOptions, GeneratorPlugin } from './types';
 import { GenerationError, generateTerraform, terraformPipeline, generateCode } from './pipeline';
 import { registerGenerator } from './registry';

--- a/apps/web/src/features/generate/pipeline.ts
+++ b/apps/web/src/features/generate/pipeline.ts
@@ -1,4 +1,4 @@
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type {
   GeneratedOutput,
   GenerationOptions,

--- a/apps/web/src/features/generate/providers/aws/subtypes.ts
+++ b/apps/web/src/features/generate/providers/aws/subtypes.ts
@@ -1,4 +1,4 @@
-import type { BlockCategory } from '../../../../shared/types/index';
+import type { BlockCategory } from '@cloudblocks/schema';
 
 export interface SubtypeEntry {
   displayName: string;

--- a/apps/web/src/features/generate/providers/azure/subtypes.ts
+++ b/apps/web/src/features/generate/providers/azure/subtypes.ts
@@ -1,4 +1,4 @@
-import type { BlockCategory } from '../../../../shared/types/index';
+import type { BlockCategory } from '@cloudblocks/schema';
 
 export interface SubtypeEntry {
   displayName: string;

--- a/apps/web/src/features/generate/providers/gcp/subtypes.ts
+++ b/apps/web/src/features/generate/providers/gcp/subtypes.ts
@@ -1,4 +1,4 @@
-import type { BlockCategory } from '../../../../shared/types/index';
+import type { BlockCategory } from '@cloudblocks/schema';
 
 export interface SubtypeEntry {
   displayName: string;

--- a/apps/web/src/features/generate/pulumi.test.ts
+++ b/apps/web/src/features/generate/pulumi.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { normalizePulumi, generateIndexTs, generatePulumiYaml, pulumiPlugin } from './pulumi';
 import { azureProviderDefinition } from './provider';
-import type { ArchitectureModel, Block, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 import type { GenerationOptions } from './types';
 
 const basePosition = { x: 0, y: 0, z: 0 };

--- a/apps/web/src/features/generate/pulumi.ts
+++ b/apps/web/src/features/generate/pulumi.ts
@@ -1,4 +1,4 @@
-import type { ArchitectureModel, Block, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 import type {
   GenerationOptions,
   GeneratorPlugin,

--- a/apps/web/src/features/generate/terraform.test.ts
+++ b/apps/web/src/features/generate/terraform.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ArchitectureModel, Block, Connection, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 import { azureProvider } from './provider';
 import {
   generateMainTf,

--- a/apps/web/src/features/generate/terraform.ts
+++ b/apps/web/src/features/generate/terraform.ts
@@ -1,4 +1,4 @@
-import type { ArchitectureModel, Block, Plate, Connection } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Plate, Connection } from '@cloudblocks/schema';
 import type {
   GenerationOptions,
   NormalizedModel,

--- a/apps/web/src/features/generate/terraformPlugin.test.ts
+++ b/apps/web/src/features/generate/terraformPlugin.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { terraformPlugin } from './terraformPlugin';
 import { azureProviderDefinition } from './provider';
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type { GenerationOptions } from './types';
 
 const testArchitecture: ArchitectureModel = {

--- a/apps/web/src/features/generate/types.ts
+++ b/apps/web/src/features/generate/types.ts
@@ -1,4 +1,4 @@
-import type { ArchitectureModel, BlockCategory, PlateType, ProviderType } from '../../shared/types/index';
+import type { ArchitectureModel, BlockCategory, PlateType, ProviderType } from '@cloudblocks/schema';
 
 /**
  * Code Generation Types (v1.0)

--- a/apps/web/src/features/learning/__tests__/integration.test.ts
+++ b/apps/web/src/features/learning/__tests__/integration.test.ts
@@ -22,7 +22,7 @@ import type {
   ArchitectureSnapshot,
   StepValidationRule,
 } from '../../../shared/types/learning';
-import type { BlockCategory, PlateType, SubnetAccess } from '../../../shared/types';
+import type { BlockCategory, PlateType, SubnetAccess } from '@cloudblocks/schema';
 
 const EMPTY_ARCHITECTURE: ArchitectureSnapshot = {
   name: 'Empty Test Architecture',

--- a/apps/web/src/features/learning/step-validator.test.ts
+++ b/apps/web/src/features/learning/step-validator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type { StepValidationRule } from '../../shared/types/learning';
 import { evaluateRule, evaluateRules } from './step-validator';
 

--- a/apps/web/src/features/learning/step-validator.ts
+++ b/apps/web/src/features/learning/step-validator.ts
@@ -1,4 +1,4 @@
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type { StepValidationRule } from '../../shared/types/learning';
 import { validateArchitecture } from '../../entities/validation/engine';
 

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -1,59 +1,49 @@
 // CloudBlocks Platform - Core Domain Types
 // Based on DOMAIN_MODEL.md §12
 
-// ─── Plate Types ───────────────────────────────────────────
+import type {
+  ArchitectureModel,
+  BlockCategory,
+  BlockRole,
+  PlateType,
+  Size,
+  SubnetAccess,
+} from '@cloudblocks/schema';
 
-// ─── Layer Hierarchy (v2.0) ────────────────────────────────
-export type LayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet' | 'resource';
+export type {
+  Aggregation,
+  AggregationMode,
+  ArchitectureModel,
+  Block,
+  BlockCategory,
+  BlockRole,
+  Connection,
+  ConnectionType,
+  ExternalActor,
+  LayerType,
+  Plate,
+  PlateType,
+  Position,
+  ProviderType,
+  Size,
+  SubnetAccess,
+} from '@cloudblocks/schema';
 
+export {
+  BLOCK_ROLES,
+  CONNECTION_TYPE_LABELS,
+  VALID_PARENTS,
+} from '@cloudblocks/domain';
 
-export const VALID_PARENTS: Record<LayerType, LayerType[]> = {
-  global: [],           // root level
-  edge: [],             // root level
-  region: ['global'],   // or root
-  zone: ['region'],
-  subnet: ['zone', 'region'],
-  resource: ['subnet', 'zone', 'region', 'edge', 'global'],
-};
-
-export type PlateType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
-export type SubnetAccess = 'public' | 'private';
-
-export interface Plate {
-  id: string;
-  name: string;
-  type: PlateType;
-  subnetAccess?: SubnetAccess; // only for subnet type
-  profileId?: PlateProfileId;
-  parentId: string | null; // null for root plate
-  children: string[]; // mixed list: child plate IDs + block IDs (intentional for MVP; consider splitting to childPlateIds/childBlockIds in v1.0)
-  position: Position;
-  size: Size;
-  metadata: Record<string, unknown>;
-}
-
-// ─── Block Types ───────────────────────────────────────────
-
-export type BlockCategory = 'compute' | 'database' | 'storage' | 'gateway' | 'function' | 'queue' | 'event' | 'analytics' | 'identity' | 'observability';
-export type ProviderType = 'azure' | 'aws' | 'gcp';
-
-
-// ─── Aggregation (v2.0 §8) ──────────────────────────────────
-
-export type AggregationMode = 'single' | 'count';
-
-export interface Aggregation {
-  mode: AggregationMode;
-  count: number; // must be >= 1
-}
+export type {
+  RuleDefinition,
+  RuleSeverity,
+  RuleType,
+  ValidationError,
+  ValidationResult,
+} from '@cloudblocks/domain';
 
 // ─── Role Model (v2.0 §9) ────────────────────────────────────
-
-export type BlockRole = 'primary' | 'secondary' | 'reader' | 'writer' | 'public' | 'private' | 'internal' | 'external';
-
-export const BLOCK_ROLES: readonly BlockRole[] = [
-  'primary', 'secondary', 'reader', 'writer', 'public', 'private', 'internal', 'external',
-] as const;
 
 export interface RoleVisualIndicator {
   icon: string;       // emoji or symbol badge
@@ -71,82 +61,6 @@ export const ROLE_VISUAL_INDICATORS: Record<BlockRole, RoleVisualIndicator> = {
   internal: { icon: '⇐', label: 'Internal' },
   external: { icon: '⇒', label: 'External' },
 };
-export interface Block {
-  id: string;
-  name: string;
-  category: BlockCategory;
-  placementId: string; // parent plate ID
-  position: Position; // relative to parent plate
-  metadata: Record<string, unknown>;
-  provider?: ProviderType;
-  subtype?: string;
-  config?: Record<string, unknown>;
-  aggregation?: Aggregation; // v2.0 §8 — multiple identical resources
-  roles?: BlockRole[];       // v2.0 §9 — visual-only role indicators
-}
-
-// ─── Connection ────────────────────────────────────────────
-
-/**
- * Connection direction represents the **initiator** of the request.
- * Arrow points from the entity that starts communication.
- * Response flows implicitly in the reverse direction.
- */
-export type ConnectionType = 'dataflow' | 'http' | 'internal' | 'data' | 'async';
-
-export const CONNECTION_TYPE_LABELS: Record<ConnectionType, string> = {
-  dataflow: 'Data Flow',
-  http: 'HTTP',
-  internal: 'Internal',
-  data: 'Data',
-  async: 'Async',
-};
-
-export interface Connection {
-  id: string;
-  sourceId: string; // block or external actor ID (initiator)
-  targetId: string; // block or external actor ID (receiver)
-  type: ConnectionType;
-  metadata: Record<string, unknown>;
-}
-
-// ─── External Actor ────────────────────────────────────────
-
-export interface ExternalActor {
-  id: string;
-  name: string; // e.g., "Internet"
-  type: 'internet';
-  position: Position;
-}
-
-// ─── Spatial ───────────────────────────────────────────────
-
-export interface Position {
-  x: number;
-  y: number;
-  z: number;
-}
-
-export interface Size {
-  width: number;
-  height: number;
-  depth: number;
-}
-
-// ─── Architecture Model (root) ─────────────────────────────
-
-export interface ArchitectureModel {
-  id: string;
-  name: string;
-  version: string; // user-facing architecture revision (not schema version; see schema.ts)
-  plates: Plate[];
-  blocks: Block[];
-  connections: Connection[];
-  externalActors: ExternalActor[];
-  createdAt: string; // ISO 8601
-  updatedAt: string; // ISO 8601
-}
-
 // ─── Workspace ─────────────────────────────────────────────
 
 export interface Workspace {
@@ -161,33 +75,6 @@ export interface Workspace {
   branch?: string;
   lastSyncAt?: string;
   backendWorkspaceId?: string;
-}
-
-// ─── Rule Engine Types ─────────────────────────────────────
-
-export type RuleSeverity = 'error' | 'warning';
-export type RuleType = 'placement' | 'connection';
-
-export interface RuleDefinition {
-  id: string;
-  name: string;
-  type: RuleType;
-  severity: RuleSeverity;
-  description: string;
-}
-
-export interface ValidationError {
-  ruleId: string;
-  severity: RuleSeverity;
-  message: string;
-  suggestion?: string;
-  targetId: string; // block or connection ID
-}
-
-export interface ValidationResult {
-  valid: boolean;
-  errors: ValidationError[];
-  warnings: ValidationError[];
 }
 
 // ─── Visual Identity ───────────────────────────────────────
@@ -475,6 +362,10 @@ export const DEFAULT_PLATE_PROFILE: Record<PlateType, PlateProfileId> = {
 
 export function getPlateProfile(profileId: PlateProfileId): PlateProfile {
   return PLATE_PROFILES[profileId];
+}
+
+export function isPlateProfileId(value: string): value is PlateProfileId {
+  return value in PLATE_PROFILES;
 }
 
 export function buildPlateSizeFromProfileId(profileId: PlateProfileId): Size {

--- a/apps/web/src/shared/types/schema.ts
+++ b/apps/web/src/shared/types/schema.ts
@@ -71,11 +71,12 @@ export function deserialize(json: string): Workspace[] {
     if (ws.architecture?.plates) {
       for (const plate of ws.architecture.plates) {
         if (!plate.profileId) {
-          plate.profileId = inferLegacyPlateProfileId({
+          const inferredProfileId = inferLegacyPlateProfileId({
             type: plate.type,
             size: { width: plate.size.width, depth: plate.size.depth },
           });
-          const profileSize = buildPlateSizeFromProfileId(plate.profileId);
+          plate.profileId = inferredProfileId;
+          const profileSize = buildPlateSizeFromProfileId(inferredProfileId);
           plate.size = profileSize;
         }
       }

--- a/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
@@ -5,7 +5,7 @@ import { CommandCard } from './CommandCard';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore, type ToolMode } from '../../entities/store/uiStore';
 import { useWorkerStore } from '../../entities/store/workerStore';
-import type { ArchitectureModel, Block, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
 
 vi.mock('./CommandCard.css', () => ({}));
 vi.mock('../../shared/ui/PromptDialog', () => ({

--- a/apps/web/src/widgets/bottom-panel/CommandCard.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.tsx
@@ -29,12 +29,8 @@ import {
   type ActionType,
   type PlateActionType,
 } from './useTechTree';
-import {
-  BLOCK_COLORS,
-  BLOCK_FRIENDLY_NAMES,
-  BLOCK_ICONS,
-} from '../../shared/types/index';
-import type { BlockCategory, Plate, ProviderType } from '../../shared/types/index';
+import { BLOCK_COLORS, BLOCK_FRIENDLY_NAMES, BLOCK_ICONS } from '../../shared/types/index';
+import type { BlockCategory, Plate, ProviderType } from '@cloudblocks/schema';
 import './CommandCard.css';
 
 interface CommandCardProps {

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { DetailPanel } from './DetailPanel';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import type { ArchitectureModel, Block, Connection, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 
 vi.mock('./DetailPanel.css', () => ({}));
 

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -13,18 +13,9 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import {
-  BLOCK_FRIENDLY_NAMES,
-  BLOCK_DESCRIPTIONS,
-  BLOCK_ICONS,
-  BLOCK_COLORS,
-  DEFAULT_PLATE_PROFILE,
-  getPlateProfile,
-  PLATE_COLORS,
-  PLATE_PROFILES,
-  SUBNET_ACCESS_COLORS,
-} from '../../shared/types/index';
-import type { Block, Plate, PlateProfileId } from '../../shared/types/index';
+import { BLOCK_FRIENDLY_NAMES, BLOCK_DESCRIPTIONS, BLOCK_ICONS, BLOCK_COLORS, DEFAULT_PLATE_PROFILE, getPlateProfile, isPlateProfileId, PLATE_COLORS, PLATE_PROFILES, SUBNET_ACCESS_COLORS } from '../../shared/types/index';
+import type { PlateProfileId } from '../../shared/types/index';
+import type { Block, Plate } from '@cloudblocks/schema';
 import './DetailPanel.css';
 
 interface DetailPanelProps {
@@ -208,7 +199,9 @@ function PlateDetail({ plate, className }: { plate: Plate; className: string }) 
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
   const setPlateProfile = useArchitectureStore((s) => s.setPlateProfile);
 
-  const profileId = plate.profileId ?? DEFAULT_PLATE_PROFILE[plate.type];
+  const profileId = plate.profileId && isPlateProfileId(plate.profileId)
+    ? plate.profileId
+    : DEFAULT_PLATE_PROFILE[plate.type];
   const profile = getPlateProfile(profileId);
   const profileFilterType = plate.type === 'subnet' ? 'subnet' : 'region';
   const profileOptions = Object.values(PLATE_PROFILES).filter(

--- a/apps/web/src/widgets/bottom-panel/Minimap.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/Minimap.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { Minimap } from './Minimap';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import type { ArchitectureModel, Block, Connection, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 
 vi.mock('./Minimap.css', () => ({}));
 

--- a/apps/web/src/widgets/bottom-panel/Portrait.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/Portrait.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { Portrait } from './Portrait';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import type { ArchitectureModel, Block, Connection, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 
 vi.mock('./Portrait.css', () => ({}));
 vi.mock('../../shared/assets/azure-icons/virtual-machine.svg', () => ({ default: 'vm.svg' }));

--- a/apps/web/src/widgets/bottom-panel/Portrait.tsx
+++ b/apps/web/src/widgets/bottom-panel/Portrait.tsx
@@ -11,12 +11,7 @@
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { getPlateFaceColors } from '../../entities/plate/plateFaceColors';
-import {
-  BLOCK_FRIENDLY_NAMES,
-  BLOCK_COLORS,
-  PLATE_COLORS,
-  SUBNET_ACCESS_COLORS,
-} from '../../shared/types/index';
+import { BLOCK_FRIENDLY_NAMES, BLOCK_COLORS, PLATE_COLORS, SUBNET_ACCESS_COLORS } from '../../shared/types/index';
 import vmIcon from '../../shared/assets/azure-icons/virtual-machine.svg';
 import sqlIcon from '../../shared/assets/azure-icons/sql-database.svg';
 import storageIcon from '../../shared/assets/azure-icons/storage-account.svg';

--- a/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
-import type { ArchitectureModel, BlockCategory, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, BlockCategory, Plate } from '@cloudblocks/schema';
 import {
   ACTION_DEFINITIONS,
   ACTION_GRID,

--- a/apps/web/src/widgets/bottom-panel/useTechTree.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
-import type { BlockCategory } from '../../shared/types/index';
+import type { BlockCategory } from '@cloudblocks/schema';
 
 export type ResourceType =
   | 'network'

--- a/apps/web/src/widgets/code-preview/CodePreview.test.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { CodePreview } from './CodePreview';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 
 // Mock the pipeline module
 vi.mock('../../features/generate/pipeline', () => {

--- a/apps/web/src/widgets/code-preview/CodePreview.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.tsx
@@ -3,7 +3,7 @@ import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { generateCode, GenerationError } from '../../features/generate/pipeline';
 import type { GeneratedOutput, GenerationOptions, GeneratorId } from '../../features/generate/types';
-import type { ProviderType } from '../../shared/types/index';
+import type { ProviderType } from '@cloudblocks/schema';
 import './CodePreview.css';
 
 const GENERATORS: { id: GeneratorId; label: string }[] = [

--- a/apps/web/src/widgets/flow-diagram/FlowDiagram.test.tsx
+++ b/apps/web/src/widgets/flow-diagram/FlowDiagram.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { FlowDiagram } from './FlowDiagram';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
-import type { ArchitectureModel, Block, Connection, ExternalActor } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, ExternalActor } from '@cloudblocks/schema';
 
 vi.mock('./FlowDiagram.css', () => ({}));
 

--- a/apps/web/src/widgets/flow-diagram/FlowDiagram.tsx
+++ b/apps/web/src/widgets/flow-diagram/FlowDiagram.tsx
@@ -1,11 +1,7 @@
 import { useMemo } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
-import {
-  BLOCK_COLORS,
-  BLOCK_FRIENDLY_NAMES,
-  BLOCK_ICONS,
-} from '../../shared/types/index';
-import type { Block, Connection, ExternalActor } from '../../shared/types/index';
+import { BLOCK_COLORS, BLOCK_FRIENDLY_NAMES, BLOCK_ICONS } from '../../shared/types/index';
+import type { Block, Connection, ExternalActor } from '@cloudblocks/schema';
 import './FlowDiagram.css';
 
 function buildFlowChain(

--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -10,7 +10,7 @@ import { useUIStore } from '../../entities/store/uiStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { apiPost } from '../../shared/api/client';
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 
 const emptyArch: ArchitectureModel = {
   id: 'arch-1',

--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -11,7 +11,7 @@ import { useUIStore } from '../../entities/store/uiStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { apiGet, apiPost, apiPut } from '../../shared/api/client';
-import type { ArchitectureModel } from '../../shared/types/index';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 
 const emptyArch: ArchitectureModel = {
   id: 'arch-1',

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -17,7 +17,7 @@ import { MenuBar } from './MenuBar';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import type { ArchitectureModel, Block, Connection, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 import { apiPost } from '../../shared/api/client';
 import { toast } from 'react-hot-toast';
 import { confirmDialog } from '../../shared/ui/ConfirmDialog';

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -9,7 +9,7 @@ import { computeArchitectureDiff } from '../../features/diff/engine';
 import { apiPost } from '../../shared/api/client';
 import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import type { PullResponse } from '../../shared/types/api';
-import type { ArchitectureModel, ProviderType } from '../../shared/types';
+import type { ArchitectureModel, ProviderType } from '@cloudblocks/schema';
 import { audioService } from '../../shared/utils/audioService';
 import type { SoundName } from '../../shared/utils/audioService';
 import './MenuBar.css';

--- a/apps/web/src/widgets/resource-bar/ResourceBar.test.tsx
+++ b/apps/web/src/widgets/resource-bar/ResourceBar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ResourceBar } from './ResourceBar';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
-import type { ArchitectureModel, Block, Connection, Plate } from '../../shared/types/index';
+import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 
 const createArchitecture = (
   plates: Plate[] = [],

--- a/apps/web/src/widgets/validation-panel/ValidationPanel.test.tsx
+++ b/apps/web/src/widgets/validation-panel/ValidationPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { ValidationPanel } from './ValidationPanel';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import type { ValidationResult } from '../../shared/types/index';
+import type { ValidationResult } from '@cloudblocks/domain';
 
 describe('ValidationPanel', () => {
   beforeEach(() => {

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -24,5 +24,9 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    { "path": "../../packages/schema" },
+    { "path": "../../packages/cloudblocks-domain" }
+  ]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,9 @@
 {
-  "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+"files": [],
+"references": [
+{ "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "../../packages/schema" },
+    { "path": "../../packages/cloudblocks-domain" }
+]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@cloudblocks/domain':
+        specifier: workspace:*
+        version: link:../../packages/cloudblocks-domain
+      '@cloudblocks/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
       interactjs:
         specifier: ^1.10.27
         version: 1.10.27


### PR DESCRIPTION
## Summary

Migrate all `apps/web` imports to use the extracted `@cloudblocks/schema` and `@cloudblocks/domain` packages instead of the monolithic `shared/types` barrel.

## Changes

- **79 files** updated across source and test files
- Added `@cloudblocks/schema` and `@cloudblocks/domain` as workspace dependencies in `apps/web/package.json`
- `shared/types/index.ts` now re-exports from packages while keeping frontend-only types local
- Net reduction: 163 insertions vs 333 deletions (cleaner imports)
- Added `.gitignore` rules for stale screenshot artifacts and SQLite DB files

## Migration Strategy

Per M17_SCHEMA_BOUNDARIES.md §5.3:
1. `shared/types/index.ts` re-exports from packages (backward-compatible)
2. Consumer files updated to import directly from packages where possible
3. Frontend-only types (`PlateProfileId`, tool modes, UI state types) remain in `shared/types/`

## Verification

- ✅ `pnpm build` passes
- ✅ `pnpm lint` passes
- ✅ All 1512 tests pass
- ✅ No type errors

## Dependencies

- Requires #423 (✅ merged) — @cloudblocks/schema package
- Requires #425 (✅ merged) — @cloudblocks/domain package

Fixes #426