### PR TITLE
docs: update README, ARCHITECTURE.md, and API_SPEC.md with restructured roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ Design cloud infrastructure by placing blocks on plates, connect components, val
 
 > **[▶ Try the Live Demo](https://yeongseon.github.io/cloudblocks/)** — Frontend-only playground. Visual builder, code generation, and templates work instantly. AI and GitHub features require the backend ([setup guide](docs/guides/TUTORIALS.md)).
 
+## Monorepo Layout
+
+CloudBlocks uses a monorepo with one frontend app, one backend app, and shared TypeScript packages:
+
+| Path | Package | Current role |
+|--|--|--|
+| `apps/web` | `@cloudblocks/web` | Frontend SPA. Owns validation engine, generation pipeline, and template system. |
+| `apps/api` | - | FastAPI backend. Handles GitHub OAuth/session auth, workspace/repo operations, and AI integration proxying. |
+| `packages/schema` | `@cloudblocks/schema` | Canonical architecture model types/enums and JSON Schema output. |
+| `packages/cloudblocks-domain` | `@cloudblocks/domain` | Shared domain helpers (hierarchy rules, labels, validation types). |
+
+The frontend imports architecture/domain types from `@cloudblocks/schema` and `@cloudblocks/domain` instead of defining local model types.
+Python models in `apps/api/app/models/generated/` are auto-generated from the TypeScript schema (`packages/schema/dist/architecture-model.schema.json`).
+
 ## Why CloudBlocks?
 
 Most IaC tools work **code → diagram** (visualize existing infra). CloudBlocks works **architecture → code** (model visually, compile to infra).
@@ -35,7 +49,7 @@ Most IaC tools work **code → diagram** (visualize existing infra). CloudBlocks
 - ⚡ **Architecture compiler** — Visual designs compile to Terraform, Bicep, and Pulumi
 - ✅ **Validation engine** — Real-time rule checking for placement and connections
 - 📦 **10 resource categories** — Compute, database, storage, gateway, function, queue, event, analytics, identity, observability
-- 🔗 **GitHub integration** — OAuth login, repo sync, PR creation, architecture diff
+- 🔗 **GitHub integration** — OAuth login, repo sync, PR creation, architecture diff (backend API)
 - 📚 **Learning mode** — Guided scenarios to learn cloud architecture patterns
 
 ## Quick Start

--- a/docs/api/API_SPEC.md
+++ b/docs/api/API_SPEC.md
@@ -3,15 +3,21 @@
 > **Implementation Status (Phase 7+)**
 >
 > Authentication and GitHub OAuth session flow are implemented with cookie-based sessions.
-> Auth and GitHub integration are implemented; server-side generation, validation, and templates remain planned.
+> Auth and GitHub integration are implemented. AI generation/suggestion/cost endpoints are implemented. Generation routes currently track run metadata and status.
 
 ## Overview
 
-The CloudBlocks API is a **thin orchestration backend** built with Python FastAPI. It handles authentication, code generation orchestration, and GitHub integration — but does NOT store architecture data.
+The CloudBlocks API is a FastAPI backend for authenticated integrations. It handles GitHub OAuth/session auth, workspace/repo operations, and AI integration endpoints — but does NOT store architecture source-of-truth data.
 
 **Base URL**: `/api/v1`
 
-**Design Principle**: The backend is a workflow orchestrator, not a CRUD service. Architecture data lives in GitHub repos.
+**Design Principle**: The backend owns integration/session concerns. Architecture modeling, validation, generation, and template runtime behavior live in the frontend app (`apps/web`). Architecture data lives in GitHub repos.
+
+## Contract Boundaries
+
+- Frontend-owned (`apps/web`): validation engine, code generation pipeline, and template system.
+- Shared model contract: TypeScript schema in `packages/schema` (`@cloudblocks/schema`).
+- Backend model contract: Python models in `apps/api/app/models/generated/` generated from `packages/schema/dist/architecture-model.schema.json`.
 
 ## Currently Implemented
 
@@ -45,14 +51,15 @@ GET  /api/v1/workspaces/{workspace_id}/generate/{run_id} → Get generation run 
 GET  /api/v1/workspaces/{workspace_id}/preview  → Preview generated code (placeholder: returns empty files)
 
 POST /api/v1/ai/generate                        → AI architecture generation (requires stored OpenAI key)
-POST /api/v1/ai/suggest                         → AI improvement suggestions (placeholder: returns empty)
+POST /api/v1/ai/suggest                         → AI improvement suggestions
+POST /api/v1/ai/cost                            → Infrastructure cost estimation
 
 POST /api/v1/ai/keys                            → Store AI API key (encrypted, upsert by provider)
 GET  /api/v1/ai/keys                            → List stored AI key providers
 DELETE /api/v1/ai/keys/{provider}               → Delete AI API key by provider
 ```
 
-Auth, session workspace binding, and GitHub integration routes are implemented in the backend codebase. Server-side generation/validation/template routes remain planned or scaffolded as noted below.
+Auth, session workspace binding, GitHub integration, and AI routes are implemented in the backend codebase. Generation routes are scaffolded for run tracking and status.
 
 ---
 
@@ -100,11 +107,11 @@ DELETE /api/v1/workspaces/:id          → Delete workspace
 
 > **Note**: The metadata DB uses `workspaces` (not `projects`). See [STORAGE_ARCHITECTURE.md](../model/STORAGE_ARCHITECTURE.md) for the actual schema.
 
-## Scaffolded (Placeholder): Server-side Code Generation (Milestone 5+)
+## Generation Run Tracking (Current Backend Surface)
 
-Generate infrastructure code from architecture. In Milestone 3, code generation runs client-side (export to file/clipboard). Starting from Milestone 5, the backend reads `architecture.json` from GitHub, runs the generator, and commits the output back. The endpoints below are for server-side generation (Milestone 5+).
+Code generation execution is frontend-owned in `apps/web`. Backend generation routes currently provide authenticated run tracking/status records and a preview placeholder.
 
-> **Note**: Routes exist and accept requests, but generation logic is a placeholder. `POST .../generate` creates a run record in `pending` status without executing actual generation. `GET .../preview` returns an empty file list with a placeholder message.
+> **Note**: `POST .../generate` creates a run record in `pending` status without executing the frontend generator pipeline. `GET .../preview` currently returns an empty file list with a placeholder message.
 
 ```
 POST   /api/v1/workspaces/:id/generate    → Trigger code generation
@@ -112,22 +119,25 @@ GET    /api/v1/workspaces/:id/generate/:runId  → Get generation status
 GET    /api/v1/workspaces/:id/preview     → Preview generated code (no commit)
 ```
 
-## AI Routes (Implemented / Placeholder)
+## AI Routes (Implemented)
 
 AI-assisted architecture generation and suggestions. Requires a stored OpenAI API key.
 
 > **Scope note**: This section documents the route surface only. Detailed AI usage examples, prompt engineering, and the dedicated AI guide are tracked in #320.
 
-### AI Generation (Implemented)
+### AI Generation and Suggestions (Implemented)
 
 ```
 POST /api/v1/ai/generate    → Generate architecture from natural language prompt
-POST /api/v1/ai/suggest     → Suggest architecture improvements (placeholder: returns empty)
+POST /api/v1/ai/suggest     → Suggest architecture improvements
+POST /api/v1/ai/cost        → Estimate infrastructure cost
 ```
 
 `POST /api/v1/ai/generate` calls the OpenAI API using the user's stored key. It requires `prompt`, `provider` (default `"aws"`), and `complexity` (default `"intermediate"`) fields. Returns `{ architecture: {...} }`.
 
-`POST /api/v1/ai/suggest` is a placeholder — accepts `{ architecture: {...} }` but returns `{ suggestions: [], score: {} }`.
+`POST /api/v1/ai/suggest` analyzes architecture payloads and returns structured suggestions.
+
+`POST /api/v1/ai/cost` converts architecture blocks to Terraform JSON mappings and returns cost estimates via Infracost.
 
 ### AI Key Management (Implemented)
 
@@ -152,29 +162,17 @@ POST   /api/v1/workspaces/:id/pr        → Create PR with changes
 GET    /api/v1/workspaces/:id/commits   → List recent commits
 ```
 
-## Planned: Server-side Validation (Milestone 3+)
+## Not in Backend API Contract
 
-Validate architecture against rules. Can run client-side or server-side.
+The following capabilities are intentionally frontend-owned in the current architecture and are not exposed as backend routes:
 
-> **Note**: Client-side validation is already implemented in Milestone 1 (`apps/web/src/entities/validation/`).
-
-```
-POST   /api/v1/validate                 → Validate architecture (server-side)
-```
-
-## Planned: Server-side Templates (Milestone 6+)
-
-Browse and use architecture templates.
-
-```
-GET    /api/v1/templates                → List available templates
-GET    /api/v1/templates/:id            → Get template details
-POST   /api/v1/templates/:id/use        → Create workspace from template
-```
+- Validation engine execution (`apps/web/src/entities/validation/`)
+- Template registry/application flow (`apps/web/src/features/templates/`)
+- Runtime generation pipeline (`apps/web/src/features/generate/`)
 
 ## Request/Response Formats
 
-### Create Workspace (Scaffolded)
+### Create Workspace (Implemented)
 
 **Request:**
 ```json
@@ -182,7 +180,7 @@ POST   /api/v1/templates/:id/use        → Create workspace from template
   "name": "My 3-Tier App",
   "generator": "terraform",
   "provider": "azure",
-  "githubRepo": "user/my-infra"
+  "github_repo": "user/my-infra"
 }
 ```
 
@@ -190,25 +188,27 @@ POST   /api/v1/templates/:id/use        → Create workspace from template
 ```json
 {
   "id": "ws-a1b2c3d4",
+  "owner_id": "user-123",
   "name": "My 3-Tier App",
   "generator": "terraform",
   "provider": "azure",
-  "githubRepo": "user/my-infra",
-  "githubBranch": "main",
-  "createdAt": "2025-01-01T00:00:00Z",
-  "updatedAt": "2025-01-01T00:00:00Z"
+  "github_repo": "user/my-infra",
+  "github_branch": "main",
+  "last_synced_at": null,
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
 }
 ```
 
-### Trigger Code Generation (Planned)
+### Trigger Code Generation (Current Placeholder Route)
 
 **Request:**
 ```json
 {
   "generator": "terraform",
   "provider": "azure",
-  "commitMessage": "Update 3-tier architecture",
-  "createPR": true,
+  "commit_message": "Update 3-tier architecture",
+  "create_pr": true,
   "branch": "feature/update-arch"
 }
 ```
@@ -216,51 +216,40 @@ POST   /api/v1/templates/:id/use        → Create workspace from template
 **Response (202):**
 ```json
 {
-  "runId": "run-e5f6g7h8",
+  "id": "run-e5f6g7h8",
+  "workspace_id": "ws-a1b2c3d4",
   "status": "pending",
-  "message": "Generation job created"
+  "generator": "terraform",
+  "commit_sha": null,
+  "pull_request_url": null,
+  "error_message": null,
+  "started_at": "2025-01-01T00:00:01Z",
+  "completed_at": null,
+  "created_at": "2025-01-01T00:00:01Z"
 }
 ```
 
-### Generation Status (Planned)
+### Generation Status (Implemented Route)
+
+> **Current behavior**: Run records are created in `pending` status. Background worker transitions are not wired in the current backend implementation.
 
 **Response (200):**
 ```json
 {
-  "runId": "run-e5f6g7h8",
+  "id": "run-e5f6g7h8",
+  "workspace_id": "ws-a1b2c3d4",
   "status": "completed",
   "generator": "terraform",
-  "commitSha": "abc123def456",
-  "files": [
-    "infra/terraform/main.tf",
-    "infra/terraform/variables.tf",
-    "infra/terraform/outputs.tf"
-  ],
-  "pullRequestUrl": "https://github.com/user/my-infra/pull/1",
-  "startedAt": "2025-01-01T00:00:01Z",
-  "completedAt": "2025-01-01T00:00:05Z"
+  "commit_sha": "abc123def456",
+  "pull_request_url": "https://github.com/user/my-infra/pull/1",
+  "error_message": null,
+  "started_at": "2025-01-01T00:00:01Z",
+  "completed_at": "2025-01-01T00:00:05Z",
+  "created_at": "2025-01-01T00:00:01Z"
 }
 ```
 
 > **Note**: Status values match the actual migration schema: `pending`, `running`, `completed`, `failed`.
-
-### Validation Response
-
-```json
-{
-  "valid": false,
-  "errors": [
-    {
-      "ruleId": "rule-compute-subnet",
-      "severity": "error",
-      "message": "Compute block must be placed on a Subnet Plate",
-      "suggestion": "Move the Compute block to a Subnet Plate",
-      "targetId": "block-abc123"
-    }
-  ],
-  "warnings": []
-}
-```
 
 ## Error Format
 
@@ -290,7 +279,7 @@ All errors follow a consistent format:
 | `GENERATION_FAILED` | 500 | Code generation failed |
 | `INTERNAL_ERROR` | 500 | Server error |
 
-## Rate Limiting (Planned)
+## Rate Limiting (Target Policy)
 
 - **Authenticated**: 100 requests/minute
 - **Unauthenticated**: 20 requests/minute

--- a/docs/concept/ARCHITECTURE.md
+++ b/docs/concept/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 This document defines the system architecture for the CloudBlocks Platform.
 
-CloudBlocks is an **Architecture Compiler** — it models cloud infrastructure using a **Lego-style composition system**, validates designs against architectural rules, and generates deployable infrastructure code (Terraform, Bicep, Pulumi). The long-term architecture follows a **Git-native** model where GitHub repos serve as the primary data store.
+CloudBlocks is an **Architecture Compiler** — it models cloud infrastructure using a **Lego-style composition system**, validates designs against architectural rules, and generates deployable infrastructure code (Terraform, Bicep, Pulumi). The current architecture is **Git-native**: GitHub repos are the source of truth for architecture payloads and generated artifacts.
 
 > **Technical approach**: CloudBlocks is a **2D-first editor with 2.5D rendering**, rather than a full 3D engine. The internal model is a 2D coordinate system with containment hierarchy. The rendering layer projects this into an isometric view using SVG + CSS transforms.
 > See [ADR-0010](../adr/0010-svg-only-rendering-model.md) for the definitive rendering technology decision.
@@ -61,17 +61,12 @@ cloudblocks/
     web/              # Frontend SPA (React + SVG/CSS)
     api/              # Backend API (Python FastAPI)
   packages/
-    cloudblocks-domain/    # Domain model (placeholder)
-    cloudblocks-ui/        # UI components (placeholder)
-    schema/                # Schema definitions (placeholder)
-    scenario-library/      # Tutorial scenarios (placeholder)
-    terraform-templates/   # Terraform templates (placeholder)
+    schema/                # @cloudblocks/schema (canonical model types + enums + JSON Schema)
+    cloudblocks-domain/    # @cloudblocks/domain (hierarchy rules, labels, validation types)
   docs/              # Documentation
   examples/          # Example architecture READMEs
   infra/             # Deployment scaffolds (Docker, Terraform, k8s)
 ```
-
-> **Note**: The `packages/` directory currently contains placeholder packages. The aspirational modular structure (model, rule-engine, generator, providers) will be extracted from `apps/web/` as the codebase matures.
 
 ---
 
@@ -106,11 +101,11 @@ No backend required. All state lives in the browser.
                      │
                      ▼
 ┌────────────────────────────────────────────────────────┐
-│           Backend API (Thin Orchestration Layer)        │
+│      Backend API (Integration + Session Layer)          │
 │                  Python FastAPI                         │
 │   ┌──────┐ ┌───────────┐ ┌────────┐ ┌──────────┐     │
-│   │ Auth │ │ Generator │ │ GitHub │ │ Job      │     │
-│   │      │ │ Orchestr. │ │ Integ. │ │ Runner   │     │
+│   │ Auth │ │ Workspace │ │ GitHub │ │ AI       │     │
+│   │      │ │ Metadata  │ │ Integ. │ │ Proxy    │     │
 │   └──────┘ └───────────┘ └────────┘ └──────────┘     │
 │                     │                                   │
 │            ┌────────┴────────┐                         │
@@ -144,9 +139,11 @@ The frontend is a SPA built with React and SVG + CSS transforms. In Milestone 1,
 - Architecture validation (in-browser Rule Engine)
 - Local persistence (localStorage)
 
-### Responsibilities (Milestone 5+ — implemented)
+### Responsibilities (Current)
 - Drag and drop interaction
-- Code generation preview (client-side for simple cases)
+- Validation engine execution (placement, aggregation, role, connection, provider warnings)
+- Code generation pipeline and preview (Terraform, Bicep, Pulumi)
+- Template registry and template application flow
 - GitHub sync UI (commit, branch, PR)
 - Local-first store (localStorage)
 
@@ -162,8 +159,8 @@ The frontend is a SPA built with React and SVG + CSS transforms. In Milestone 1,
 apps/web/src/
 ├── main.tsx
 ├── app/                 # App shell
-├── shared/              # Types, utils, storage
-│   ├── types/           # Domain types (Plate, Block, Connection, Template)
+├── shared/              # Type re-exports, utils, storage
+│   ├── types/           # Re-exports from @cloudblocks/schema and @cloudblocks/domain
 │   └── utils/           # ID generation, storage operations
 ├── entities/            # Domain entities
 │   ├── store/           # Zustand architecture store
@@ -198,7 +195,8 @@ apps/web/src/
 └── assets/
 ```
 
-> **Note**: `features/generate/` implements the Terraform/Bicep/Pulumi code generation pipeline (Milestone 3+). `features/templates/` implements architecture templates with a gallery UI (Milestone 4). `features/ai/` provides AI architecture generation. `features/diff/` implements architecture diff (Milestone 7). `features/learning/` provides Learning Mode (Milestone 6C).
+> **Package boundary**: `apps/web` imports canonical model/domain definitions from `@cloudblocks/schema` and `@cloudblocks/domain`; it does not maintain an independent local schema package.
+> `features/generate/` and `features/templates/` are frontend-owned runtime modules.
 
 ## 2.2 MVP Architecture (Milestone 1)
 
@@ -212,27 +210,27 @@ Browser (React + SVG/CSS)
 └── localStorage (workspace persistence)
 ```
 
-## 2.3 Backend Layer (Milestone 5+) — Thin Orchestration Layer
+## 2.3 Backend Layer (Milestone 5+) — Integration and Session Layer
 
-The backend is **NOT a heavy CRUD service**. It is a **workflow orchestrator** that mediates between the UI, GitHub, and the generation engine.
+The backend is **NOT a heavy CRUD service**. It provides authenticated integration endpoints for GitHub and AI services, plus workspace/session metadata.
 
 > **Current status**: Backend auth/session modules are implemented with cookie-based session auth (`cb_oauth`, `cb_session`) and SQLite-backed session persistence.
 
-### What the Backend Will Do
+### What the Backend Does
 
 | Responsibility | Description |
 |---------------|-------------|
 | Auth / Identity | GitHub OAuth + cookie-based server sessions |
-| Generator Orchestration | Validate → transform → generate IaC code |
-| GitHub Integration | Repo selection, branch creation, commit, PR |
-| Job Runner | Async generation, validation, deployment triggers |
-| Metadata DB | User, workspace index, run status, audit summary |
+| GitHub Integration | Repo listing/creation, architecture sync/pull, commit history, PR creation |
+| AI Integration Proxy | AI generation/suggestions/cost endpoints backed by stored provider API keys |
+| Workspace Metadata | Workspace index and settings (linked to GitHub repos) |
+| Metadata DB | User/session/workspace/run/key metadata |
 
 ### What the Backend Will NOT Store
 
 | Data | Where It Lives |
 |------|---------------|
-| Architecture specs (JSON) | GitHub repo |
+| Architecture specs (`architecture.json`) | GitHub repo |
 | Generated Terraform/Bicep/Pulumi | GitHub repo |
 | Templates | GitHub repo |
 | Full prompt/log history | GitHub / Blob Storage |
@@ -312,7 +310,8 @@ GET  /api/v1/workspaces/{id}/preview         → placeholder, returns empty file
 
 AI (see #320 for detailed guide):
 POST /api/v1/ai/generate                     → AI architecture generation (OpenAI)
-POST /api/v1/ai/suggest                      → placeholder, returns empty suggestions
+POST /api/v1/ai/suggest                      → AI architecture suggestion engine
+POST /api/v1/ai/cost                         → Infrastructure cost estimation
 POST /api/v1/ai/keys                         → store AI API key (encrypted)
 GET  /api/v1/ai/keys                         → list stored key providers
 DELETE /api/v1/ai/keys/{provider}            → delete stored key
@@ -349,7 +348,7 @@ Key responsibilities:
 
 ## 3.5 Architecture Model Schema
 
-The canonical model types are defined in `apps/web/src/shared/types/index.ts`. The domain model consists of the following core entities:
+The canonical model types are defined in `packages/schema` (`@cloudblocks/schema`) and re-exported for frontend usage from `apps/web/src/shared/types/index.ts`. The domain model consists of the following core entities:
 
 - **Plate** — Infrastructure boundary (network / subnet), with containment hierarchy (`parentId`, `children`)
 - **Block** — Infrastructure resource (`category`: compute / database / storage / gateway / function / queue / event / analytics / identity / observability), placed on a plate via `placementId`
@@ -357,11 +356,12 @@ The canonical model types are defined in `apps/web/src/shared/types/index.ts`. T
 - **ExternalActor** — External endpoint (e.g., Internet)
 - **ArchitectureModel** — Root container for all entities
 
+> The backend uses generated Python models in `apps/api/app/models/generated/architecture_model.py`, built from `packages/schema/dist/architecture-model.schema.json`.
 > For full TypeScript interfaces, field specifications, and JSON examples, see [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md) §14 (Implementation Schema).
 
 ### Serialization Format
 
-- Serialization is versioned through `schemaVersion` and currently uses `"2.0.0"` (see `apps/web/src/shared/types/schema.ts`).
+- Serialization is versioned through `schemaVersion` and currently uses `"2.0.0"` (source constant: `packages/schema/src/index.ts`).
 - The persisted root payload shape is `{ schemaVersion, workspaces[] }`, where each workspace contains one `architecture: ArchitectureModel`.
 - For broader domain semantics and lifecycle rules, see [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md).
 
@@ -418,7 +418,7 @@ Validation flow in `engine.ts`:
 
 # 5. Code Generation Pipeline (Milestone 3+)
 
-> **Status**: Implemented in Milestone 3. The Terraform generator is functional.
+> **Status**: Implemented in the frontend (`apps/web/src/features/generate`). Terraform, Bicep, and Pulumi generators are available in the web app.
 
 The core value delivery — transforming visual architecture into deployable IaC code. The pipeline follows a multi-stage process: Normalize → Validate → Provider Map → Generate → Format → Output.
 
@@ -426,21 +426,19 @@ The core value delivery — transforming visual architecture into deployable IaC
 >
 > For provider-specific resource mapping, see [provider.md](../engine/provider.md).
 
-### Planned Module Structure (Milestone 3+)
+### Current Module Structure
 
 ```text
-generators/
-  adapters/
-    azure_adapter.ts
-    aws_adapter.ts
-  terraform/
-    network.tf.ts
-    compute.tf.ts
-    database.tf.ts
-  normalization/
-    model_normalizer.ts
-  formatter/
-    output_formatter.ts
+apps/web/src/features/generate/
+  pipeline.ts
+  terraform.ts
+  bicep.ts
+  pulumi.ts
+  provider.ts
+  providers/
+    aws/
+    azure/
+    gcp/
 ```
 
 ### Layer Responsibilities
@@ -554,7 +552,7 @@ The persisted format uses `schemaVersion: "2.0.0"` with a `workspaces[]` array, 
 
 > For the full workspace model and serialization format, see [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md) §13 (Workspace Model) and §14 (Implementation Schema).
 
-### Milestone 3+ Storage (Local-First + GitHub Sync — Planned)
+### Milestone 3+ Storage (Local-First + GitHub Sync)
 
 localStorage for local state + optional GitHub sync:
 
@@ -603,15 +601,15 @@ The architecture supports horizontal scalability:
 Frontend (Milestone 1: SPA with SVG + CSS transforms + DOM layering, 2.5D isometric view, localStorage persistence)
 Core Model (Zustand store — 2D coordinates + hierarchy)
 Rule Engine (in-browser validation)
-Code Generation (Milestone 3: Terraform generator — ✅ implemented)
-Backend (Milestone 5+: Thin orchestration layer — FastAPI — implemented for auth/session + GitHub integration)
+Code Generation (frontend-owned pipeline in apps/web/features/generate)
+Backend (FastAPI integration/session API — auth/session + GitHub + AI proxying)
 GitHub Integration (Milestone 5+: repo list/create, sync, pull, PR, commits — implemented)
 ```
 
 This architecture enables:
 - Visual architecture design with 2.5D isometric blocks
 - Rule-based validation of cloud infrastructure
-- Automated infrastructure code generation (implemented client-side; server-side orchestration planned)
+- Automated infrastructure code generation in the frontend pipeline
 - Git-native collaboration and version control (implemented)
 - Lightweight deployment with minimal infrastructure cost
 


### PR DESCRIPTION
## Summary
Update project documentation to reflect the restructured monorepo layout with shared packages (@cloudblocks/schema, @cloudblocks/domain) and the JSON Schema bridge to the Python backend.

Fixes #431