### PR TITLE
fix(web): validate pulled GitHub architecture before store replacement

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -1709,6 +1709,69 @@ describe('architectureStore', () => {
     });
   });
 
+  describe('replaceArchitecture – validation', () => {
+    it('throws when snapshot is not an object', () => {
+      expect(() => getState().replaceArchitecture('not-an-object' as unknown as ArchitectureSnapshot))
+        .toThrow('root must be an object');
+    });
+
+    it('throws when plates is missing', () => {
+      const invalid = { blocks: [], connections: [] } as unknown as ArchitectureSnapshot;
+      expect(() => getState().replaceArchitecture(invalid))
+        .toThrow('plates must be an array');
+    });
+
+    it('throws when blocks is missing', () => {
+      const invalid = { plates: [], connections: [] } as unknown as ArchitectureSnapshot;
+      expect(() => getState().replaceArchitecture(invalid))
+        .toThrow('blocks must be an array');
+    });
+
+    it('throws when a plate has invalid type', () => {
+      const invalid = {
+        plates: [{
+          id: 'p1', name: 'Net', type: 'invalid-type',
+          parentId: null, children: [],
+          position: { x: 0, y: 0, z: 0 },
+          size: { width: 12, height: 0.3, depth: 10 },
+        }],
+        blocks: [],
+        connections: [],
+      } as unknown as ArchitectureSnapshot;
+      expect(() => getState().replaceArchitecture(invalid))
+        .toThrow('type must be one of');
+    });
+
+    it('throws when a block references non-existent plate', () => {
+      const invalid = {
+        plates: [{
+          id: 'p1', name: 'Net', type: 'region',
+          parentId: null, children: [],
+          position: { x: 0, y: 0, z: 0 },
+          size: { width: 12, height: 0.3, depth: 10 },
+        }],
+        blocks: [{
+          id: 'b1', name: 'VM', category: 'compute',
+          placementId: 'missing-plate',
+          position: { x: 0, y: 0.5, z: 0 },
+        }],
+        connections: [],
+      } as unknown as ArchitectureSnapshot;
+      expect(() => getState().replaceArchitecture(invalid))
+        .toThrow('does not reference an existing plate');
+    });
+
+    it('does not modify state when validation fails', () => {
+      getState().addPlate('region', 'Original', null);
+      const archBefore = JSON.parse(JSON.stringify(getArch())) as ArchitectureModel;
+
+      const invalid = { blocks: [] } as unknown as ArchitectureSnapshot;
+      expect(() => getState().replaceArchitecture(invalid)).toThrow();
+
+      expect(getArch()).toEqual(archBefore);
+    });
+  });
+
   // ── Auto-validation subscriber ──
 
   describe('auto-validation', () => {

--- a/apps/web/src/entities/store/slices/index.ts
+++ b/apps/web/src/entities/store/slices/index.ts
@@ -1,5 +1,5 @@
 export { createDomainSlice } from './domainSlice';
 export { createHistorySlice } from './historySlice';
-export { createPersistenceSlice } from './persistenceSlice';
+export { createPersistenceSlice, validateArchitectureShape } from './persistenceSlice';
 export { createValidationSlice } from './validationSlice';
 export { createWorkspaceSlice } from './workspaceSlice';

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -74,14 +74,9 @@ const validateSize = (value: unknown, context: string): void => {
   }
 };
 
-const validateImportData = (
+export const validateArchitectureShape = (
   imported: unknown,
-  jsonLength: number
 ): { valid: true } => {
-  if (jsonLength > MAX_IMPORT_SIZE_BYTES) {
-    throw new Error('Import exceeds 5MB limit');
-  }
-
   if (!isRecord(imported)) {
     throw new Error('Invalid architecture format: root must be an object');
   }
@@ -224,6 +219,17 @@ const validateImportData = (
   });
 
   return { valid: true };
+};
+
+const validateImportData = (
+  imported: unknown,
+  jsonLength: number,
+): { valid: true } => {
+  if (jsonLength > MAX_IMPORT_SIZE_BYTES) {
+    throw new Error('Import exceeds 5MB limit');
+  }
+
+  return validateArchitectureShape(imported);
 };
 
 type PersistenceSlice = Pick<
@@ -370,6 +376,8 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (
   },
 
   replaceArchitecture: (snapshot: ArchitectureSnapshot) => {
+    validateArchitectureShape(snapshot);
+
     const state = get();
     const now = new Date().toISOString();
     const newArch: ArchitectureModel = {

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -3,6 +3,7 @@ import { AiPromptBar } from '../../features/ai';
 import { useAiStore } from '../../features/ai/store';
 import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
+import { validateArchitectureShape } from '../../entities/store/slices';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { computeArchitectureDiff } from '../../features/diff/engine';
@@ -176,6 +177,7 @@ export function MenuBar() {
       const response = await apiPost<PullResponse>(
         `/api/v1/workspaces/${encodeURIComponent(wsId)}/pull`,
       );
+      validateArchitectureShape(response.architecture);
       const remoteArch = response.architecture as unknown as ArchitectureModel;
       const localArch = useArchitectureStore.getState().workspace.architecture;
       const delta = computeArchitectureDiff(remoteArch, localArch);


### PR DESCRIPTION
## Summary

- Extract `validateArchitectureShape()` from `validateImportData()` to enable reuse across pull and diff paths
- Add structural validation to `replaceArchitecture()` (GitHub pull path) — previously used type cast without validation
- Add structural validation to `handleCompareWithGitHub()` in MenuBar (diff path) — previously cast API response directly
- Add 5 test cases for `replaceArchitecture` with invalid data (non-object, missing plates/blocks, invalid plate type, orphan block, state preservation on failure)

## Changes

| File | Change |
|------|--------|
| `persistenceSlice.ts` | Extract + export `validateArchitectureShape`, call it in `replaceArchitecture` |
| `slices/index.ts` | Re-export `validateArchitectureShape` |
| `MenuBar.tsx` | Import and call `validateArchitectureShape` before casting in `handleCompareWithGitHub` |
| `architectureStore.test.ts` | Add `replaceArchitecture – validation` describe block with 5 tests |

## Testing

- All 1524 tests pass
- Build succeeds
- Zero LSP diagnostics

Fixes #490