### PR TITLE
fix(web): recursive plate movement, child clamping, AI validation, githubRepo hydration

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -657,6 +657,45 @@ describe('architectureStore', () => {
       expect(resized?.profileId).toBe('subnet-scale');
       expect(resized?.position).toEqual({ x: 4, y: 0.3, z: 4 });
     });
+
+    it('clamps child plates and blocks when parent plate shrinks', () => {
+      // Region default (network-platform): 16 x 20
+      getState().addPlate('region', 'VNet', null);
+      const regionId = getArch().plates[0].id;
+
+      // Subnet default (subnet-service): 6 x 8
+      getState().addPlate('subnet', 'Public', regionId, 'public');
+      const subnetId = getArch().plates[1].id;
+
+      // Add a block on the region
+      getState().addBlock('compute', 'VM', regionId);
+      const blockId = getArch().blocks[0].id;
+
+      // Move subnet and block to the far edge (will be beyond bounds after resize)
+      getState().movePlatePosition(subnetId, 100, 100);
+      getState().moveBlockPosition(blockId, 100, 100);
+
+      // Verify they are clamped to region edges before resize
+      const subnetBefore = getArch().plates.find((p) => p.id === subnetId)!;
+      const blockBefore = getArch().blocks.find((b) => b.id === blockId)!;
+      expect(subnetBefore.position.x).toBeGreaterThan(0);
+      expect(blockBefore.position.x).toBeGreaterThan(0);
+
+      // Shrink the region from network-platform (16x20) to network-sandbox (8x12)
+      getState().setPlateProfile(regionId, 'network-sandbox');
+
+      // After resize, children should be clamped within the new smaller bounds
+      const subnetAfter = getArch().plates.find((p) => p.id === subnetId)!;
+      const blockAfter = getArch().blocks.find((b) => b.id === blockId)!;
+      const regionAfter = getArch().plates.find((p) => p.id === regionId)!;
+
+      // Subnet relative position should be clamped: max relative x = (8/2) - (6/2) = 1
+      const subnetRelX = subnetAfter.position.x - regionAfter.position.x;
+      expect(subnetRelX).toBeLessThanOrEqual(1);
+
+      // Block position should be within new bounds: max x = (8/2) - (2.4/2) = 2.8
+      expect(blockAfter.position.x).toBeLessThanOrEqual(2.8);
+    });
   });
 
   describe('movePlatePosition', () => {
@@ -701,6 +740,32 @@ describe('architectureStore', () => {
       expect(outerAfter?.position.z).toBe((outerBefore?.position.z ?? 0) - 1.5);
       expect(innerAfter?.position.x).toBe((innerBefore?.position.x ?? 0) + 1.25);
       expect(innerAfter?.position.z).toBe((innerBefore?.position.z ?? 0) - 1.5);
+    });
+
+    it('moves deeply nested descendant plates recursively', () => {
+      getState().addPlate('region', 'VNet', null);
+      const regionId = getArch().plates[0].id;
+      getState().addPlate('subnet', 'Outer', regionId, 'public');
+      const outerId = getArch().plates[1].id;
+      getState().addPlate('subnet', 'Inner', outerId, 'private');
+      const innerId = getArch().plates[2].id;
+
+      const regionBefore = getArch().plates.find((p) => p.id === regionId)!;
+      const outerBefore = getArch().plates.find((p) => p.id === outerId)!;
+      const innerBefore = getArch().plates.find((p) => p.id === innerId)!;
+
+      getState().movePlatePosition(regionId, 3, -2);
+
+      const regionAfter = getArch().plates.find((p) => p.id === regionId)!;
+      const outerAfter = getArch().plates.find((p) => p.id === outerId)!;
+      const innerAfter = getArch().plates.find((p) => p.id === innerId)!;
+
+      expect(regionAfter.position.x).toBe(regionBefore.position.x + 3);
+      expect(regionAfter.position.z).toBe(regionBefore.position.z - 2);
+      expect(outerAfter.position.x).toBe(outerBefore.position.x + 3);
+      expect(outerAfter.position.z).toBe(outerBefore.position.z - 2);
+      expect(innerAfter.position.x).toBe(innerBefore.position.x + 3);
+      expect(innerAfter.position.z).toBe(innerBefore.position.z - 2);
     });
 
     it('no-ops when moving a non-existent plate', () => {
@@ -1388,6 +1453,47 @@ describe('architectureStore', () => {
       const workspaceCalls = spy.mock.calls.filter(([k]) => k === 'cloudblocks:workspaces');
       expect(workspaceCalls.length).toBeGreaterThan(0);
       spy.mockRestore();
+    });
+  });
+
+  describe('setGithubRepo', () => {
+    it('sets githubRepo on the current workspace', () => {
+      const wsId = getState().workspace.id;
+      getState().setGithubRepo(wsId, 'owner/repo');
+
+      expect(getState().workspace.githubRepo).toBe('owner/repo');
+    });
+
+    it('does not modify current workspace when updating a non-current workspace', () => {
+      getState().createWorkspace('Second');
+      const secondId = getState().workspace.id;
+      const firstId = getState().workspaces.find((ws) => ws.id !== secondId)!.id;
+
+      getState().setGithubRepo(firstId, 'owner/other-repo');
+
+      expect(getState().workspace.githubRepo).toBeUndefined();
+      const firstInList = getState().workspaces.find((ws) => ws.id === firstId);
+      expect(firstInList?.githubRepo).toBe('owner/other-repo');
+    });
+
+    it('persists the update to storage', () => {
+      const spy = vi.spyOn(localStorage, 'setItem');
+      const wsId = getState().workspace.id;
+
+      getState().setGithubRepo(wsId, 'owner/repo');
+
+      const workspaceCalls = spy.mock.calls.filter(([k]) => k === 'cloudblocks:workspaces');
+      expect(workspaceCalls.length).toBeGreaterThan(0);
+      spy.mockRestore();
+    });
+
+    it('clears githubRepo when set to undefined', () => {
+      const wsId = getState().workspace.id;
+      getState().setGithubRepo(wsId, 'owner/repo');
+      expect(getState().workspace.githubRepo).toBe('owner/repo');
+
+      getState().setGithubRepo(wsId, undefined);
+      expect(getState().workspace.githubRepo).toBeUndefined();
     });
   });
 

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -430,7 +430,43 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         }
       }
 
