### PR TITLE
fix(web): resolve 16 M18 DevOps UX bugs across diff engine, GitHub widgets, and store helpers

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -477,6 +477,7 @@ describe('BlockSprite', () => {
       },
       connections: { added: [], removed: [], modified: [] },
       externalActors: { added: [], removed: [], modified: [] },
+      rootChanges: [],
       summary: { totalChanges: 1, hasBreakingChanges: false },
     });
 

--- a/apps/web/src/entities/plate/PlateSprite.test.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.test.tsx
@@ -355,6 +355,7 @@ describe('PlateSprite', () => {
       blocks: { added: [], removed: [], modified: [] },
       connections: { added: [], removed: [], modified: [] },
       externalActors: { added: [], removed: [], modified: [] },
+      rootChanges: [],
       summary: { totalChanges: 1, hasBreakingChanges: false },
     });
 

--- a/apps/web/src/entities/store/slices/helpers.ts
+++ b/apps/web/src/entities/store/slices/helpers.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../shared/utils/history';
 import { generateId } from '../../../shared/utils/id';
 import { useWorkerStore } from '../workerStore';
+import { useUIStore } from '../uiStore';
 import type { ArchitectureState } from './types';
 
 const DEFAULT_WORKSPACE_NAME = 'My Architecture';
@@ -120,6 +121,7 @@ export function resetTransientState(): Pick<
   'validationResult' | 'history' | 'canUndo' | 'canRedo'
 > {
   useWorkerStore.getState().resetWorker();
+  useUIStore.getState().setDiffMode(false);
   return {
     validationResult: null,
     history: resetHistory(),

--- a/apps/web/src/entities/store/uiStore.test.ts
+++ b/apps/web/src/entities/store/uiStore.test.ts
@@ -709,6 +709,7 @@ describe('useUIStore', () => {
         blocks: { added: [], removed: [], modified: [] },
         connections: { added: [], removed: [], modified: [] },
         externalActors: { added: [], removed: [], modified: [] },
+        rootChanges: [],
         summary: { totalChanges: 0, hasBreakingChanges: false },
       };
       const mockBase = {
@@ -736,6 +737,7 @@ describe('useUIStore', () => {
         blocks: { added: [], removed: [], modified: [] },
         connections: { added: [], removed: [], modified: [] },
         externalActors: { added: [], removed: [], modified: [] },
+        rootChanges: [],
         summary: { totalChanges: 0, hasBreakingChanges: false },
       };
       useUIStore.getState().setDiffMode(true, mockDelta, null);

--- a/apps/web/src/features/diff/engine.test.ts
+++ b/apps/web/src/features/diff/engine.test.ts
@@ -108,6 +108,7 @@ describe('computeArchitectureDiff', () => {
     expect(delta.blocks).toEqual({ added: [], removed: [], modified: [] });
     expect(delta.connections).toEqual({ added: [], removed: [], modified: [] });
     expect(delta.externalActors).toEqual({ added: [], removed: [], modified: [] });
+    expect(delta.rootChanges).toEqual([]);
     expect(delta.summary).toEqual({ totalChanges: 0, hasBreakingChanges: false });
   });
 
@@ -138,7 +139,8 @@ describe('computeArchitectureDiff', () => {
     expect(delta.blocks.removed).toHaveLength(0);
     expect(delta.connections.removed).toHaveLength(0);
     expect(delta.externalActors.removed).toHaveLength(0);
-    expect(delta.summary).toEqual({ totalChanges: 6, hasBreakingChanges: false });
+    expect(delta.rootChanges).toHaveLength(2);
+    expect(delta.summary).toEqual({ totalChanges: 8, hasBreakingChanges: false });
   });
 
   it('marks all entities as removed when head is empty', () => {
@@ -155,7 +157,8 @@ describe('computeArchitectureDiff', () => {
     expect(delta.blocks.added).toHaveLength(0);
     expect(delta.connections.added).toHaveLength(0);
     expect(delta.externalActors.added).toHaveLength(0);
-    expect(delta.summary).toEqual({ totalChanges: 6, hasBreakingChanges: true });
+    expect(delta.rootChanges).toHaveLength(2);
+    expect(delta.summary).toEqual({ totalChanges: 8, hasBreakingChanges: true });
   });
 
   it('detects added entities across all entity types', () => {
@@ -418,7 +421,7 @@ describe('computeArchitectureDiff', () => {
 
     const delta = computeArchitectureDiff(base, head);
 
-    expect(delta.summary).toEqual({ totalChanges: 4, hasBreakingChanges: false });
+    expect(delta.summary).toEqual({ totalChanges: 4, hasBreakingChanges: true });
   });
 
   it('flags breaking changes when blocks are removed', () => {
@@ -620,6 +623,86 @@ describe('computeArchitectureDiff', () => {
     expect(paths).toContain('metadata.nested.region');
     expect(paths).not.toContain('metadata.optional');
     expect(paths).not.toContain('metadata.nested.keep');
+  });
+  it('tracks root-level metadata changes in rootChanges', () => {
+    const base = createBaseArchitecture();
+    const head: ArchitectureModel = {
+      ...base,
+      id: 'arch-2',
+      name: 'Renamed Architecture',
+    };
+
+    const delta = computeArchitectureDiff(base, head);
+
+    expect(delta.rootChanges).toHaveLength(2);
+    expect(delta.rootChanges.find((c) => c.path === 'id')).toEqual({
+      path: 'id',
+      oldValue: 'arch-1',
+      newValue: 'arch-2',
+    });
+    expect(delta.rootChanges.find((c) => c.path === 'name')).toEqual({
+      path: 'name',
+      oldValue: 'Test Architecture',
+      newValue: 'Renamed Architecture',
+    });
+    expect(delta.summary.totalChanges).toBe(2);
+  });
+
+  it('includes rootChanges count in summary totalChanges', () => {
+    const base = createBaseArchitecture();
+    const head: ArchitectureModel = {
+      ...base,
+      name: 'Updated Name',
+      blocks: [
+        ...base.blocks,
+        {
+          id: 'block-3',
+          name: 'New Block',
+          category: 'storage',
+          placementId: 'plate-2',
+          position: { x: 3, y: 0, z: 1 },
+          metadata: {},
+        },
+      ],
+    };
+
+    const delta = computeArchitectureDiff(base, head);
+
+    expect(delta.rootChanges).toHaveLength(1);
+    expect(delta.blocks.added).toHaveLength(1);
+    expect(delta.summary.totalChanges).toBe(2);
+  });
+
+  it('flags breaking changes when plates are removed', () => {
+    const base = createBaseArchitecture();
+    const head: ArchitectureModel = {
+      ...base,
+      plates: base.plates.filter((plate) => plate.id !== 'plate-2'),
+    };
+
+    const delta = computeArchitectureDiff(base, head);
+
+    expect(delta.summary.hasBreakingChanges).toBe(true);
+  });
+
+  it('does not include entity paths or volatile paths in rootChanges', () => {
+    const base = createBaseArchitecture();
+    const head: ArchitectureModel = {
+      ...base,
+      version: '2.0',
+      createdAt: '2026-12-31T00:00:00Z',
+      updatedAt: '2026-12-31T00:00:00Z',
+    };
+
+    const delta = computeArchitectureDiff(base, head);
+
+    expect(delta.rootChanges).toHaveLength(1);
+    expect(delta.rootChanges[0]?.path).toBe('version');
+    const rootPaths = delta.rootChanges.map((c) => c.path);
+    expect(rootPaths).not.toContain('createdAt');
+    expect(rootPaths).not.toContain('updatedAt');
+    expect(rootPaths).not.toContain('plates');
+    expect(rootPaths).not.toContain('blocks');
   });
 });
 

--- a/apps/web/src/features/diff/engine.ts
+++ b/apps/web/src/features/diff/engine.ts
@@ -2,6 +2,7 @@ import type { ArchitectureModel, Block, Connection, ExternalActor, Plate } from 
 import type { DiffDelta, DiffState, EntityDiff, PropertyChange } from '../../shared/types/diff';
 
 const ROOT_VOLATILE_PATHS = new Set(['createdAt', 'updatedAt']);
+const ROOT_ENTITY_PATHS = new Set(['plates', 'blocks', 'connections', 'externalActors', 'createdAt', 'updatedAt']);
 const NO_IGNORED_ROOT_PATHS = new Set<string>();
 
 type DiffableEntity = Plate | Block | Connection | ExternalActor;
@@ -120,11 +121,15 @@ function computeSummary(delta: Omit<DiffDelta, 'summary'>): DiffDelta['summary']
     delta.connections.modified.length +
     delta.externalActors.added.length +
     delta.externalActors.removed.length +
-    delta.externalActors.modified.length;
+    delta.externalActors.modified.length +
+    delta.rootChanges.length;
 
   return {
     totalChanges,
-    hasBreakingChanges: delta.blocks.removed.length > 0 || delta.connections.removed.length > 0,
+    hasBreakingChanges:
+      delta.plates.removed.length > 0 ||
+      delta.blocks.removed.length > 0 ||
+      delta.connections.removed.length > 0,
   };
 }
 
@@ -178,6 +183,7 @@ export function computeArchitectureDiff(base: ArchitectureModel, head: Architect
       blocks: createEmptyEntityDiff<Block>(),
       connections: createEmptyEntityDiff<Connection>(),
       externalActors: createEmptyEntityDiff<ExternalActor>(),
+      rootChanges: [],
       summary: {
         totalChanges: 0,
         hasBreakingChanges: false,
@@ -185,11 +191,18 @@ export function computeArchitectureDiff(base: ArchitectureModel, head: Architect
     };
   }
 
+  const rootChanges = diffValues(normalizedBase, normalizedHead, '', ROOT_VOLATILE_PATHS)
+    .filter((change) => {
+      const rootKey = change.path.split('.')[0];
+      return !ROOT_ENTITY_PATHS.has(rootKey);
+    });
+
   const deltaWithoutSummary = {
     plates: compareEntityCollections(normalizedBase.plates, normalizedHead.plates),
     blocks: compareEntityCollections(normalizedBase.blocks, normalizedHead.blocks),
     connections: compareEntityCollections(normalizedBase.connections, normalizedHead.connections),
     externalActors: compareEntityCollections(normalizedBase.externalActors, normalizedHead.externalActors),
+    rootChanges,
   };
 
   return {

--- a/apps/web/src/shared/types/diff.ts
+++ b/apps/web/src/shared/types/diff.ts
@@ -21,6 +21,7 @@ export interface DiffDelta {
   blocks: EntityDiff<Block>;
   connections: EntityDiff<Connection>;
   externalActors: EntityDiff<ExternalActor>;
+  rootChanges: PropertyChange[];
   summary: {
     totalChanges: number;
     hasBreakingChanges: boolean;

--- a/apps/web/src/widgets/diff-panel/DiffPanel.test.tsx
+++ b/apps/web/src/widgets/diff-panel/DiffPanel.test.tsx
@@ -161,6 +161,7 @@ function makeDiffDelta(): DiffDelta {
         },
       ],
     },
+    rootChanges: [],
     summary: {
       totalChanges: 12,
       hasBreakingChanges: true,

--- a/apps/web/src/widgets/diff-panel/DiffPanel.tsx
+++ b/apps/web/src/widgets/diff-panel/DiffPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { useUIStore } from '../../entities/store/uiStore';
 import type { DiffDelta } from '../../shared/types/diff';
 import './DiffPanel.css';
@@ -44,46 +44,20 @@ function getEntityLabel(entity: { id: string }): string {
 export function DiffPanel() {
   const diffMode = useUIStore((s) => s.diffMode);
   const diffDelta = useUIStore((s) => s.diffDelta);
-  const [collapsedSections, setCollapsedSections] = useState<Record<SectionKey, boolean>>({
-    plates: false,
-    blocks: false,
-    connections: false,
-    externalActors: false,
-  });
-  const [expandedModified, setExpandedModified] = useState<Record<string, boolean>>({});
+  const [trackedDelta, setTrackedDelta] = useState(diffDelta);
+  const [trackedMode, setTrackedMode] = useState(diffMode);
+  const [generation, setGeneration] = useState(0);
 
-  const summaryCounts = useMemo(() => {
-    if (!diffDelta) return { added: 0, modified: 0, removed: 0 };
-
-    const entities: Array<DiffDelta[SectionKey]> = [
-      diffDelta.plates,
-      diffDelta.blocks,
-      diffDelta.connections,
-      diffDelta.externalActors,
-    ];
-
-    return entities.reduce(
-      (acc, section) => ({
-        added: acc.added + section.added.length,
-        modified: acc.modified + section.modified.length,
-        removed: acc.removed + section.removed.length,
-      }),
-      { added: 0, modified: 0, removed: 0 },
-    );
-  }, [diffDelta]);
+  if (trackedDelta !== diffDelta || trackedMode !== diffMode) {
+    setTrackedDelta(diffDelta);
+    setTrackedMode(diffMode);
+    setGeneration((g) => g + 1);
+  }
 
   if (!diffMode) return null;
 
   const handleClose = () => {
     useUIStore.getState().setDiffMode(false);
-  };
-
-  const toggleSection = (key: SectionKey) => {
-    setCollapsedSections((prev) => ({ ...prev, [key]: !prev[key] }));
-  };
-
-  const toggleModifiedDetails = (key: string) => {
-    setExpandedModified((prev) => ({ ...prev, [key]: !prev[key] }));
   };
 
   if (!diffDelta) {
@@ -100,11 +74,46 @@ export function DiffPanel() {
     );
   }
 
+  return <DiffPanelContent key={generation} diffDelta={diffDelta} onClose={handleClose} />;
+}
+
+function DiffPanelContent({ diffDelta, onClose }: { diffDelta: DiffDelta; onClose: () => void }) {
+  const [collapsedSections, setCollapsedSections] = useState<Record<SectionKey, boolean>>({
+    plates: false,
+    blocks: false,
+    connections: false,
+    externalActors: false,
+  });
+  const [expandedModified, setExpandedModified] = useState<Record<string, boolean>>({});
+
+  const toggleSection = (key: SectionKey) => {
+    setCollapsedSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const toggleModifiedDetails = (key: string) => {
+    setExpandedModified((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const entities: Array<DiffDelta[SectionKey]> = [
+    diffDelta.plates,
+    diffDelta.blocks,
+    diffDelta.connections,
+    diffDelta.externalActors,
+  ];
+  const summaryCounts = entities.reduce(
+    (acc, section) => ({
+      added: acc.added + section.added.length,
+      modified: acc.modified + section.modified.length,
+      removed: acc.removed + section.removed.length,
+    }),
+    { added: 0, modified: 0, removed: 0 },
+  );
+
   return (
     <div className="diff-panel">
       <div className="diff-panel-header">
         <h3 className="diff-panel-title">🔍 Architecture Diff</h3>
-        <button type="button" className="diff-panel-close" onClick={handleClose} aria-label="Close architecture diff panel">
+        <button type="button" className="diff-panel-close" onClick={onClose} aria-label="Close architecture diff panel">
           ✕
         </button>
       </div>
@@ -123,6 +132,23 @@ export function DiffPanel() {
         <div className="diff-no-changes">No changes</div>
       ) : (
         <div className="diff-sections">
+          {diffDelta.rootChanges.length > 0 && (
+            <section className="diff-entity-section">
+              <div className="diff-entity-header diff-entity-header-static">
+                <span>Metadata</span>
+                <span>{diffDelta.rootChanges.length}</span>
+              </div>
+              <div className="diff-entity-items">
+                {diffDelta.rootChanges.map((change) => (
+                  <div key={change.path} className="diff-property-change-row">
+                    <span className="diff-property-path">{change.path}</span>
+                    <span className="diff-property-arrow">: {formatValue(change.oldValue)} -&gt; {formatValue(change.newValue)}</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
           {SECTION_CONFIG.map(({ key, label }) => {
             const section = diffDelta[key];
             const sectionTotal = section.added.length + section.modified.length + section.removed.length;

--- a/apps/web/src/widgets/github-pr/GitHubPR.css
+++ b/apps/web/src/widgets/github-pr/GitHubPR.css
@@ -123,6 +123,30 @@
   text-decoration: underline;
 }
 
+.github-pr-result {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  background: rgba(76, 175, 80, 0.12);
+  border: 1px solid rgba(76, 175, 80, 0.35);
+  border-radius: 4px;
+}
+
+.github-pr-result-info {
+  font-size: 12px;
+  color: #a5d6a7;
+  font-weight: 500;
+}
+
+.github-pr-result-info code {
+  font-family: 'Consolas', 'Monaco', monospace;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
 .github-pr-empty {
   padding: 10px;
   text-align: center;

--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -101,6 +101,8 @@ describe('GitHubPR', () => {
     });
 
     expect(await screen.findByText('https://github.com/owner/repo/pull/42')).toBeInTheDocument();
+    expect(screen.getByText(/PR #42/)).toBeInTheDocument();
+    expect(screen.getByText('cloudblocks/update')).toBeInTheDocument();
   });
 
   it('shows error when PR creation fails', async () => {
@@ -153,6 +155,17 @@ describe('GitHubPR', () => {
     expect(submitButton).toBeDisabled();
 
     await user.type(titleField, '   ');
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('disables submit button when commit message is empty', async () => {
+    const user = userEvent.setup();
+    render(<GitHubPR />);
+
+    const commitField = screen.getByLabelText('Commit message');
+    const submitButton = screen.getByRole('button', { name: 'Create Pull Request' });
+
+    await user.clear(commitField);
     expect(submitButton).toBeDisabled();
   });
 

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -26,7 +26,7 @@ export function GitHubPR() {
   const cleanedTitle = title.trim();
   const cleanedBranch = branch.trim();
   const branchIsValid = !cleanedBranch || isValidGitBranchName(cleanedBranch);
-  const canSubmit = !loading && cleanedTitle.length > 0 && branchIsValid && hasBackendWorkspaceLink;
+  const canSubmit = !loading && cleanedTitle.length > 0 && commitMessage.trim().length > 0 && branchIsValid && hasBackendWorkspaceLink;
 
   if (!show) return null;
 
@@ -71,7 +71,7 @@ export function GitHubPR() {
     <div className="github-pr">
       <div className="github-pr-header">
         <h3 className="github-pr-title">🔀 Pull Request</h3>
-        <button className="github-pr-close" onClick={toggleGitHubPR} aria-label="Close pull request panel">
+        <button type="button" className="github-pr-close" onClick={toggleGitHubPR} aria-label="Close pull request panel">
           ✕
         </button>
       </div>
@@ -130,14 +130,19 @@ export function GitHubPR() {
             onChange={(e) => setCommitMessage(e.target.value)}
           />
 
-          <button className="github-pr-submit" onClick={handleSubmit} disabled={!canSubmit}>
+          <button type="button" className="github-pr-submit" onClick={handleSubmit} disabled={!canSubmit}>
             Create Pull Request
           </button>
 
           {result && (
-            <a className="github-pr-result-link" href={result.pull_request_url} target="_blank" rel="noreferrer">
-              {result.pull_request_url}
-            </a>
+            <div className="github-pr-result">
+              <div className="github-pr-result-info">
+                PR #{result.number} · Branch: <code>{result.branch}</code>
+              </div>
+              <a className="github-pr-result-link" href={result.pull_request_url} target="_blank" rel="noreferrer">
+                {result.pull_request_url}
+              </a>
+            </div>
           )}
         </div>
       )}

--- a/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
@@ -87,6 +87,7 @@ describe('GitHubRepos', () => {
 
     expect(mockApiPost).toHaveBeenCalledWith('/api/v1/github/repos', {
       name: 'new-repo',
+      description: undefined,
       private: true,
     });
 
@@ -95,6 +96,32 @@ describe('GitHubRepos', () => {
     });
 
     expect(await screen.findByText('new-repo')).toBeInTheDocument();
+  });
+
+  it('sends description when provided', async () => {
+    const user = userEvent.setup();
+    mockApiGet
+      .mockResolvedValueOnce({ repos: [] })
+      .mockResolvedValueOnce({ repos: [] });
+    mockApiPost.mockResolvedValueOnce({
+      full_name: 'owner/described-repo',
+      name: 'described-repo',
+      private: false,
+      default_branch: 'main',
+      html_url: 'https://github.com/owner/described-repo',
+    });
+
+    render(<GitHubRepos />);
+
+    await user.type(screen.getByPlaceholderText('Repository name'), 'described-repo');
+    await user.type(screen.getByPlaceholderText('Description (optional)'), 'A test repo');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(mockApiPost).toHaveBeenCalledWith('/api/v1/github/repos', {
+      name: 'described-repo',
+      description: 'A test repo',
+      private: true,
+    });
   });
 
   it('shows error when fetch repos fails', async () => {

--- a/apps/web/src/widgets/github-repos/GitHubRepos.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { apiGet, apiPost } from '../../shared/api/client';
@@ -17,11 +17,12 @@ export function GitHubRepos() {
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [newRepoName, setNewRepoName] = useState('');
+  const [newRepoDescription, setNewRepoDescription] = useState('');
   const [isPrivate, setIsPrivate] = useState(true);
   const cleanedRepoName = newRepoName.trim();
   const canCreateRepo = isValidGitHubRepoName(cleanedRepoName);
 
-  const fetchRepos = async () => {
+  const fetchRepos = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -32,12 +33,12 @@ export function GitHubRepos() {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (!show || !isAuthenticated) return;
     void fetchRepos();
-  }, [show, isAuthenticated]);
+  }, [show, isAuthenticated, fetchRepos]);
 
   if (!show) return null;
 
@@ -52,9 +53,11 @@ export function GitHubRepos() {
     try {
       await apiPost<GitHubRepo>('/api/v1/github/repos', {
         name: cleanedRepoName,
+        description: newRepoDescription.trim() || undefined,
         private: isPrivate,
       });
       setNewRepoName('');
+      setNewRepoDescription('');
       setIsPrivate(false);
       await fetchRepos();
     } catch (err) {
@@ -68,7 +71,7 @@ export function GitHubRepos() {
     <div className="github-repos">
       <div className="github-repos-header">
         <h3 className="github-repos-title">📦 GitHub Repos</h3>
-        <button className="github-repos-close" onClick={toggleGitHubRepos} aria-label="Close GitHub repos panel">
+        <button type="button" className="github-repos-close" onClick={toggleGitHubRepos} aria-label="Close GitHub repos panel">
           ✕
         </button>
       </div>
@@ -91,6 +94,13 @@ export function GitHubRepos() {
               value={newRepoName}
               onChange={(e) => setNewRepoName(e.target.value)}
             />
+            <input
+              className="github-repos-input"
+              type="text"
+              placeholder="Description (optional)"
+              value={newRepoDescription}
+              onChange={(e) => setNewRepoDescription(e.target.value)}
+            />
             <label className="github-repos-checkbox-row">
               <input
                 className="github-repos-checkbox"
@@ -100,7 +110,7 @@ export function GitHubRepos() {
               />
               <span>Private repository</span>
             </label>
-            <button className="github-repos-create-btn" onClick={handleCreateRepo} disabled={creating || !canCreateRepo}>
+            <button type="button" className="github-repos-create-btn" onClick={handleCreateRepo} disabled={creating || !canCreateRepo}>
               Create
             </button>
           </div>

--- a/apps/web/src/widgets/github-sync/GitHubSync.css
+++ b/apps/web/src/widgets/github-sync/GitHubSync.css
@@ -182,3 +182,55 @@
   border: 1px dashed #333366;
   border-radius: 4px;
 }
+
+.github-sync-warning {
+  padding: 8px;
+  font-size: 12px;
+  color: #ffb74d;
+  background: rgba(255, 152, 0, 0.12);
+  border: 1px solid rgba(255, 152, 0, 0.35);
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.github-sync-unlink-btn {
+  background: none;
+  border: none;
+  color: #ef5350;
+  cursor: pointer;
+  font-size: 11px;
+  margin-left: 8px;
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.github-sync-unlink-btn:hover {
+  background: rgba(244, 67, 54, 0.16);
+}
+
+.github-sync-confirm {
+  padding: 8px;
+  background: rgba(255, 152, 0, 0.08);
+  border: 1px solid rgba(255, 152, 0, 0.35);
+  border-radius: 4px;
+}
+
+.github-sync-confirm-message {
+  font-size: 12px;
+  color: #ffb74d;
+  margin-bottom: 8px;
+}
+
+.github-sync-confirm-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.github-sync-commit-link {
+  color: #4285f4;
+  text-decoration: none;
+}
+
+.github-sync-commit-link:hover {
+  text-decoration: underline;
+}

--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -153,6 +153,7 @@ describe('GitHubSync', () => {
     await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
     await user.click(screen.getByRole('button', { name: 'Link' }));
     await user.click(await screen.findByRole('button', { name: 'Pull from GitHub' }));
+    await user.click(await screen.findByRole('button', { name: 'Confirm Pull' }));
 
     await waitFor(() => {
       expect(mockApiPost).toHaveBeenCalledWith('/api/v1/workspaces/ws-1/pull');
@@ -182,6 +183,7 @@ describe('GitHubSync', () => {
     await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
     await user.click(screen.getByRole('button', { name: 'Link' }));
     await user.click(await screen.findByRole('button', { name: 'Pull from GitHub' }));
+    await user.click(await screen.findByRole('button', { name: 'Confirm Pull' }));
 
     expect(await screen.findByText('Network down')).toBeInTheDocument();
   });
@@ -201,9 +203,9 @@ describe('GitHubSync', () => {
     mockApiPost.mockResolvedValue({ message: 'ok', commit_sha: 'abc' });
     await user.click(await screen.findByRole('button', { name: 'Sync to GitHub' }));
 
-    // The sync succeeds but loadCommits after sync fails
+    // The sync succeeds but loadCommits after sync fails — shown in commit refresh error
     await waitFor(() => {
-      expect(screen.getByText('Commit fetch failed')).toBeInTheDocument();
+      expect(screen.getByText(/Commit list refresh failed/)).toBeInTheDocument();
     });
   });
 
@@ -283,6 +285,7 @@ describe('GitHubSync', () => {
     await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
     await user.click(screen.getByRole('button', { name: 'Link' }));
     await user.click(await screen.findByRole('button', { name: 'Pull from GitHub' }));
+    await user.click(await screen.findByRole('button', { name: 'Confirm Pull' }));
 
     expect(await screen.findByText('Failed to pull from GitHub.')).toBeInTheDocument();
   });

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -15,6 +15,7 @@ export function GitHubSync() {
 
   const workspace = useArchitectureStore((s) => s.workspace);
   const replaceArchitecture = useArchitectureStore((s) => s.replaceArchitecture);
+  const saveToStorage = useArchitectureStore((s) => s.saveToStorage);
   const setStoreBackendWorkspaceId = useArchitectureStore((s) => s.setBackendWorkspaceId);
   const setStoreGithubRepo = useArchitectureStore((s) => s.setGithubRepo);
 
@@ -28,8 +29,13 @@ export function GitHubSync() {
   const [backendWorkspaceIdInput, setBackendWorkspaceIdInput] = useState('');
   const [commitMessage, setCommitMessage] = useState('Sync architecture from CloudBlocks');
   const [commits, setCommits] = useState<GitHubCommit[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [linkLoading, setLinkLoading] = useState(false);
+  const [syncLoading, setSyncLoading] = useState(false);
+  const [pullLoading, setPullLoading] = useState(false);
+  const [commitsLoading, setCommitsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [commitRefreshError, setCommitRefreshError] = useState<string | null>(null);
+  const [pullConfirmPending, setPullConfirmPending] = useState(false);
   const requestSeqRef = useRef(0);
   const mountedRef = useRef(true);
   const showRef = useRef(show);
@@ -44,6 +50,8 @@ export function GitHubSync() {
   }, []);
 
   const effectiveWorkspaceId = backendWorkspaceId;
+  const anyLoading = linkLoading || syncLoading || pullLoading || commitsLoading;
+  const canSync = !anyLoading && commitMessage.trim().length > 0;
 
   showRef.current = show;
   authRef.current = isAuthenticated;
@@ -69,8 +77,8 @@ export function GitHubSync() {
       && effectiveWorkspaceIdRef.current === requestBackendWorkspaceId
     );
 
-    setLoading(true);
-    setError(null);
+    setCommitsLoading(true);
+    setCommitRefreshError(null);
     try {
       const response = await apiGet<{ commits: GitHubCommit[] }>(
         `/api/v1/workspaces/${encodeURIComponent(effectiveWorkspaceId)}/commits`
@@ -79,10 +87,10 @@ export function GitHubSync() {
       setCommits(response.commits);
     } catch (err) {
       if (!canApply()) return;
-      setError(err instanceof Error ? err.message : 'Failed to load commits.');
+      setCommitRefreshError(err instanceof Error ? err.message : 'Failed to load commits.');
     } finally {
       if (canApply()) {
-        setLoading(false);
+        setCommitsLoading(false);
       }
     }
   }, [effectiveWorkspaceId, linkedRepo, workspace.id]);
@@ -106,7 +114,7 @@ export function GitHubSync() {
 
     const bwsId = backendWorkspaceIdInput.trim() || workspace.id;
 
-    setLoading(true);
+    setLinkLoading(true);
     setError(null);
 
     try {
@@ -119,45 +127,74 @@ export function GitHubSync() {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to link repository.');
     } finally {
-      setLoading(false);
+      setLinkLoading(false);
     }
   };
 
-  const handleSync = async () => {
-    if (!effectiveWorkspaceId) return;
+  const handleUnlink = () => {
+    setStoreGithubRepo(workspace.id, undefined as unknown as string);
+    setCommits([]);
+    setError(null);
+    setCommitRefreshError(null);
+  };
 
-    setLoading(true);
+  const handleSync = async () => {
+    if (!effectiveWorkspaceId || !canSync) return;
+
+    setSyncLoading(true);
     setError(null);
     try {
       await apiPost<SyncResponse>(`/api/v1/workspaces/${encodeURIComponent(effectiveWorkspaceId)}/sync`, {
         architecture: workspace.architecture,
         commit_message: commitMessage,
       });
-      await loadCommits();
+      try {
+        await loadCommits();
+      } catch {
+        // commit refresh failure is non-critical
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to sync workspace.');
     } finally {
-      setLoading(false);
+      setSyncLoading(false);
     }
   };
 
-  const handlePull = async () => {
+  const handlePullRequest = () => {
+    setPullConfirmPending(true);
+  };
+
+  const handlePullConfirm = async () => {
+    setPullConfirmPending(false);
     if (!effectiveWorkspaceId) return;
 
-    setLoading(true);
+    setPullLoading(true);
     setError(null);
     try {
       const response = await apiPost<PullResponse>(
         `/api/v1/workspaces/${encodeURIComponent(effectiveWorkspaceId)}/pull`
       );
       replaceArchitecture(response.architecture as ArchitectureSnapshot);
-      await loadCommits();
+      saveToStorage();
+      try {
+        await loadCommits();
+      } catch {
+        // commit refresh failure is non-critical
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to pull from GitHub.');
     } finally {
-      setLoading(false);
+      setPullLoading(false);
     }
   };
+
+  const handlePullCancel = () => {
+    setPullConfirmPending(false);
+  };
+
+  const commitLinkUrl = linkedRepo
+    ? `https://github.com/${linkedRepo}/commit/`
+    : null;
 
   return (
     <div className="github-sync">
@@ -174,8 +211,11 @@ export function GitHubSync() {
         <div className="github-sync-empty">GitHub authentication required.</div>
       ) : (
         <>
-          {loading && <div className="github-sync-loading">Loading...</div>}
+          {anyLoading && <div className="github-sync-loading">Loading...</div>}
           {error && <div className="github-sync-error">{error}</div>}
+          {commitRefreshError && (
+            <div className="github-sync-warning">Commit list refresh failed: {commitRefreshError}</div>
+          )}
 
           {!linkedRepo ? (
             <div className="github-sync-linker">
@@ -206,7 +246,7 @@ export function GitHubSync() {
                 onChange={(e) => setBackendWorkspaceIdInput(e.target.value)}
               />
 
-              <button type="button" className="github-sync-primary-btn" onClick={() => void handleLinkRepo()} disabled={loading}>
+              <button type="button" className="github-sync-primary-btn" onClick={() => void handleLinkRepo()} disabled={linkLoading}>
                 Link
               </button>
             </div>
@@ -214,6 +254,9 @@ export function GitHubSync() {
             <div className="github-sync-content">
               <div className="github-sync-meta">
                 Linked repo: <strong>{linkedRepo}</strong>
+                <button type="button" className="github-sync-unlink-btn" onClick={handleUnlink}>
+                  Unlink
+                </button>
               </div>
 
               <label className="github-sync-label" htmlFor="github-sync-commit-message">
@@ -227,13 +270,29 @@ export function GitHubSync() {
               />
 
               <div className="github-sync-actions">
-                <button type="button" className="github-sync-primary-btn" onClick={handleSync} disabled={loading}>
+                <button type="button" className="github-sync-primary-btn" onClick={handleSync} disabled={!canSync}>
                   Sync to GitHub
                 </button>
-                <button type="button" className="github-sync-secondary-btn" onClick={handlePull} disabled={loading}>
+                <button type="button" className="github-sync-secondary-btn" onClick={handlePullRequest} disabled={anyLoading}>
                   Pull from GitHub
                 </button>
               </div>
+
+              {pullConfirmPending && (
+                <div className="github-sync-confirm">
+                  <div className="github-sync-confirm-message">
+                    Pull will overwrite your local workspace. Continue?
+                  </div>
+                  <div className="github-sync-confirm-actions">
+                    <button type="button" className="github-sync-primary-btn" onClick={() => void handlePullConfirm()}>
+                      Confirm Pull
+                    </button>
+                    <button type="button" className="github-sync-secondary-btn" onClick={handlePullCancel}>
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
 
               <div className="github-sync-commits">
                 <h4 className="github-sync-subtitle">Recent commits</h4>
@@ -244,7 +303,19 @@ export function GitHubSync() {
                     <div key={commit.sha} className="github-sync-commit-item">
                       <div className="github-sync-commit-message">{commit.message}</div>
                       <div className="github-sync-commit-meta">
-                        {commit.author} · {new Date(commit.date).toLocaleString()} · {commit.sha.slice(0, 7)}
+                        {commit.author} · {new Date(commit.date).toLocaleString()} ·{' '}
+                        {commitLinkUrl ? (
+                          <a
+                            className="github-sync-commit-link"
+                            href={`${commitLinkUrl}${commit.sha}`}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            {commit.sha.slice(0, 7)}
+                          </a>
+                        ) : (
+                          commit.sha.slice(0, 7)
+                        )}
                       </div>
                     </div>
                   ))

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -619,6 +619,7 @@ describe('MenuBar', () => {
       blocks: { added: [], removed: [], modified: [] },
       connections: { added: [], removed: [], modified: [] },
       externalActors: { added: [], removed: [], modified: [] },
+      rootChanges: [],
       summary: { totalChanges: 0, hasBreakingChanges: false },
     }, emptyArch);
 


### PR DESCRIPTION
## Summary

Fixes 16 bugs in Milestone 18 — DevOps UX, spanning the diff engine, DiffPanel, GitHub integration widgets, and store helpers.

### Diff Engine & Panel
- **#716**: Extract `rootChanges` for architecture metadata diffs (name, version, id)
- **#718**: Include `rootChanges.length` in `totalChanges` computation
- **#725**: Include `plates.removed` in `hasBreakingChanges` detection
- **#712, #742**: Reset DiffPanel collapsed/expanded state when diff data changes (React 19 Compiler-compliant generation-keyed child component pattern)

### Store Helpers
- **#706**: Reset `diffMode` in `resetTransientState()` via `useUIStore.getState().setDiffMode(false)`

### GitHubSync
- **#708**: Per-action loading states (`linkLoading`, `syncLoading`, `pullLoading`, `commitsLoading`) instead of single `loading` boolean
- **#709**: Pull confirmation dialog before overwriting local architecture
- **#711**: Separate `commitRefreshError` from main `error` state
- **#713**: Unlink repository button
- **#714**: Commit SHA links to GitHub
- **#717**: `canSync` requires non-empty commit message
- **#738**: Persist architecture to localStorage after `replaceArchitecture()` in pull handler

### GitHubPR
- **#710**: Disable submit when commit message is empty
- **#739**: Show PR number and branch name in success result

### GitHubRepos
- **#707**: Add repository description input field

### Test Updates
- Updated 8 test files to include `rootChanges: []` in all DiffDelta mock objects
- Added new tests for root-level metadata changes, breaking change detection, PR result display, description input, and empty message validation
- All 1703 tests passing, build and lint clean

Fixes #706, #707, #708, #709, #710, #711, #712, #713, #714, #716, #717, #718, #725, #738, #739, #742