### PR TITLE
fix(web): implement Ctrl+S save shortcut

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -165,6 +165,44 @@ describe('App', () => {
     expect(redoMock).toHaveBeenCalledOnce();
   });
 
+  it('handles Ctrl+S for save', () => {
+    const saveToStorageMock = vi.fn();
+    useArchitectureStore.setState({
+      loadFromStorage: loadFromStorageMock,
+      undo: undoMock,
+      redo: redoMock,
+      removeBlock: removeBlockMock,
+      removePlate: removePlateMock,
+      removeConnection: removeConnectionMock,
+      saveToStorage: saveToStorageMock,
+    });
+    render(<App />);
+    const event = new KeyboardEvent('keydown', { key: 's', ctrlKey: true, bubbles: true });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(saveToStorageMock).toHaveBeenCalledOnce();
+  });
+
+  it('handles Meta+S for save (macOS)', () => {
+    const saveToStorageMock = vi.fn();
+    useArchitectureStore.setState({
+      loadFromStorage: loadFromStorageMock,
+      undo: undoMock,
+      redo: redoMock,
+      removeBlock: removeBlockMock,
+      removePlate: removePlateMock,
+      removeConnection: removeConnectionMock,
+      saveToStorage: saveToStorageMock,
+    });
+    render(<App />);
+    const event = new KeyboardEvent('keydown', { key: 's', metaKey: true, bubbles: true });
+    const preventDefaultSpy = vi.spyOn(event, 'preventDefault');
+    window.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(saveToStorageMock).toHaveBeenCalledOnce();
+  });
+
   it('handles Delete key to remove selected block', () => {
     useUIStore.setState({ selectedId: 'block-1', setSelectedId: setSelectedIdMock });
     useArchitectureStore.setState({

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -120,6 +120,13 @@ function App() {
         setSelectedId(null);
         return;
       }
+
+      // Save: Ctrl+S or Cmd+S
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        useArchitectureStore.getState().saveToStorage();
+        return;
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
## Summary

- Add Ctrl+S / Cmd+S keyboard handler in App.tsx global shortcut handler
- Calls `saveToStorage()` and prevents browser default save dialog
- Add regression tests for both Ctrl+S and Meta+S (macOS)

Fixes #508