### PR TITLE
fix(web): batch 5 — private repo default, clipboard guard, external actor source, keyboard a11y

### DIFF
--- a/apps/web/src/entities/character/MinifigureSprite.test.tsx
+++ b/apps/web/src/entities/character/MinifigureSprite.test.tsx
@@ -288,6 +288,37 @@ describe('MinifigureSprite', () => {
     expect(useUIStore.getState().selectedId).toBeNull();
   });
 
+  it('selects worker on Enter key press', async () => {
+    const user = userEvent.setup();
+    render(<MinifigureSprite provider="azure" screenX={0} screenY={0} zIndex={1} />);
+
+    const sprite = screen.getByRole('button', { name: 'Select worker' });
+    await user.type(sprite, '{Enter}');
+
+    expect(useUIStore.getState().selectedId).toBe('worker-default');
+  });
+
+  it('selects worker on Space key press', async () => {
+    const user = userEvent.setup();
+    render(<MinifigureSprite provider="azure" screenX={0} screenY={0} zIndex={1} />);
+
+    const sprite = screen.getByRole('button', { name: 'Select worker' });
+    await user.type(sprite, ' ');
+
+    expect(useUIStore.getState().selectedId).toBe('worker-default');
+  });
+
+  it('does not select worker on Enter in delete mode', async () => {
+    const user = userEvent.setup();
+    useUIStore.setState({ toolMode: 'delete' });
+    render(<MinifigureSprite provider="azure" screenX={0} screenY={0} zIndex={1} />);
+
+    const sprite = screen.getByRole('button', { name: 'Select worker' });
+    await user.type(sprite, '{Enter}');
+
+    expect(useUIStore.getState().selectedId).toBeNull();
+  });
+
   it('applies is-selected class when selectedId is worker-default', () => {
     useUIStore.setState({ selectedId: 'worker-default' });
     const { container } = render(<MinifigureSprite provider="azure" screenX={0} screenY={0} zIndex={1} />);

--- a/apps/web/src/entities/character/MinifigureSprite.tsx
+++ b/apps/web/src/entities/character/MinifigureSprite.tsx
@@ -125,6 +125,15 @@ export const MinifigureSprite = memo(function MinifigureSprite({
     setSelectedId(workerId);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if (toolMode === 'delete') return;
+      if (toolMode === 'connect') return;
+      setSelectedId(workerId);
+    }
+  };
+
   const className = ['minifigure-sprite', isSelected && 'is-selected', `is-${workerState}`]
     .filter(Boolean)
     .join(' ');
@@ -133,7 +142,11 @@ export const MinifigureSprite = memo(function MinifigureSprite({
     <div
       ref={spriteRef}
       className={className}
+      role="button"
+      tabIndex={0}
+      aria-label="Select worker"
       onPointerUp={handleClick}
+      onKeyDown={handleKeyDown}
       style={{ left: screenX, top: screenY, zIndex }}
     >
       <MinifigureSvg provider={provider} />

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { DetailPanel } from './DetailPanel';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
+import type { ArchitectureModel, Block, Connection, ExternalActor, Plate } from '@cloudblocks/schema';
 
 vi.mock('./DetailPanel.css', () => ({}));
 
@@ -239,10 +239,45 @@ describe('DetailPanel', () => {
     expect(screen.getByText(/1 subnet$/)).toBeInTheDocument();
   });
 
-  it('renders internet source when connection source block is missing', () => {
+  it('renders external actor name when connection source is an external actor', () => {
+    const actor: ExternalActor = {
+      id: 'ext-internet',
+      name: 'Internet',
+      type: 'internet',
+      position: { x: -3, y: 0, z: 5 },
+    };
     const externalConnection: Connection = {
       id: 'ext-conn',
       sourceId: 'ext-internet',
+      targetId: 'block-1',
+      type: 'dataflow',
+      metadata: {},
+    };
+
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        architecture: {
+          ...architectureWithResources,
+          externalActors: [actor],
+          connections: [externalConnection],
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+    useUIStore.setState({ selectedId: 'ext-conn' });
+
+    render(<DetailPanel />);
+
+    expect(screen.getByText(/Internet/)).toBeInTheDocument();
+  });
+
+  it('renders Unknown when connection source is neither block nor external actor', () => {
+    const externalConnection: Connection = {
+      id: 'ext-conn',
+      sourceId: 'nonexistent-id',
       targetId: 'block-1',
       type: 'dataflow',
       metadata: {},
@@ -264,7 +299,7 @@ describe('DetailPanel', () => {
 
     render(<DetailPanel />);
 
-    expect(screen.getByText('☁️ Internet')).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
   });
 
   it('renders unknown target when connection target block is missing', () => {

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -306,6 +306,7 @@ function ConnectionDetail({ connectionId, className }: { connectionId: string; c
   if (!connection) return null;
 
   const sourceBlock = architecture.blocks.find((b) => b.id === connection.sourceId);
+  const sourceActor = architecture.externalActors.find((a) => a.id === connection.sourceId);
   const targetBlock = architecture.blocks.find((b) => b.id === connection.targetId);
 
   return (
@@ -330,8 +331,12 @@ function ConnectionDetail({ connectionId, className }: { connectionId: string; c
               <>
                 {BLOCK_ICONS[sourceBlock.category]} {sourceBlock.name}
               </>
+            ) : sourceActor ? (
+              <>
+                {sourceActor.type === 'internet' ? '☁️' : '👤'} {sourceActor.name}
+              </>
             ) : (
-              '☁️ Internet'
+              'Unknown'
             )}
           </span>
         </div>

--- a/apps/web/src/widgets/code-preview/CodePreview.test.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.test.tsx
@@ -301,6 +301,25 @@ describe('CodePreview', () => {
     expect(writeTextMock).toHaveBeenCalledWith('resource content');
   });
 
+  it('does not throw when clipboard API is unavailable', async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+    const mockOutput = {
+      files: [{ path: 'main.tf', content: 'resource content', language: 'hcl' as const }],
+      metadata: { generator: 'terraform', version: '0.3.0', provider: 'azure' as const, generatedAt: '2026-01-01T00:00:00.000Z' },
+    };
+    vi.mocked(generateCode).mockReturnValue(mockOutput);
+
+    render(<CodePreview />);
+
+    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await expect(user.click(screen.getByText(/Copy/))).resolves.toBeUndefined();
+  });
+
   it('renders empty code fallback when active tab has no file', async () => {
     const user = userEvent.setup();
     const mockOutput = {

--- a/apps/web/src/widgets/code-preview/CodePreview.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.tsx
@@ -81,7 +81,7 @@ export function CodePreview() {
   const handleCopyFile = () => {
     if (!output) return;
     const file = output.files[activeTab];
-    if (file) {
+    if (file && navigator.clipboard?.writeText) {
       navigator.clipboard.writeText(file.content).catch(() => {
         // Clipboard API may fail in some contexts
       });

--- a/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
@@ -83,7 +83,6 @@ describe('GitHubRepos', () => {
     render(<GitHubRepos />);
 
     await user.type(screen.getByPlaceholderText('Repository name'), 'new-repo');
-    await user.click(screen.getByLabelText('Private repository'));
     await user.click(screen.getByRole('button', { name: 'Create' }));
 
     expect(mockApiPost).toHaveBeenCalledWith('/api/v1/github/repos', {

--- a/apps/web/src/widgets/github-repos/GitHubRepos.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.tsx
@@ -15,7 +15,7 @@ export function GitHubRepos() {
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [newRepoName, setNewRepoName] = useState('');
-  const [isPrivate, setIsPrivate] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(true);
 
   const fetchRepos = async () => {
     setLoading(true);


### PR DESCRIPTION
## Summary

Batch 5 of M17 bug fixes — four simple UI/UX issues:

- **#557** Default new GitHub repos to private (safe default)
- **#588** Guard `navigator.clipboard` when API is unavailable (prevents crash in insecure contexts)
- **#558** Resolve external actors in connection source display — shows actor name/icon instead of hardcoded "Internet", falls back to "Unknown" for truly invalid IDs
- **#576** Add keyboard accessibility to MinifigureSprite — `role="button"`, `tabIndex={0}`, Enter/Space handlers

## Testing

- All 1557 tests pass
- ESLint clean
- TypeScript build clean

Fixes #557, fixes #558, fixes #576, fixes #588