### PR TITLE
fix(web): add contextual info to GitHub widgets (#877, #878, #879, #880, #881, #882)

### DIFF
--- a/apps/web/src/widgets/diff-panel/DiffPanel.css
+++ b/apps/web/src/widgets/diff-panel/DiffPanel.css
@@ -185,3 +185,19 @@
   border: 1px dashed #333366;
   border-radius: 4px;
 }
+
+.diff-panel-context {
+  font-size: 12px;
+  color: #9aa4d1;
+  margin-bottom: 6px;
+}
+
+.diff-panel-remote-summary {
+  font-size: 11px;
+  color: #8e95b8;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid #333366;
+  border-radius: 4px;
+  margin-bottom: 6px;
+}

--- a/apps/web/src/widgets/diff-panel/DiffPanel.test.tsx
+++ b/apps/web/src/widgets/diff-panel/DiffPanel.test.tsx
@@ -3,7 +3,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DiffPanel } from './DiffPanel';
 import { useUIStore } from '../../entities/store/uiStore';
+import { useArchitectureStore } from '../../entities/store/architectureStore';
 import type { DiffDelta } from '../../shared/types/diff';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 
 vi.mock('./DiffPanel.css', () => ({}));
 
@@ -398,5 +400,39 @@ describe('DiffPanel', () => {
     expect(screen.queryByText('+0 added')).not.toBeInTheDocument();
     expect(screen.queryByText('~0 modified')).not.toBeInTheDocument();
     expect(screen.queryByText('-0 removed')).not.toBeInTheDocument();
+  });
+
+  it('shows workspace name context line (#877)', () => {
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        name: 'Production Environment',
+      },
+    });
+    render(<DiffPanel />);
+    expect(screen.getByText('Comparing: Production Environment')).toBeInTheDocument();
+  });
+
+  it('shows remote architecture summary when diffBaseArchitecture is provided (#879)', () => {
+    const remoteArch: ArchitectureModel = {
+      id: 'remote-arch',
+      name: 'Remote',
+      version: '1.0.0',
+      plates: [{ id: 'p1' }, { id: 'p2' }] as ArchitectureModel['plates'],
+      blocks: [{ id: 'b1' }] as ArchitectureModel['blocks'],
+      connections: [{ id: 'c1' }, { id: 'c2' }, { id: 'c3' }] as ArchitectureModel['connections'],
+      externalActors: [{ id: 'a1' }] as ArchitectureModel['externalActors'],
+      createdAt: '',
+      updatedAt: '',
+    };
+    useUIStore.setState({ diffBaseArchitecture: remoteArch });
+    render(<DiffPanel />);
+    expect(screen.getByText('Remote: 2 plates · 1 blocks · 3 connections · 1 actors')).toBeInTheDocument();
+  });
+
+  it('hides remote summary when diffBaseArchitecture is null (#879)', () => {
+    useUIStore.setState({ diffBaseArchitecture: null });
+    render(<DiffPanel />);
+    expect(screen.queryByText(/^Remote:/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/widgets/diff-panel/DiffPanel.tsx
+++ b/apps/web/src/widgets/diff-panel/DiffPanel.tsx
@@ -1,7 +1,18 @@
 import { useState } from 'react';
+import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type { DiffDelta } from '../../shared/types/diff';
 import './DiffPanel.css';
+
+function summarizeArchitecture(arch: ArchitectureModel) {
+  return {
+    plates: arch.plates.length,
+    blocks: arch.blocks.length,
+    connections: arch.connections.length,
+    externalActors: arch.externalActors?.length ?? 0,
+  };
+}
 
 type SectionKey = 'plates' | 'blocks' | 'connections' | 'externalActors';
 
@@ -44,6 +55,8 @@ function getEntityLabel(entity: { id: string }): string {
 export function DiffPanel() {
   const diffMode = useUIStore((s) => s.diffMode);
   const diffDelta = useUIStore((s) => s.diffDelta);
+  const diffBaseArchitecture = useUIStore((s) => s.diffBaseArchitecture);
+  const workspaceName = useArchitectureStore((s) => s.workspace.name);
   const [trackedDelta, setTrackedDelta] = useState(diffDelta);
   const [trackedMode, setTrackedMode] = useState(diffMode);
   const [generation, setGeneration] = useState(0);
@@ -74,10 +87,28 @@ export function DiffPanel() {
     );
   }
 
-  return <DiffPanelContent key={generation} diffDelta={diffDelta} onClose={handleClose} />;
+  return (
+    <DiffPanelContent
+      key={generation}
+      diffDelta={diffDelta}
+      diffBaseArchitecture={diffBaseArchitecture}
+      workspaceName={workspaceName}
+      onClose={handleClose}
+    />
+  );
 }
 
-function DiffPanelContent({ diffDelta, onClose }: { diffDelta: DiffDelta; onClose: () => void }) {
+function DiffPanelContent({
+  diffDelta,
+  diffBaseArchitecture,
+  workspaceName,
+  onClose,
+}: {
+  diffDelta: DiffDelta;
+  diffBaseArchitecture: ArchitectureModel | null;
+  workspaceName: string;
+  onClose: () => void;
+}) {
   const [collapsedSections, setCollapsedSections] = useState<Record<SectionKey, boolean>>({
     plates: false,
     blocks: false,
@@ -117,6 +148,17 @@ function DiffPanelContent({ diffDelta, onClose }: { diffDelta: DiffDelta; onClos
           ✕
         </button>
       </div>
+
+      <div className="diff-panel-context">Comparing: {workspaceName}</div>
+
+      {diffBaseArchitecture && (() => {
+        const s = summarizeArchitecture(diffBaseArchitecture);
+        return (
+          <div className="diff-panel-remote-summary">
+            Remote: {s.plates} plates · {s.blocks} blocks · {s.connections} connections · {s.externalActors} actors
+          </div>
+        );
+      })()}
 
       <div className="diff-summary-bar">
         <span className="diff-badge diff-badge-added">+{summaryCounts.added} added</span>

--- a/apps/web/src/widgets/github-pr/GitHubPR.css
+++ b/apps/web/src/widgets/github-pr/GitHubPR.css
@@ -156,3 +156,52 @@
   border: 1px dashed #333366;
   border-radius: 4px;
 }
+
+.github-pr-arch-summary {
+  font-size: 11px;
+  color: #8e95b8;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid #333366;
+  border-radius: 4px;
+}
+
+.github-pr-baseline {
+  font-size: 11px;
+  color: #9aa4d1;
+  padding: 4px 8px;
+}
+
+.github-pr-baseline code {
+  font-family: 'Consolas', 'Monaco', monospace;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.github-pr-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.github-pr-compare-btn {
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: #ccc;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.github-pr-compare-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.github-pr-compare-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}

--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -9,6 +9,22 @@ vi.mock('../../shared/api/client', () => ({
     return fallback;
   }),
 }));
+vi.mock('react-hot-toast', () => ({
+  toast: { error: vi.fn() },
+}));
+vi.mock('../../entities/store/slices', () => ({
+  validateArchitectureShape: vi.fn(),
+}));
+vi.mock('../../features/diff/engine', () => ({
+  computeArchitectureDiff: vi.fn(() => ({
+    plates: { added: [], removed: [], modified: [] },
+    blocks: { added: [], removed: [], modified: [] },
+    connections: { added: [], removed: [], modified: [] },
+    externalActors: { added: [], removed: [], modified: [] },
+    rootChanges: [],
+    summary: { totalChanges: 0, hasBreakingChanges: false },
+  })),
+}));
 import { GitHubPR } from './GitHubPR';
 import { useUIStore } from '../../entities/store/uiStore';
 import { useAuthStore } from '../../entities/store/authStore';
@@ -365,7 +381,8 @@ describe('GitHubPR', () => {
 
   it('shows repo name in meta section when githubRepo is set', () => {
     render(<GitHubPR />);
-    expect(screen.getByText('owner/repo-one')).toBeInTheDocument();
+    const repoElements = screen.getAllByText('owner/repo-one');
+    expect(repoElements.length).toBeGreaterThanOrEqual(1);
   });
 
   it('does not show repo in meta section when githubRepo is not set', () => {
@@ -378,5 +395,45 @@ describe('GitHubPR', () => {
 
     render(<GitHubPR />);
     expect(screen.queryByText('owner/repo-one')).not.toBeInTheDocument();
+  });
+
+  it('shows local architecture summary (#878)', () => {
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        architecture: {
+          ...emptyArch,
+          plates: [{ id: 'p1' }, { id: 'p2' }] as typeof emptyArch.plates,
+          blocks: [{ id: 'b1' }] as typeof emptyArch.blocks,
+          connections: [{ id: 'c1' }] as typeof emptyArch.connections,
+        },
+      },
+    });
+
+    render(<GitHubPR />);
+    expect(screen.getByText('Local: 2 plates · 1 blocks · 1 connections')).toBeInTheDocument();
+  });
+
+  it('shows remote baseline context with base branch (#880)', () => {
+    render(<GitHubPR />);
+    expect(screen.getByText('main')).toBeInTheDocument();
+  });
+
+  it('shows Compare with GitHub button (#882)', () => {
+    render(<GitHubPR />);
+    expect(screen.getByRole('button', { name: 'Compare with GitHub' })).toBeInTheDocument();
+  });
+
+  it('compare button calls API and opens diff mode (#882)', async () => {
+    const user = userEvent.setup();
+    const remoteArch = { ...emptyArch, id: 'remote' };
+    mockApiPost.mockResolvedValueOnce({ architecture: remoteArch });
+
+    render(<GitHubPR />);
+    await user.click(screen.getByRole('button', { name: 'Compare with GitHub' }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith('/api/v1/workspaces/backend-ws-1/pull');
+    });
   });
 });

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
+import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { validateArchitectureShape } from '../../entities/store/slices';
+import { computeArchitectureDiff } from '../../features/diff/engine';
 import { apiPost, getApiErrorMessage } from '../../shared/api/client';
 import { isValidGitBranchName } from '../../shared/utils/githubValidation';
-import type { PullRequestResponse } from '../../shared/types/api';
+import type { PullRequestResponse, PullResponse } from '../../shared/types/api';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import './GitHubPR.css';
 
 export function GitHubPR() {
@@ -28,6 +32,7 @@ function GitHubPRContent() {
   const [branch, setBranch] = useState('');
   const [commitMessage, setCommitMessage] = useState('Update architecture via CloudBlocks');
   const [loading, setLoading] = useState(false);
+  const [comparing, setComparing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<PullRequestResponse | null>(null);
   const cleanedTitle = title.trim();
@@ -39,7 +44,7 @@ function GitHubPRContent() {
       : 'main';
   const headMatchesBaseBranch = cleanedBranch.length > 0 && cleanedBranch === baseBranch;
   const branchIsValid = !cleanedBranch || isValidGitBranchName(cleanedBranch);
-  const canSubmit = !loading && cleanedTitle.length > 0 && cleanedCommitMessage.length > 0 && branchIsValid && !headMatchesBaseBranch && hasBackendWorkspaceLink;
+  const canSubmit = !loading && !comparing && cleanedTitle.length > 0 && cleanedCommitMessage.length > 0 && branchIsValid && !headMatchesBaseBranch && hasBackendWorkspaceLink;
   const effectiveWorkspaceId = workspace.backendWorkspaceId || workspace.id;
 
   if (!show) return null;
@@ -89,6 +94,28 @@ function GitHubPRContent() {
     }
   };
 
+  const handleCompareWithGitHub = async () => {
+    const backendWorkspaceId = workspace.backendWorkspaceId;
+    if (!backendWorkspaceId) return;
+
+    setComparing(true);
+    setError(null);
+    try {
+      const response = await apiPost<PullResponse>(
+        `/api/v1/workspaces/${encodeURIComponent(backendWorkspaceId)}/pull`,
+      );
+      validateArchitectureShape(response.architecture);
+      const remoteArch = response.architecture as unknown as ArchitectureModel;
+      const localArch = useArchitectureStore.getState().workspace.architecture;
+      const delta = computeArchitectureDiff(remoteArch, localArch);
+      useUIStore.getState().setDiffMode(true, delta, remoteArch);
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to fetch remote architecture'));
+    } finally {
+      setComparing(false);
+    }
+  };
+
   return (
     <div className="github-pr">
       <div className="github-pr-header">
@@ -107,6 +134,7 @@ function GitHubPRContent() {
       ) : (
         <div className="github-pr-content">
           {loading && <div className="github-pr-loading">Loading...</div>}
+          {comparing && <div className="github-pr-loading">Comparing with GitHub...</div>}
           {error && <div className="github-pr-error">{error}</div>}
           <div className="github-pr-meta">
             Workspace ID: <code>{effectiveWorkspaceId}</code>
@@ -115,6 +143,15 @@ function GitHubPRContent() {
                 {' · '}Repo: <code>{workspace.githubRepo}</code>
               </>
             ) : null}
+          </div>
+
+          <div className="github-pr-arch-summary">
+            Local: {workspace.architecture.plates.length} plates · {workspace.architecture.blocks.length} blocks · {workspace.architecture.connections.length} connections
+          </div>
+
+          <div className="github-pr-baseline">
+            Base branch: <code>{baseBranch}</code>
+            {workspace.githubRepo ? <> · Repo: <code>{workspace.githubRepo}</code></> : null}
           </div>
 
           <label className="github-pr-label" htmlFor="github-pr-title">
@@ -161,9 +198,14 @@ function GitHubPRContent() {
             onChange={(e) => setCommitMessage(e.target.value)}
           />
 
-          <button type="button" className="github-pr-submit" onClick={handleSubmit} disabled={!canSubmit}>
-            Create Pull Request
-          </button>
+          <div className="github-pr-actions">
+            <button type="button" className="github-pr-submit" onClick={handleSubmit} disabled={!canSubmit}>
+              Create Pull Request
+            </button>
+            <button type="button" className="github-pr-compare-btn" onClick={() => void handleCompareWithGitHub()} disabled={loading || comparing}>
+              Compare with GitHub
+            </button>
+          </div>
 
           {result && (
             <div className="github-pr-result">

--- a/apps/web/src/widgets/github-sync/GitHubSync.css
+++ b/apps/web/src/widgets/github-sync/GitHubSync.css
@@ -234,3 +234,18 @@
 .github-sync-commit-link:hover {
   text-decoration: underline;
 }
+
+.github-sync-arch-summary {
+  font-size: 11px;
+  color: #8e95b8;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid #333366;
+  border-radius: 4px;
+}
+
+.github-sync-reconciliation {
+  font-size: 11px;
+  color: #9aa4d1;
+  padding: 4px 8px;
+}

--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -5,6 +5,26 @@ vi.mock('../../shared/api/client', () => ({
   apiPost: vi.fn(),
   apiGet: vi.fn(),
   apiPut: vi.fn(),
+  getApiErrorMessage: vi.fn((err: unknown, fallback: string) => {
+    if (err instanceof Error) return err.message;
+    return fallback;
+  }),
+}));
+vi.mock('react-hot-toast', () => ({
+  toast: { error: vi.fn() },
+}));
+vi.mock('../../entities/store/slices', () => ({
+  validateArchitectureShape: vi.fn(),
+}));
+vi.mock('../../features/diff/engine', () => ({
+  computeArchitectureDiff: vi.fn(() => ({
+    plates: { added: [], removed: [], modified: [] },
+    blocks: { added: [], removed: [], modified: [] },
+    connections: { added: [], removed: [], modified: [] },
+    externalActors: { added: [], removed: [], modified: [] },
+    rootChanges: [],
+    summary: { totalChanges: 0, hasBreakingChanges: false },
+  })),
 }));
 import { GitHubSync } from './GitHubSync';
 import { useUIStore } from '../../entities/store/uiStore';
@@ -471,6 +491,81 @@ describe('GitHubSync', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('stale commit')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows local architecture summary when repo is linked (#878)', async () => {
+    const user = userEvent.setup();
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        architecture: {
+          ...emptyArch,
+          plates: [{ id: 'p1' }, { id: 'p2' }] as typeof emptyArch.plates,
+          blocks: [{ id: 'b1' }] as typeof emptyArch.blocks,
+          connections: [{ id: 'c1' }, { id: 'c2' }] as typeof emptyArch.connections,
+        },
+      },
+    });
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(await screen.findByText('Local: 2 plates · 1 blocks · 2 connections')).toBeInTheDocument();
+  });
+
+  it('shows "Never synced" when no commits exist (#881)', async () => {
+    const user = userEvent.setup();
+    mockApiGet.mockResolvedValue({ commits: [] });
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(await screen.findByText('⚠ Never synced with remote')).toBeInTheDocument();
+  });
+
+  it('shows "Previously synced" when commits exist (#881)', async () => {
+    const user = userEvent.setup();
+    mockApiGet.mockResolvedValue({
+      commits: [{ sha: 'abc', message: 'commit', author: 'octocat', date: '2025-01-01T00:00:00Z', html_url: '' }],
+    });
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(await screen.findByText('✓ Previously synced')).toBeInTheDocument();
+  });
+
+  it('shows Compare with GitHub button when repo is linked (#882)', async () => {
+    const user = userEvent.setup();
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+
+    expect(await screen.findByRole('button', { name: 'Compare with GitHub' })).toBeInTheDocument();
+  });
+
+  it('compare button calls API and opens diff mode (#882)', async () => {
+    const user = userEvent.setup();
+    const remoteArch = { ...emptyArch, id: 'remote' };
+    mockApiPost.mockResolvedValueOnce({ message: 'ok', commit_sha: 'abc' });
+    mockApiPost.mockResolvedValueOnce({ architecture: remoteArch });
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    await user.click(await screen.findByRole('button', { name: 'Compare with GitHub' }));
+
+    await waitFor(() => {
+      expect(mockApiPost).toHaveBeenCalledWith('/api/v1/workspaces/ws-1/pull');
     });
   });
 });

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import { apiGet, apiPost, apiPut } from '../../shared/api/client';
+import { validateArchitectureShape } from '../../entities/store/slices';
+import { computeArchitectureDiff } from '../../features/diff/engine';
+import { apiGet, apiPost, apiPut, getApiErrorMessage } from '../../shared/api/client';
 import { isValidGitHubRepoFullName } from '../../shared/utils/githubValidation';
 import type { GitHubCommit, PullResponse, SyncResponse } from '../../shared/types/api';
 import type { ArchitectureSnapshot } from '../../shared/types/learning';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import './GitHubSync.css';
 
 interface LinkedRepoState {
@@ -49,6 +53,7 @@ export function GitHubSync() {
   const [error, setError] = useState<string | null>(null);
   const [commitRefreshError, setCommitRefreshError] = useState<string | null>(null);
   const [pullConfirmPending, setPullConfirmPending] = useState(false);
+  const [comparing, setComparing] = useState(false);
   const requestSeqRef = useRef(0);
   const mountedRef = useRef(true);
   const showRef = useRef(show);
@@ -58,7 +63,7 @@ export function GitHubSync() {
   const effectiveWorkspaceIdRef = useRef<string | null>(null);
 
   const trimmedCommitMessage = commitMessage.trim();
-  const busy = linking || syncing || pulling;
+  const busy = linking || syncing || pulling || comparing;
 
   useEffect(() => {
     if (workspace.githubRepo) {
@@ -226,6 +231,27 @@ export function GitHubSync() {
     setPullConfirmPending(false);
   };
 
+  const handleCompareWithGitHub = async () => {
+    if (!effectiveWorkspaceId) return;
+
+    setComparing(true);
+    setError(null);
+    try {
+      const response = await apiPost<PullResponse>(
+        `/api/v1/workspaces/${encodeURIComponent(effectiveWorkspaceId)}/pull`,
+      );
+      validateArchitectureShape(response.architecture);
+      const remoteArch = response.architecture as unknown as ArchitectureModel;
+      const localArch = useArchitectureStore.getState().workspace.architecture;
+      const delta = computeArchitectureDiff(remoteArch, localArch);
+      useUIStore.getState().setDiffMode(true, delta, remoteArch);
+    } catch (err) {
+      toast.error(getApiErrorMessage(err, 'Failed to fetch remote architecture'));
+    } finally {
+      setComparing(false);
+    }
+  };
+
   const commitLinkUrl = linkedRepo
     ? `https://github.com/${linkedRepo}/commit/`
     : null;
@@ -248,6 +274,7 @@ export function GitHubSync() {
           {linking && <div className="github-sync-loading">Linking repository...</div>}
           {syncing && <div className="github-sync-loading">Syncing to GitHub...</div>}
           {pulling && <div className="github-sync-loading">Pulling from GitHub...</div>}
+          {comparing && <div className="github-sync-loading">Comparing with GitHub...</div>}
           {loadingCommits && <div className="github-sync-loading">Loading recent commits...</div>}
           {error && <div className="github-sync-error">{error}</div>}
           {commitRefreshError && (
@@ -296,6 +323,14 @@ export function GitHubSync() {
                 </button>
               </div>
 
+              <div className="github-sync-arch-summary">
+                Local: {workspace.architecture.plates.length} plates · {workspace.architecture.blocks.length} blocks · {workspace.architecture.connections.length} connections
+              </div>
+
+              <div className="github-sync-reconciliation">
+                {commits.length > 0 ? '✓ Previously synced' : '⚠ Never synced with remote'}
+              </div>
+
               <label className="github-sync-label" htmlFor="github-sync-commit-message">
                 Commit message
               </label>
@@ -313,6 +348,9 @@ export function GitHubSync() {
                 </button>
                 <button type="button" className="github-sync-secondary-btn" onClick={handlePullRequest} disabled={anyLoading}>
                   Pull from GitHub
+                </button>
+                <button type="button" className="github-sync-secondary-btn" onClick={() => void handleCompareWithGitHub()} disabled={anyLoading || comparing}>
+                  Compare with GitHub
                 </button>
               </div>
 


### PR DESCRIPTION
## Summary
- **DiffPanel**: Show active workspace name and remote architecture summary (plates/blocks/connections/actors counts) for orientation context
- **GitHubSync**: Show local architecture summary, reconciliation status (synced vs never synced), and "Compare with GitHub" button
- **GitHubPR**: Show local architecture summary, baseline context (base branch + repo), and "Compare with GitHub" button
- 12 new tests covering all contextual info features across 3 widget test files

## Issues
Fixes #877, #878, #879, #880, #881, #882

## Test Results
- 1752 tests passed, 0 failures
- Branch coverage: 90.14% (≥ 90% threshold)
- Build: ✅ | Lint: ✅ | LSP diagnostics: 0 errors