### PR TITLE
fix(web): resolve workspace package imports for Vite and Vitest

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@cloudblocks/domain': path.resolve(__dirname, '../../packages/cloudblocks-domain/src/index.ts'),
+      '@cloudblocks/schema': path.resolve(__dirname, '../../packages/schema/src/index.ts'),
+    },
+  },
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@cloudblocks/domain': path.resolve(__dirname, '../../packages/cloudblocks-domain/src/index.ts'),
+      '@cloudblocks/schema': path.resolve(__dirname, '../../packages/schema/src/index.ts'),
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "dev": "pnpm --filter @cloudblocks/web dev",
-    "build": "pnpm --filter @cloudblocks/web build",
+    "build:packages": "pnpm --filter @cloudblocks/schema build && pnpm --filter @cloudblocks/domain build",
+    "dev": "pnpm run build:packages && pnpm --filter @cloudblocks/web dev",
+    "build": "pnpm run build:packages && pnpm --filter @cloudblocks/web build",
     "lint": "pnpm --filter @cloudblocks/web lint",
     "preview": "pnpm --filter @cloudblocks/web preview",
     "clean": "pnpm -r exec rm -rf node_modules dist .turbo"


### PR DESCRIPTION
## Summary

- Add `resolve.alias` in `vite.config.ts` and `vitest.config.ts` so `@cloudblocks/domain` and `@cloudblocks/schema` resolve to their source entry points (no pre-build needed for dev server)
- Add `build:packages` script to root `package.json` so `tsc -b` can find compiled workspace dependencies during `pnpm build`
- Root `dev` and `build` scripts now run `build:packages` first

## Changed Files

| File | Change |
|------|--------|
| `apps/web/vite.config.ts` | Add resolve aliases for both workspace packages |
| `apps/web/vitest.config.ts` | Same resolve aliases for test environment |
| `package.json` | Add `build:packages` script; chain it into `dev` and `build` |

## Verification

- `pnpm build` ✅ (packages build first, then web builds successfully)
- `pnpm --filter @cloudblocks/web test` ✅ (87 files, 1516 tests pass)

Fixes #489