### PR TITLE
fix(web): improve workspace persistence and model cleanup (#644, #645, #648, #650, #666, #667, #670, #671, #672, #673)

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -354,6 +354,41 @@ describe('architectureStore', () => {
 
       expect(getState().workspace.architecture).toBe(before);
     });
+
+    it('deep-copies nested config, aggregation, and roles', () => {
+      getState().addPlate('region', 'VNet', null);
+      const netId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Sub', netId, 'public');
+      const subId = getArch().plates[1].id;
+
+      getState().addBlock('compute', 'VM', subId, 'azure', 'vm', { nested: { sku: 'B2ms' } });
+      const sourceId = getArch().blocks[0].id;
+
+      useArchitectureStore.setState((state) => ({
+        workspace: {
+          ...state.workspace,
+          architecture: {
+            ...state.workspace.architecture,
+            blocks: state.workspace.architecture.blocks.map((block) =>
+              block.id === sourceId
+                ? { ...block, aggregation: { mode: 'count', count: 2 }, roles: ['primary', 'secondary'] }
+                : block
+            ),
+          },
+        },
+      }));
+
+      getState().duplicateBlock(sourceId);
+
+      const source = getArch().blocks[0];
+      const duplicate = getArch().blocks[1];
+      expect(duplicate.config).toEqual(source.config);
+      expect(duplicate.config).not.toBe(source.config);
+      expect(duplicate.aggregation).toEqual(source.aggregation);
+      expect(duplicate.aggregation).not.toBe(source.aggregation);
+      expect(duplicate.roles).toEqual(source.roles);
+      expect(duplicate.roles).not.toBe(source.roles);
+    });
   });
 
   describe('renameBlock', () => {
@@ -970,6 +1005,36 @@ describe('architectureStore', () => {
       expect(getState().canUndo).toBe(false);
       expect(getState().canRedo).toBe(false);
     });
+
+    it('loadFromStorage falls back to first workspace when active ID is missing', () => {
+      getState().saveToStorage();
+      localStorage.setItem('cloudblocks:activeWorkspaceId', 'missing-id');
+
+      useArchitectureStore.setState({
+        workspace: { ...getState().workspace, id: 'temp' },
+        workspaces: [],
+      });
+
+      getState().loadFromStorage();
+      const stored = JSON.parse(localStorage.getItem('cloudblocks:workspaces') as string) as {
+        workspaces: Array<{ id: string }>;
+      };
+      expect(getState().workspace.id).toBe(stored.workspaces[0].id);
+    });
+
+    it('does not save active workspace ID when saveWorkspaces fails', () => {
+      const setItemSpy = vi.spyOn(localStorage, 'setItem').mockImplementation((key, value) => {
+        if (key === 'cloudblocks:workspaces') {
+          throw new Error('save failed');
+        }
+        Storage.prototype.setItem.call(localStorage, key, value);
+      });
+
+      const success = getState().saveToStorage();
+      expect(success).toBe(false);
+      expect(setItemSpy).not.toHaveBeenCalledWith('cloudblocks:activeWorkspaceId', expect.any(String));
+      setItemSpy.mockRestore();
+    });
   });
 
   describe('resetWorkspace', () => {
@@ -989,13 +1054,27 @@ describe('architectureStore', () => {
       expect(getState().workspace.id).toBe(workspaceId);
       expect(getState().workspace.name).toBe(workspaceName);
     });
+
+    it('does not save active workspace ID when saveWorkspaces fails', () => {
+      const setItemSpy = vi.spyOn(localStorage, 'setItem').mockImplementation((key, value) => {
+        if (key === 'cloudblocks:workspaces') {
+          throw new Error('save failed');
+        }
+        Storage.prototype.setItem.call(localStorage, key, value);
+      });
+
+      getState().resetWorkspace();
+      expect(setItemSpy).not.toHaveBeenCalledWith('cloudblocks:activeWorkspaceId', expect.any(String));
+      setItemSpy.mockRestore();
+    });
   });
 
   describe('renameWorkspace', () => {
-    it('updates workspace and architecture name', () => {
+    it('updates workspace name without mutating architecture name', () => {
+      const previousArchitectureName = getArch().name;
       getState().renameWorkspace('New Name');
       expect(getState().workspace.name).toBe('New Name');
-      expect(getArch().name).toBe('New Name');
+      expect(getArch().name).toBe(previousArchitectureName);
     });
 
     it('updates updatedAt timestamp', () => {
@@ -1003,6 +1082,15 @@ describe('architectureStore', () => {
       vi.setSystemTime(new Date('2025-06-01T00:00:00Z'));
       getState().renameWorkspace('Renamed');
       expect(getState().workspace.updatedAt).not.toBe(before);
+    });
+
+    it('persists renamed workspace', () => {
+      getState().renameWorkspace('Persisted Rename');
+      const stored = JSON.parse(localStorage.getItem('cloudblocks:workspaces') as string) as {
+        workspaces: Array<{ id: string; name: string }>;
+      };
+      const savedWorkspace = stored.workspaces.find((workspace) => workspace.id === getState().workspace.id);
+      expect(savedWorkspace?.name).toBe('Persisted Rename');
     });
   });
 
@@ -1079,6 +1167,30 @@ describe('architectureStore', () => {
         expect(secondInList?.architecture.plates).toHaveLength(1);
       }
     });
+
+    it('persists outgoing workspace before switching', () => {
+      getState().createWorkspace('Second');
+      const secondId = getState().workspace.id;
+      getState().addPlate('region', 'Second Plate', null);
+      const firstId = getState().workspaces.find((ws) => ws.id !== secondId)?.id;
+
+      getState().switchWorkspace(firstId as string);
+
+      const stored = JSON.parse(localStorage.getItem('cloudblocks:workspaces') as string) as {
+        workspaces: Array<{ id: string; architecture: { plates: unknown[] } }>;
+      };
+      expect(stored.workspaces.find((ws) => ws.id === secondId)?.architecture.plates).toHaveLength(1);
+    });
+
+    it('saves active workspace ID after switching', () => {
+      const setItemSpy = vi.spyOn(localStorage, 'setItem');
+      const firstId = getState().workspace.id;
+      getState().createWorkspace('Second');
+      getState().switchWorkspace(firstId);
+
+      expect(setItemSpy).toHaveBeenCalledWith('cloudblocks:activeWorkspaceId', firstId);
+      setItemSpy.mockRestore();
+    });
   });
 
   describe('deleteWorkspace', () => {
@@ -1110,6 +1222,32 @@ describe('architectureStore', () => {
       expect(getState().workspace).toBeDefined();
       expect(getState().workspace.id).not.toBe(onlyId);
       expect(getState().workspaces).toHaveLength(1);
+    });
+
+    it('persists current workspace when deleting non-current workspace', () => {
+      const firstId = getState().workspace.id;
+      getState().createWorkspace('Second');
+      const currentId = getState().workspace.id;
+
+      getState().deleteWorkspace(firstId);
+
+      const stored = JSON.parse(localStorage.getItem('cloudblocks:workspaces') as string) as {
+        workspaces: Array<{ id: string }>;
+      };
+      expect(stored.workspaces.some((workspace) => workspace.id === currentId)).toBe(true);
+    });
+  });
+
+  describe('setBackendWorkspaceId', () => {
+    it('updates and persists backendWorkspaceId for current workspace', () => {
+      const workspaceId = getState().workspace.id;
+      getState().setBackendWorkspaceId(workspaceId, 'backend-123');
+
+      expect(getState().workspace.backendWorkspaceId).toBe('backend-123');
+      const stored = JSON.parse(localStorage.getItem('cloudblocks:workspaces') as string) as {
+        workspaces: Array<{ id: string; backendWorkspaceId?: string }>;
+      };
+      expect(stored.workspaces.find((workspace) => workspace.id === workspaceId)?.backendWorkspaceId).toBe('backend-123');
     });
   });
 

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -237,6 +237,19 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         id: generateId('block'),
         name: `${sourceBlock.name} (copy)`,
         position,
+        metadata: structuredClone(sourceBlock.metadata),
+        config:
+          sourceBlock.config === undefined
+            ? undefined
+            : structuredClone(sourceBlock.config),
+        aggregation:
+          sourceBlock.aggregation === undefined
+            ? undefined
+            : structuredClone(sourceBlock.aggregation),
+        roles:
+          sourceBlock.roles === undefined
+            ? undefined
+            : structuredClone(sourceBlock.roles),
       };
 
       return withHistory(state, {

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -7,7 +7,6 @@ import type { ArchitectureSlice, ArchitectureState } from './types';
 import {
   createDefaultWorkspace,
   resetTransientState,
-  touchModel,
   upsertCurrentWorkspace,
   withHistory,
 } from './helpers';
@@ -288,8 +287,10 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (
     };
 
     const updatedList = upsertCurrentWorkspace(state.workspaces, cleared);
-    saveWorkspaces(updatedList);
-    saveActiveWorkspaceId(cleared.id);
+    const saved = saveWorkspaces(updatedList);
+    if (saved) {
+      saveActiveWorkspaceId(cleared.id);
+    }
 
     set({
       workspace: cleared,
@@ -299,20 +300,22 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (
   },
 
   renameWorkspace: (name) => {
-    set((state) => ({
-      workspace: {
-        ...state.workspace,
-        name,
-        architecture: touchModel({
-          ...state.workspace.architecture,
-          name,
-        }),
-        updatedAt: new Date().toISOString(),
-      },
-    }));
+    const state = get();
+    const renamed: Workspace = {
+      ...state.workspace,
+      name,
+      updatedAt: new Date().toISOString(),
+    };
+    const updatedList = upsertCurrentWorkspace(state.workspaces, renamed);
+    saveWorkspaces(updatedList);
+
+    set({
+      workspace: renamed,
+      workspaces: updatedList,
+    });
   },
 
-  importArchitecture: (json) => {
+  importArchitecture: (json): string | null => {
     try {
       const importedRaw = JSON.parse(json) as unknown;
       validateImportData(importedRaw, json.length);
@@ -355,8 +358,10 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (
       const updatedList = upsertCurrentWorkspace(state.workspaces, state.workspace);
       updatedList.push(newWorkspace);
 
-      saveWorkspaces(updatedList);
-      saveActiveWorkspaceId(newWorkspace.id);
+      const saved = saveWorkspaces(updatedList);
+      if (saved) {
+        saveActiveWorkspaceId(newWorkspace.id);
+      }
 
       set({
         workspace: newWorkspace,
@@ -396,8 +401,10 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (
     const updatedList = upsertCurrentWorkspace(state.workspaces, state.workspace);
     updatedList.push(newWorkspace);
 
-    saveWorkspaces(updatedList);
-    saveActiveWorkspaceId(newWorkspace.id);
+    const saved = saveWorkspaces(updatedList);
+    if (saved) {
+      saveActiveWorkspaceId(newWorkspace.id);
+    }
 
     set({
       workspace: newWorkspace,

--- a/apps/web/src/entities/store/slices/workspaceSlice.ts
+++ b/apps/web/src/entities/store/slices/workspaceSlice.ts
@@ -59,9 +59,11 @@ export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (
       return;
     }
 
-    const updatedList = state.workspaces.map((workspace) =>
-      workspace.id === state.workspace.id ? state.workspace : workspace
-    );
+    const updatedList = upsertCurrentWorkspace(state.workspaces, state.workspace);
+    const saved = saveWorkspaces(updatedList);
+    if (saved) {
+      saveActiveWorkspaceId(target.id);
+    }
 
     set({
       workspace: target,
@@ -72,7 +74,8 @@ export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (
 
   deleteWorkspace: (id) => {
     const state = get();
-    const filtered = state.workspaces.filter((workspace) => workspace.id !== id);
+    const workspaceListWithCurrent = upsertCurrentWorkspace(state.workspaces, state.workspace);
+    const filtered = workspaceListWithCurrent.filter((workspace) => workspace.id !== id);
 
     if (state.workspace.id === id) {
       const next = filtered.length > 0 ? filtered[0] : createDefaultWorkspace();
@@ -137,15 +140,15 @@ export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (
 
   setBackendWorkspaceId: (workspaceId, backendId) => {
     const state = get();
-    if (state.workspace.id === workspaceId) {
-      set({
-        workspace: { ...state.workspace, backendWorkspaceId: backendId },
-      });
-    }
-    set({
-      workspaces: state.workspaces.map((ws) =>
-        ws.id === workspaceId ? { ...ws, backendWorkspaceId: backendId } : ws
-      ),
-    });
+    const workspace =
+      state.workspace.id === workspaceId
+        ? { ...state.workspace, backendWorkspaceId: backendId }
+        : state.workspace;
+    const workspaces = upsertCurrentWorkspace(state.workspaces, workspace).map((ws) =>
+      ws.id === workspaceId ? { ...ws, backendWorkspaceId: backendId } : ws
+    );
+
+    saveWorkspaces(workspaces);
+    set({ workspace, workspaces });
   },
 });

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -69,11 +69,6 @@ export interface Workspace {
   architecture: ArchitectureModel;
   createdAt: string;
   updatedAt: string;
-  // GitHub integration (optional for backward compatibility)
-  repoOwner?: string;
-  repoName?: string;
-  branch?: string;
-  lastSyncAt?: string;
   backendWorkspaceId?: string;
 }
 


### PR DESCRIPTION
## Summary
- Fix workspace persistence sequencing for active workspace ID and ensure writes happen only after successful workspace saves.
- Make workspace actions self-contained for switch/delete/backend-id updates, including persistence of outgoing/current workspace snapshots.
- Remove deprecated Workspace Git sync fields and harden block duplication to deep-copy nested data structures.
- Add regression coverage for duplicate block deep-copying, rename behavior, active workspace restore, switch/delete persistence, and backend workspace ID persistence.

Fixes #644
Fixes #645
Fixes #648
Fixes #650
Fixes #666
Fixes #667
Fixes #670
Fixes #671
Fixes #672
Fixes #673