-      return withHistory(state, { ...arch, plates });
+      const finalPlate = plates.find((candidate) => candidate.id === plateId)!;
+
+      plates = plates.map((candidate) => {
+        if (candidate.parentId !== plateId) return candidate;
+        const relPos = {
+          x: candidate.position.x - finalPlate.position.x,
+          z: candidate.position.z - finalPlate.position.z,
+        };
+        const clamped = clampWithinParent(
+          relPos,
+          { width: nextSize.width, depth: nextSize.depth },
+          { width: candidate.size.width, depth: candidate.size.depth },
+        );
+        return {
+          ...candidate,
+          position: {
+            x: finalPlate.position.x + clamped.x,
+            y: candidate.position.y,
+            z: finalPlate.position.z + clamped.z,
+          },
+        };
+      });
+
+      const blocks = arch.blocks.map((block) => {
+        if (block.placementId !== plateId) return block;
+        const clamped = clampWithinParent(
+          { x: block.position.x, z: block.position.z },
+          { width: nextSize.width, depth: nextSize.depth },
+          DEFAULT_BLOCK_SIZE,
+        );
+        return {
+          ...block,
+          position: { x: clamped.x, y: block.position.y, z: clamped.z },
+        };
+      });
+
+      return withHistory(state, { ...arch, plates, blocks });
     });
   },
 
@@ -475,8 +511,19 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         }
       }
 
