### PR TITLE
fix(web): default new GitHub repos to private

### DIFF
--- a/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
@@ -83,7 +83,6 @@ describe('GitHubRepos', () => {
     render(<GitHubRepos />);
 
     await user.type(screen.getByPlaceholderText('Repository name'), 'new-repo');
-    await user.click(screen.getByLabelText('Private repository'));
     await user.click(screen.getByRole('button', { name: 'Create' }));
 
     expect(mockApiPost).toHaveBeenCalledWith('/api/v1/github/repos', {

--- a/apps/web/src/widgets/github-repos/GitHubRepos.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.tsx
@@ -15,7 +15,7 @@ export function GitHubRepos() {
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [newRepoName, setNewRepoName] = useState('');
-  const [isPrivate, setIsPrivate] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(true);
 
   const fetchRepos = async () => {
     setLoading(true);


### PR DESCRIPTION
## Summary
- **Fixes #557**: New repo creation now defaults to private
- Changed `isPrivate` initial state from `false` to `true`
- Updated test to reflect the secure default (no longer needs explicit checkbox click for private)

## Test plan
- [x] All 13 GitHubRepos tests pass
- [ ] Manual: open repo creation dialog and verify "Private" is checked by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)