### PR TITLE
fix(web): add Ctrl+S save, load confirmation, centralized logout

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -65,6 +65,7 @@ describe('App', () => {
   const removePlateMock = vi.fn();
   const removeConnectionMock = vi.fn();
   const loadFromStorageMock = vi.fn();
+  const saveToStorageMock = vi.fn();
   const setSelectedIdMock = vi.fn();
   const checkSessionMock = vi.fn();
 
@@ -87,6 +88,7 @@ describe('App', () => {
     });
     useArchitectureStore.setState({
       loadFromStorage: loadFromStorageMock,
+      saveToStorage: saveToStorageMock,
       undo: undoMock,
       redo: redoMock,
       removeBlock: removeBlockMock,
@@ -133,6 +135,20 @@ describe('App', () => {
   it('calls checkSession on mount', () => {
     render(<App />);
     expect(checkSessionMock).toHaveBeenCalledOnce();
+  });
+
+  it('handles Ctrl+S for save', () => {
+    render(<App />);
+    const preventDefaultMock = vi.fn();
+    fireEvent.keyDown(window, { key: 's', ctrlKey: true, preventDefault: preventDefaultMock });
+    expect(saveToStorageMock).toHaveBeenCalledOnce();
+  });
+
+  it('handles Meta+S for save (macOS)', () => {
+    render(<App />);
+    const preventDefaultMock = vi.fn();
+    fireEvent.keyDown(window, { key: 's', metaKey: true, preventDefault: preventDefaultMock });
+    expect(saveToStorageMock).toHaveBeenCalledOnce();
   });
 
   it('handles Ctrl+Z for undo', () => {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -33,6 +33,7 @@ const DiffPanel = lazy(() => import('../widgets/diff-panel/DiffPanel').then(m =>
 
 function App() {
   const loadFromStorage = useArchitectureStore((s) => s.loadFromStorage);
+  const saveToStorage = useArchitectureStore((s) => s.saveToStorage);
   const undo = useArchitectureStore((s) => s.undo);
   const redo = useArchitectureStore((s) => s.redo);
   const removeBlock = useArchitectureStore((s) => s.removeBlock);
@@ -71,6 +72,13 @@ function App() {
       // Don't intercept when typing in input/textarea
       const target = e.target as HTMLElement;
       if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+        return;
+      }
+
+      // Save: Ctrl+S / Cmd+S
+      if (e.key === 's' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        saveToStorage();
         return;
       }
 
@@ -124,7 +132,7 @@ function App() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, selectedId, removeBlock, removePlate, removeConnection, setSelectedId, interactionState, cancelInteraction]);
+  }, [undo, redo, saveToStorage, selectedId, removeBlock, removePlate, removeConnection, setSelectedId, interactionState, cancelInteraction]);
 
   return (
     <div className="app">

--- a/apps/web/src/entities/store/authStore.test.ts
+++ b/apps/web/src/entities/store/authStore.test.ts
@@ -3,12 +3,14 @@ import type { ApiUser } from '../../shared/types/api';
 
 vi.mock('../../shared/api/client', () => ({
   apiGet: vi.fn(),
+  apiPost: vi.fn(),
 }));
 
-import { apiGet } from '../../shared/api/client';
+import { apiGet, apiPost } from '../../shared/api/client';
 import { useAuthStore } from './authStore';
 
 const mockApiGet = vi.mocked(apiGet);
+const mockApiPost = vi.mocked(apiPost);
 
 const mockUser: ApiUser = {
   id: 'user-1',
@@ -21,6 +23,7 @@ const mockUser: ApiUser = {
 describe('useAuthStore', () => {
   beforeEach(() => {
     mockApiGet.mockReset();
+    mockApiPost.mockReset();
     useAuthStore.setState({
       status: 'unknown',
       user: null,
@@ -145,5 +148,33 @@ describe('useAuthStore', () => {
     // Should still be authenticated from call2, not error from call1
     expect(state.status).toBe('authenticated');
     expect(state.error).toBe(null);
+  });
+
+  it('logout sets anonymous state on success', async () => {
+    useAuthStore.setState({ status: 'authenticated', user: mockUser });
+    mockApiPost.mockResolvedValueOnce({ message: 'ok' });
+
+    await useAuthStore.getState().logout();
+
+    const state = useAuthStore.getState();
+    expect(mockApiPost).toHaveBeenCalledWith('/api/v1/auth/logout');
+    expect(state.status).toBe('anonymous');
+    expect(state.user).toBe(null);
+    expect(state.error).toBe(null);
+  });
+
+  it('logout calls checkSession on failure', async () => {
+    useAuthStore.setState({ status: 'authenticated', user: mockUser });
+    mockApiPost.mockRejectedValueOnce(new Error('Network error'));
+    // checkSession will be called as fallback — mock a successful session check
+    mockApiGet.mockResolvedValueOnce(mockUser);
+
+    await useAuthStore.getState().logout();
+
+    const state = useAuthStore.getState();
+    expect(mockApiPost).toHaveBeenCalledWith('/api/v1/auth/logout');
+    // checkSession was called as recovery, which sets authenticated
+    expect(mockApiGet).toHaveBeenCalledWith('/api/v1/auth/session');
+    expect(state.status).toBe('authenticated');
   });
 });

--- a/apps/web/src/entities/store/authStore.ts
+++ b/apps/web/src/entities/store/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { apiGet } from '../../shared/api/client';
+import { apiGet, apiPost } from '../../shared/api/client';
 import type { ApiUser, SessionUserResponse } from '../../shared/types/api';
 
 type AuthStatus = 'unknown' | 'authenticated' | 'anonymous';
@@ -14,6 +14,7 @@ interface AuthState {
   setAnonymous: () => void;
   setError: (error: string | null) => void;
   checkSession: () => Promise<void>;
+  logout: () => Promise<void>;
 }
 
 let _checkSessionSeq = 0;
@@ -51,6 +52,16 @@ export const useAuthStore = create<AuthState>((set) => ({
       } else {
         set({ hydrated: true, error: 'Session check failed' });
       }
+    }
+  },
+
+  logout: async () => {
+    try {
+      await apiPost<{ message: string }>('/api/v1/auth/logout');
+      set({ status: 'anonymous', user: null, error: null });
+    } catch {
+      set({ error: 'Logout failed. Checking session…' });
+      await useAuthStore.getState().checkSession();
     }
   },
 }));

--- a/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
@@ -65,9 +65,9 @@ describe('GitHubLogin', () => {
     expect(window.location.href).toContain('#oauth-callback');
   });
 
-  it('sign out calls setAnonymous', async () => {
+  it('sign out calls logout from authStore', async () => {
     const user = userEvent.setup();
-    const setAnonymousSpy = vi.spyOn(useAuthStore.getState(), 'setAnonymous');
+    const logoutMock = vi.fn();
     useAuthStore.setState({
       status: 'authenticated',
       user: {
@@ -77,15 +77,13 @@ describe('GitHubLogin', () => {
         display_name: 'The Octocat',
         avatar_url: null,
       },
+      logout: logoutMock,
     });
-    mockApiPost.mockResolvedValueOnce({ message: 'ok' });
 
     render(<GitHubLogin />);
     await user.click(screen.getByRole('button', { name: 'Sign Out' }));
 
-    expect(mockApiPost).toHaveBeenCalledWith('/api/v1/auth/logout');
-    expect(setAnonymousSpy).toHaveBeenCalledOnce();
-    setAnonymousSpy.mockRestore();
+    expect(logoutMock).toHaveBeenCalledOnce();
   });
 
   it('shows error when sign in fails', async () => {

--- a/apps/web/src/widgets/github-login/GitHubLogin.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.tsx
@@ -16,7 +16,7 @@ export function GitHubLogin() {
   const status = useAuthStore((s) => s.status);
   const authError = useAuthStore((s) => s.error);
   const setError = useAuthStore((s) => s.setError);
-  const setAnonymous = useAuthStore((s) => s.setAnonymous);
+  const logout = useAuthStore((s) => s.logout);
 
   const [isWorking, setIsWorking] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
@@ -45,8 +45,7 @@ export function GitHubLogin() {
     setLocalError(null);
     setError(null);
 
-    await apiPost<{ message: string }>('/api/v1/auth/logout').catch(() => {});
-    setAnonymous();
+    await logout();
 
     setIsWorking(false);
   };

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -284,6 +284,12 @@ describe('MenuBar', () => {
 
     await openMenu(user, 'File');
     await user.click(within(getMenuDropdown('File')).getByRole('button', { name: /Load Workspace/ }));
+    await waitFor(() => {
+      expect(confirmDialog).toHaveBeenCalledWith(
+        'Loading will replace current workspace with saved data. Unsaved changes will be lost.',
+        'Load Workspace?',
+      );
+    });
     expect(loadFromStorageMock).toHaveBeenCalledOnce();
 
     await openMenu(user, 'File');
@@ -314,6 +320,19 @@ describe('MenuBar', () => {
 
     await waitFor(() => {
       expect(resetWorkspaceMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not load workspace when load confirmation is canceled', async () => {
+    const user = userEvent.setup();
+    vi.mocked(confirmDialog).mockResolvedValue(false);
+    render(<MenuBar />);
+
+    const fileDropdown = await openMenu(user, 'File');
+    await user.click(within(fileDropdown).getByRole('button', { name: /Load Workspace/ }));
+
+    await waitFor(() => {
+      expect(loadFromStorageMock).not.toHaveBeenCalled();
     });
   });
 
@@ -547,6 +566,7 @@ describe('MenuBar', () => {
 
   it('handles authenticated GitHub menu actions', async () => {
     const user = userEvent.setup();
+    const logoutMock = vi.fn();
     useAuthStore.setState({
       status: 'authenticated',
       user: {
@@ -556,6 +576,7 @@ describe('MenuBar', () => {
         display_name: null,
         avatar_url: null,
       },
+      logout: logoutMock,
     });
 
     render(<MenuBar />);
@@ -581,7 +602,7 @@ describe('MenuBar', () => {
     await user.click(githubButton);
     githubDropdown = getMenuDropdown(/octocat/);
     await user.click(within(githubDropdown).getByRole('button', { name: /Sign Out/ }));
-    expect(useUIStore.getState().showGitHubLogin).toBe(true);
+    expect(logoutMock).toHaveBeenCalledOnce();
   });
 
   it('compare with GitHub calls backend and enables diff mode', async () => {

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -52,6 +52,7 @@ export function MenuBar() {
 
   const isAuthenticated = useAuthStore((s) => s.status) === 'authenticated';
   const user = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
 
   const removePlate = useArchitectureStore((s) => s.removePlate);
   const removeBlock = useArchitectureStore((s) => s.removeBlock);
@@ -128,8 +129,14 @@ export function MenuBar() {
     }
   };
 
-  const handleLoad = () => {
-    loadFromStorage();
+  const handleLoad = async () => {
+    const confirmed = await confirmDialog(
+      'Loading will replace current workspace with saved data. Unsaved changes will be lost.',
+      'Load Workspace?',
+    );
+    if (confirmed) {
+      loadFromStorage();
+    }
   };
 
   const handleExport = () => {
@@ -459,7 +466,7 @@ export function MenuBar() {
                 <span className="menu-item-left">🔍 Compare with GitHub</span>
               </button>
               <div className="menu-separator" />
-              <button type="button" className="menu-item" onClick={() => handleAction(toggleGitHubLogin)}>
+              <button type="button" className="menu-item" onClick={() => handleAction(logout)}>
                 <span className="menu-item-left">🚪 Sign Out</span>
               </button>
             </div>


### PR DESCRIPTION
## Summary

- **#508**: Add Ctrl+S / Cmd+S keyboard shortcut to save workspace
- **#516**: Show confirmation dialog before Load Workspace overwrites unsaved changes
- **#522**: Centralize logout in `authStore.logout()`, wire Sign Out menu item to call it directly
- **#524**: Prevent marking auth anonymous on logout API failure — falls back to `checkSession()` for reconciliation

## Changes

### `authStore.ts`
- Import `apiPost`, add `logout()` method: calls `/api/v1/auth/logout`, sets anonymous on success, calls `checkSession()` on failure

### `App.tsx`
- Add `saveToStorage` selector + Ctrl+S/Cmd+S handler with `preventDefault()`

### `MenuBar.tsx`
- `handleLoad` now async with `confirmDialog()` before `loadFromStorage()`
- Sign Out button calls `logout()` instead of `toggleGitHubLogin`

### `GitHubLogin.tsx`
- `handleSignOut` uses `authStore.logout()` instead of inline `apiPost` + `setAnonymous`

### Tests
- `App.test.tsx`: Ctrl+S and Cmd+S save shortcut tests
- `MenuBar.test.tsx`: Load confirmation dialog test, load cancel test, Sign Out calls `logout()` test
- `GitHubLogin.test.tsx`: Sign out calls `logout()` from authStore
- `authStore.test.ts`: `logout()` success and failure path tests

Fixes #508, #516, #522, #524