### PR TITLE
fix(web): improve ConfirmDialog and PromptDialog keyboard, focus, and cleanup

### DIFF
--- a/apps/web/src/shared/ui/ConfirmDialog.test.tsx
+++ b/apps/web/src/shared/ui/ConfirmDialog.test.tsx
@@ -50,4 +50,42 @@ describe('confirmDialog', () => {
 
     await expect(promise).resolves.toBe(false);
   });
+
+  it('focuses Cancel button when opened', async () => {
+    render(<div />);
+
+    confirmDialog('Keep editing?', 'Discard draft?');
+    await screen.findByRole('dialog');
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+  });
+
+  it('resolves false when Escape is pressed', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const promise = confirmDialog('Keep editing?', 'Discard draft?');
+    await screen.findByRole('dialog');
+
+    await user.keyboard('{Escape}');
+
+    await expect(promise).resolves.toBe(false);
+  });
+
+  it('settles existing dialog before rendering a new one', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const firstPromise = confirmDialog('First message', 'First title');
+    await screen.findByText('First message');
+
+    const secondPromise = confirmDialog('Second message', 'Second title');
+    await screen.findByText('Second message');
+
+    await expect(firstPromise).resolves.toBe(false);
+    expect(screen.queryByText('First message')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    await expect(secondPromise).resolves.toBe(true);
+  });
 });

--- a/apps/web/src/shared/ui/ConfirmDialog.tsx
+++ b/apps/web/src/shared/ui/ConfirmDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
@@ -10,8 +11,25 @@ interface ConfirmDialogProps {
   onConfirm: () => void;
 }
 
-function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDialogProps) {
-  return createPortal(
+function ConfirmDialogContent({ title, message, onCancel, onConfirm }: ConfirmDialogProps) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelButtonRef.current?.focus();
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        onCancel();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onCancel]);
+
+  return (
     <div className="confirm-dialog-overlay" role="presentation" onClick={onCancel}>
       <div
         className="confirm-dialog"
@@ -28,7 +46,12 @@ function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDial
           {message}
         </p>
         <div className="confirm-dialog-actions">
-          <button type="button" className="confirm-dialog-btn" onClick={onCancel}>
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            className="confirm-dialog-btn"
+            onClick={onCancel}
+          >
             Cancel
           </button>
           <button
@@ -40,7 +63,18 @@ function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDial
           </button>
         </div>
       </div>
-    </div>,
+    </div>
+  );
+}
+
+function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDialogProps) {
+  return createPortal(
+    <ConfirmDialogContent
+      title={title}
+      message={message}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />,
     document.body,
   );
 }
