### PR TITLE
fix(web): use stable keys and show correct identity labels

### DIFF
--- a/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
@@ -119,6 +119,35 @@ describe('DetailPanel', () => {
     expect(screen.getByText('API VM')).toBeInTheDocument();
   });
 
+  it('shows provider and subtype identity for provider-specific blocks', () => {
+    const providerSpecificBlock: Block = {
+      ...sourceBlock,
+      id: 'block-provider-specific',
+      provider: 'aws',
+      subtype: 'ec2',
+    };
+
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        architecture: {
+          ...architectureWithResources,
+          blocks: [providerSpecificBlock],
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+    useUIStore.setState({ selectedId: 'block-provider-specific' });
+
+    render(<DetailPanel />);
+
+    expect(screen.getByText('AWS / ec2')).toBeInTheDocument();
+    expect(screen.getByText('Provider')).toBeInTheDocument();
+    expect(screen.getByText('Subtype')).toBeInTheDocument();
+  });
+
   it('renders plate detail including size and contents count', () => {
     useUIStore.setState({ selectedId: 'subnet-1' });
 

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -127,6 +127,10 @@ function BlockDetail({ block, className }: { block: Block; className: string }) 
   }, [newName, block.id, block.name, renameBlock]);
 
   const color = getBlockColor(block.provider ?? 'azure', block.subtype, block.category);
+  const providerLabel = block.provider ? block.provider.toUpperCase() : null;
+  const typeIdentity = block.provider || block.subtype
+    ? [providerLabel, block.subtype].filter(Boolean).join(' / ')
+    : BLOCK_FRIENDLY_NAMES[block.category];
 
   return (
     <div className={`detail-panel detail-panel--block ${className}`}>
@@ -166,12 +170,28 @@ function BlockDetail({ block, className }: { block: Block; className: string }) 
         <div className="detail-property">
           <span className="detail-property-label">Type</span>
           <span className="detail-property-value">
-            {BLOCK_FRIENDLY_NAMES[block.category]}
+            {typeIdentity}
             <span className="detail-property-hint" title={BLOCK_DESCRIPTIONS[block.category]}>
               ℹ️
             </span>
           </span>
         </div>
+
+        {block.provider && (
+          <div className="detail-property">
+            <span className="detail-property-label">Provider</span>
+            <span className="detail-property-value detail-property-tag" style={{ backgroundColor: `${color}20`, color }}>
+              {providerLabel}
+            </span>
+          </div>
+        )}
+
+        {block.subtype && (
+          <div className="detail-property">
+            <span className="detail-property-label">Subtype</span>
+            <span className="detail-property-value">{block.subtype}</span>
+          </div>
+        )}
 
         <div className="detail-property">
           <span className="detail-property-label">Category</span>

--- a/apps/web/src/widgets/flow-diagram/FlowDiagram.test.tsx
+++ b/apps/web/src/widgets/flow-diagram/FlowDiagram.test.tsx
@@ -35,10 +35,10 @@ const makeConnection = (id: string, sourceId: string, targetId: string): Connect
   metadata: {},
 });
 
