### PR TITLE
fix(web): replace brick emoji with provider-aware SVG icons (#526, #495)

### DIFF
--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -1,6 +1,7 @@
 import { memo, useId, useMemo } from 'react';
 import type { BlockCategory, BlockRole, ProviderType } from '@cloudblocks/schema';
-import { BLOCK_SHORT_NAMES, BLOCK_ICONS, ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
+import { BLOCK_SHORT_NAMES, ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
+import { getBlockIconUrl } from '../../shared/utils/iconResolver';
 import { getBlockDimensions, getBlockVisualProfile } from '../../shared/types/visualProfile';
 import { StudDefs, StudGrid } from '../../shared/components/IsometricStud';
 import {
@@ -36,7 +37,7 @@ export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, na
   const faceColors = getBlockFaceColors(category, provider ?? 'azure', subtype);
   const studColors = getBlockStudColors(category, provider ?? 'azure', subtype);
   const shortName = BLOCK_SHORT_NAMES[category];
-  const icon = BLOCK_ICONS[category];
+  const iconUrl = getBlockIconUrl(provider ?? 'azure', category, subtype);
 
   // ─── v2.0: silhouette from CU dimensions ───────────────────
   const { topFacePoints, leftSidePoints, rightSidePoints } = getSilhouetteFromCU(
@@ -84,7 +85,7 @@ export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, na
 
   const minDim = Math.min(studsX, studsY);
   const labelFontSize = minDim <= 1 ? 8 : minDim <= 2 ? 10 : 13;
-  const iconFontSize = minDim <= 1 ? 10 : minDim <= 2 ? 14 : 18;
+  const iconSize = minDim <= 1 ? 12 : minDim <= 2 ? 16 : 20;
 
   return (
     <svg
@@ -116,15 +117,14 @@ export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, na
         {name ?? shortName}
       </text>
 
-      <text
+      <image
+        href={iconUrl}
+        width={iconSize}
+        height={iconSize}
+        x={-iconSize / 2}
+        y={-iconSize / 2}
         transform={`matrix(0.8975,-0.4410,0,1,${rightLabelX},${wallCenterY})`}
-        fontFamily="system-ui, -apple-system, sans-serif"
-        fontSize={iconFontSize}
-        textAnchor="middle"
-        dominantBaseline="middle"
-      >
-        {icon}
-      </text>
+      />
 
       {aggregationCount != null && aggregationCount > 1 && (
         <g data-testid="aggregation-badge">

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -307,10 +307,12 @@ describe('BlockSvg SVG structure', () => {
     expect(lines.length).toBe(1);
   });
 
-  it('renders short name and icon text elements', () => {
+  it('renders short name text and icon image elements', () => {
     const { container } = render(<BlockSvg category="compute" />);
     const texts = container.querySelectorAll('text');
-    expect(texts.length).toBe(2);
+    const images = container.querySelectorAll('image');
+    expect(texts.length).toBe(1); // name on left wall
+    expect(images.length).toBe(1); // icon on right wall
   });
 
   it('has aria-hidden for decorative SVG', () => {
@@ -477,6 +479,7 @@ describe('BlockSvg name prop', () => {
     const { container } = render(<BlockSvg category="database" name="ProdDB" />);
     const texts = container.querySelectorAll('text');
     expect(texts[0].textContent).toBe('ProdDB');
-    expect(texts[1].textContent).not.toBe('ProdDB');
+    const images = container.querySelectorAll('image');
+    expect(images.length).toBe(1);
   });
 });

--- a/apps/web/src/entities/plate/PlateSprite.test.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.test.tsx
@@ -26,7 +26,7 @@ vi.mock('./PlateSvg', () => ({
     <div
       data-testid="plate-svg"
       data-label={props.label}
-      data-emoji={props.emoji}
+      data-icon-url={props.iconUrl}
       data-top-face-color={props.topFaceColor}
     />
   ),

--- a/apps/web/src/entities/plate/PlateSprite.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.tsx
@@ -6,6 +6,7 @@ import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 import { getDiffState } from '../../features/diff/engine';
 import type { DiffDelta } from '../../shared/types/diff';
+import { getPlateIconUrl } from '../../shared/utils/iconResolver';
 import { screenDeltaToWorld, snapToGrid, worldSizeToScreen } from '../../shared/utils/isometric';
 import { audioService } from '../../shared/utils/audioService';
 import { canPlaceBlock } from '../validation/placement';
@@ -166,17 +167,7 @@ export const PlateSprite = memo(function PlateSprite({
           ? 'Zone Layer'
           : 'Region Layer';
   const label = plate.name || typeLabel;
-  const emoji = plate.type === 'subnet'
-    ? plate.subnetAccess === 'public'
-      ? '🔓'
-      : '🔒'
-    : plate.type === 'global'
-      ? '🌎'
-      : plate.type === 'edge'
-        ? '🛰️'
-        : plate.type === 'zone'
-          ? '🧭'
-          : '🌐';
+  const iconUrl = getPlateIconUrl(plate.type, plate.subnetAccess);
 
   const { screenWidth, screenHeight } = worldSizeToScreen(plate.size.width, plate.size.height, plate.size.depth);
 
@@ -228,7 +219,7 @@ export const PlateSprite = memo(function PlateSprite({
             leftSideColor={faceColors.leftSideColor}
             rightSideColor={faceColors.rightSideColor}
             label={label}
-            emoji={emoji}
+            iconUrl={iconUrl}
           />
         </div>
       </button>

--- a/apps/web/src/entities/plate/PlateSvg.test.tsx
+++ b/apps/web/src/entities/plate/PlateSvg.test.tsx
@@ -33,34 +33,38 @@ function renderPlateSvg(props?: Partial<ComponentProps<typeof PlateSvg>>) {
   );
 }
 
-// ─── Label & Emoji Rendering ────────────────────────────────
+// ─── Label & Icon Rendering ─────────────────────────────────
 
-describe('PlateSvg — label and emoji', () => {
-  it('renders both label and emoji when both props are provided', () => {
-    renderPlateSvg({ label: 'Public Subnet', emoji: '🌐' });
+describe('PlateSvg — label and icon', () => {
+  it('renders both label and icon when both props are provided', () => {
+    const { container } = renderPlateSvg({ label: 'Public Subnet', iconUrl: 'test-icon.svg' });
 
     expect(screen.getByText('Public Subnet')).toBeInTheDocument();
-    expect(screen.getByText('🌐')).toBeInTheDocument();
+    const images = container.querySelectorAll('image');
+    expect(images.length).toBe(1);
+    expect(images[0]).toHaveAttribute('href', 'test-icon.svg');
   });
 
-  it('renders label only when emoji is omitted', () => {
-    renderPlateSvg({ label: 'Private Subnet' });
+  it('renders label only when iconUrl is omitted', () => {
+    const { container } = renderPlateSvg({ label: 'Private Subnet' });
 
     expect(screen.getByText('Private Subnet')).toBeInTheDocument();
-    expect(screen.queryByText('🌐')).not.toBeInTheDocument();
+    expect(container.querySelectorAll('image').length).toBe(0);
   });
 
-  it('renders emoji only when label is omitted', () => {
-    renderPlateSvg({ emoji: '🔒' });
+  it('renders icon only when label is omitted', () => {
+    const { container } = renderPlateSvg({ iconUrl: 'test-icon.svg' });
 
-    expect(screen.getByText('🔒')).toBeInTheDocument();
+    const images = container.querySelectorAll('image');
+    expect(images.length).toBe(1);
     expect(screen.queryByText('Public Subnet')).not.toBeInTheDocument();
   });
 
-  it('renders no text elements when neither label nor emoji provided', () => {
+  it('renders no text or image elements when neither label nor iconUrl provided', () => {
     const { container } = renderPlateSvg();
 
     expect(container.querySelectorAll('text')).toHaveLength(0);
+    expect(container.querySelectorAll('image')).toHaveLength(0);
   });
 });
 
@@ -222,13 +226,13 @@ describe('PlateSvg — layer-type visuals', () => {
     expect(globalFontSize).toBeGreaterThan(subnetFontSize);
   });
 
-  it('global plate emoji uses larger font than zone', () => {
-    const { container: globalC } = renderPlateSvg({ plateType: 'global', emoji: '🌎' });
-    const { container: zoneC } = renderPlateSvg({ plateType: 'zone', emoji: '🧭' });
+  it('global plate icon uses larger size than zone', () => {
+    const { container: globalC } = renderPlateSvg({ plateType: 'global', iconUrl: 'icon-g.svg' });
+    const { container: zoneC } = renderPlateSvg({ plateType: 'zone', iconUrl: 'icon-z.svg' });
 
-    const globalEmoji = Number(globalC.querySelector('text')?.getAttribute('font-size'));
-    const zoneEmoji = Number(zoneC.querySelector('text')?.getAttribute('font-size'));
-    expect(globalEmoji).toBeGreaterThan(zoneEmoji);
+    const globalSize = Number(globalC.querySelector('image')?.getAttribute('width'));
+    const zoneSize = Number(zoneC.querySelector('image')?.getAttribute('width'));
+    expect(globalSize).toBeGreaterThan(zoneSize);
   });
 });
 

--- a/apps/web/src/entities/plate/PlateSvg.tsx
+++ b/apps/web/src/entities/plate/PlateSvg.tsx
@@ -12,7 +12,7 @@ interface LayerVisuals {
   strokeWidth: number;       // border thickness (wider = more prominent)
   strokeOpacity: number;     // border visibility
   labelFontSize: number;     // label text size
-  emojiFontSize: number;     // emoji text size
+  emojiFontSize: number;     // icon display size (px)
   cornerRadius: number;      // 0 = sharp diamond, unused today (future use)
 }
 
@@ -67,7 +67,7 @@ export interface PlateSvgProps {
   leftSideColor: string;
   rightSideColor: string;
   label?: string;
-  emoji?: string;
+  iconUrl?: string;
 }
 
 // ─── Component ─────────────────────────────────────────────
@@ -83,7 +83,7 @@ export const PlateSvg = memo(function PlateSvg({
   leftSideColor,
   rightSideColor,
   label,
-  emoji,
+  iconUrl,
 }: PlateSvgProps) {
   // CU-based pixel conversion: 1 CU = 1 stud, rendered via TILE_W/H/Z
   const screenWidth = (studsX + studsY) * TILE_W / 2;
@@ -180,16 +180,15 @@ export const PlateSvg = memo(function PlateSvg({
         </text>
       ) : null}
 
-      {emoji ? (
-        <text
+      {iconUrl ? (
+        <image
+          href={iconUrl}
+          width={visuals.emojiFontSize}
+          height={visuals.emojiFontSize}
+          x={-visuals.emojiFontSize / 2}
+          y={-visuals.emojiFontSize / 2}
           transform={`matrix(0.8975,-0.4410,0,1,${rightLabelX},${wallCenterY})`}
-          fontFamily="system-ui, -apple-system, sans-serif"
-          fontSize={visuals.emojiFontSize}
-          textAnchor="middle"
-          dominantBaseline="middle"
-        >
-          {emoji}
-        </text>
+        />
       ) : null}
     </svg>
   );

--- a/apps/web/src/shared/utils/iconResolver.test.ts
+++ b/apps/web/src/shared/utils/iconResolver.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { getBlockIconUrl, getPlateIconUrl } from './iconResolver';
+import type { BlockCategory, PlateType, ProviderType } from '@cloudblocks/schema';
+
+describe('getBlockIconUrl', () => {
+  const ALL_CATEGORIES: BlockCategory[] = [
+    'compute', 'database', 'storage', 'gateway', 'function',
+    'queue', 'event', 'analytics', 'identity', 'observability',
+  ];
+  const ALL_PROVIDERS: ProviderType[] = ['azure', 'aws', 'gcp'];
+
+  it.each(ALL_CATEGORIES)(
+    'returns a non-empty string for category %s with azure provider',
+    (category) => {
+      const url = getBlockIconUrl('azure', category);
+      expect(typeof url).toBe('string');
+      expect(url.length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(ALL_PROVIDERS)(
+    'returns a valid icon URL for provider %s',
+    (provider) => {
+      const url = getBlockIconUrl(provider, 'compute');
+      expect(typeof url).toBe('string');
+      expect(url.length).toBeGreaterThan(0);
+    },
+  );
+
+  it('aws and gcp fall back to azure icons', () => {
+    ALL_CATEGORIES.forEach((category) => {
+      const azure = getBlockIconUrl('azure', category);
+      const aws = getBlockIconUrl('aws', category);
+      const gcp = getBlockIconUrl('gcp', category);
+      expect(aws).toBe(azure);
+      expect(gcp).toBe(azure);
+    });
+  });
+
+  it('ignores unknown subtype and still returns category icon', () => {
+    const url = getBlockIconUrl('azure', 'compute', 'unknown-service');
+    const baseline = getBlockIconUrl('azure', 'compute');
+    expect(url).toBe(baseline);
+  });
+});
+
+describe('getPlateIconUrl', () => {
+  const ALL_PLATE_TYPES: PlateType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
+
+  it.each(ALL_PLATE_TYPES)(
+    'returns a non-empty string for plate type %s',
+    (plateType) => {
+      const url = getPlateIconUrl(plateType);
+      expect(typeof url).toBe('string');
+      expect(url.length).toBeGreaterThan(0);
+    },
+  );
+
+  it('subnet uses a different icon than network-layer plates', () => {
+    const subnetUrl = getPlateIconUrl('subnet');
+    const regionUrl = getPlateIconUrl('region');
+    expect(subnetUrl).not.toBe(regionUrl);
+  });
+
+  it('all network-layer plates share the same icon', () => {
+    const networkTypes: PlateType[] = ['global', 'edge', 'region', 'zone'];
+    const urls = networkTypes.map((t) => getPlateIconUrl(t));
+    const unique = new Set(urls);
+    expect(unique.size).toBe(1);
+  });
+
+  it('subnetAccess parameter does not change the result', () => {
+    const publicUrl = getPlateIconUrl('subnet', 'public');
+    const privateUrl = getPlateIconUrl('subnet', 'private');
+    const noAccess = getPlateIconUrl('subnet');
+    expect(publicUrl).toBe(privateUrl);
+    expect(publicUrl).toBe(noAccess);
+  });
+});

--- a/apps/web/src/shared/utils/iconResolver.ts
+++ b/apps/web/src/shared/utils/iconResolver.ts
@@ -1,0 +1,85 @@
+import type { BlockCategory, PlateType, ProviderType, SubnetAccess } from '@cloudblocks/schema';
+
+// ─── Azure Icon Imports ──────────────────────────────────────
+import vmIcon from '../assets/azure-icons/virtual-machine.svg';
+import sqlIcon from '../assets/azure-icons/sql-database.svg';
+import storageIcon from '../assets/azure-icons/storage-account.svg';
+import gatewayIcon from '../assets/azure-icons/application-gateway.svg';
+import functionIcon from '../assets/azure-icons/logic-apps.svg';
+import queueIcon from '../assets/azure-icons/service-bus.svg';
+import eventIcon from '../assets/azure-icons/event-hub.svg';
+import vnetIcon from '../assets/azure-icons/virtual-network.svg';
+import subnetIcon from '../assets/azure-icons/subnet.svg';
+
+// ─── Block Icon Maps ─────────────────────────────────────────
+
+/** Azure category → icon mapping (canonical source). */
+const AZURE_BLOCK_ICONS: Record<BlockCategory, string> = {
+  compute: vmIcon,
+  database: sqlIcon,
+  storage: storageIcon,
+  gateway: gatewayIcon,
+  function: functionIcon,
+  queue: queueIcon,
+  event: eventIcon,
+  analytics: vmIcon,       // no dedicated analytics icon yet
+  identity: storageIcon,   // no dedicated identity icon yet
+  observability: eventIcon, // no dedicated observability icon yet
+};
+
+/**
+ * Provider-specific block icon overrides.
+ * AWS and GCP fall back to Azure icons until vendor packs are added.
+ */
+const PROVIDER_BLOCK_ICONS: Record<ProviderType, Record<BlockCategory, string>> = {
+  azure: AZURE_BLOCK_ICONS,
+  aws: { ...AZURE_BLOCK_ICONS },  // fallback: Azure icons
+  gcp: { ...AZURE_BLOCK_ICONS },  // fallback: Azure icons
+};
+
+// ─── Plate Icon Maps ─────────────────────────────────────────
+
+/** Plate type → icon mapping. */
+const PLATE_ICONS: Record<PlateType, string> = {
+  global: vnetIcon,
+  edge: vnetIcon,
+  region: vnetIcon,
+  zone: vnetIcon,
+  subnet: subnetIcon,
+};
+
+// ─── Public API ──────────────────────────────────────────────
+
+/**
+ * Resolve the SVG icon URL for a block.
+ *
+ * Priority:
+ *   1. Provider + category mapping
+ *   2. Azure fallback (always available)
+ *
+ * @returns An SVG asset URL string (Vite-resolved)
+ */
+export function getBlockIconUrl(
+  provider: ProviderType,
+  category: BlockCategory,
+  _subtype?: string,
+): string {
+  return PROVIDER_BLOCK_ICONS[provider]?.[category]
+    ?? AZURE_BLOCK_ICONS[category]
+    ?? vmIcon;
+}
+
+/**
+ * Resolve the SVG icon URL for a plate.
+ *
+ * Subnet plates always use the subnet icon regardless of access level.
+ * Network-layer plates (global, edge, region, zone) use the VNet icon.
+ *
+ * @returns An SVG asset URL string (Vite-resolved)
+ */
+export function getPlateIconUrl(
+  plateType: PlateType,
+  _subnetAccess?: SubnetAccess,
+): string {
+  return PLATE_ICONS[plateType] ?? vnetIcon;
+}

--- a/apps/web/src/widgets/bottom-panel/Portrait.tsx
+++ b/apps/web/src/widgets/bottom-panel/Portrait.tsx
@@ -1,9 +1,8 @@
 /**
- * Portrait Panel — Azure Resource Icon Display (StarCraft-style unit portrait)
+ * Portrait Panel — Resource Icon Display (StarCraft-style unit portrait)
  *
- * Shows the Azure product icon of the selected resource,
- * like a character face in StarCraft's unit wireframe panel.
- * Shows CloudBlocks logo when nothing is selected.
+ * Shows the product icon of the selected resource using provider-aware
+ * icon resolution. Shows CloudBlocks logo when nothing is selected.
  *
  * Based on VISUAL_DESIGN_SPEC.md §7.4
  */
@@ -14,41 +13,12 @@ import { useWorkerStore } from '../../entities/store/workerStore';
 import { getPlateFaceColors } from '../../entities/plate/plateFaceColors';
 import { BLOCK_FRIENDLY_NAMES, CONNECTION_TYPE_LABELS, PLATE_COLORS, SUBNET_ACCESS_COLORS } from '../../shared/types/index';
 import { getBlockColor } from '../../entities/block/blockFaceColors';
-import vmIcon from '../../shared/assets/azure-icons/virtual-machine.svg';
-import sqlIcon from '../../shared/assets/azure-icons/sql-database.svg';
-import storageIcon from '../../shared/assets/azure-icons/storage-account.svg';
-import gatewayIcon from '../../shared/assets/azure-icons/application-gateway.svg';
-import functionIcon from '../../shared/assets/azure-icons/logic-apps.svg';
-import queueIcon from '../../shared/assets/azure-icons/service-bus.svg';
-import eventIcon from '../../shared/assets/azure-icons/event-hub.svg';
-import vnetIcon from '../../shared/assets/azure-icons/virtual-network.svg';
-import subnetIcon from '../../shared/assets/azure-icons/subnet.svg';
+import { getBlockIconUrl, getPlateIconUrl } from '../../shared/utils/iconResolver';
 import './Portrait.css';
 
 interface PortraitProps {
   className?: string;
 }
-
-const BLOCK_ICONS: Record<string, string> = {
-  compute: vmIcon,
-  database: sqlIcon,
-  storage: storageIcon,
-  gateway: gatewayIcon,
-  function: functionIcon,
-  queue: queueIcon,
-  event: eventIcon,
-  analytics: vmIcon,
-  identity: storageIcon,
-  observability: eventIcon,
-};
-
-const PLATE_ICONS: Record<string, Record<string, string>> = {
-  global: { default: vnetIcon },
-  edge: { default: vnetIcon },
-  region: { default: vnetIcon },
-  zone: { default: vnetIcon },
-  subnet: { public: subnetIcon, private: subnetIcon },
-};
 
 export function Portrait({ className = '' }: PortraitProps) {
   const selectedId = useUIStore((s) => s.selectedId);
@@ -94,7 +64,7 @@ export function Portrait({ className = '' }: PortraitProps) {
     return (
       <div className={`portrait-panel portrait-panel--block ${className}`}>
         <div className="portrait-content">
-          <img src={BLOCK_ICONS[selectedBlock.category]} alt={BLOCK_FRIENDLY_NAMES[selectedBlock.category]} className="portrait-icon-img" />
+          <img src={getBlockIconUrl(selectedBlock.provider ?? 'azure', selectedBlock.category, selectedBlock.subtype)} alt={BLOCK_FRIENDLY_NAMES[selectedBlock.category]} className="portrait-icon-img" />
           <span className="portrait-label">{selectedBlock.name}</span>
         </div>
         <div className="portrait-badge" style={{ backgroundColor: color }}>
@@ -112,9 +82,7 @@ export function Portrait({ className = '' }: PortraitProps) {
 
     const faceColors = getPlateFaceColors(selectedPlate);
 
-    const plateIcon = selectedPlate.type === 'subnet'
-      ? PLATE_ICONS.subnet[selectedPlate.subnetAccess ?? 'private']
-      : PLATE_ICONS[selectedPlate.type].default;
+    const plateIcon = getPlateIconUrl(selectedPlate.type, selectedPlate.subnetAccess);
 
     const altText = selectedPlate.type === 'subnet'
       ? `${selectedPlate.subnetAccess === 'public' ? 'Public' : 'Private'} Subnet`


### PR DESCRIPTION
## Summary

- Replace emoji-based icons on isometric block/plate surfaces with provider-aware SVG `<image>` elements
- Add `iconResolver.ts` module with `getBlockIconUrl()` and `getPlateIconUrl()` functions (Azure icons with AWS/GCP fallback)
- Update `PlateSvg` prop from `emoji` to `iconUrl`, `BlockSvg` icon from `<text>` emoji to `<image>` SVG
- Make Portrait panel use shared icon resolver instead of local icon maps
- Update all related test files and add iconResolver test coverage

Fixes #526, Fixes #495