### PR TITLE
fix(web): reset GitHubPR form state on panel reopen

### DIFF
--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -205,4 +205,31 @@ describe('GitHubPR', () => {
       expect(mockApiPost).toHaveBeenCalledWith('/api/v1/workspaces/ws-1/pr', expect.any(Object));
     });
   });
+
+  it('resets form and error state on reopen', async () => {
+    const user = userEvent.setup();
+    mockApiPost.mockRejectedValueOnce(new Error('PR failed'));
+
+    const { rerender } = render(<GitHubPR />);
+
+    // Edit form and trigger an error
+    await user.clear(screen.getByLabelText('Title'));
+    await user.type(screen.getByLabelText('Title'), 'Custom title');
+    await user.type(screen.getByLabelText('Body (optional)'), 'Some body');
+    await user.click(screen.getByRole('button', { name: 'Create Pull Request' }));
+    expect(await screen.findByText('PR failed')).toBeInTheDocument();
+
+    // Close the panel
+    useUIStore.setState({ showGitHubPR: false });
+    rerender(<GitHubPR />);
+
+    // Reopen the panel
+    useUIStore.setState({ showGitHubPR: true });
+    rerender(<GitHubPR />);
+
+    // Form should be reset to defaults
+    expect(screen.getByLabelText('Title')).toHaveValue('Update cloud architecture');
+    expect(screen.getByLabelText('Body (optional)')).toHaveValue('');
+    expect(screen.queryByText('PR failed')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
@@ -20,6 +20,21 @@ export function GitHubPR() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<PullRequestResponse | null>(null);
+
+  // Reset local form/result/error state when panel transitions from closed to open
+  const prevShowRef = useRef(show);
+  useEffect(() => {
+    if (show && !prevShowRef.current) {
+      setTitle('Update cloud architecture');
+      setBody('');
+      setBranch('');
+      setCommitMessage('Update architecture via CloudBlocks');
+      setLoading(false);
+      setError(null);
+      setResult(null);
+    }
+    prevShowRef.current = show;
+  }, [show]);
 
   if (!show) return null;
 


### PR DESCRIPTION
## Summary
- Reset title, body, branch, commit message, error, result, and loading state when the PR panel transitions from closed to open
- Uses a `useRef` to detect false→true transitions so in-progress form state is not disturbed while panel is open
- Added regression test verifying form resets to defaults after close/reopen with error state

Fixes #519