### PR TITLE
fix(web): batch 6 — sign-out close, username fallback, aria-labels, disabled empty create, filter reset

### DIFF
--- a/apps/web/src/widgets/code-preview/CodePreview.test.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.test.tsx
@@ -55,7 +55,7 @@ describe('CodePreview', () => {
     const user = userEvent.setup();
     useUIStore.setState({ showCodePreview: true });
     render(<CodePreview />);
-    await user.click(screen.getByText('✕'));
+    await user.click(screen.getByRole('button', { name: 'Close code preview panel' }));
     expect(useUIStore.getState().showCodePreview).toBe(false);
   });
 

--- a/apps/web/src/widgets/code-preview/CodePreview.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.tsx
@@ -107,7 +107,7 @@ export function CodePreview() {
     <div className="code-preview">
       <div className="code-preview-header">
         <h3 className="code-preview-title">⚡ Code Generation</h3>
-        <button type="button" className="code-preview-close" onClick={toggleCodePreview}>
+        <button type="button" className="code-preview-close" onClick={toggleCodePreview} aria-label="Close code preview panel">
           ✕
         </button>
       </div>

--- a/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
@@ -65,7 +65,7 @@ describe('GitHubLogin', () => {
     expect(window.location.href).toContain('#oauth-callback');
   });
 
-  it('sign out calls logout from authStore', async () => {
+  it('sign out calls logout from authStore and closes panel', async () => {
     const user = userEvent.setup();
     const logoutMock = vi.fn();
     useAuthStore.setState({
@@ -84,6 +84,7 @@ describe('GitHubLogin', () => {
     await user.click(screen.getByRole('button', { name: 'Sign Out' }));
 
     expect(logoutMock).toHaveBeenCalledOnce();
+    expect(useUIStore.getState().showGitHubLogin).toBe(false);
   });
 
   it('shows error when sign in fails', async () => {
@@ -106,7 +107,7 @@ describe('GitHubLogin', () => {
     expect(await screen.findByText('Failed to start GitHub login.')).toBeInTheDocument();
   });
 
-  it('shows user info without avatar', () => {
+  it('shows user info without avatar, falls back to github_username', () => {
     useAuthStore.setState({
       status: 'authenticated',
       user: {
@@ -119,9 +120,25 @@ describe('GitHubLogin', () => {
     });
 
     render(<GitHubLogin />);
-    expect(screen.getByText('Unknown User')).toBeInTheDocument();
+    expect(screen.getByText('octocat')).toBeInTheDocument();
     expect(screen.getByText('@octocat')).toBeInTheDocument();
     expect(screen.queryByRole('img')).not.toBeInTheDocument();
+  });
+
+  it('shows Unknown User when both display_name and github_username are null', () => {
+    useAuthStore.setState({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        github_username: null,
+        email: null,
+        display_name: null,
+        avatar_url: null,
+      },
+    });
+
+    render(<GitHubLogin />);
+    expect(screen.getByText('Unknown User')).toBeInTheDocument();
   });
 
   it('shows user info without github username', () => {
@@ -141,10 +158,11 @@ describe('GitHubLogin', () => {
     expect(screen.getByText('@unknown')).toBeInTheDocument();
   });
 
-  it('close button toggles panel', async () => {
+  it('close button has accessible label and toggles panel', async () => {
     const user = userEvent.setup();
     render(<GitHubLogin />);
-    await user.click(screen.getByText('✕'));
+    const closeBtn = screen.getByRole('button', { name: 'Close GitHub login panel' });
+    await user.click(closeBtn);
     expect(useUIStore.getState().showGitHubLogin).toBe(false);
   });
 

--- a/apps/web/src/widgets/github-login/GitHubLogin.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.tsx
@@ -48,13 +48,14 @@ export function GitHubLogin() {
     await logout();
 
     setIsWorking(false);
+    toggleGitHubLogin();
   };
 
   return (
     <div className="github-login">
       <div className="github-login-header">
         <h3 className="github-login-title">🔐 GitHub Login</h3>
-        <button className="github-login-close" onClick={toggleGitHubLogin}>
+        <button className="github-login-close" onClick={toggleGitHubLogin} aria-label="Close GitHub login panel">
           ✕
         </button>
       </div>
@@ -73,7 +74,7 @@ export function GitHubLogin() {
               />
             )}
             <div className="github-login-user-info">
-              <div className="github-login-user-name">{user?.display_name ?? 'Unknown User'}</div>
+              <div className="github-login-user-name">{user?.display_name ?? user?.github_username ?? 'Unknown User'}</div>
               <div className="github-login-user-username">@{user?.github_username ?? 'unknown'}</div>
             </div>
             <button className="github-login-signout" onClick={handleSignOut} disabled={isWorking}>

--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -146,7 +146,7 @@ describe('GitHubPR', () => {
   it('close button toggles panel', async () => {
     const user = userEvent.setup();
     render(<GitHubPR />);
-    await user.click(screen.getByText('✕'));
+    await user.click(screen.getByRole('button', { name: 'Close pull request panel' }));
     expect(useUIStore.getState().showGitHubPR).toBe(false);
   });
 

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -50,7 +50,7 @@ export function GitHubPR() {
     <div className="github-pr">
       <div className="github-pr-header">
         <h3 className="github-pr-title">🔀 Pull Request</h3>
-        <button className="github-pr-close" onClick={toggleGitHubPR}>
+        <button className="github-pr-close" onClick={toggleGitHubPR} aria-label="Close pull request panel">
           ✕
         </button>
       </div>

--- a/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
@@ -124,6 +124,14 @@ describe('GitHubRepos', () => {
     expect(mockApiPost).not.toHaveBeenCalled();
   });
 
+  it('disables create button when repository name is empty', async () => {
+    mockApiGet.mockResolvedValueOnce({ repos: [] });
+    render(<GitHubRepos />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+    });
+  });
+
   it('shows error when create repo fails', async () => {
     const user = userEvent.setup();
     mockApiGet.mockResolvedValueOnce({ repos: [] });
@@ -168,11 +176,12 @@ describe('GitHubRepos', () => {
     expect(await screen.findByText('private')).toBeInTheDocument();
   });
 
-  it('close button toggles panel', async () => {
+  it('close button has accessible label and toggles panel', async () => {
     const user = userEvent.setup();
     mockApiGet.mockResolvedValueOnce({ repos: [] });
     render(<GitHubRepos />);
-    await user.click(screen.getByText('✕'));
+    const closeBtn = screen.getByRole('button', { name: 'Close GitHub repos panel' });
+    await user.click(closeBtn);
     expect(useUIStore.getState().showGitHubRepos).toBe(false);
   });
 

--- a/apps/web/src/widgets/github-repos/GitHubRepos.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.tsx
@@ -62,7 +62,7 @@ export function GitHubRepos() {
     <div className="github-repos">
       <div className="github-repos-header">
         <h3 className="github-repos-title">📦 GitHub Repos</h3>
-        <button className="github-repos-close" onClick={toggleGitHubRepos}>
+        <button className="github-repos-close" onClick={toggleGitHubRepos} aria-label="Close GitHub repos panel">
           ✕
         </button>
       </div>
@@ -92,7 +92,7 @@ export function GitHubRepos() {
               />
               <span>Private repository</span>
             </label>
-            <button className="github-repos-create-btn" onClick={handleCreateRepo} disabled={creating}>
+            <button className="github-repos-create-btn" onClick={handleCreateRepo} disabled={creating || !newRepoName.trim()}>
               Create
             </button>
           </div>

--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -290,7 +290,7 @@ describe('GitHubSync', () => {
   it('close button toggles panel', async () => {
     const user = userEvent.setup();
     render(<GitHubSync />);
-    await user.click(screen.getByText('✕'));
+    await user.click(screen.getByRole('button', { name: 'Close GitHub sync panel' }));
     expect(useUIStore.getState().showGitHubSync).toBe(false);
   });
 

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -122,7 +122,7 @@ export function GitHubSync() {
     <div className="github-sync">
       <div className="github-sync-header">
         <h3 className="github-sync-title">🔄 GitHub Sync</h3>
-        <button className="github-sync-close" onClick={toggleGitHubSync}>
+        <button className="github-sync-close" onClick={toggleGitHubSync} aria-label="Close GitHub sync panel">
           ✕
         </button>
       </div>

--- a/apps/web/src/widgets/learning-panel/LearningPanel.test.tsx
+++ b/apps/web/src/widgets/learning-panel/LearningPanel.test.tsx
@@ -278,7 +278,7 @@ describe('LearningPanel widgets', () => {
 
   it('close button calls abandonLearning', () => {
     render(<LearningPanel />);
-    fireEvent.click(screen.getByRole('button', { name: '×' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close learning panel' }));
     expect(abandonLearning).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/widgets/learning-panel/LearningPanel.tsx
+++ b/apps/web/src/widgets/learning-panel/LearningPanel.tsx
@@ -82,7 +82,7 @@ export function LearningPanel() {
     <div className="learning-panel-container">
       <div className="learning-panel-header">
         <h3 className="learning-panel-title">{activeScenario.name}</h3>
-        <button type="button" className="learning-panel-close-btn" onClick={handleClose}>
+        <button type="button" className="learning-panel-close-btn" onClick={handleClose} aria-label="Close learning panel">
           ×
         </button>
       </div>

--- a/apps/web/src/widgets/scenario-gallery/ScenarioGallery.test.tsx
+++ b/apps/web/src/widgets/scenario-gallery/ScenarioGallery.test.tsx
@@ -151,7 +151,7 @@ describe('ScenarioGallery', () => {
   it('close button toggles gallery off', () => {
     useUIStore.setState({ showScenarioGallery: true });
     render(<ScenarioGallery />);
-    fireEvent.click(screen.getByRole('button', { name: '✕' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close scenario gallery' }));
     expect(useUIStore.getState().showScenarioGallery).toBe(false);
   });
 
@@ -175,6 +175,30 @@ describe('ScenarioGallery', () => {
     expect(screen.queryByText('Serverless HTTP API')).not.toBeInTheDocument();
 
     unmount();
+    render(<ScenarioGallery />);
+
+    expect(screen.getByText('Build a Three-Tier Web Application')).toBeInTheDocument();
+    expect(screen.getByText('Serverless HTTP API')).toBeInTheDocument();
+    expect(screen.getByText('Event-Driven Data Pipeline')).toBeInTheDocument();
+  });
+
+  it('resets difficulty filter to All after starting a scenario', async () => {
+    const user = userEvent.setup();
+    useUIStore.setState({ showScenarioGallery: true });
+    const { unmount } = render(<ScenarioGallery />);
+
+    await user.click(screen.getByRole('button', { name: 'Beginner' }));
+    expect(screen.queryByText('Serverless HTTP API')).not.toBeInTheDocument();
+
+    const card = screen.getByText('Build a Three-Tier Web Application').closest('.scenario-gallery-card');
+    if (!(card instanceof HTMLElement)) {
+      throw new Error('Expected scenario card');
+    }
+    await user.click(within(card).getByRole('button', { name: 'Start' }));
+
+    unmount();
+    useUIStore.setState({ showScenarioGallery: true });
+    registerBuiltinScenarios();
     render(<ScenarioGallery />);
 
     expect(screen.getByText('Build a Three-Tier Web Application')).toBeInTheDocument();

--- a/apps/web/src/widgets/scenario-gallery/ScenarioGallery.tsx
+++ b/apps/web/src/widgets/scenario-gallery/ScenarioGallery.tsx
@@ -36,6 +36,7 @@ export function ScenarioGallery() {
 
   const handleStart = (id: string) => {
     startLearningScenario(id);
+    setActiveDifficulty('all');
     toggleScenarioGallery();
   };
 
@@ -43,7 +44,7 @@ export function ScenarioGallery() {
     <div className="scenario-gallery">
       <div className="scenario-gallery-header">
         <h2 className="scenario-gallery-title">Scenario Gallery</h2>
-        <button type="button" className="scenario-gallery-close" onClick={toggleScenarioGallery}>
+        <button type="button" className="scenario-gallery-close" onClick={toggleScenarioGallery} aria-label="Close scenario gallery">
           ✕
         </button>
       </div>

--- a/apps/web/src/widgets/template-gallery/TemplateGallery.test.tsx
+++ b/apps/web/src/widgets/template-gallery/TemplateGallery.test.tsx
@@ -35,7 +35,7 @@ describe('TemplateGallery', () => {
     const user = userEvent.setup();
     useUIStore.setState({ showTemplateGallery: true });
     render(<TemplateGallery />);
-    const closeBtn = screen.getByText('✕');
+    const closeBtn = screen.getByRole('button', { name: 'Close template gallery' });
     await user.click(closeBtn);
     expect(useUIStore.getState().showTemplateGallery).toBe(false);
   });
@@ -133,6 +133,35 @@ describe('TemplateGallery', () => {
     render(<TemplateGallery />);
 
     // After remount, all templates should be visible again (All filter)
+    expect(screen.getByText('Three-Tier Web Application')).toBeInTheDocument();
+    expect(screen.getByText('Serverless HTTP API')).toBeInTheDocument();
+  });
+
+  it('resets category filter to All after using a template', async () => {
+    const user = userEvent.setup();
+    useUIStore.setState({ showTemplateGallery: true });
+    const saveToStorageSpy = vi.fn();
+    const loadFromTemplateSpy = vi.fn();
+    useArchitectureStore.setState({
+      saveToStorage: saveToStorageSpy,
+      loadFromTemplate: loadFromTemplateSpy,
+    });
+
+    const { unmount } = render(<TemplateGallery />);
+
+    // Select a non-default filter
+    await user.click(screen.getByRole('button', { name: 'Serverless' }));
+    expect(screen.queryByText('Three-Tier Web Application')).not.toBeInTheDocument();
+
+    // Use the template — this should reset the filter
+    const useButtons = screen.getAllByText('Use Template');
+    await user.click(useButtons[0]);
+
+    // Remount and verify all templates are visible
+    unmount();
+    useUIStore.setState({ showTemplateGallery: true });
+    render(<TemplateGallery />);
+
     expect(screen.getByText('Three-Tier Web Application')).toBeInTheDocument();
     expect(screen.getByText('Serverless HTTP API')).toBeInTheDocument();
   });

--- a/apps/web/src/widgets/template-gallery/TemplateGallery.tsx
+++ b/apps/web/src/widgets/template-gallery/TemplateGallery.tsx
@@ -41,6 +41,7 @@ export function TemplateGallery() {
   const handleUseTemplate = (template: ArchitectureTemplate) => {
     loadFromTemplate(template);
     saveToStorage();
+    setActiveCategory('all');
     toggleTemplateGallery();
   };
 
@@ -48,7 +49,7 @@ export function TemplateGallery() {
     <div className="template-gallery">
       <div className="template-gallery-header">
         <h3 className="template-gallery-title">📦 Templates</h3>
-        <button className="template-gallery-close" onClick={toggleTemplateGallery}>
+        <button className="template-gallery-close" onClick={toggleTemplateGallery} aria-label="Close template gallery">
           ✕
         </button>
       </div>

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
@@ -80,7 +80,8 @@ describe('WorkspaceManager', () => {
     const user = userEvent.setup();
     useUIStore.setState({ showWorkspaceManager: true });
     render(<WorkspaceManager />);
-    await user.click(screen.getByText('✕'));
+    const closeBtn = screen.getByRole('button', { name: 'Close workspace manager panel' });
+    await user.click(closeBtn);
     expect(useUIStore.getState().showWorkspaceManager).toBe(false);
   });
 
@@ -122,6 +123,12 @@ describe('WorkspaceManager', () => {
     render(<WorkspaceManager />);
     await user.click(screen.getByText('+ Create'));
     expect(createWorkspaceMock).not.toHaveBeenCalled();
+  });
+
+  it('disables create button when name input is empty', () => {
+    useUIStore.setState({ showWorkspaceManager: true });
+    render(<WorkspaceManager />);
+    expect(screen.getByRole('button', { name: '+ Create' })).toBeDisabled();
   });
 
   it('does not create workspace with whitespace-only name', async () => {

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
@@ -44,7 +44,7 @@ export function WorkspaceManager() {
     <div className="workspace-manager">
       <div className="workspace-manager-header">
         <h3 className="workspace-manager-title">📂 Workspaces</h3>
-        <button className="workspace-manager-close" onClick={toggleWorkspaceManager}>
+        <button className="workspace-manager-close" onClick={toggleWorkspaceManager} aria-label="Close workspace manager panel">
           ✕
         </button>
       </div>
@@ -60,7 +60,7 @@ export function WorkspaceManager() {
             if (e.key === 'Enter') handleCreate();
           }}
         />
-        <button className="workspace-manager-create-btn" onClick={handleCreate}>
+        <button className="workspace-manager-create-btn" onClick={handleCreate} disabled={!newName.trim()}>
           + Create
         </button>
       </div>


### PR DESCRIPTION
## Summary
- **#605** — Sign-out now closes the GitHub login panel
- **#602** — Fallback to `github_username` when `display_name` is null
- **#606** — Add `aria-label` to all panel close buttons (9 panels)
- **#608** — Disable Create button when name input is empty (GitHubRepos, WorkspaceManager)
- **#583** — Reset gallery filter to "All" on Use Template / Start Scenario

## Changes
- 9 source files updated (GitHubLogin, GitHubRepos, WorkspaceManager, TemplateGallery, ScenarioGallery, GitHubSync, GitHubPR, CodePreview, LearningPanel)
- 9 test files updated with new tests for aria-labels, disabled states, and filter reset behavior

## Verification
- ESLint: ✅ clean
- Vitest: ✅ 1566 tests passing
- TypeScript: ✅ build clean

Fixes #605, Fixes #602, Fixes #606, Fixes #608, Fixes #583