### PR TITLE
fix(web): hide profile selector for global/edge/zone plates

### DIFF
--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -204,10 +204,11 @@ function PlateDetail({ plate, className }: { plate: Plate; className: string }) 
     ? plate.profileId
     : DEFAULT_PLATE_PROFILE[plate.type];
   const profile = getPlateProfile(profileId);
+  const hasProfileSupport = plate.type === 'region' || plate.type === 'subnet';
   const profileFilterType = plate.type === 'subnet' ? 'subnet' : 'region';
-  const profileOptions = Object.values(PLATE_PROFILES).filter(
-    (candidate) => candidate.type === profileFilterType
-  );
+  const profileOptions = hasProfileSupport
+    ? Object.values(PLATE_PROFILES).filter((candidate) => candidate.type === profileFilterType)
+    : [];
 
   const parentPlate = plate.parentId
     ? architecture.plates.find((p) => p.id === plate.parentId)
@@ -248,28 +249,32 @@ function PlateDetail({ plate, className }: { plate: Plate; className: string }) 
           </span>
         </div>
 
-        <div className="detail-property">
-          <label className="detail-property-label" htmlFor={`plate-profile-${plate.id}`}>Profile</label>
-          <span className="detail-property-value">
-            <select
-              id={`plate-profile-${plate.id}`}
-              className="detail-property-select"
-              value={profileId}
-              onChange={(event) => setPlateProfile(plate.id, event.target.value as PlateProfileId)}
-            >
-              {profileOptions.map((candidate) => (
-                <option key={candidate.id} value={candidate.id}>
-                  {candidate.displayName} - {candidate.studsX}x{candidate.studsY}
-                </option>
-              ))}
-            </select>
-          </span>
-        </div>
+        {hasProfileSupport && (
+          <>
+            <div className="detail-property">
+              <label className="detail-property-label" htmlFor={`plate-profile-${plate.id}`}>Profile</label>
+              <span className="detail-property-value">
+                <select
+                  id={`plate-profile-${plate.id}`}
+                  className="detail-property-select"
+                  value={profileId}
+                  onChange={(event) => setPlateProfile(plate.id, event.target.value as PlateProfileId)}
+                >
+                  {profileOptions.map((candidate) => (
+                    <option key={candidate.id} value={candidate.id}>
+                      {candidate.displayName} - {candidate.studsX}x{candidate.studsY}
+                    </option>
+                  ))}
+                </select>
+              </span>
+            </div>
 
-        <div className="detail-property">
-          <span className="detail-property-label">Profile Note</span>
-          <span className="detail-property-value detail-property-description">{profile.description}</span>
-        </div>
+            <div className="detail-property">
+              <span className="detail-property-label">Profile Note</span>
+              <span className="detail-property-value detail-property-description">{profile.description}</span>
+            </div>
+          </>
+        )}
 
         {parentPlate && (
           <div className="detail-property">


### PR DESCRIPTION
## Summary
- Hide the profile selector and profile note for plate types that don't support profiles (global, edge, zone)
- Only region and subnet plates now show the profile dropdown
- Profile options array is set to empty for unsupported plate types as an extra guard

Closes #585

## Test plan
- [x] Existing DetailPanel tests pass (19/19)
- [ ] Verify region plates still show profile selector
- [ ] Verify subnet plates still show profile selector
- [ ] Verify global/edge/zone plates no longer show profile selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)