### PR TITLE
fix(web): sync AI generate provider with global provider selector

### DIFF
--- a/apps/web/src/features/ai/components/AiPromptBar.test.tsx
+++ b/apps/web/src/features/ai/components/AiPromptBar.test.tsx
@@ -3,89 +3,85 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { AiPromptBar } from './AiPromptBar';
 
 describe('AiPromptBar', () => {
-  it('renders input, provider selector, and submit button', () => {
-    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} />);
-    
+  it('renders input, provider label, and submit button', () => {
+    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} provider="azure" />);
+
     expect(screen.getByPlaceholderText('Describe your cloud architecture...')).toBeInTheDocument();
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText('AZURE')).toBeInTheDocument();
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
   it('submit button disabled when input is empty', () => {
-    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} />);
-    
+    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} provider="aws" />);
+
     const submitBtn = screen.getByRole('button');
     expect(submitBtn).toBeDisabled();
   });
 
   it('typing text enables submit button', () => {
-    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} />);
-    
+    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} provider="aws" />);
+
     const input = screen.getByPlaceholderText('Describe your cloud architecture...');
     fireEvent.change(input, { target: { value: 'Create a highly available app' } });
-    
+
     const submitBtn = screen.getByRole('button');
     expect(submitBtn).not.toBeDisabled();
   });
 
-  it('clicking submit calls onSubmit with prompt and default provider (aws)', () => {
+  it('clicking submit calls onSubmit with prompt and provider prop', () => {
     const handleSubmit = vi.fn();
-    render(<AiPromptBar onSubmit={handleSubmit} isLoading={false} />);
-    
+    render(<AiPromptBar onSubmit={handleSubmit} isLoading={false} provider="aws" />);
+
     const input = screen.getByPlaceholderText('Describe your cloud architecture...');
     fireEvent.change(input, { target: { value: 'Create a web app' } });
-    
+
     const submitBtn = screen.getByRole('button');
     fireEvent.click(submitBtn);
-    
+
     expect(handleSubmit).toHaveBeenCalledWith('Create a web app', 'aws');
   });
 
   it('pressing Enter calls onSubmit', () => {
     const handleSubmit = vi.fn();
-    render(<AiPromptBar onSubmit={handleSubmit} isLoading={false} />);
-    
+    render(<AiPromptBar onSubmit={handleSubmit} isLoading={false} provider="aws" />);
+
     const input = screen.getByPlaceholderText('Describe your cloud architecture...');
     fireEvent.change(input, { target: { value: 'Create a web app' } });
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-    
+
     expect(handleSubmit).toHaveBeenCalledWith('Create a web app', 'aws');
   });
 
-  it('changing provider and submitting passes correct provider', () => {
+  it('uses provider from prop, not a hardcoded default', () => {
     const handleSubmit = vi.fn();
-    render(<AiPromptBar onSubmit={handleSubmit} isLoading={false} />);
-    
+    render(<AiPromptBar onSubmit={handleSubmit} isLoading={false} provider="gcp" />);
+
+    expect(screen.getByText('GCP')).toBeInTheDocument();
+
     const input = screen.getByPlaceholderText('Describe your cloud architecture...');
     fireEvent.change(input, { target: { value: 'Create a web app' } });
-    
-    const select = screen.getByRole('combobox');
-    fireEvent.change(select, { target: { value: 'gcp' } });
-    
+
     const submitBtn = screen.getByRole('button');
     fireEvent.click(submitBtn);
-    
+
     expect(handleSubmit).toHaveBeenCalledWith('Create a web app', 'gcp');
   });
 
-  it('shows loading indicator and disables inputs when isLoading is true', () => {
-    render(<AiPromptBar onSubmit={vi.fn()} isLoading={true} />);
-    
+  it('shows loading indicator and disables input when isLoading is true', () => {
+    render(<AiPromptBar onSubmit={vi.fn()} isLoading={true} provider="aws" />);
+
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
-    
+
     const input = screen.getByPlaceholderText('Describe your cloud architecture...');
     expect(input).toBeDisabled();
-    
-    const select = screen.getByRole('combobox');
-    expect(select).toBeDisabled();
-    
+
     const submitBtn = screen.getByRole('button');
     expect(submitBtn).toBeDisabled();
   });
 
   it('displays error message when error prop is set', () => {
-    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} error="Failed to generate architecture" />);
-    
+    render(<AiPromptBar onSubmit={vi.fn()} isLoading={false} provider="aws" error="Failed to generate architecture" />);
+
     expect(screen.getByText('Failed to generate architecture')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/ai/components/AiPromptBar.tsx
+++ b/apps/web/src/features/ai/components/AiPromptBar.tsx
@@ -5,12 +5,12 @@ import './AiPromptBar.css';
 interface AiPromptBarProps {
   onSubmit: (prompt: string, provider: string) => void;
   isLoading: boolean;
+  provider: string;
   error?: string;
 }
 
-export const AiPromptBar: React.FC<AiPromptBarProps> = ({ onSubmit, isLoading, error }) => {
+export const AiPromptBar: React.FC<AiPromptBarProps> = ({ onSubmit, isLoading, provider, error }) => {
   const [prompt, setPrompt] = useState('');
-  const [provider, setProvider] = useState('aws');
 
   const handleSubmit = () => {
     if (prompt.trim() && !isLoading) {
@@ -36,16 +36,7 @@ export const AiPromptBar: React.FC<AiPromptBarProps> = ({ onSubmit, isLoading, e
           onKeyDown={handleKeyDown}
           disabled={isLoading}
         />
-        <select
-          className="ai-provider-select"
-          value={provider}
-          onChange={(e) => setProvider(e.target.value)}
-          disabled={isLoading}
-        >
-          <option value="aws">AWS</option>
-          <option value="azure">Azure</option>
-          <option value="gcp">GCP</option>
-        </select>
+        <span className="ai-provider-label">{provider.toUpperCase()}</span>
         <button
           className="ai-submit-btn"
           onClick={handleSubmit}

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -742,7 +742,7 @@ describe('MenuBar', () => {
     await user.type(promptInput, 'Create a 3-tier web app');
     await user.click(screen.getByTitle('Generate Architecture'));
 
-    expect(generateMock).toHaveBeenCalledWith('Create a 3-tier web app', 'aws');
+    expect(generateMock).toHaveBeenCalledWith('Create a 3-tier web app', 'azure');
   });
 
   it('shows validation badge with Valid text when validationResult is valid', async () => {

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -378,7 +378,7 @@ export function MenuBar() {
       
       </nav>
 
-      <AiPromptBar onSubmit={handleAiSubmit} isLoading={aiLoading} error={aiError ?? undefined} />
+      <AiPromptBar onSubmit={handleAiSubmit} isLoading={aiLoading} provider={activeProvider} error={aiError ?? undefined} />
 
       <div className="menu-bar-divider" />
 


### PR DESCRIPTION
## Summary
- **Fixes #513**: AI prompt bar now uses the global `activeProvider` instead of its own local state
- Replaced local `useState('aws')` with a `provider` prop sourced from `activeProvider`
- Removed redundant provider `<select>` dropdown, replaced with display-only label
- Updated AiPromptBar and MenuBar tests

## Test plan
- [x] All 8 AiPromptBar tests pass
- [x] All 31 MenuBar tests pass
- [x] AI submission uses global provider (azure by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)