### PR TITLE
fix(web): harden ConfirmDialog and PromptDialog with focus, Escape, a11y, and cleanup fixes

### DIFF
--- a/apps/web/src/shared/ui/ConfirmDialog.test.tsx
+++ b/apps/web/src/shared/ui/ConfirmDialog.test.tsx
@@ -50,4 +50,49 @@ describe('confirmDialog', () => {
 
     await expect(promise).resolves.toBe(false);
   });
+
+  it('resolves false when Escape is pressed', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const promise = confirmDialog('Discard changes?', 'Confirm');
+    await screen.findByRole('dialog');
+
+    await user.keyboard('{Escape}');
+
+    await expect(promise).resolves.toBe(false);
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('focuses the Cancel button when the dialog opens', async () => {
+    render(<div />);
+
+    confirmDialog('Are you sure?', 'Confirm');
+    await screen.findByRole('dialog');
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus();
+    });
+  });
+
+  it('uses settle path when replacing an in-flight dialog', async () => {
+    render(<div />);
+
+    const first = confirmDialog('First?', 'First');
+    await screen.findByRole('dialog');
+
+    const second = confirmDialog('Second?', 'Second');
+
+    await expect(first).resolves.toBe(false);
+
+    await waitFor(() => {
+      expect(screen.getByText('Second?')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    await expect(second).resolves.toBe(true);
+  });
 });

--- a/apps/web/src/shared/ui/ConfirmDialog.tsx
+++ b/apps/web/src/shared/ui/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
+import { useEffect, useRef } from 'react';
 import './ConfirmDialog.css';
 
 interface ConfirmDialogProps {
@@ -10,8 +11,16 @@ interface ConfirmDialogProps {
   onConfirm: () => void;
 }
 
-function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDialogProps) {
-  return createPortal(
+// Internal-only component used by the imperative confirmDialog() API below.
+// eslint-disable-next-line react-refresh/only-export-components
+function ConfirmDialogContent({ title, message, onCancel, onConfirm }: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelRef.current?.focus();
+  }, []);
+
+  return (
     <div className="confirm-dialog-overlay" role="presentation" onClick={onCancel}>
       <div
         className="confirm-dialog"
@@ -20,6 +29,11 @@ function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDial
         aria-labelledby="confirm-dialog-title"
         aria-describedby="confirm-dialog-message"
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            onCancel();
+          }
+        }}
       >
         <h3 id="confirm-dialog-title" className="confirm-dialog-title">
           {title}
@@ -28,7 +42,7 @@ function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDial
           {message}
         </p>
         <div className="confirm-dialog-actions">
-          <button type="button" className="confirm-dialog-btn" onClick={onCancel}>
+          <button ref={cancelRef} type="button" className="confirm-dialog-btn" onClick={onCancel}>
             Cancel
           </button>
           <button
@@ -40,9 +54,12 @@ function renderDialogPortal({ title, message, onCancel, onConfirm }: ConfirmDial
           </button>
         </div>
       </div>
-    </div>,
-    document.body,
+    </div>
   );
+}
+
+function renderDialogPortal(props: ConfirmDialogProps) {
+  return createPortal(<ConfirmDialogContent {...props} />, document.body);
 }
 
 let dialogRoot: Root | null = null;
