### PR TITLE
chore: release v0.17.0 — Product Structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,67 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 ---
 
+## [v0.17.0] — 2026-03-21
+
+**Milestone 17 — Product Structure**
+
+Restructured the monorepo from a scaffolded prototype into a modular, separation-ready architecture. Resolved rendering model ambiguity, extracted shared packages with real consumers, redefined backend responsibilities, and established version alignment policy.
+
+### Architecture & Packages
+- SVG-only rendering model confirmed and documented (ADR-0010); unused Three.js dependencies removed
+- `@cloudblocks/schema` extracted as single source of truth for ArchitectureModel contract
+- `@cloudblocks/domain` extracted with shared domain helpers (hierarchy rules, labels, validation types)
+- Empty placeholder packages removed from `packages/`
+- All package versions aligned with root version under documented versioning policy
+
+### Domain Model Fixes
+- Deep-copy nested block fields when duplicating blocks (#644)
+- Move all descendant plates when a parent plate moves, not just direct children (#643)
+- Decouple workspace renaming from architecture name mutation (#645)
+
+### Code Generation & Providers
+- Provider-aware region input in CodePreview — each provider gets its own region in compare mode (#564)
+- Clear stale single-provider output when the selected generator changes (#642)
+- Do not preserve stale generated code after changing the active provider (#639)
+- Derive CodePreview generator options from the generator registry instead of a hardcoded list (#657)
+- Use actual generated metadata version consistently across generator plugins and UI (#654)
+- Preserve file tab selection semantics across provider comparison mode (#653)
+
+### Workspace & Persistence
+- Persist and restore the active workspace id using existing storage helpers (#648)
+- Persist the new active workspace id after switchWorkspace (#666)
+- Make switchWorkspace self-contained instead of relying on callers to save first (#667)
+- Persist backendWorkspaceId updates instead of keeping them in memory only (#672)
+- Upsert the current workspace before persisting non-current workspace deletion (#671)
+- Avoid updating the active workspace id key when workspace persistence fails (#650)
+- Do not ignore saveWorkspaces failures in workspace lifecycle actions (#651)
+- Persist workspace renames or make renameWorkspace explicitly in-memory only (#670)
+- Remove or wire dead repoOwner/repoName/branch/lastSyncAt workspace fields (#673)
+- Do not keep dead active-workspace storage helpers if the runtime will not use them (#647)
+
+### UI & UX
+- Redesign Internet external actor as globe brick (#451)
+- Provider-aware SVG icons for blocks and plates (#526, #495)
+- Give Ctrl+S/Cmd+S save the same success/failure feedback as the menu save action (#675)
+- Use explicit ScenarioGallery open/close semantics instead of blind toggle (#676)
+- Route 'Show Learning Panel' to a real entry flow when no scenario is active (#640)
+- Expose or remove dead generator registry listing APIs from the runtime surface (#656)
+- Align importArchitecture return type with its string-or-null implementation (#655)
+
+### Dialog & Accessibility
+- Support Escape-key dismissal in ConfirmDialog (#660)
+- Focus an action button when ConfirmDialog opens (#659)
+- Close or unmount the previous ConfirmDialog before resolving a new one (#661)
+- Add Escape-key dismissal parity to PromptDialog overlay interactions (#664)
+- Use the same cleanup path in PromptDialog when replacing an in-flight dialog (#665)
+- Give PromptDialog input an explicit accessible label (#668)
+- Avoid global document.querySelector coupling in PromptDialog value lookup (#669)
+
+### Stats
+- 4 Epics, 30 issues closed, 1697 tests passing, branch coverage 90.12%
+
+---
+
 ## [v0.16.0] — 2026-03-20
 
 **Milestone 16 — Documentation Architecture & Canonical Cleanup**

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cd apps/api && pip install -e ".[dev]" && uvicorn app.main:app --reload
 | v0.14.0 | AI-Assisted Architecture | ✅ |
 | v0.15.0 | v2.0 Specification Implementation | ✅ |
 | v0.16.0 | Documentation Architecture | ✅ |
-| v0.17.0 | Product Structure | 🔄 |
+| v0.17.0 | Product Structure | ✅ |
 | v0.18.0 | DevOps UX | 🔄 |
 
 See [CHANGELOG.md](CHANGELOG.md) for release details and [full roadmap](docs/concept/ROADMAP.md) for milestone breakdown.

--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -916,7 +916,7 @@ Scope:
 
 ---
 
-## Milestone 17 — Product Structure
+## Milestone 17 — Product Structure ✅
 
 Goal:
 Restructure the monorepo from a scaffolded prototype into a modular, separation-ready architecture. Resolve rendering model ambiguity, extract shared packages, redefine backend responsibilities, and establish version policy.
@@ -937,13 +937,13 @@ Scope:
 - 5 Areas (A-E) covering rendering, packages, backend, monorepo, and versioning
 
 ### Exit Criteria
-- [ ] Rendering model documented in ADR; unused dependencies removed or justified
-- [ ] `packages/` contains real extracted code with actual consumers
-- [ ] `@cloudblocks/schema` is the single source of truth for the ArchitectureModel contract
-- [ ] Backend role accurately documented; API surface defined as explicit contract
-- [ ] All package versions aligned with documented versioning policy
-- [ ] `pnpm build`, `pnpm lint`, and tests pass from root for all apps and packages
-- [ ] No placeholder/empty packages remain in `packages/`
+- [x] Rendering model documented in ADR; unused dependencies removed or justified
+- [x] `packages/` contains real extracted code with actual consumers
+- [x] `@cloudblocks/schema` is the single source of truth for the ArchitectureModel contract
+- [x] Backend role accurately documented; API surface defined as explicit contract
+- [x] All package versions aligned with documented versioning policy
+- [x] `pnpm build`, `pnpm lint`, and tests pass from root for all apps and packages
+- [x] No placeholder/empty packages remain in `packages/`
 
 ### Dependencies
 - Milestone 16 complete
@@ -1119,12 +1119,18 @@ Milestone 14 (Complete)
 - BYOK API key management with Fernet encryption
 
 Milestone 17+ (Planned)
-- Modular monorepo structure with extracted packages
 - DevOps operational control center
 - MVP polish and launch operations with deployment hardening
 - Internationalization support
 - Community contributors > 10
 - GitHub stars growth trajectory
+
+Milestone 17 (Complete)
+- Modular monorepo structure with extracted packages
+- SVG-only rendering model confirmed (ADR-0010)
+- @cloudblocks/schema and @cloudblocks/domain extracted with real consumers
+- 30 bug fixes across domain model, workspace persistence, dialogs, and code generation
+- Version alignment policy enforced
 
 ---
 
@@ -1162,7 +1168,7 @@ The roadmap evolves CloudBlocks from:
 
 → AI-Assisted Architecture (Milestone 14) ✅
 
-→ Product Structure (Milestone 17)
+→ Product Structure (Milestone 17) ✅
 
 → DevOps UX (Milestone 18)
 
@@ -1180,7 +1186,7 @@ Milestone 8 (Complete) ✅
     │               └── Milestone 13 (Terraform Pipeline) ✅
     │                       └── Milestone 15 (v2.0 Spec) ✅
     │                               └── Milestone 16 (Doc Architecture) ✅
-    │                                       └── Milestone 17 (Product Structure)
+    │                                       └── Milestone 17 (Product Structure) ✅
     │                                               └── Milestone 18 (DevOps UX)
     │                                                       └── Milestone 19 (MVP Polish & Launch)
     │               └── Milestone 14 (AI Roadmap) ✅ ←── also benefits from Milestone 13

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Architecture compiler that converts visual infrastructure designs into Terraform, Bicep, and Pulumi code",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- Version bump to v0.17.0
- CHANGELOG.md updated with M17 release notes
- ROADMAP.md exit criteria checked, heading marked ✅, summary chain updated
- README.md roadmap table updated

## Milestone 17 — Product Structure
All 30 implementation issues closed. 4 Epics closed. 1697 tests passing, branch coverage 90.12%.

Key achievements:
- SVG-only rendering model confirmed (ADR-0010)
- `@cloudblocks/schema` and `@cloudblocks/domain` extracted with real consumers
- Backend role redefined and documented
- 30 bug fixes across domain model, workspace persistence, dialogs, and code generation
- Version alignment policy enforced across all packages