### PR TITLE
fix(web): render worker detail state in Portrait and DetailPanel

### DIFF
--- a/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { DetailPanel } from './DetailPanel';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { useWorkerStore } from '../../entities/store/workerStore';
 import type { ArchitectureModel, Block, Connection, ExternalActor, Plate } from '@cloudblocks/schema';
 
 vi.mock('./DetailPanel.css', () => ({}));
@@ -475,5 +476,23 @@ describe('DetailPanel', () => {
 
     expect(screen.getByText("Welcome to CloudBlocks!")).toBeInTheDocument();
     expect(screen.queryByText("No selection")).not.toBeInTheDocument();
+  });
+
+  it('renders worker detail when selectedId is worker-default', () => {
+    useUIStore.setState({ selectedId: 'worker-default' });
+    useWorkerStore.setState({
+      workerState: 'building',
+      workerPosition: [2, 0, 3],
+      activeBuild: { blockId: 'block-1', targetPosition: [1, 0, 1], progress: 0.5, startedAt: Date.now() },
+      buildQueue: [],
+    });
+
+    render(<DetailPanel />);
+
+    expect(screen.getByText('Worker')).toBeInTheDocument();
+    expect(screen.getByText('building')).toBeInTheDocument();
+    expect(screen.getByText('(2.0, 0.0, 3.0)')).toBeInTheDocument();
+    expect(screen.getByText(/block-1.*50%/)).toBeInTheDocument();
+    expect(screen.getByText('0 task(s)')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -13,6 +13,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { useWorkerStore } from '../../entities/store/workerStore';
 import { BLOCK_FRIENDLY_NAMES, BLOCK_DESCRIPTIONS, BLOCK_ICONS, CONNECTION_TYPE_LABELS, DEFAULT_PLATE_PROFILE, getPlateProfile, isPlateProfileId, PLATE_COLORS, PLATE_PROFILES, SUBNET_ACCESS_COLORS } from '../../shared/types/index';
 import type { PlateProfileId } from '../../shared/types/index';
 import type { Block, Plate } from '@cloudblocks/schema';
@@ -39,6 +40,10 @@ export function DetailPanel({ className = '' }: DetailPanelProps) {
       return <IdleState className={className} />;
     }
     return <WelcomeState className={className} />;
+  }
+
+  if (selectedId === 'worker-default') {
+    return <WorkerDetail className={className} />;
   }
 
   if (selectedBlock) {
@@ -291,6 +296,52 @@ function PlateDetail({ plate, className }: { plate: Plate; className: string }) 
             {childBlocks.length} block{childBlocks.length !== 1 ? 's' : ''}
             {childPlates.length > 0 && `, ${childPlates.length} subnet${childPlates.length !== 1 ? 's' : ''}`}
           </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Worker Detail ────────────────────────────────────────
+
+function WorkerDetail({ className }: { className: string }) {
+  const workerState = useWorkerStore((s) => s.workerState);
+  const workerPosition = useWorkerStore((s) => s.workerPosition);
+  const activeBuild = useWorkerStore((s) => s.activeBuild);
+  const buildQueue = useWorkerStore((s) => s.buildQueue);
+
+  return (
+    <div className={`detail-panel detail-panel--worker ${className}`}>
+      <div className="detail-header">
+        <span className="detail-header-icon">🧑‍🔧</span>
+        <span className="detail-header-name">Worker</span>
+      </div>
+
+      <div className="detail-divider" />
+
+      <div className="detail-properties">
+        <div className="detail-property">
+          <span className="detail-property-label">State</span>
+          <span className="detail-property-value">{workerState}</span>
+        </div>
+
+        <div className="detail-property">
+          <span className="detail-property-label">Position</span>
+          <span className="detail-property-value detail-property-mono">
+            ({workerPosition[0].toFixed(1)}, {workerPosition[1].toFixed(1)}, {workerPosition[2].toFixed(1)})
+          </span>
+        </div>
+
+        <div className="detail-property">
+          <span className="detail-property-label">Active Build</span>
+          <span className="detail-property-value">
+            {activeBuild ? `${activeBuild.blockId} (${Math.round(activeBuild.progress * 100)}%)` : 'None'}
+          </span>
+        </div>
+
+        <div className="detail-property">
+          <span className="detail-property-label">Queued</span>
+          <span className="detail-property-value">{buildQueue.length} task(s)</span>
         </div>
       </div>
     </div>

--- a/apps/web/src/widgets/bottom-panel/Portrait.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/Portrait.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { Portrait } from './Portrait';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { useWorkerStore } from '../../entities/store/workerStore';
 import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 
 vi.mock('./Portrait.css', () => ({}));
@@ -206,5 +207,15 @@ describe('Portrait', () => {
 
     expect(screen.getByText('Async')).toBeInTheDocument();
     expect(screen.getByText('async')).toBeInTheDocument();
+  });
+
+  it('renders worker portrait when selectedId is worker-default', () => {
+    useUIStore.setState({ selectedId: 'worker-default' });
+    useWorkerStore.setState({ workerState: 'idle' });
+
+    render(<Portrait />);
+
+    expect(screen.getByText('Worker')).toBeInTheDocument();
+    expect(screen.getByText('idle')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/widgets/bottom-panel/Portrait.tsx
+++ b/apps/web/src/widgets/bottom-panel/Portrait.tsx
@@ -10,6 +10,7 @@
 
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { useWorkerStore } from '../../entities/store/workerStore';
 import { getPlateFaceColors } from '../../entities/plate/plateFaceColors';
 import { BLOCK_FRIENDLY_NAMES, CONNECTION_TYPE_LABELS, PLATE_COLORS, SUBNET_ACCESS_COLORS } from '../../shared/types/index';
 import { getBlockColor } from '../../entities/block/blockFaceColors';
@@ -57,6 +58,23 @@ export function Portrait({ className = '' }: PortraitProps) {
   const selectedBlock = architecture.blocks.find((b) => b.id === selectedId);
   const selectedPlate = architecture.plates.find((p) => p.id === selectedId);
   const selectedConnection = architecture.connections.find((c) => c.id === selectedId);
+
+  const workerState = useWorkerStore((s) => s.workerState);
+
+  // Worker selected
+  if (selectedId === 'worker-default') {
+    return (
+      <div className={`portrait-panel portrait-panel--worker ${className}`}>
+        <div className="portrait-content">
+          <span className="portrait-icon">🧑‍🔧</span>
+          <span className="portrait-label">Worker</span>
+        </div>
+        <div className="portrait-badge" style={{ backgroundColor: '#FF9800' }}>
+          {workerState}
+        </div>
+      </div>
+    );
+  }
 
   // No selection — show logo
   if (!selectedId || (!selectedBlock && !selectedPlate && !selectedConnection)) {


### PR DESCRIPTION
## Summary
- **Fixes #563**: Portrait and DetailPanel now show worker-specific content when selectedId is worker-default
- Portrait shows worker icon with state badge (idle/moving/building)
- DetailPanel shows state, 3D position, active build progress, and queue count
- Added regression tests for both panels

## Test plan
- [x] All 13 Portrait tests pass (including new worker test)
- [x] All 16 DetailPanel tests pass (including new worker test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)