-const makeExternalActor = (id: string): ExternalActor => ({
+const makeExternalActor = (id: string, name = 'Internet'): ExternalActor => ({
   id,
   type: 'internet',
-  name: 'Internet',
+  name,
   position: { x: -3, y: 0, z: 5 },
 });
 
@@ -106,6 +106,25 @@ describe('FlowDiagram', () => {
     render(<FlowDiagram />);
     expect(screen.getByText('Internet')).toBeInTheDocument();
     expect(screen.getByText('☁')).toBeInTheDocument();
+  });
+
+  it('renders external actor node with custom actor name', () => {
+    const blocks: Block[] = [makeBlock('gateway-1', 'gateway')];
+    const externalActors: ExternalActor[] = [makeExternalActor('external-1', 'Partner API')];
+    const connections: Connection[] = [makeConnection('c1', 'external-1', 'gateway-1')];
+
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Flow WS',
+        architecture: { ...baseArchitecture, blocks, externalActors, connections },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+
+    render(<FlowDiagram />);
+    expect(screen.getByText('Partner API')).toBeInTheDocument();
   });
 
   it('renders arrows between nodes', () => {

--- a/apps/web/src/widgets/flow-diagram/FlowDiagram.tsx
+++ b/apps/web/src/widgets/flow-diagram/FlowDiagram.tsx
@@ -79,7 +79,7 @@ export function FlowDiagram() {
           content = (
             <div className="flow-node flow-node-external">
               <span className="flow-icon">☁</span>
-              Internet
+              {actor.name || 'External Actor'}
             </div>
           );
         } else if (block) {

--- a/apps/web/src/widgets/learning-panel/HintPopup.tsx
+++ b/apps/web/src/widgets/learning-panel/HintPopup.tsx
@@ -21,13 +21,24 @@ export function HintPopup() {
   }
 
   const visibleHints = currentStep.hints.slice(0, currentHintIndex + 1);
+  const hintOccurrences = new Map<string, number>();
+  const hintCards = visibleHints.map((hint, index) => {
+    const occurrence = (hintOccurrences.get(hint) ?? 0) + 1;
+    hintOccurrences.set(hint, occurrence);
+
+    return {
+      key: `${currentStep.id}-${hint}-${occurrence}`,
+      hint,
+      order: index + 1,
+    };
+  });
 
   return (
     <div className="hint-popup-container">
-      {visibleHints.map((hint, index) => (
-        <div key={hint} className="hint-popup-card">
-          <h4 className="hint-popup-title">💡 Hint {index + 1}</h4>
-          <p className="hint-popup-text">{hint}</p>
+      {hintCards.map((hintCard) => (
+        <div key={hintCard.key} className="hint-popup-card">
+          <h4 className="hint-popup-title">💡 Hint {hintCard.order}</h4>
+          <p className="hint-popup-text">{hintCard.hint}</p>
         </div>
       ))}
     </div>

--- a/apps/web/src/widgets/learning-panel/LearningPanel.test.tsx
+++ b/apps/web/src/widgets/learning-panel/LearningPanel.test.tsx
@@ -207,6 +207,55 @@ describe('LearningPanel widgets', () => {
     expect(screen.getByText('Complete requirement')).toBeInTheDocument();
   });
 
+  it('matches validation outcomes to rules by rule identity, not result index', () => {
+    const activeScenario = useLearningStore.getState().activeScenario;
+    const progress = useLearningStore.getState().progress;
+    if (!activeScenario || !progress) {
+      throw new Error('Expected active scenario and progress');
+    }
+
+    const rules: StepValidationRule[] = [
+      { type: 'plate-exists', plateType: 'region' },
+      { type: 'architecture-valid' },
+    ];
+
+    useLearningStore.setState({
+      activeScenario: {
+        ...activeScenario,
+        steps: [
+          {
+            ...activeScenario.steps[0],
+            validationRules: rules,
+          },
+        ],
+      },
+      progress: {
+        ...progress,
+        currentStepIndex: 0,
+      },
+    });
+
+    vi.mocked(getValidationDetails).mockReturnValue({
+      passed: false,
+      results: [
+        { rule: rules[1], passed: true },
+        { rule: rules[0], passed: false },
+      ],
+    });
+
+    render(<LearningPanel />);
+
+    const regionRuleItem = screen.getByText('Add a region plate').closest('li');
+    const validRuleItem = screen.getByText('Fix validation issues').closest('li');
+
+    if (!(regionRuleItem instanceof HTMLElement) || !(validRuleItem instanceof HTMLElement)) {
+      throw new Error('Expected validation list items');
+    }
+
+    expect(regionRuleItem).toHaveTextContent('✗');
+    expect(validRuleItem).toHaveTextContent('✓');
+  });
+
   it('disables Next Step button when current step is incomplete', () => {
     useLearningStore.setState({ isCurrentStepComplete: false });
     render(<LearningPanel />);
@@ -321,6 +370,37 @@ describe('LearningPanel widgets', () => {
       throw new Error('Expected active step node');
     }
     expect(activeNode).toHaveTextContent('2');
+  });
+
+  it('StepProgress maps step status by stepId even when progress order differs', () => {
+    const progress = useLearningStore.getState().progress;
+    const activeScenario = useLearningStore.getState().activeScenario;
+    if (!progress || !activeScenario) {
+      throw new Error('Expected progress and active scenario');
+    }
+
+    const firstStepId = activeScenario.steps[0]?.id;
+    const secondStepId = activeScenario.steps[1]?.id;
+    if (!firstStepId || !secondStepId) {
+      throw new Error('Expected first two step ids');
+    }
+
+    useLearningStore.setState({
+      progress: {
+        ...progress,
+        currentStepIndex: 1,
+        steps: [
+          { stepId: secondStepId, status: 'active', hintsUsed: 0 },
+          { stepId: firstStepId, status: 'completed', hintsUsed: 0 },
+        ],
+      },
+    });
+
+    render(<StepProgress />);
+
+    const nodes = Array.from(document.querySelectorAll('.step-progress-node'));
+    expect(nodes[0]).toHaveTextContent('✓');
+    expect(nodes[1]).toHaveClass('active');
   });
 
   it('StepProgress falls back to locked state and empty title when indices mismatch', () => {

--- a/apps/web/src/widgets/learning-panel/LearningPanel.tsx
+++ b/apps/web/src/widgets/learning-panel/LearningPanel.tsx
@@ -7,6 +7,27 @@ import { StepProgress } from './StepProgress';
 import { HintPopup } from './HintPopup';
 import { CompletionScreen } from './CompletionScreen';
 
+function getRuleIdentifier(rule: StepValidationRule): string {
+  switch (rule.type) {
+    case 'plate-exists':
+      return `plate-exists:${rule.plateType}:${rule.subnetAccess ?? 'any'}`;
+    case 'block-exists':
+      return `block-exists:${rule.category}:${rule.onPlateType ?? 'any'}:${rule.onSubnetAccess ?? 'any'}`;
+    case 'connection-exists':
+      return `connection-exists:${rule.sourceCategory}:${rule.targetCategory}`;
+    case 'entity-on-plate':
+      return `entity-on-plate:${rule.entityCategory}:${rule.plateType}:${rule.subnetAccess ?? 'any'}`;
+    case 'architecture-valid':
+      return 'architecture-valid';
+    case 'min-block-count':
+      return `min-block-count:${rule.category}:${rule.count}`;
+    case 'min-plate-count':
+      return `min-plate-count:${rule.plateType}:${rule.count}`;
+    default:
+      return 'unknown-rule';
+  }
+}
+
 function describeRule(rule: StepValidationRule): string {
   switch (rule.type) {
     case 'plate-exists':
@@ -59,6 +80,9 @@ export function LearningPanel() {
 
   const validationDetails = getValidationDetails();
   const rules = currentStep.validationRules || [];
+  const validationResultByRuleId = new Map(
+    validationDetails.results.map((result) => [getRuleIdentifier(result.rule), result.passed]),
+  );
   const maxHints = currentStep.hints ? currentStep.hints.length : 0;
   const allHintsShown = currentHintIndex >= maxHints - 1;
 
@@ -97,9 +121,10 @@ export function LearningPanel() {
           {rules.length > 0 && (
             <ul className="validation-list">
               {rules.map((rule, index) => {
-                const isPass = validationDetails.results[index]?.passed ?? false;
+                const ruleId = getRuleIdentifier(rule);
+                const isPass = validationResultByRuleId.get(ruleId) ?? false;
                 return (
-                  <li key={`${rule.type}-${index}`} className="validation-item">
+                  <li key={`${ruleId}-${index}`} className="validation-item">
                     <span className={`validation-icon ${isPass ? 'pass' : 'fail'}`}>
                       {isPass ? '✓' : '✗'}
                     </span>

--- a/apps/web/src/widgets/learning-panel/StepProgress.tsx
+++ b/apps/web/src/widgets/learning-panel/StepProgress.tsx
@@ -10,6 +10,7 @@ export function StepProgress() {
 
   const currentStepIndex = progress.currentStepIndex;
   const steps = activeScenario.steps;
+  const stepStatusByStepId = new Map(progress.steps.map((step) => [step.stepId, step.status]));
   const currentStepTitle = steps[currentStepIndex]?.title || '';
 
   return (
@@ -17,7 +18,7 @@ export function StepProgress() {
       <div className="step-progress-bar">
         <div className="step-progress-line" />
         {steps.map((step, index) => {
-          const stepStatus = progress.steps[index]?.status || 'locked';
+          const stepStatus = stepStatusByStepId.get(step.id) ?? 'locked';
           const isActive = index === currentStepIndex;
           
           let nodeClass = 'step-progress-node';

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -17,6 +17,7 @@ import { MenuBar } from './MenuBar';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { useLearningStore } from '../../entities/store/learningStore';
 import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
 import { apiPost } from '../../shared/api/client';
 import { toast } from 'react-hot-toast';
@@ -168,6 +169,8 @@ describe('MenuBar', () => {
       showCodePreview: false,
       showWorkspaceManager: false,
       showTemplateGallery: false,
+      showLearningPanel: false,
+      showScenarioGallery: false,
       showGitHubLogin: false,
       showGitHubRepos: false,
       showGitHubSync: false,
@@ -186,6 +189,12 @@ describe('MenuBar', () => {
     });
 
     setArchitectureState();
+    useLearningStore.setState({
+      activeScenario: null,
+      progress: null,
+      currentHintIndex: -1,
+      isCurrentStepComplete: false,
+    });
   });
 
   afterEach(() => {
@@ -497,7 +506,7 @@ describe('MenuBar', () => {
     expect(useUIStore.getState().showTemplateGallery).toBe(true);
   }, 15000);
 
-  it('handles Build menu scenario gallery and learning panel (merged from Learn menu)', async () => {
+  it('routes Show Learning Panel to scenario gallery when no scenario is active', async () => {
     const user = userEvent.setup();
     render(<MenuBar />);
 
@@ -507,7 +516,59 @@ describe('MenuBar', () => {
 
     buildDropdown = await openMenu(user, 'Build');
     await user.click(within(buildDropdown).getByRole('button', { name: /Show Learning Panel/ }));
+    expect(useUIStore.getState().showScenarioGallery).toBe(true);
+    expect(useUIStore.getState().showLearningPanel).toBe(false);
+
+    buildDropdown = await openMenu(user, 'Build');
+    const learningPanelButton = within(buildDropdown).getByRole('button', { name: /Show Learning Panel/ });
+    expect(learningPanelButton.textContent).not.toContain('\u2713');
+  });
+
+  it('opens learning panel when an active scenario exists', async () => {
+    const user = userEvent.setup();
+    useLearningStore.setState({
+      activeScenario: {
+        id: 'scenario-1',
+        name: 'Test Scenario',
+        description: 'Scenario for menu test',
+        difficulty: 'beginner',
+        category: 'general',
+        tags: [],
+        estimatedMinutes: 5,
+        steps: [
+          {
+            id: 'step-1',
+            order: 1,
+            title: 'Step 1',
+            instruction: 'Do one thing',
+            hints: [],
+            validationRules: [],
+          },
+        ],
+        initialArchitecture: {
+          name: 'Initial',
+          version: '1.0.0',
+          plates: [],
+          blocks: [],
+          connections: [],
+          externalActors: [],
+        },
+      },
+      progress: {
+        scenarioId: 'scenario-1',
+        currentStepIndex: 0,
+        steps: [{ stepId: 'step-1', status: 'active', hintsUsed: 0 }],
+        startedAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+
+    render(<MenuBar />);
+
+    let buildDropdown = await openMenu(user, 'Build');
+    await user.click(within(buildDropdown).getByRole('button', { name: /Show Learning Panel/ }));
+
     expect(useUIStore.getState().showLearningPanel).toBe(true);
+    expect(useUIStore.getState().showScenarioGallery).toBe(false);
 
     buildDropdown = await openMenu(user, 'Build');
     const learningPanelButton = within(buildDropdown).getByRole('button', { name: /Show Learning Panel/ });
@@ -567,6 +628,12 @@ describe('MenuBar', () => {
   it('handles authenticated GitHub menu actions', async () => {
     const user = userEvent.setup();
     const logoutMock = vi.fn();
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        backendWorkspaceId: 'backend-ws-1',
+      },
+    });
     useAuthStore.setState({
       status: 'authenticated',
       user: {
@@ -605,9 +672,39 @@ describe('MenuBar', () => {
     expect(logoutMock).toHaveBeenCalledOnce();
   });
 
+  it('disables GitHub sync/pr/compare actions without backend workspace link', async () => {
+    const user = userEvent.setup();
+    useAuthStore.setState({
+      status: 'authenticated',
+      user: {
+        id: 'user-1',
+        github_username: 'octocat',
+        email: null,
+        display_name: null,
+        avatar_url: null,
+      },
+    });
+
+    render(<MenuBar />);
+
+    const githubButton = screen.getByRole('button', { name: /octocat/ });
+    await user.click(githubButton);
+    const githubDropdown = getMenuDropdown(/octocat/);
+
+    expect(within(githubDropdown).getByRole('button', { name: /Sync/ })).toBeDisabled();
+    expect(within(githubDropdown).getByRole('button', { name: /Create PR/ })).toBeDisabled();
+    expect(within(githubDropdown).getByRole('button', { name: /Compare with GitHub/ })).toBeDisabled();
+  });
+
   it('compare with GitHub calls backend and enables diff mode', async () => {
     const user = userEvent.setup();
     vi.mocked(apiPost).mockResolvedValue({ architecture: emptyArch });
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        backendWorkspaceId: 'backend-ws-1',
+      },
+    });
     useAuthStore.setState({
       status: 'authenticated',
       user: {
@@ -626,7 +723,7 @@ describe('MenuBar', () => {
     const githubDropdown = getMenuDropdown(/octocat/);
     await user.click(within(githubDropdown).getByRole('button', { name: /Compare with GitHub/ }));
 
-    expect(apiPost).toHaveBeenCalledWith('/api/v1/workspaces/ws-1/pull');
+    expect(apiPost).toHaveBeenCalledWith('/api/v1/workspaces/backend-ws-1/pull');
     expect(useUIStore.getState().diffMode).toBe(true);
   });
 
@@ -712,6 +809,12 @@ describe('MenuBar', () => {
   it('shows toast error when compare with GitHub fails', async () => {
     const user = userEvent.setup();
     vi.mocked(apiPost).mockRejectedValue(new Error('pull failed'));
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        backendWorkspaceId: 'backend-ws-1',
+      },
+    });
     useAuthStore.setState({
       status: 'authenticated',
       user: {

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -3,6 +3,7 @@ import { AiPromptBar } from '../../features/ai';
 import { useAiStore } from '../../features/ai/store';
 import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
+import { useLearningStore } from '../../entities/store/learningStore';
 import { validateArchitectureShape } from '../../entities/store/slices';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
@@ -46,6 +47,7 @@ export function MenuBar() {
   const toggleScenarioGallery = useUIStore((s) => s.toggleScenarioGallery);
   const toggleLearningPanel = useUIStore((s) => s.toggleLearningPanel);
   const showLearningPanel = useUIStore((s) => s.showLearningPanel);
+  const activeScenario = useLearningStore((s) => s.activeScenario);
   const isSoundMuted = useUIStore((s) => s.isSoundMuted);
   const toggleSound = useUIStore((s) => s.toggleSound);
   const playSound = (name: SoundName) => { if (!isSoundMuted) audioService.playSound(name); };
@@ -64,6 +66,7 @@ export function MenuBar() {
   const resetWorkspace = useArchitectureStore((s) => s.resetWorkspace);
   const validationResult = useArchitectureStore((s) => s.validationResult);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
+  const backendWorkspaceId = useArchitectureStore((s) => s.workspace.backendWorkspaceId);
   const canUndo = useArchitectureStore((s) => s.canUndo);
   const canRedo = useArchitectureStore((s) => s.canRedo);
   const undo = useArchitectureStore((s) => s.undo);
@@ -71,6 +74,7 @@ export function MenuBar() {
   const importArchitecture = useArchitectureStore((s) => s.importArchitecture);
 
   const importInputRef = useRef<HTMLInputElement>(null);
+  const hasBackendWorkspaceLink = Boolean(backendWorkspaceId);
 
   useEffect(() => {
     const handleDocumentClick = (e: MouseEvent) => {
@@ -187,8 +191,16 @@ export function MenuBar() {
   };
 
   const handleCompareWithGitHub = async () => {
-    const ws = useArchitectureStore.getState().workspace;
-    const wsId = ws.backendWorkspaceId ?? ws.id;
+    if (!backendWorkspaceId) {
+      toast.error('Workspace must be linked to backend before using GitHub compare.');
+      return;
+    }
+
+    const wsId = backendWorkspaceId;
+    if (!wsId) {
+      toast.error('Workspace must be linked to backend before using GitHub compare.');
+      return;
+    }
     try {
       const response = await apiPost<PullResponse>(
         `/api/v1/workspaces/${encodeURIComponent(wsId)}/pull`,
@@ -215,6 +227,22 @@ export function MenuBar() {
     if (diffMode) {
       useUIStore.getState().setDiffMode(false);
     }
+  };
+
+  const handleToggleLearningPanel = () => {
+    if (showLearningPanel) {
+      toggleLearningPanel();
+      return;
+    }
+
+    if (!activeScenario) {
+      if (!useUIStore.getState().showScenarioGallery) {
+        toggleScenarioGallery();
+      }
+      return;
+    }
+
+    toggleLearningPanel();
   };
 
   return (
@@ -339,7 +367,7 @@ export function MenuBar() {
             <button type="button" className="menu-item" onClick={() => handleAction(toggleScenarioGallery)}>
               <span className="menu-item-left">📚 Browse Scenarios</span>
             </button>
-            <button type="button" className="menu-item" onClick={() => handleAction(toggleLearningPanel)}>
+            <button type="button" className="menu-item" onClick={() => handleAction(handleToggleLearningPanel)}>
               <span className="menu-item-left">{showLearningPanel ? '✓ ' : ''}📖 Show Learning Panel</span>
             </button>
           </div>
@@ -457,13 +485,31 @@ export function MenuBar() {
               <button type="button" className="menu-item" onClick={() => handleAction(toggleGitHubRepos)}>
                 <span className="menu-item-left">📦 Repos</span>
               </button>
-              <button type="button" className="menu-item" onClick={() => handleAction(toggleGitHubSync)}>
+              <button
+                type="button"
+                className="menu-item"
+                onClick={() => handleAction(toggleGitHubSync)}
+                disabled={!hasBackendWorkspaceLink}
+                title={!hasBackendWorkspaceLink ? 'Link workspace to backend to use GitHub sync.' : undefined}
+              >
                 <span className="menu-item-left">🔄 Sync</span>
               </button>
-              <button type="button" className="menu-item" onClick={() => handleAction(toggleGitHubPR)}>
+              <button
+                type="button"
+                className="menu-item"
+                onClick={() => handleAction(toggleGitHubPR)}
+                disabled={!hasBackendWorkspaceLink}
+                title={!hasBackendWorkspaceLink ? 'Link workspace to backend to create pull requests.' : undefined}
+              >
                 <span className="menu-item-left">🔀 Create PR</span>
               </button>
-              <button type="button" className="menu-item" onClick={() => handleAction(handleCompareWithGitHub)}>
+              <button
+                type="button"
+                className="menu-item"
+                onClick={() => handleAction(handleCompareWithGitHub)}
+                disabled={!hasBackendWorkspaceLink}
+                title={!hasBackendWorkspaceLink ? 'Link workspace to backend to compare with GitHub.' : undefined}
+              >
                 <span className="menu-item-left">🔍 Compare with GitHub</span>
               </button>
               <div className="menu-separator" />

--- a/apps/web/src/widgets/scene-canvas/DragGhost.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/DragGhost.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach, vi, type Mock } from 'vitest';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { DragGhost } from './DragGhost';
 import { useUIStore } from '../../entities/store/uiStore';
 
@@ -74,6 +74,7 @@ describe('DragGhost', () => {
     const ghost = container.querySelector('g.drag-ghost');
     expect(ghost).not.toBeNull();
     expect(ghost?.querySelectorAll('polygon')).toHaveLength(3);
+    expect(screen.getByText('Azure / Virtual Machine')).toBeInTheDocument();
   });
 
   it('renders nothing after drag is cancelled', () => {

--- a/apps/web/src/widgets/scene-canvas/DragGhost.tsx
+++ b/apps/web/src/widgets/scene-canvas/DragGhost.tsx
@@ -4,6 +4,7 @@ import { useUIStore } from '../../entities/store/uiStore';
 import { StudDefs, StudGrid } from '../../shared/components/IsometricStud';
 import { useRafCallback } from '../../shared/hooks/useRafCallback';
 import { getBlockDimensions, getBlockVisualProfile } from '../../shared/types/visualProfile';
+import { BLOCK_FRIENDLY_NAMES } from '../../shared/types/index';
 import {
   BLOCK_MARGIN,
   BLOCK_PADDING,
@@ -38,6 +39,8 @@ export function DragGhost({
 }: DragGhostProps) {
   const interactionState = useUIStore((s) => s.interactionState);
   const draggedBlockCategory = useUIStore((s) => s.draggedBlockCategory);
+  const draggedResourceName = useUIStore((s) => s.draggedResourceName);
+  const activeProvider = useUIStore((s) => s.activeProvider);
   const [pointerPosition, setPointerPosition] = useState<{ x: number; y: number } | null>(null);
   const activeCategory = draggedBlockCategory ?? 'compute';
 
@@ -60,6 +63,8 @@ export function DragGhost({
   const topFacePoints = `${cx},${topY} ${rightX},${midY} ${cx},${bottomY} ${leftX},${midY}`;
   const leftSidePoints = `${leftX},${midY} ${cx},${bottomY} ${cx},${bottomY + sideWallPx} ${leftX},${midY + sideWallPx}`;
   const rightSidePoints = `${cx},${bottomY} ${rightX},${midY} ${rightX},${midY + sideWallPx} ${cx},${bottomY + sideWallPx}`;
+  const providerName = activeProvider === 'azure' ? 'Azure' : activeProvider === 'aws' ? 'AWS' : 'GCP';
+  const dragIdentityLabel = `${providerName} / ${draggedResourceName ?? BLOCK_FRIENDLY_NAMES[activeCategory]}`;
 
   const studs = useMemo(() => {
     const positions: Array<{ x: number; y: number; key: string }> = [];
@@ -134,6 +139,9 @@ export function DragGhost({
       <polygon points={rightSidePoints} fill={faceColors.rightSideColor} />
       <line x1={leftX} y1={midY} x2={cx} y2={topY} stroke={EDGE_HIGHLIGHT_COLOR} strokeWidth={EDGE_HIGHLIGHT_STROKE_WIDTH} strokeOpacity={EDGE_HIGHLIGHT_OPACITY} />
       <StudGrid studId={studId} studs={studs} />
+      <text x={cx} y={svgHeight + 12} textAnchor="middle" fontSize={10} fill="#D1D5DB">
+        {dragIdentityLabel}
+      </text>
     </g>
   );
 }

--- a/apps/web/src/widgets/validation-panel/ValidationPanel.test.tsx
+++ b/apps/web/src/widgets/validation-panel/ValidationPanel.test.tsx
@@ -146,6 +146,28 @@ describe('ValidationPanel', () => {
     expect(screen.getByText(/Target: block-3/)).toBeInTheDocument();
   });
 
+  it('shows a fallback when targetId is missing', () => {
+    const result: ValidationResult = {
+      valid: false,
+      errors: [
+        {
+          ruleId: 'placement-unknown-target',
+          severity: 'error',
+          message: 'Resource placement is invalid',
+          targetId: '',
+        },
+      ],
+      warnings: [],
+    };
+
+    useUIStore.setState({ showValidation: true });
+    useArchitectureStore.setState({ validationResult: result });
+    render(<ValidationPanel />);
+
+    expect(screen.getByText(/Rule: placement-unknown-target/)).toBeInTheDocument();
+    expect(screen.getByText(/Target: Unknown target/)).toBeInTheDocument();
+  });
+
   it('shows success message when valid and no errors/warnings', () => {
     useUIStore.setState({ showValidation: true });
     useArchitectureStore.setState({

--- a/apps/web/src/widgets/validation-panel/ValidationPanel.tsx
+++ b/apps/web/src/widgets/validation-panel/ValidationPanel.tsx
@@ -22,8 +22,8 @@ export function ValidationPanel() {
       {validationResult.errors.length > 0 && (
         <div className="validation-section">
           <h4 className="validation-section-title">Errors ({validationResult.errors.length})</h4>
-          {validationResult.errors.map((error, i) => (
-            <div key={i} className="validation-item validation-error">
+          {validationResult.errors.map((error) => (
+            <div key={`${error.ruleId}-${error.targetId ?? 'unknown'}`} className="validation-item validation-error">
               <div className="validation-message">{error.message}</div>
               {error.suggestion && (
                 <div className="validation-suggestion">
@@ -31,7 +31,7 @@ export function ValidationPanel() {
                 </div>
               )}
               <div className="validation-meta">
-                Rule: {error.ruleId} | Target: {error.targetId}
+                Rule: {error.ruleId} | Target: {error.targetId && error.targetId.length > 0 ? error.targetId : 'Unknown target'}
               </div>
             </div>
           ))}
@@ -41,8 +41,8 @@ export function ValidationPanel() {
       {validationResult.warnings.length > 0 && (
         <div className="validation-section">
           <h4 className="validation-section-title">Warnings ({validationResult.warnings.length})</h4>
-          {validationResult.warnings.map((warning, i) => (
-            <div key={i} className="validation-item validation-warning">
+          {validationResult.warnings.map((warning) => (
+            <div key={`${warning.ruleId}-${warning.targetId ?? 'unknown'}`} className="validation-item validation-warning">
               <div className="validation-message">{warning.message}</div>
               {warning.suggestion && (
                 <div className="validation-suggestion">
@@ -50,7 +50,7 @@ export function ValidationPanel() {
                 </div>
               )}
               <div className="validation-meta">
-                Rule: {warning.ruleId} | Target: {warning.targetId}
+                Rule: {warning.ruleId} | Target: {warning.targetId && warning.targetId.length > 0 ? warning.targetId : 'Unknown target'}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Use stable React keys instead of array indexes in lists
- Show actual identity labels for blocks, external actors, and drag ghosts
- Route learning panel action to gallery when no scenario is active
- Handle undefined targetId in validation items

Fixes #618
Fixes #619
Fixes #621
Fixes #622
Fixes #623
Fixes #638
Fixes #640
Fixes #546
Fixes #547