@@ -78,7 +112,7 @@ export function confirmDialog(message: string, title = 'Confirm'): Promise<boole
   }
 
   if (resolver) {
-    resolver(false);
+    settle(false);
   }
 
   return new Promise<boolean>((resolve) => {

--- a/apps/web/src/shared/ui/PromptDialog.test.tsx
+++ b/apps/web/src/shared/ui/PromptDialog.test.tsx
@@ -8,18 +8,19 @@ describe('promptDialog', () => {
     render(<div />);
     const user = userEvent.setup();
 
-    const promise = promptDialog('Rename plate:', 'Rename', 'My VNet');
+    const message = 'Rename plate:';
+    const promise = promptDialog(message, 'Rename', 'My VNet');
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Rename')).toBeInTheDocument();
-    expect(screen.getByText('Rename plate:')).toBeInTheDocument();
+    expect(screen.getByText(message)).toBeInTheDocument();
 
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
+    const input = screen.getByRole('textbox', { name: message });
     expect(input).toBeInTheDocument();
-    expect(input?.value).toBe('My VNet');
+    expect(input).toHaveValue('My VNet');
 
-    await user.clear(input!);
-    await user.type(input!, 'New Name');
+    await user.clear(input);
+    await user.type(input, 'New Name');
 
     await user.click(screen.getByRole('button', { name: 'OK' }));
 
@@ -62,27 +63,56 @@ describe('promptDialog', () => {
     render(<div />);
     const user = userEvent.setup();
 
-    const promise = promptDialog('Rename block:', 'Rename', 'App VM');
+    const message = 'Rename block:';
+    const promise = promptDialog(message, 'Rename', 'App VM');
     await screen.findByRole('dialog');
 
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
-    await user.clear(input!);
-    await user.type(input!, 'Web Server{Enter}');
+    const input = screen.getByRole('textbox', { name: message });
+    await user.clear(input);
+    await user.type(input, 'Web Server{Enter}');
 
     await expect(promise).resolves.toBe('Web Server');
   });
 
-  it('resolves null when Escape is pressed', async () => {
+  it('resolves null when Escape is pressed from anywhere in dialog', async () => {
     render(<div />);
     const user = userEvent.setup();
 
     const promise = promptDialog('Rename block:', 'Rename', 'App VM');
     await screen.findByRole('dialog');
 
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
-    await user.click(input!);
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
     await user.keyboard('{Escape}');
 
     await expect(promise).resolves.toBeNull();
+  });
+
+  it('exposes input accessible name from message', async () => {
+    render(<div />);
+
+    const message = 'Enter workspace name:';
+    promptDialog(message, 'Rename workspace', 'Main Workspace');
+
+    expect(await screen.findByRole('textbox', { name: message })).toBeInTheDocument();
+  });
+
+  it('settles existing prompt before rendering a new one', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const firstPromise = promptDialog('First prompt', 'Rename', 'One');
+    await screen.findByText('First prompt');
+
+    const secondPromise = promptDialog('Second prompt', 'Rename', 'Two');
+    const secondInput = await screen.findByRole('textbox', { name: 'Second prompt' });
+
+    await expect(firstPromise).resolves.toBeNull();
+    expect(screen.queryByText('First prompt')).not.toBeInTheDocument();
+
+    await user.clear(secondInput);
+    await user.type(secondInput, 'Updated Two');
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+
+    await expect(secondPromise).resolves.toBe('Updated Two');
   });
 });

--- a/apps/web/src/shared/ui/PromptDialog.tsx
+++ b/apps/web/src/shared/ui/PromptDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
@@ -11,18 +12,23 @@ interface PromptDialogProps {
   onConfirm: (value: string) => void;
 }
 
-function getInputValue(): string {
-  return document.querySelector<HTMLInputElement>('.prompt-dialog-input')?.value ?? '';
-}
-
-function renderDialogPortal({
+function PromptDialogContent({
   title,
   message,
   defaultValue,
   onCancel,
   onConfirm,
 }: PromptDialogProps) {
-  return createPortal(
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const getInputValue = (): string => inputRef.current?.value ?? '';
+
+  return (
     <div className="confirm-dialog-overlay" role="presentation" onClick={onCancel}>
       <div
         className="confirm-dialog"
@@ -30,6 +36,11 @@ function renderDialogPortal({
         aria-modal="true"
         aria-labelledby="prompt-dialog-title"
         aria-describedby="prompt-dialog-message"
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            onCancel();
+          }
+        }}
         onClick={(event) => event.stopPropagation()}
       >
         <h3 id="prompt-dialog-title" className="confirm-dialog-title">
@@ -39,14 +50,14 @@ function renderDialogPortal({
           {message}
         </p>
         <input
+          ref={inputRef}
           className="prompt-dialog-input"
           type="text"
+          aria-label={message}
           defaultValue={defaultValue}
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
               onConfirm(getInputValue());
-            } else if (event.key === 'Escape') {
-              onCancel();
             }
           }}
         />
@@ -63,7 +74,19 @@ function renderDialogPortal({
           </button>
         </div>
       </div>
-    </div>,
+    </div>
+  );
+}
+
+function renderDialogPortal({ title, message, defaultValue, onCancel, onConfirm }: PromptDialogProps) {
+  return createPortal(
+    <PromptDialogContent
+      title={title}
+      message={message}
+      defaultValue={defaultValue}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />,
     document.body,
   );
 }
@@ -93,16 +116,6 @@ function settle(value: string | null): void {
   unmountDialog();
 }
 
-function focusInput(): void {
-  requestAnimationFrame(() => {
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
-    if (input) {
-      input.focus();
-      input.select();
-    }
-  });
-}
-
 export function promptDialog(
   message: string,
   title = 'Prompt',
@@ -115,7 +128,7 @@ export function promptDialog(
   }
 
   if (resolver) {
-    resolver(null);
+    settle(null);
   }
 
   return new Promise<string | null>((resolve) => {
@@ -129,6 +142,5 @@ export function promptDialog(
         onConfirm: (value: string) => settle(value),
       }),
     );
-    focusInput();
   });
 }


### PR DESCRIPTION
## Summary
Improve dialog accessibility, keyboard support, and lifecycle management.

- Focus action button on ConfirmDialog open
- Escape-key dismissal for both dialogs
- Consistent cleanup path when replacing in-flight dialogs
- Accessible label for PromptDialog input
- Replace global querySelector with React ref

Fixes #659
Fixes #660
Fixes #661
Fixes #664
Fixes #665
Fixes #668
Fixes #669