+      const descendantIds = new Set<string>([id]);
+      const collectDescendants = (parentId: string) => {
+        for (const candidate of arch.plates) {
+          if (candidate.parentId === parentId && !descendantIds.has(candidate.id)) {
+            descendantIds.add(candidate.id);
+            collectDescendants(candidate.id);
+          }
+        }
+      };
+      collectDescendants(id);
+
       const plates = arch.plates.map((candidate) => {
-        if (candidate.id === id || candidate.parentId === id) {
+        if (descendantIds.has(candidate.id)) {
           return {
             ...candidate,
             position: {

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -62,6 +62,7 @@ export interface ArchitectureState {
   loadFromTemplate: (template: ArchitectureTemplate) => void;
   replaceArchitecture: (snapshot: ArchitectureSnapshot) => void;
   setBackendWorkspaceId: (workspaceId: string, backendId: string) => void;
+  setGithubRepo: (workspaceId: string, repo: string | undefined) => void;
 }
 
 export type ArchitectureSlice<T> = StateCreator<ArchitectureState, [], [], T>;

--- a/apps/web/src/entities/store/slices/workspaceSlice.ts
+++ b/apps/web/src/entities/store/slices/workspaceSlice.ts
@@ -19,6 +19,7 @@ type WorkspaceSlice = Pick<
   | 'deleteWorkspace'
   | 'cloneWorkspace'
   | 'setBackendWorkspaceId'
+  | 'setGithubRepo'
 >;
 
 export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (
@@ -153,6 +154,27 @@ export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (
 
     const updatedList = state.workspaces.map((ws) =>
       ws.id === workspaceId ? { ...ws, backendWorkspaceId: backendId } : ws
+    );
+
+    saveWorkspaces(
+      upsertCurrentWorkspace(updatedList, updatedWorkspace)
+    );
+
+    set({
+      workspace: updatedWorkspace,
+      workspaces: updatedList,
+    });
+  },
+
+  setGithubRepo: (workspaceId, repo) => {
+    const state = get();
+    const updatedWorkspace =
+      state.workspace.id === workspaceId
+        ? { ...state.workspace, githubRepo: repo }
+        : state.workspace;
+
+    const updatedList = state.workspaces.map((ws) =>
+      ws.id === workspaceId ? { ...ws, githubRepo: repo } : ws
     );
 
     saveWorkspaces(

--- a/apps/web/src/features/ai/store.test.ts
+++ b/apps/web/src/features/ai/store.test.ts
@@ -85,6 +85,34 @@ describe('useAiStore', () => {
 
       expect(useAiStore.getState().generateError).toBe('Failed to generate architecture');
     });
+
+    it('sets error and skips replaceArchitecture when result has warnings', async () => {
+      const response = {
+        architecture: { plates: [], blocks: [], connections: [] },
+        explanation: 'done',
+        warnings: ['missing region plate'],
+      };
+      mockGenerate.mockResolvedValueOnce(response);
+
+      await useAiStore.getState().generate('test', 'aws');
+
+      expect(useAiStore.getState().generateError).toBe('AI output has warnings: missing region plate');
+      expect(mockReplaceArchitecture).not.toHaveBeenCalled();
+    });
+
+    it('sets error when architecture shape is invalid', async () => {
+      const response = {
+        architecture: { plates: 'not-an-array', blocks: [], connections: [] },
+        explanation: 'done',
+        warnings: [],
+      };
+      mockGenerate.mockResolvedValueOnce(response);
+
+      await useAiStore.getState().generate('test', 'aws');
+
+      expect(useAiStore.getState().generateError).toBe('AI generated an invalid architecture that cannot be loaded.');
+      expect(mockReplaceArchitecture).not.toHaveBeenCalled();
+    });
   });
 
   describe('suggest', () => {

--- a/apps/web/src/features/ai/store.ts
+++ b/apps/web/src/features/ai/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
+import { validateArchitectureShape } from '../../entities/store/slices/index';
 import type { ArchitectureSnapshot } from '../../shared/types/learning';
 import {
   generateArchitecture,
@@ -48,6 +49,18 @@ export const useAiStore = create<AiState>((set) => ({
     try {
       const result = await generateArchitecture({ prompt, provider });
       set({ generateResult: result, generateLoading: false });
+
+      if (result.warnings.length > 0) {
+        set({ generateError: `AI output has warnings: ${result.warnings.join('; ')}` });
+        return;
+      }
+
+      try {
+        validateArchitectureShape(result.architecture);
+      } catch {
+        set({ generateError: 'AI generated an invalid architecture that cannot be loaded.' });
+        return;
+      }
 
       const arch = result.architecture as unknown as ArchitectureSnapshot;
       useArchitectureStore.getState().replaceArchitecture(arch);

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -70,6 +70,7 @@ export interface Workspace {
   createdAt: string;
   updatedAt: string;
   backendWorkspaceId?: string;
+  githubRepo?: string;
 }
 
 // ─── Visual Identity ───────────────────────────────────────

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
@@ -16,14 +16,16 @@ export function GitHubSync() {
   const workspace = useArchitectureStore((s) => s.workspace);
   const replaceArchitecture = useArchitectureStore((s) => s.replaceArchitecture);
   const setStoreBackendWorkspaceId = useArchitectureStore((s) => s.setBackendWorkspaceId);
+  const setStoreGithubRepo = useArchitectureStore((s) => s.setGithubRepo);
 
   const isAuthenticated = useAuthStore((s) => s.status) === 'authenticated';
   const authStatus = useAuthStore((s) => s.status);
 
+  const linkedRepo = workspace.githubRepo ?? null;
+  const backendWorkspaceId = workspace.backendWorkspaceId ?? null;
+
   const [repoInput, setRepoInput] = useState('');
   const [backendWorkspaceIdInput, setBackendWorkspaceIdInput] = useState('');
-  const [linkedRepo, setLinkedRepo] = useState<string | null>(null);
-  const [backendWorkspaceId, setBackendWorkspaceIdState] = useState<string | null>(null);
   const [commitMessage, setCommitMessage] = useState('Sync architecture from CloudBlocks');
   const [commits, setCommits] = useState<GitHubCommit[]>([]);
   const [loading, setLoading] = useState(false);
@@ -41,10 +43,7 @@ export function GitHubSync() {
     requestSeqRef.current += 1;
   }, []);
 
-  const effectiveWorkspaceId = useMemo(() => {
-    if (backendWorkspaceId) return backendWorkspaceId;
-    return null;
-  }, [backendWorkspaceId]);
+  const effectiveWorkspaceId = backendWorkspaceId;
 
   showRef.current = show;
   authRef.current = isAuthenticated;
@@ -94,7 +93,7 @@ export function GitHubSync() {
     return () => {
       requestSeqRef.current += 1;
     };
-  }, [show, isAuthenticated, linkedRepo, effectiveWorkspaceId, loadCommits]);
+  }, [show, isAuthenticated, linkedRepo, loadCommits]);
 
   if (!show) return null;
 
@@ -115,9 +114,8 @@ export function GitHubSync() {
         github_repo: cleanedRepo,
       });
 
-      setLinkedRepo(cleanedRepo);
+      setStoreGithubRepo(workspace.id, cleanedRepo);
       setStoreBackendWorkspaceId(workspace.id, bwsId);
-      setBackendWorkspaceIdState(bwsId);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to link repository.');
     } finally {
@@ -165,7 +163,7 @@ export function GitHubSync() {
     <div className="github-sync">
       <div className="github-sync-header">
         <h3 className="github-sync-title">🔄 GitHub Sync</h3>
-        <button className="github-sync-close" onClick={toggleGitHubSync} aria-label="Close GitHub sync panel">
+        <button type="button" className="github-sync-close" onClick={toggleGitHubSync} aria-label="Close GitHub sync panel">
           ✕
         </button>
       </div>
@@ -182,7 +180,7 @@ export function GitHubSync() {
           {!linkedRepo ? (
             <div className="github-sync-linker">
               <div className="github-sync-empty">No GitHub repo linked.</div>
-              <button className="github-sync-open-repos" onClick={toggleGitHubRepos}>
+              <button type="button" className="github-sync-open-repos" onClick={toggleGitHubRepos}>
                 Open GitHub Repos
               </button>
 
@@ -208,7 +206,7 @@ export function GitHubSync() {
                 onChange={(e) => setBackendWorkspaceIdInput(e.target.value)}
               />
 
-              <button className="github-sync-primary-btn" onClick={() => void handleLinkRepo()} disabled={loading}>
+              <button type="button" className="github-sync-primary-btn" onClick={() => void handleLinkRepo()} disabled={loading}>
                 Link
               </button>
             </div>
@@ -229,10 +227,10 @@ export function GitHubSync() {
               />
 
               <div className="github-sync-actions">
-                <button className="github-sync-primary-btn" onClick={handleSync} disabled={loading}>
+                <button type="button" className="github-sync-primary-btn" onClick={handleSync} disabled={loading}>
                   Sync to GitHub
                 </button>
-                <button className="github-sync-secondary-btn" onClick={handlePull} disabled={loading}>
+                <button type="button" className="github-sync-secondary-btn" onClick={handlePull} disabled={loading}>
                   Pull from GitHub
                 </button>
               </div>


### PR DESCRIPTION
## Summary

- **#643**: `movePlatePosition` now recursively collects all nested descendant plates (not just direct children) and moves the entire subtree together
- **#579**: `setPlateProfile` clamps child plates and blocks within parent bounds when a plate shrinks
- **#506**: AI `generate()` rejects output containing warnings or invalid architecture shape before calling `replaceArchitecture()`
- **#501**: Added `githubRepo` field to `Workspace` interface with `setGithubRepo` store action; `GitHubSync` derives state from workspace store instead of local `useState`

## Changes

### domainSlice.ts
- `movePlatePosition`: replaced flat `parentId === id` filter with recursive `collectDescendants()` using `Set<string>`
- `setPlateProfile`: after resize, clamps child plates (by `parentId`) and child blocks (by `placementId`) within new bounds

### features/ai/store.ts
- `generate()`: checks `result.warnings.length > 0` and `validateArchitectureShape()` before `replaceArchitecture()`

### shared/types/index.ts + slices/types.ts + slices/workspaceSlice.ts
- Added `githubRepo?: string` to `Workspace` interface
- Added `setGithubRepo(workspaceId, repo)` action following `setBackendWorkspaceId` pattern

### GitHubSync.tsx
- Derived `linkedRepo` and `backendWorkspaceId` from workspace store
- Removed local `useState`/`useMemo` for these values
- Added `type="button"` to all buttons

### Tests
- 3-level plate hierarchy movement test
- Child plate + block clamping on resize test
- AI warnings rejection test
- AI invalid shape rejection test
- `setGithubRepo` persistence tests (set, non-current workspace, storage, clear)

Fixes #643, Fixes #579, Fixes #506, Fixes #501