### PR TITLE
fix(web): make provider comparison region input provider-aware

### DIFF
--- a/apps/web/src/widgets/code-preview/CodePreview.css
+++ b/apps/web/src/widgets/code-preview/CodePreview.css
@@ -223,3 +223,30 @@
   margin: 0;
   max-height: 180px;
 }
+
+.code-preview-region-group {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  width: 100%;
+}
+
+.code-preview-region-row {
+  display: flex;
+  gap: 6px;
+}
+
+.code-preview-region-field {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.code-preview-region-provider-label {
+  font-size: 9px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}

--- a/apps/web/src/widgets/code-preview/CodePreview.test.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.test.tsx
@@ -380,9 +380,9 @@ describe('CodePreview', () => {
     await user.click(screen.getByText('🚀 Compare Providers'));
 
     expect(vi.mocked(generateCode)).toHaveBeenCalledTimes(3);
-    expect(screen.getByText('AZURE')).toBeInTheDocument();
-    expect(screen.getByText('AWS')).toBeInTheDocument();
-    expect(screen.getByText('GCP')).toBeInTheDocument();
+    expect(screen.getAllByText('AZURE').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('AWS').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('GCP').length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText('provider=azure')).toBeInTheDocument();
     expect(screen.getByText('provider=aws')).toBeInTheDocument();
     expect(screen.getByText('provider=gcp')).toBeInTheDocument();
@@ -662,6 +662,77 @@ describe('CodePreview', () => {
     rerender(<CodePreview />);
 
     expect(screen.getByDisplayValue('us-east-1')).toBeInTheDocument();
+  });
+
+  it('passes provider-specific regions in compare mode', async () => {
+    const user = userEvent.setup();
+    vi.mocked(generateCode).mockImplementation((_, options) => ({
+      files: [{ path: 'main.tf', content: `region=${options.region}`, language: 'hcl' as const }],
+      metadata: {
+        generator: 'terraform',
+        version: '0.3.0',
+        provider: options.provider,
+        generatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    }));
+
+    render(<CodePreview />);
+
+    await user.click(screen.getByRole('checkbox'));
+
+    // Verify per-provider region inputs are rendered
+    expect(screen.getByDisplayValue('eastus')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('us-east-1')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('us-central1')).toBeInTheDocument();
+
+    await user.click(screen.getByText('🚀 Compare Providers'));
+
+    // Verify each provider received its own default region
+    expect(vi.mocked(generateCode)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'azure', region: 'eastus' }),
+    );
+    expect(vi.mocked(generateCode)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'aws', region: 'us-east-1' }),
+    );
+    expect(vi.mocked(generateCode)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'gcp', region: 'us-central1' }),
+    );
+  });
+
+  it('allows editing per-provider region inputs in compare mode', async () => {
+    const user = userEvent.setup();
+    vi.mocked(generateCode).mockImplementation((_, options) => ({
+      files: [{ path: 'main.tf', content: `region=${options.region}`, language: 'hcl' as const }],
+      metadata: {
+        generator: 'terraform',
+        version: '0.3.0',
+        provider: options.provider,
+        generatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    }));
+
+    render(<CodePreview />);
+
+    await user.click(screen.getByRole('checkbox'));
+
+    // Edit the Azure region
+    const azureInput = screen.getByDisplayValue('eastus');
+    await user.clear(azureInput);
+    await user.type(azureInput, 'westus2');
+
+    await user.click(screen.getByText('🚀 Compare Providers'));
+
+    expect(vi.mocked(generateCode)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'azure', region: 'westus2' }),
+    );
+    expect(vi.mocked(generateCode)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ provider: 'aws', region: 'us-east-1' }),
+    );
   });
 
   it('clears output and errors when generator changes', async () => {

--- a/apps/web/src/widgets/code-preview/CodePreview.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.tsx
@@ -31,7 +31,7 @@ export function CodePreview() {
   }));
   const [activeTab, setActiveTab] = useState(0);
   const [projectName, setProjectName] = useState(sanitizedName);