@@ -78,7 +95,7 @@ export function confirmDialog(message: string, title = 'Confirm'): Promise<boole
   }
 
   if (resolver) {
-    resolver(false);
+    settle(false);
   }
 
   return new Promise<boolean>((resolve) => {

--- a/apps/web/src/shared/ui/PromptDialog.test.tsx
+++ b/apps/web/src/shared/ui/PromptDialog.test.tsx
@@ -14,12 +14,12 @@ describe('promptDialog', () => {
     expect(screen.getByText('Rename')).toBeInTheDocument();
     expect(screen.getByText('Rename plate:')).toBeInTheDocument();
 
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
+    const input = screen.getByRole('textbox', { name: 'Rename' });
     expect(input).toBeInTheDocument();
-    expect(input?.value).toBe('My VNet');
+    expect(input).toHaveValue('My VNet');
 
-    await user.clear(input!);
-    await user.type(input!, 'New Name');
+    await user.clear(input);
+    await user.type(input, 'New Name');
 
     await user.click(screen.getByRole('button', { name: 'OK' }));
 
@@ -65,24 +65,84 @@ describe('promptDialog', () => {
     const promise = promptDialog('Rename block:', 'Rename', 'App VM');
     await screen.findByRole('dialog');
 
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
-    await user.clear(input!);
-    await user.type(input!, 'Web Server{Enter}');
+    const input = screen.getByRole('textbox', { name: 'Rename' });
+    await user.clear(input);
+    await user.type(input, 'Web Server{Enter}');
 
     await expect(promise).resolves.toBe('Web Server');
   });
 
-  it('resolves null when Escape is pressed', async () => {
+  it('resolves null when Escape is pressed on input', async () => {
     render(<div />);
     const user = userEvent.setup();
 
     const promise = promptDialog('Rename block:', 'Rename', 'App VM');
     await screen.findByRole('dialog');
 
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
-    await user.click(input!);
+    const input = screen.getByRole('textbox', { name: 'Rename' });
+    await user.click(input);
     await user.keyboard('{Escape}');
 
     await expect(promise).resolves.toBeNull();
+  });
+
+  it('resolves null when Escape is pressed on a button', async () => {
+    render(<div />);
+    const user = userEvent.setup();
+
+    const promise = promptDialog('Rename block:', 'Rename', 'App VM');
+    await screen.findByRole('dialog');
+
+    await user.tab();
+    await user.keyboard('{Escape}');
+
+    await expect(promise).resolves.toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('focuses and selects the input on open', async () => {
+    render(<div />);
+
+    promptDialog('Enter name:', 'Rename', 'Default');
+    await screen.findByRole('dialog');
+
+    await waitFor(() => {
+      const input = screen.getByRole('textbox', { name: 'Rename' });
+      expect(input).toHaveFocus();
+    });
+  });
+
+  it('input has an accessible label', async () => {
+    render(<div />);
+
+    promptDialog('Workspace name:', 'New Workspace', 'Untitled');
+    await screen.findByRole('dialog');
+
+    const input = screen.getByRole('textbox', { name: 'New Workspace' });
+    expect(input).toBeInTheDocument();
+  });
+
+  it('uses settle path when replacing an in-flight dialog', async () => {
+    render(<div />);
+
+    const first = promptDialog('First name:', 'First');
+    await screen.findByRole('dialog');
+
+    const second = promptDialog('Second name:', 'Second');
+
+    await expect(first).resolves.toBeNull();
+
+    await waitFor(() => {
+      expect(screen.getByText('Second name:')).toBeInTheDocument();
+    });
+
+    const user = userEvent.setup();
+    const input = screen.getByRole('textbox', { name: 'Second' });
+    await user.clear(input);
+    await user.type(input, 'value');
+    await user.click(screen.getByRole('button', { name: 'OK' }));
+    await expect(second).resolves.toBe('value');
   });
 });

--- a/apps/web/src/shared/ui/PromptDialog.tsx
+++ b/apps/web/src/shared/ui/PromptDialog.tsx
@@ -1,6 +1,7 @@
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
+import { useEffect, useRef } from 'react';
 import './PromptDialog.css';
 
 interface PromptDialogProps {
@@ -11,18 +12,26 @@ interface PromptDialogProps {
   onConfirm: (value: string) => void;
 }
 
-function getInputValue(): string {
-  return document.querySelector<HTMLInputElement>('.prompt-dialog-input')?.value ?? '';
-}
-
-function renderDialogPortal({
+// Internal-only component used by the imperative promptDialog() API below.
+// eslint-disable-next-line react-refresh/only-export-components
+function PromptDialogContent({
   title,
   message,
   defaultValue,
   onCancel,
   onConfirm,
 }: PromptDialogProps) {
-  return createPortal(
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  }, []);
+
+  return (
     <div className="confirm-dialog-overlay" role="presentation" onClick={onCancel}>
       <div
         className="confirm-dialog"
@@ -31,6 +40,11 @@ function renderDialogPortal({
         aria-labelledby="prompt-dialog-title"
         aria-describedby="prompt-dialog-message"
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') {
+            onCancel();
+          }
+        }}
       >
         <h3 id="prompt-dialog-title" className="confirm-dialog-title">
           {title}
@@ -39,14 +53,14 @@ function renderDialogPortal({
           {message}
         </p>
         <input
+          ref={inputRef}
           className="prompt-dialog-input"
           type="text"
           defaultValue={defaultValue}
+          aria-label={title}
           onKeyDown={(event) => {
             if (event.key === 'Enter') {
-              onConfirm(getInputValue());
-            } else if (event.key === 'Escape') {
-              onCancel();
+              onConfirm(inputRef.current?.value ?? '');
             }
           }}
         />
@@ -57,15 +71,18 @@ function renderDialogPortal({
           <button
             type="button"
             className="confirm-dialog-btn confirm-dialog-btn-confirm"
-            onClick={() => onConfirm(getInputValue())}
+            onClick={() => onConfirm(inputRef.current?.value ?? '')}
           >
             OK
           </button>
         </div>
       </div>
-    </div>,
-    document.body,
+    </div>
   );
+}
+
+function renderDialogPortal(props: PromptDialogProps) {
+  return createPortal(<PromptDialogContent {...props} />, document.body);
 }
 
 let dialogRoot: Root | null = null;
@@ -93,16 +110,6 @@ function settle(value: string | null): void {
   unmountDialog();
 }
 
-function focusInput(): void {
-  requestAnimationFrame(() => {
-    const input = document.querySelector<HTMLInputElement>('.prompt-dialog-input');
-    if (input) {
-      input.focus();
-      input.select();
-    }
-  });
-}
-
 export function promptDialog(
   message: string,
   title = 'Prompt',
@@ -115,7 +122,7 @@ export function promptDialog(
   }
 
   if (resolver) {
-    resolver(null);
+    settle(null);
   }
 
   return new Promise<string | null>((resolve) => {
@@ -129,6 +136,5 @@ export function promptDialog(
         onConfirm: (value: string) => settle(value),
       }),
     );
-    focusInput();
   });
 }


### PR DESCRIPTION
## Summary

- Extract `ConfirmDialogContent` and `PromptDialogContent` as internal React components to enable proper hook usage (`useRef`, `useEffect`)
- Auto-focus Cancel button when ConfirmDialog opens
- Add Escape-key dismissal to both ConfirmDialog and PromptDialog (dialog-level `onKeyDown`)
- Use `settle()` cleanup path when replacing in-flight dialogs instead of raw `resolver()` calls
- Add `aria-label` to PromptDialog input for accessibility
- Replace `document.querySelector` with `useRef` for PromptDialog input value lookup

## Testing

- 15 tests covering all 7 fixes (focus, Escape on overlay, Escape on button, accessible label, settle path for back-to-back dialogs)
- Full test suite: 1601/1601 pass
- Lint: clean
- Build: clean

Fixes #659, #660, #661, #664, #665, #668, #669