### PR TITLE
fix(web): right-panel mutual exclusion, mount AI panels, render resource names

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -30,6 +30,8 @@ const GitHubRepos = lazy(() => import('../widgets/github-repos/GitHubRepos').the
 const GitHubSync = lazy(() => import('../widgets/github-sync/GitHubSync').then(m => ({ default: m.GitHubSync })));
 const GitHubPR = lazy(() => import('../widgets/github-pr/GitHubPR').then(m => ({ default: m.GitHubPR })));
 const DiffPanel = lazy(() => import('../widgets/diff-panel/DiffPanel').then(m => ({ default: m.DiffPanel })));
+const SuggestionsPanel = lazy(() => import('../features/ai/components/SuggestionsPanel').then(m => ({ default: m.SuggestionsPanel })));
+const CostPanel = lazy(() => import('../features/ai/components/CostPanel').then(m => ({ default: m.CostPanel })));
 
 function App() {
   const loadFromStorage = useArchitectureStore((s) => s.loadFromStorage);
@@ -53,6 +55,8 @@ function App() {
   const showGitHubPR = useUIStore((s) => s.showGitHubPR);
   const showTemplateGallery = useUIStore((s) => s.showTemplateGallery);
   const showScenarioGallery = useUIStore((s) => s.showScenarioGallery);
+  const showSuggestionsPanel = useUIStore((s) => s.showSuggestionsPanel);
+  const showCostPanel = useUIStore((s) => s.showCostPanel);
   const workspaceId = useArchitectureStore((s) => s.workspace.id);
 
   useEffect(() => {
@@ -168,6 +172,8 @@ function App() {
             {showGitHubPR && <GitHubPR key={`pr-${workspaceId}`} />}
             <DiffPanel />
             {showScenarioGallery && <ScenarioGallery />}
+            {showSuggestionsPanel && <SuggestionsPanel />}
+            {showCostPanel && <CostPanel />}
           </Suspense>
         </div>
       </div>

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -268,7 +268,7 @@ export const BlockSprite = memo(function BlockSprite({
         aria-label={`Block: ${block.name}`}
       >
         <div className="block-img" draggable={false}>
-          <BlockSvg category={block.category} provider={block.provider} subtype={block.subtype} aggregationCount={block.aggregation?.count} roles={block.roles} />
+          <BlockSvg category={block.category} provider={block.provider} subtype={block.subtype} name={block.name} aggregationCount={block.aggregation?.count} roles={block.roles} />
         </div>
         {block.provider && (
           <span

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -19,11 +19,12 @@ interface BlockSvgProps {
   category: BlockCategory;
   provider?: ProviderType;
   subtype?: string;
+  name?: string;              // user-given resource name (overrides shortName on left wall)
   aggregationCount?: number; // v2.0 §8 — show ×N badge when > 1
   roles?: BlockRole[];        // v2.0 §9 — visual-only role indicators
 }
 
-export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, aggregationCount, roles }: BlockSvgProps) {
+export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, name, aggregationCount, roles }: BlockSvgProps) {
   // ─── v2.0: CU-based dimension resolution ───────────────────
   const cu = getBlockDimensions(category, provider, subtype);
   const dims = cuToSilhouetteDimensions(cu);
@@ -112,7 +113,7 @@ export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, ag
         textAnchor="middle"
         dominantBaseline="middle"
       >
-        {shortName}
+        {name ?? shortName}
       </text>
 
       <text

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -7,6 +7,8 @@ import { getBlockDimensions, CATEGORY_TIER_MAP, TIER_DIMENSIONS } from '../../..
 import type { BlockCategory, BlockRole, ProviderType } from '@cloudblocks/schema';
 import { BLOCK_PADDING, TILE_H, TILE_W, TILE_Z } from '../../../shared/tokens/designTokens';
 
+import { BLOCK_SHORT_NAMES } from '../../../shared/types/index';
+
 // ─── Test Helpers ─────────────────────────────────────────────
 
 /** Extract all polygon elements from rendered SVG. */
@@ -453,5 +455,28 @@ describe('BlockSvg role badges', () => {
     );
     expect(container.querySelector('[data-testid="aggregation-badge"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="role-badge-primary"]')).not.toBeNull();
+  });
+});
+
+// ─── Name Prop Tests ──────────────────────────────────────────
+
+describe('BlockSvg name prop', () => {
+  it('renders shortName on left wall when name is not provided', () => {
+    const { container } = render(<BlockSvg category="compute" />);
+    const texts = container.querySelectorAll('text');
+    expect(texts[0].textContent).toBe(BLOCK_SHORT_NAMES.compute);
+  });
+
+  it('renders custom name on left wall when name is provided', () => {
+    const { container } = render(<BlockSvg category="compute" name="MyVM" />);
+    const texts = container.querySelectorAll('text');
+    expect(texts[0].textContent).toBe('MyVM');
+  });
+
+  it('does not affect icon on right wall', () => {
+    const { container } = render(<BlockSvg category="database" name="ProdDB" />);
+    const texts = container.querySelectorAll('text');
+    expect(texts[0].textContent).toBe('ProdDB');
+    expect(texts[1].textContent).not.toBe('ProdDB');
   });
 });

--- a/apps/web/src/entities/plate/PlateSprite.test.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.test.tsx
@@ -95,9 +95,9 @@ describe('PlateSprite', () => {
   });
 
   it.each([
-    ['region', makeNetworkPlate(), 'Region Layer', '#2563EB'],
-    ['public-subnet', makeSubnetPlate('public'), 'Public Subnet', '#22C55E'],
-    ['private-subnet', makeSubnetPlate('private'), 'Private Subnet', '#6366F1'],
+    ['region', makeNetworkPlate(), 'Network Plate', '#2563EB'],
+    ['public-subnet', makeSubnetPlate('public'), 'public subnet', '#22C55E'],
+    ['private-subnet', makeSubnetPlate('private'), 'private subnet', '#6366F1'],
   ] as const)('renders correct PlateSvg for %s', (_, plate, expectedLabel, expectedTopColor) => {
     render(<PlateSprite plate={plate} screenX={0} screenY={0} zIndex={1} />);
 

--- a/apps/web/src/entities/plate/PlateSprite.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.tsx
@@ -154,7 +154,7 @@ export const PlateSprite = memo(function PlateSprite({
     : getPlateProfile(DEFAULT_PLATE_PROFILE[plate.type]);
   const studColors = getPlateStudColors(plate);
   const faceColors = getPlateFaceColors(plate);
-  const label = plate.type === 'subnet'
+  const typeLabel = plate.type === 'subnet'
     ? plate.subnetAccess === 'public'
       ? 'Public Subnet'
       : 'Private Subnet'
@@ -165,6 +165,7 @@ export const PlateSprite = memo(function PlateSprite({
         : plate.type === 'zone'
           ? 'Zone Layer'
           : 'Region Layer';
+  const label = plate.name || typeLabel;
   const emoji = plate.type === 'subnet'
     ? plate.subnetAccess === 'public'
       ? '🔓'

--- a/apps/web/src/entities/store/uiStore.test.ts
+++ b/apps/web/src/entities/store/uiStore.test.ts
@@ -21,6 +21,8 @@ describe('useUIStore', () => {
       showGitHubRepos: false,
       showGitHubSync: false,
       showGitHubPR: false,
+      showSuggestionsPanel: false,
+      showCostPanel: false,
       activeProvider: 'azure',
       editorMode: 'build',
       showLearningPanel: false,
@@ -48,6 +50,8 @@ describe('useUIStore', () => {
       expect(state.showGitHubRepos).toBe(false);
       expect(state.showGitHubSync).toBe(false);
       expect(state.showGitHubPR).toBe(false);
+      expect(state.showSuggestionsPanel).toBe(false);
+      expect(state.showCostPanel).toBe(false);
       expect(state.activeProvider).toBe('azure');
       expect(state.editorMode).toBe('build');
       expect(state.showLearningPanel).toBe(false);
@@ -754,7 +758,7 @@ describe('useUIStore', () => {
   describe('State isolation', () => {
     it('should not affect other state properties when setting one property', () => {
       const initialState = useUIStore.getState();
-      useUIStore.getState().setSelectedId('id-1');
+      useUIStore.getState().setSelectedId('some-id');
       expect(useUIStore.getState().toolMode).toBe(initialState.toolMode);
       expect(useUIStore.getState().showBlockPalette).toBe(initialState.showBlockPalette);
     });
@@ -772,6 +776,108 @@ describe('useUIStore', () => {
       useUIStore.getState().toggleProperties();
       expect(useUIStore.getState().showBlockPalette).toBe(false);
       expect(useUIStore.getState().showProperties).toBe(false);
+    });
+  });
+
+  describe('right-panel mutual exclusion', () => {
+    it('opening CodePreview closes other right panels', () => {
+      useUIStore.getState().toggleGitHubLogin();
+      expect(useUIStore.getState().showGitHubLogin).toBe(true);
+
+      useUIStore.getState().toggleCodePreview();
+      expect(useUIStore.getState().showCodePreview).toBe(true);
+      expect(useUIStore.getState().showGitHubLogin).toBe(false);
+    });
+
+    it('opening GitHubLogin closes other right panels', () => {
+      useUIStore.getState().toggleCodePreview();
+      expect(useUIStore.getState().showCodePreview).toBe(true);
+
+      useUIStore.getState().toggleGitHubLogin();
+      expect(useUIStore.getState().showGitHubLogin).toBe(true);
+      expect(useUIStore.getState().showCodePreview).toBe(false);
+    });
+
+    it('opening GitHubRepos closes other right panels', () => {
+      useUIStore.getState().toggleGitHubPR();
+      expect(useUIStore.getState().showGitHubPR).toBe(true);
+
+      useUIStore.getState().toggleGitHubRepos();
+      expect(useUIStore.getState().showGitHubRepos).toBe(true);
+      expect(useUIStore.getState().showGitHubPR).toBe(false);
+    });
+
+    it('opening SuggestionsPanel closes other right panels', () => {
+      useUIStore.getState().toggleCodePreview();
+      expect(useUIStore.getState().showCodePreview).toBe(true);
+
+      useUIStore.getState().toggleSuggestionsPanel();
+      expect(useUIStore.getState().showSuggestionsPanel).toBe(true);
+      expect(useUIStore.getState().showCodePreview).toBe(false);
+    });
+
+    it('opening CostPanel closes other right panels', () => {
+      useUIStore.getState().toggleGitHubSync();
+      expect(useUIStore.getState().showGitHubSync).toBe(true);
+
+      useUIStore.getState().toggleCostPanel();
+      expect(useUIStore.getState().showCostPanel).toBe(true);
+      expect(useUIStore.getState().showGitHubSync).toBe(false);
+    });
+
+    it('closing a right panel does not open others', () => {
+      useUIStore.getState().toggleCodePreview();
+      expect(useUIStore.getState().showCodePreview).toBe(true);
+
+      useUIStore.getState().toggleCodePreview();
+      expect(useUIStore.getState().showCodePreview).toBe(false);
+      expect(useUIStore.getState().showGitHubLogin).toBe(false);
+      expect(useUIStore.getState().showGitHubRepos).toBe(false);
+      expect(useUIStore.getState().showSuggestionsPanel).toBe(false);
+      expect(useUIStore.getState().showCostPanel).toBe(false);
+    });
+
+    it('does not affect left-side or center panels', () => {
+      useUIStore.getState().toggleWorkspaceManager();
+      expect(useUIStore.getState().showWorkspaceManager).toBe(true);
+
+      useUIStore.getState().toggleCodePreview();
+      expect(useUIStore.getState().showCodePreview).toBe(true);
+      expect(useUIStore.getState().showWorkspaceManager).toBe(true);
+    });
+  });
+
+  describe('toggleSuggestionsPanel', () => {
+    it('defaults to false', () => {
+      expect(useUIStore.getState().showSuggestionsPanel).toBe(false);
+    });
+
+    it('toggles from false to true', () => {
+      useUIStore.getState().toggleSuggestionsPanel();
+      expect(useUIStore.getState().showSuggestionsPanel).toBe(true);
+    });
+
+    it('toggles back to false', () => {
+      useUIStore.getState().toggleSuggestionsPanel();
+      useUIStore.getState().toggleSuggestionsPanel();
+      expect(useUIStore.getState().showSuggestionsPanel).toBe(false);
+    });
+  });
+
+  describe('toggleCostPanel', () => {
+    it('defaults to false', () => {
+      expect(useUIStore.getState().showCostPanel).toBe(false);
+    });
+
+    it('toggles from false to true', () => {
+      useUIStore.getState().toggleCostPanel();
+      expect(useUIStore.getState().showCostPanel).toBe(true);
+    });
+
+    it('toggles back to false', () => {
+      useUIStore.getState().toggleCostPanel();
+      useUIStore.getState().toggleCostPanel();
+      expect(useUIStore.getState().showCostPanel).toBe(false);
     });
   });
 });

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -61,6 +61,10 @@ interface UIState {
   toggleGitHubSync: () => void;
   showGitHubPR: boolean;
   toggleGitHubPR: () => void;
+  showSuggestionsPanel: boolean;
+  toggleSuggestionsPanel: () => void;
+  showCostPanel: boolean;
+  toggleCostPanel: () => void;
 
   // ── Editor mode ──
   editorMode: EditorMode;
@@ -92,6 +96,28 @@ interface UIState {
   // ── Sound preference ──
   isSoundMuted: boolean;
   toggleSound: () => void;
+}
+
+/** Keys that occupy the right-side panel slot — only one may be open. */
+const RIGHT_PANEL_KEYS = [
+  'showCodePreview',
+  'showGitHubLogin',
+  'showGitHubRepos',
+  'showGitHubSync',
+  'showGitHubPR',
+  'showSuggestionsPanel',
+  'showCostPanel',
+] as const;
+
+type RightPanelKey = (typeof RIGHT_PANEL_KEYS)[number];
+
+/** Returns a partial state that closes every right panel except the given key. */
+function closeOtherRightPanels(except: RightPanelKey): Partial<UIState> {
+  const patch: Record<string, boolean> = {};
+  for (const key of RIGHT_PANEL_KEYS) {
+    if (key !== except) patch[key] = false;
+  }
+  return patch as Partial<UIState>;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -176,7 +202,10 @@ export const useUIStore = create<UIState>((set) => ({
 
   showCodePreview: false,
   toggleCodePreview: () =>
-    set((s) => ({ showCodePreview: !s.showCodePreview })),
+    set((s) => ({
+      showCodePreview: !s.showCodePreview,
+      ...(!s.showCodePreview ? closeOtherRightPanels('showCodePreview') : {}),
+    })),
 
   showWorkspaceManager: false,
   toggleWorkspaceManager: () =>
@@ -188,19 +217,45 @@ export const useUIStore = create<UIState>((set) => ({
 
   showGitHubLogin: false,
   toggleGitHubLogin: () =>
-    set((s) => ({ showGitHubLogin: !s.showGitHubLogin })),
+    set((s) => ({
+      showGitHubLogin: !s.showGitHubLogin,
+      ...(!s.showGitHubLogin ? closeOtherRightPanels('showGitHubLogin') : {}),
+    })),
 
   showGitHubRepos: false,
   toggleGitHubRepos: () =>
-    set((s) => ({ showGitHubRepos: !s.showGitHubRepos })),
+    set((s) => ({
+      showGitHubRepos: !s.showGitHubRepos,
+      ...(!s.showGitHubRepos ? closeOtherRightPanels('showGitHubRepos') : {}),
+    })),
 
   showGitHubSync: false,
   toggleGitHubSync: () =>
-    set((s) => ({ showGitHubSync: !s.showGitHubSync })),
+    set((s) => ({
+      showGitHubSync: !s.showGitHubSync,
+      ...(!s.showGitHubSync ? closeOtherRightPanels('showGitHubSync') : {}),
+    })),
 
   showGitHubPR: false,
   toggleGitHubPR: () =>
-    set((s) => ({ showGitHubPR: !s.showGitHubPR })),
+    set((s) => ({
+      showGitHubPR: !s.showGitHubPR,
+      ...(!s.showGitHubPR ? closeOtherRightPanels('showGitHubPR') : {}),
+    })),
+
+  showSuggestionsPanel: false,
+  toggleSuggestionsPanel: () =>
+    set((s) => ({
+      showSuggestionsPanel: !s.showSuggestionsPanel,
+      ...(!s.showSuggestionsPanel ? closeOtherRightPanels('showSuggestionsPanel') : {}),
+    })),
+
+  showCostPanel: false,
+  toggleCostPanel: () =>
+    set((s) => ({
+      showCostPanel: !s.showCostPanel,
+      ...(!s.showCostPanel ? closeOtherRightPanels('showCostPanel') : {}),
+    })),
 
   editorMode: 'build',
   setEditorMode: (mode) => set({ editorMode: mode }),

--- a/apps/web/src/features/ai/index.ts
+++ b/apps/web/src/features/ai/index.ts
@@ -1,4 +1,2 @@
 export { AiPromptBar } from './components/AiPromptBar';
-export { SuggestionsPanel } from './components/SuggestionsPanel';
-export { CostPanel } from './components/CostPanel';
 export { useAiStore } from './store';

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -43,6 +43,8 @@ export function MenuBar() {
   const toggleGitHubRepos = useUIStore((s) => s.toggleGitHubRepos);
   const toggleGitHubSync = useUIStore((s) => s.toggleGitHubSync);
   const toggleGitHubPR = useUIStore((s) => s.toggleGitHubPR);
+  const toggleSuggestionsPanel = useUIStore((s) => s.toggleSuggestionsPanel);
+  const toggleCostPanel = useUIStore((s) => s.toggleCostPanel);
   const diffMode = useUIStore((s) => s.diffMode);
   const toggleScenarioGallery = useUIStore((s) => s.toggleScenarioGallery);
   const toggleLearningPanel = useUIStore((s) => s.toggleLearningPanel);
@@ -361,6 +363,12 @@ export function MenuBar() {
             <div className="menu-separator" />
             <button type="button" className="menu-item" onClick={() => handleAction(toggleTemplateGallery)}>
               <span className="menu-item-left">📦 Browse Templates</span>
+            </button>
+            <button type="button" className="menu-item" onClick={() => handleAction(toggleSuggestionsPanel)}>
+              <span className="menu-item-left">🤖 AI Suggestions</span>
+            </button>
+            <button type="button" className="menu-item" onClick={() => handleAction(toggleCostPanel)}>
+              <span className="menu-item-left">💰 Cost Estimate</span>
             </button>
             <div className="menu-separator" />
             <button type="button" className="menu-item" onClick={() => handleAction(toggleScenarioGallery)}>


### PR DESCRIPTION
## Summary

- **#601 Panel overlap**: Added mutual exclusion for all 7 right-side panels (`CodePreview`, `GitHubLogin`, `GitHubRepos`, `GitHubSync`, `GitHubPR`, `SuggestionsPanel`, `CostPanel`). Opening one automatically closes the others. Left-side and center panels are unaffected.
- **#514 AI panels not accessible**: Mounted `SuggestionsPanel` and `CostPanel` in `App.tsx` with lazy loading and code-splitting. Added "AI Suggestions" and "Cost Estimate" menu items under the Build menu in `MenuBar.tsx`. Removed static re-exports from the AI barrel to enable proper code-splitting.
- **#529 Resource names on canvas**: `BlockSvg` now accepts an optional `name` prop that overrides the generic `shortName` on the left wall. `BlockSprite` passes `block.name` through. `PlateSprite` uses `plate.name` as label (falling back to the type-derived label when name is empty).

## Changed Files

| File | Change |
|------|--------|
| `uiStore.ts` | Added `RIGHT_PANEL_KEYS`, `closeOtherRightPanels()`, mutual exclusion logic in all 7 right-panel toggles, new `showSuggestionsPanel`/`showCostPanel` state + toggles |
| `uiStore.test.ts` | Added mutual exclusion tests, new panel toggle tests, removed orphaned duplicate tests |
| `App.tsx` | Added lazy imports + conditional rendering for `SuggestionsPanel` and `CostPanel` |
| `MenuBar.tsx` | Added "AI Suggestions" and "Cost Estimate" menu items under Build menu |
| `BlockSvg.tsx` | Added optional `name` prop, renders `name ?? shortName` on left wall |
| `BlockSprite.tsx` | Passes `block.name` to `BlockSvg` |
| `PlateSprite.tsx` | Uses `plate.name` as label, falls back to type-derived label |
| `PlateSprite.test.tsx` | Updated expected labels to match new name-first behavior |
| `BlockSvg.test.tsx` | Added name prop rendering tests |
| `features/ai/index.ts` | Removed static re-exports of `SuggestionsPanel`/`CostPanel` to enable code-splitting |

Fixes #601, Fixes #514, Fixes #529