### PR TITLE
fix(web): persist block subtype, validate moveBlock placement, restore architecture on abandon, reset worker state

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -296,6 +296,17 @@ describe('architectureStore', () => {
       expect(blocks[0].provider).toBe('aws');
     });
 
+    it('persists subtype when provided', () => {
+      getState().addPlate('region', 'VNet', null);
+      const netId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Sub', netId, 'public');
+      const subId = getArch().plates[1].id;
+
+      getState().addBlock('compute', 'VM', subId, 'azure', 'vm');
+
+      expect(getArch().blocks[0].subtype).toBe('vm');
+    });
+
     it('no-ops on non-existent plate', () => {
       const blocksBefore = getArch().blocks.length;
       getState().addBlock('compute', 'VM', 'nonexistent');
@@ -585,6 +596,22 @@ describe('architectureStore', () => {
       const before = getState().workspace.architecture;
       getState().moveBlock(blockId, 'missing-target');
       expect(getState().workspace.architecture).toBe(before);
+    });
+
+    it('rejects move when placement rules are violated', () => {
+      getState().addPlate('region', 'VNet', null);
+      const netId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Sub', netId, 'private');
+      const privateSubId = getArch().plates[1].id;
+
+      getState().addBlock('gateway', 'FW', privateSubId);
+      const blockId = getArch().blocks[0].id;
+
+      const before = getState().workspace.architecture;
+      getState().moveBlock(blockId, netId);
+
+      expect(getState().workspace.architecture).toBe(before);
+      expect(getArch().blocks[0].placementId).toBe(privateSubId);
     });
   });
 

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -5,6 +5,7 @@ import { generateId } from '../../../shared/utils/id';
 import type { ArchitectureSlice, ArchitectureState } from './types';
 import { canConnect } from '../../validation/connection';
 import type { EndpointType } from '../../validation/connection';
+import { validatePlacement } from '../../validation/placement';
 import {
   clampWithinParent,
   DEFAULT_PLATE_SIZE,
@@ -337,6 +338,10 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
       );
 
       if (!targetPlate) {
+        return state;
+      }
+
+      if (validatePlacement(block, targetPlate) !== null) {
         return state;
       }
 

--- a/apps/web/src/entities/store/slices/helpers.ts
+++ b/apps/web/src/entities/store/slices/helpers.ts
@@ -9,6 +9,7 @@ import {
   resetHistory,
 } from '../../../shared/utils/history';
 import { generateId } from '../../../shared/utils/id';
+import { useWorkerStore } from '../workerStore';
 import type { ArchitectureState } from './types';
 
 const DEFAULT_WORKSPACE_NAME = 'My Architecture';
@@ -118,6 +119,7 @@ export function resetTransientState(): Pick<
   ArchitectureState,
   'validationResult' | 'history' | 'canUndo' | 'canRedo'
 > {
+  useWorkerStore.getState().resetWorker();
   return {
     validationResult: null,
     history: resetHistory(),

--- a/apps/web/src/entities/store/workerStore.test.ts
+++ b/apps/web/src/entities/store/workerStore.test.ts
@@ -141,4 +141,19 @@ describe('workerStore', () => {
     expect(useWorkerStore.getState().workerPosition).toEqual([9, 8, 7]);
   });
 
+  it('resetWorker clears build state and restores default position', () => {
+    const store = useWorkerStore.getState();
+    store.startBuild('block-1', [1, 1, 1]);
+    store.startBuild('block-2', [2, 2, 2]);
+    store.setWorkerPosition([5, 5, 5]);
+
+    store.resetWorker();
+
+    const state = useWorkerStore.getState();
+    expect(state.workerState).toBe('idle');
+    expect(state.workerPosition).toEqual([-3, 0, -6]);
+    expect(state.buildQueue).toEqual([]);
+    expect(state.activeBuild).toBeNull();
+  });
+
 });

