### PR TITLE
refactor(web): consolidate workspace and tsconfig configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,13 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "dev": "pnpm --filter @cloudblocks/web dev",
-    "build": "pnpm --filter @cloudblocks/web build",
-    "lint": "pnpm --filter @cloudblocks/web lint",
+    "build": "pnpm --filter @cloudblocks/schema build && pnpm --filter @cloudblocks/domain build && pnpm --filter @cloudblocks/web build",
+    "build:packages": "pnpm --filter @cloudblocks/schema build && pnpm --filter @cloudblocks/domain build",
+    "build:web": "pnpm --filter @cloudblocks/web build",
+    "typecheck": "tsc -b",
+    "lint": "pnpm -r --filter './packages/*' --filter @cloudblocks/web lint",
+    "test": "pnpm --filter @cloudblocks/web test",
+    "test:web": "pnpm --filter @cloudblocks/web test",
     "preview": "pnpm --filter @cloudblocks/web preview",
     "clean": "pnpm -r exec rm -rf node_modules dist .turbo"
   },

--- a/packages/cloudblocks-domain/eslint.config.js
+++ b/packages/cloudblocks-domain/eslint.config.js
@@ -1,0 +1,20 @@
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist', 'coverage']),
+  {
+    files: ['**/*.ts'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+    ],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+    },
+  },
+])

--- a/packages/cloudblocks-domain/package.json
+++ b/packages/cloudblocks-domain/package.json
@@ -26,7 +26,10 @@
     "@cloudblocks/schema": "workspace:*"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.0.3",
     "typescript": "~5.9.3",
+    "typescript-eslint": "^8.56.1",
     "vitest": "^4.1.0"
   }
 }

--- a/packages/schema/eslint.config.js
+++ b/packages/schema/eslint.config.js
@@ -1,0 +1,20 @@
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+import { defineConfig, globalIgnores } from 'eslint/config'
+
+export default defineConfig([
+  globalIgnores(['dist', 'coverage']),
+  {
+    files: ['**/*.ts'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+    ],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      }],
+    },
+  },
+])

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -24,9 +24,12 @@
     "generate:schema": "tsx scripts/generate-schema.ts"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
+    "eslint": "^10.0.3",
     "ts-json-schema-generator": "2.4.0",
     "tsx": "^4.19.0",
     "typescript": "~5.9.3",
+    "typescript-eslint": "^8.56.1",
     "vitest": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,15 +102,30 @@ importers:
         specifier: workspace:*
         version: link:../schema
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.0.3)
+      eslint:
+        specifier: ^10.0.3
+        version: 10.0.3
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.56.1
+        version: 8.57.0(eslint@10.0.3)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.19.15)(jsdom@29.0.0)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))
 
   packages/schema:
     devDependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.0.3)
+      eslint:
+        specifier: ^10.0.3
+        version: 10.0.3
       ts-json-schema-generator:
         specifier: 2.4.0
         version: 2.4.0
@@ -120,6 +135,9 @@ importers:
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.56.1
+        version: 8.57.0(eslint@10.0.3)(typescript@5.9.3)
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@22.19.15)(jsdom@29.0.0)(vite@8.0.0(@types/node@22.19.15)(esbuild@0.27.4)(tsx@4.21.0))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/schema" },
+    { "path": "packages/cloudblocks-domain" },
+    { "path": "apps/web/tsconfig.app.json" },
+    { "path": "apps/web/tsconfig.node.json" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add root `tsconfig.json` with project references for all packages
- Update root `package.json` scripts to support build/typecheck/lint/test across all modules
- Add ESLint flat config to `@cloudblocks/schema` and `@cloudblocks/domain`
- Verify `pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm test` work from monorepo root

## Notes
- Directory `packages/cloudblocks-domain/` is intentionally NOT renamed to `packages/domain/` — the tsconfig references, workspace imports, and CI all reference the current path. Renaming would be high-risk for low value.
- Package lint uses the same ESLint flat config format as `apps/web`

Fixes #432