### PR TITLE
fix(web): reset GitHubRepos local state on panel reopen

### DIFF
--- a/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
@@ -191,4 +191,32 @@ describe('GitHubRepos', () => {
     expect(screen.getByText('Loading...')).toBeInTheDocument();
     resolvePost({ full_name: 'owner/new-repo', name: 'new-repo', private: false, default_branch: 'main', html_url: 'https://github.com/owner/new-repo' });
   });
+
+  it('resets form and error state on reopen', async () => {
+    const user = userEvent.setup();
+    mockApiGet
+      .mockResolvedValueOnce({ repos: [] }) // initial fetch
+      .mockRejectedValueOnce(new Error('Create failed')) // create fails — sets error
+      .mockResolvedValueOnce({ repos: [] }); // re-fetch on reopen
+    mockApiPost.mockRejectedValueOnce(new Error('Create failed'));
+
+    const { rerender } = render(<GitHubRepos />);
+
+    // Type a repo name and trigger a create error
+    await user.type(screen.getByPlaceholderText('Repository name'), 'my-repo');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+    expect(await screen.findByText('Create failed')).toBeInTheDocument();
+
+    // Close the panel
+    useUIStore.setState({ showGitHubRepos: false });
+    rerender(<GitHubRepos />);
+
+    // Reopen the panel
+    useUIStore.setState({ showGitHubRepos: true });
+    rerender(<GitHubRepos />);
+
+    // Error and form state should be cleared
+    expect(screen.queryByText('Create failed')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Repository name')).toHaveValue('');
+  });
 });

--- a/apps/web/src/widgets/github-repos/GitHubRepos.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { apiGet, apiPost } from '../../shared/api/client';
@@ -16,6 +16,18 @@ export function GitHubRepos() {
   const [error, setError] = useState<string | null>(null);
   const [newRepoName, setNewRepoName] = useState('');
   const [isPrivate, setIsPrivate] = useState(false);
+
+  // Reset local form/error state when panel transitions from closed to open
+  const prevShowRef = useRef(show);
+  useEffect(() => {
+    if (show && !prevShowRef.current) {
+      setError(null);
+      setNewRepoName('');
+      setIsPrivate(false);
+      setCreating(false);
+    }
+    prevShowRef.current = show;
+  }, [show]);
 
   const fetchRepos = async () => {
     setLoading(true);


### PR DESCRIPTION
## Summary
- Clear error, form inputs (`newRepoName`, `isPrivate`), and `creating` flag when the repos panel transitions from closed to open
- Uses a `useRef` to detect false→true transitions so existing state while panel is open is not affected
- Added regression test verifying error and form state are cleared on close/reopen

Fixes #537