### PR TITLE
fix(web): show user-facing feedback when Import JSON fails

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -1122,6 +1122,33 @@ describe('architectureStore', () => {
       expect(getArch().blocks).toHaveLength(1);
     });
 
+    it('returns success result on valid import', () => {
+      const arch = {
+        name: 'Test',
+        plates: [{ id: 'p1', name: 'Net', type: 'region', parentId: null, children: [], position: { x: 0, y: 0, z: 0 }, size: { width: 10, height: 0.3, depth: 10 }, metadata: {} }],
+        blocks: [],
+        connections: [],
+      };
+      const result = getState().importArchitecture(JSON.stringify(arch));
+      expect(result).toEqual({ success: true });
+    });
+
+    it('returns error result on invalid JSON', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const result = getState().importArchitecture('not-valid-json');
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+      spy.mockRestore();
+    });
+
+    it('returns error result when plates/blocks are missing', () => {
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const result = getState().importArchitecture(JSON.stringify({ name: 'No data' }));
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('plates');
+      spy.mockRestore();
+    });
+
     it('normalizes missing fields with defaults', () => {
       const minimal = {
         plates: [

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -339,8 +339,11 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (
         workspaces: updatedList,
         ...resetTransientState(),
       });
+      return { success: true };
     } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
       console.error('Failed to import architecture:', error);
+      return { success: false, error: message };
     }
   },
 

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -57,7 +57,7 @@ export interface ArchitectureState {
   switchWorkspace: (id: string) => void;
   deleteWorkspace: (id: string) => void;
   cloneWorkspace: (id: string) => void;
-  importArchitecture: (json: string) => void;
+  importArchitecture: (json: string) => { success: boolean; error?: string };
   exportArchitecture: () => string;
   loadFromTemplate: (template: ArchitectureTemplate) => void;
   replaceArchitecture: (snapshot: ArchitectureSnapshot) => void;

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -72,7 +72,7 @@ const loadFromStorageMock = vi.fn();
 const resetWorkspaceMock = vi.fn();
 const undoMock = vi.fn();
 const redoMock = vi.fn();
-const importArchitectureMock = vi.fn();
+const importArchitectureMock = vi.fn().mockReturnValue({ success: true });
 
 function getMenuDropdown(triggerLabel: RegExp | string): HTMLElement {
   const trigger = screen.getByRole('button', { name: triggerLabel });
@@ -372,6 +372,48 @@ describe('MenuBar', () => {
 
     vi.stubGlobal('FileReader', originalFileReader);
   }, 15000);
+
+  it('shows alert when import fails', () => {
+    importArchitectureMock.mockReturnValueOnce({ success: false, error: 'plates is required' });
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+    render(<MenuBar />);
+    const fileInput = document.querySelector('input[type="file"]');
+    if (!(fileInput instanceof HTMLInputElement)) {
+      throw new Error('Expected hidden file input to be present');
+    }
+
+    let capturedOnload: ((ev: ProgressEvent<FileReader>) => void) | null = null;
+    const originalFileReader = window.FileReader;
+    class MockFileReader {
+      set onload(handler: ((ev: ProgressEvent<FileReader>) => void) | null) {
+        capturedOnload = handler;
+      }
+      get onload(): ((ev: ProgressEvent<FileReader>) => void) | null {
+        return capturedOnload;
+      }
+      readAsText(): void { /* noop */ }
+    }
+    vi.stubGlobal('FileReader', MockFileReader);
+
+    Object.defineProperty(fileInput, 'files', {
+      value: [new File(['{}'], 'bad.json', { type: 'application/json' })],
+      writable: true,
+      configurable: true,
+    });
+    fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+
+    const onloadHandler = capturedOnload as ((ev: ProgressEvent<FileReader>) => void) | null;
+    if (onloadHandler !== null) {
+      onloadHandler({ target: { result: '{}' } } as unknown as ProgressEvent<FileReader>);
+    }
+
+    expect(importArchitectureMock).toHaveBeenCalledWith('{}');
+    expect(alertSpy).toHaveBeenCalledWith('Import failed: plates is required');
+
+    alertSpy.mockRestore();
+    vi.stubGlobal('FileReader', originalFileReader);
+  });
 
   it('does nothing when import change event has no file', () => {
     render(<MenuBar />);

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -150,7 +150,10 @@ export function MenuBar() {
     reader.onload = (ev) => {
       const text = ev.target?.result;
       if (typeof text === 'string') {
-        importArchitecture(text);
+        const result = importArchitecture(text);
+        if (!result.success) {
+          window.alert(`Import failed: ${result.error}`);
+        }
       }
     };
     reader.readAsText(file);


### PR DESCRIPTION
## Summary
- `importArchitecture()` now returns `{ success: boolean; error?: string }` instead of `void`
- MenuBar shows `window.alert()` with the validation error message when import fails
- Previously, import failures were only logged to `console.error` — users had no feedback

### Changes
- `slices/types.ts` — Updated return type
- `slices/persistenceSlice.ts` — Return structured result from try/catch
- `MenuBar.tsx` — Check result and call `window.alert` on failure
- `architectureStore.test.ts` — 3 new tests for return value (success, invalid JSON, missing fields)
- `MenuBar.test.tsx` — New test verifying `window.alert` is called with error message

Fixes #510