-  const [region, setRegion] = useState(DEFAULT_REGION_BY_PROVIDER[activeProvider]);
+  const [regions, setRegions] = useState<Record<ProviderType, string>>({ ...DEFAULT_REGION_BY_PROVIDER });
   const [prevProvider, setPrevProvider] = useState(activeProvider);
   const [generator, setGenerator] = useState<GeneratorId>(
     generatorOptions[0]?.id ?? 'terraform'
@@ -49,7 +49,10 @@ export function CodePreview() {
 
   if (activeProvider !== prevProvider) {
     setPrevProvider(activeProvider);
-    setRegion(DEFAULT_REGION_BY_PROVIDER[activeProvider]);
+    setRegions((prev) => ({
+      ...prev,
+      [activeProvider]: DEFAULT_REGION_BY_PROVIDER[activeProvider],
+    }));
     setError(null);
     setOutput(null);
     setComparisonOutputs(null);
@@ -87,7 +90,6 @@ export function CodePreview() {
       const baseOptions = {
         mode: 'draft',
         projectName,
-        region,
         generator,
       } as const;
 
@@ -97,7 +99,11 @@ export function CodePreview() {
         const errors: Partial<Record<ProviderType, string>> = {};
 
         for (const provider of PROVIDERS) {
-          const options: GenerationOptions = { ...baseOptions, provider };
+          const options: GenerationOptions = {
+            ...baseOptions,
+            provider,
+            region: regions[provider],
+          };
           try {
             generated[provider] = generateCode(architecture, options);
           } catch (providerError) {
@@ -124,6 +130,7 @@ export function CodePreview() {
         const options: GenerationOptions = {
           ...baseOptions,
           provider: activeProvider,
+          region: regions[activeProvider],
         };
         const result = generateCode(architecture, options);
         setOutput(result);
@@ -229,15 +236,38 @@ export function CodePreview() {
             onChange={(e) => setProjectName(e.target.value)}
           />
         </label>
-        <label className="code-preview-field">
-          <span className="code-preview-field-label">Region</span>
-          <input
-            className="code-preview-input"
-            type="text"
-            value={region}
-            onChange={(e) => setRegion(e.target.value)}
-          />
-        </label>
+        {effectiveCompare ? (
+          <div className="code-preview-region-group">
+            <span className="code-preview-field-label">Regions</span>
+            <div className="code-preview-region-row">
+              {PROVIDERS.map((provider) => (
+                <label key={provider} className="code-preview-region-field">
+                  <span className="code-preview-region-provider-label">{provider.toUpperCase()}</span>
+                  <input
+                    className="code-preview-input"
+                    type="text"
+                    value={regions[provider]}
+                    onChange={(e) =>
+                      setRegions((prev) => ({ ...prev, [provider]: e.target.value }))
+                    }
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <label className="code-preview-field">
+            <span className="code-preview-field-label">Region</span>
+            <input
+              className="code-preview-input"
+              type="text"
+              value={regions[activeProvider]}
+              onChange={(e) =>
+                setRegions((prev) => ({ ...prev, [activeProvider]: e.target.value }))
+              }
+            />
+          </label>
+        )}
         <label className="code-preview-field code-preview-field-checkbox">
           <span className="code-preview-field-label">Compare</span>
           <label className="code-preview-checkbox-label">


### PR DESCRIPTION
## Summary

- Replaces single `region` state with per-provider `regions` record (`Record<ProviderType, string>`) initialized from `DEFAULT_REGION_BY_PROVIDER`
- In compare mode, each provider now gets its own region input field (Azure/AWS/GCP) and passes its provider-specific region to code generation
- In single-provider mode, behavior is unchanged — shows one region input for the active provider
- Adds 2 new tests verifying per-provider region passing and editing in compare mode

Fixes #564