--- a/apps/web/src/entities/store/workerStore.ts
+++ b/apps/web/src/entities/store/workerStore.ts
@@ -20,6 +20,7 @@ interface WorkerStoreState {
   completeBuild: () => void;
   cancelBuild: () => void;
   setWorkerPosition: (pos: [number, number, number]) => void;
+  resetWorker: () => void;
 }
 
 const createBuildTask = (
@@ -106,5 +107,14 @@ export const useWorkerStore = create<WorkerStoreState>((set, get) => ({
 
   setWorkerPosition: (pos) => {
     set({ workerPosition: pos });
+  },
+
+  resetWorker: () => {
+    set({
+      workerState: 'idle',
+      workerPosition: [-3, 0, -6],
+      buildQueue: [],
+      activeBuild: null,
+    });
   },
 }));

--- a/apps/web/src/features/learning/scenario-engine.test.ts
+++ b/apps/web/src/features/learning/scenario-engine.test.ts
@@ -344,6 +344,26 @@ describe('scenario-engine', () => {
   });
 
   describe('abandonLearning', () => {
+    it('restores pre-learning architecture', () => {
+      const customArch: ArchitectureSnapshot = {
+        name: 'User Work',
+        version: '1',
+        plates: [],
+        blocks: [],
+        connections: [],
+        externalActors: [],
+      };
+      useArchitectureStore.getState().replaceArchitecture(customArch);
+
+      startLearningScenario('scenario-three-tier');
+      const scenarioArch = architectureSnapshot();
+      expect(scenarioArch.name).not.toBe('User Work');
+
+      abandonLearning();
+
+      expect(architectureSnapshot().name).toBe('User Work');
+    });
+
     it('clears learning store via abandonScenario', () => {
       startLearningScenario('scenario-three-tier');
       const abandonSpy = vi.spyOn(useLearningStore.getState(), 'abandonScenario');

--- a/apps/web/src/features/learning/scenario-engine.ts
+++ b/apps/web/src/features/learning/scenario-engine.ts
@@ -6,8 +6,10 @@ import { startHintSubscription, startHintTimer, stopHintSubscription } from './h
 import { evaluateRules } from './step-validator';
 import type { ValidationResult } from './step-validator';
 import type { StepValidationRule } from '../../shared/types/learning';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 
 let unsubscribe: (() => void) | null = null;
+let preLearningSnapshot: ArchitectureModel | null = null;
 
 function hasActiveScenario(): boolean {
   const { activeScenario, progress } = useLearningStore.getState();
@@ -32,6 +34,9 @@ export function startLearningScenario(scenarioId: string): void {
     throw new Error(`Scenario not found: ${scenarioId}`);
   }
 
+  preLearningSnapshot = JSON.parse(
+    JSON.stringify(useArchitectureStore.getState().workspace.architecture),
+  );
   useArchitectureStore.getState().replaceArchitecture(scenario.initialArchitecture);
   useUIStore.getState().setEditorMode('learn');
   useLearningStore.getState().startScenario(scenario);
@@ -97,6 +102,11 @@ export function resetCurrentStep(): void {
 
 export function abandonLearning(): void {
   useLearningStore.getState().abandonScenario();
+
+  if (preLearningSnapshot) {
+    useArchitectureStore.getState().replaceArchitecture(preLearningSnapshot);
+    preLearningSnapshot = null;
+  }
 
   const uiState = useUIStore.getState();
   uiState.setEditorMode('build');

--- a/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
@@ -177,7 +177,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByTitle('Create Virtual Machine'));
 
-    expect(addBlockMock).toHaveBeenCalledWith('compute', 'Virtual Machine 1', 'subnet-public-1', 'azure');
+    expect(addBlockMock).toHaveBeenCalledWith('compute', 'Virtual Machine 1', 'subnet-public-1', 'azure', 'vm');
   });
 
   it('smoke: create VM from Compute tab then show block actions when selected', async () => {
@@ -201,7 +201,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByTitle('Create Virtual Machine'));
 
-    expect(addBlockMock).toHaveBeenCalledWith('compute', 'Virtual Machine 1', 'subnet-public-1', 'azure');
+    expect(addBlockMock).toHaveBeenCalledWith('compute', 'Virtual Machine 1', 'subnet-public-1', 'azure', 'vm');
 
     act(() => {
       useArchitectureStore.setState({

--- a/apps/web/src/widgets/bottom-panel/CommandCard.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.tsx
@@ -385,7 +385,7 @@ function CreationMode() {
 
       counterRef.current += 1;
       const name = `${def.label} ${counterRef.current}`;
-      addBlock(def.blockCategory, name, targetId, activeProvider);
+      addBlock(def.blockCategory, name, targetId, activeProvider, def.id);
       playSound('block-snap');
     }
   }, [activeProvider, addPlate, addBlock, techTree, playSound]);


### PR DESCRIPTION
## Summary

- **#536** — Pass `def.id` (resource subtype) as 5th arg to `addBlock()` in CommandCard so palette-created blocks persist their concrete subtype (e.g., `vm`, `app-service`)
- **#577** — Add `validatePlacement()` check in `moveBlock()` (domainSlice) to reject moves that violate placement rules (e.g., gateway → region)
- **#531** — Snapshot architecture before `startLearningScenario()` and restore it in `abandonLearning()` so the user's work is preserved
- **#600** — Add `resetWorker()` action to workerStore and call it from `resetTransientState()`, covering all 9 workspace lifecycle transitions

## Test Coverage

- `architectureStore.test.ts`: Added "persists subtype when provided" and "rejects move when placement rules are violated"
- `scenario-engine.test.ts`: Added "restores pre-learning architecture"
- `workerStore.test.ts`: Added "resetWorker clears build state and restores default position"
- `CommandCard.test.ts`: Updated 2 existing tests to expect 5th subtype arg

**Coverage**: 90.02% branches (threshold: 90%)

Fixes #536, Fixes #577, Fixes #531, Fixes #600