### PR TITLE
fix(web): auto-capture checkpoint for Reset Step on all learning steps

### DIFF
--- a/apps/web/src/features/learning/scenario-engine.test.ts
+++ b/apps/web/src/features/learning/scenario-engine.test.ts
@@ -295,13 +295,19 @@ describe('scenario-engine', () => {
       expect(architectureSnapshot()).toEqual(checkpoint);
     });
 
-    it('does not change architecture when step has no checkpoint', () => {
+    it('restores auto-captured snapshot when step has no explicit checkpoint', () => {
       startLearningScenario('scenario-three-tier');
-      const before = architectureSnapshot();
+      const initial = architectureSnapshot();
+
+      // Mutate architecture after starting
+      useArchitectureStore.getState().replaceArchitecture({
+        ...initial,
+        name: 'User Mutation',
+      });
 
       resetCurrentStep();
 
-      expect(architectureSnapshot()).toEqual(before);
+      expect(architectureSnapshot()).toEqual(initial);
     });
 
     it('resets hints', () => {

--- a/apps/web/src/features/learning/scenario-engine.ts
+++ b/apps/web/src/features/learning/scenario-engine.ts
@@ -34,6 +34,11 @@ function cacheStepCheckpoint(stepId: string, checkpoint?: ArchitectureSnapshot):
   checkpointCache.set(stepId, checkpoint);
 }
 
+function captureCurrentArchitecture(): ArchitectureSnapshot {
+  const { workspace } = useArchitectureStore.getState();
+  return JSON.parse(JSON.stringify(workspace.architecture));
+}
+
 export function startLearningScenario(scenarioId: string): void {
   const scenario = getScenario(scenarioId);
   if (!scenario) {
@@ -43,6 +48,11 @@ export function startLearningScenario(scenarioId: string): void {
   useArchitectureStore.getState().replaceArchitecture(scenario.initialArchitecture);
   useUIStore.getState().setEditorMode('learn');
   useLearningStore.getState().startScenario(scenario);
+
+  const firstStep = scenario.steps[0];
+  if (firstStep) {
+    checkpointCache.set(firstStep.id, captureCurrentArchitecture());
+  }
 
   const uiState = useUIStore.getState();
   if (!uiState.showLearningPanel) {
@@ -74,6 +84,11 @@ export function advanceToNextStep(): void {
     return;
   }
 
+  const nextStep = activeScenario.steps[progress.currentStepIndex + 1];
+  if (nextStep && !checkpointCache.has(nextStep.id)) {
+    checkpointCache.set(nextStep.id, captureCurrentArchitecture());
+  }
+
   learningState.advanceStep();
   syncCurrentStepCompletion();
 }
@@ -91,8 +106,9 @@ export function resetCurrentStep(): void {
     return;
   }
 
-  if (currentStep.checkpoint) {
-    useArchitectureStore.getState().replaceArchitecture(currentStep.checkpoint);
+  const snapshot = currentStep.checkpoint ?? checkpointCache.get(currentStep.id);
+  if (snapshot) {
+    useArchitectureStore.getState().replaceArchitecture(snapshot);
   }
 
   learningState.resetHints();


### PR DESCRIPTION
## Summary
- **Fixes #556**: Reset Step now reliably restores architecture for all steps, not just those with explicit checkpoints
- Auto-captures architecture snapshot when entering each step (both at scenario start and on advance)
- Uses auto-captured snapshot as fallback when no explicit checkpoint is defined
- Updated regression test to verify reset after user mutation on checkpoint-less step

## Test plan
- [x] All 30 scenario-engine tests pass
- [x] Test verifies architecture restoration on steps without explicit checkpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)