### PR TITLE
fix(web): persist PR result per workspace and show recent PR context (#887, #888)

### DIFF
--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -1,5 +1,5 @@
 import type { StateCreator } from 'zustand';
-import type { PlateProfileId, Workspace } from '../../../shared/types/index';
+import type { LastPrResult, PlateProfileId, Workspace } from '../../../shared/types/index';
 import type { ArchitectureModel, BlockCategory, ProviderType, PlateType, SubnetAccess } from '@cloudblocks/schema';
 import type { ValidationResult } from '@cloudblocks/domain';
 import type { ArchitectureSnapshot } from '../../../shared/types/learning';
@@ -63,6 +63,7 @@ export interface ArchitectureState {
   replaceArchitecture: (snapshot: ArchitectureSnapshot) => void;
   setBackendWorkspaceId: (workspaceId: string, backendId: string) => void;
   setGithubRepo: (workspaceId: string, repo: string | undefined) => void;
+  setLastPrResult: (workspaceId: string, result: LastPrResult) => void;
 }
 
 export type ArchitectureSlice<T> = StateCreator<ArchitectureState, [], [], T>;

--- a/apps/web/src/entities/store/slices/workspaceSlice.ts
+++ b/apps/web/src/entities/store/slices/workspaceSlice.ts
@@ -20,6 +20,7 @@ type WorkspaceSlice = Pick<
   | 'cloneWorkspace'
   | 'setBackendWorkspaceId'
   | 'setGithubRepo'
+  | 'setLastPrResult'
 >;
 
 export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (
@@ -175,6 +176,27 @@ export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (
 
     const updatedList = state.workspaces.map((ws) =>
       ws.id === workspaceId ? { ...ws, githubRepo: repo } : ws
+    );
+
+    saveWorkspaces(
+      upsertCurrentWorkspace(updatedList, updatedWorkspace)
+    );
+
+    set({
+      workspace: updatedWorkspace,
+      workspaces: updatedList,
+    });
+  },
+
+  setLastPrResult: (workspaceId, result) => {
+    const state = get();
+    const updatedWorkspace =
+      state.workspace.id === workspaceId
+        ? { ...state.workspace, lastPrResult: result }
+        : state.workspace;
+
+    const updatedList = state.workspaces.map((ws) =>
+      ws.id === workspaceId ? { ...ws, lastPrResult: result } : ws
     );
 
     saveWorkspaces(

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -63,6 +63,13 @@ export const ROLE_VISUAL_INDICATORS: Record<BlockRole, RoleVisualIndicator> = {
 };
 // ─── Workspace ─────────────────────────────────────────────
 
+export interface LastPrResult {
+  url: string;
+  number: number;
+  branch: string;
+  createdAt: string;
+}
+
 export interface Workspace {
   id: string;
   name: string;
@@ -71,6 +78,7 @@ export interface Workspace {
   updatedAt: string;
   backendWorkspaceId?: string;
   githubRepo?: string;
+  lastPrResult?: LastPrResult;
 }
 
 // ─── Visual Identity ───────────────────────────────────────

--- a/apps/web/src/widgets/github-pr/GitHubPR.css
+++ b/apps/web/src/widgets/github-pr/GitHubPR.css
@@ -205,3 +205,34 @@
   opacity: 0.45;
   cursor: not-allowed;
 }
+
+.github-pr-recent-pr {
+  font-size: 11px;
+  color: #a5d6a7;
+  padding: 6px 8px;
+  background: rgba(76, 175, 80, 0.08);
+  border: 1px solid rgba(76, 175, 80, 0.25);
+  border-radius: 4px;
+}
+
+.github-pr-recent-pr-label {
+  font-weight: 600;
+  color: #81c784;
+}
+
+.github-pr-recent-pr a {
+  color: #82b1ff;
+  text-decoration: none;
+}
+
+.github-pr-recent-pr a:hover {
+  text-decoration: underline;
+}
+
+.github-pr-recent-pr code {
+  font-family: 'Consolas', 'Monaco', monospace;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}

--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -436,4 +436,79 @@ describe('GitHubPR', () => {
       expect(mockApiPost).toHaveBeenCalledWith('/api/v1/workspaces/backend-ws-1/pull');
     });
   });
+
+  it('persists PR result to workspace store on successful submission (#887)', async () => {
+    const user = userEvent.setup();
+    mockApiPost.mockResolvedValue({
+      pull_request_url: 'https://github.com/owner/repo/pull/99',
+      number: 99,
+      branch: 'cloudblocks/update',
+    });
+
+    render(<GitHubPR />);
+    await user.click(screen.getByRole('button', { name: 'Create Pull Request' }));
+
+    await waitFor(() => {
+      const ws = useArchitectureStore.getState().workspace;
+      expect(ws.lastPrResult).toBeDefined();
+      expect(ws.lastPrResult?.number).toBe(99);
+      expect(ws.lastPrResult?.url).toBe('https://github.com/owner/repo/pull/99');
+      expect(ws.lastPrResult?.branch).toBe('cloudblocks/update');
+      expect(ws.lastPrResult?.createdAt).toBeTruthy();
+    });
+  });
+
+  it('shows recent PR banner when lastPrResult exists and no current result (#888)', () => {
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        lastPrResult: {
+          url: 'https://github.com/owner/repo/pull/55',
+          number: 55,
+          branch: 'feature/old',
+          createdAt: '2025-03-20T10:00:00Z',
+        },
+      },
+    });
+
+    render(<GitHubPR />);
+    expect(screen.getByText('Recent PR:')).toBeInTheDocument();
+    expect(screen.getByText('#55')).toBeInTheDocument();
+    expect(screen.getByText('feature/old')).toBeInTheDocument();
+  });
+
+  it('hides recent PR banner when current result is shown (#888)', async () => {
+    const user = userEvent.setup();
+    useArchitectureStore.setState({
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        lastPrResult: {
+          url: 'https://github.com/owner/repo/pull/55',
+          number: 55,
+          branch: 'feature/old',
+          createdAt: '2025-03-20T10:00:00Z',
+        },
+      },
+    });
+
+    mockApiPost.mockResolvedValue({
+      pull_request_url: 'https://github.com/owner/repo/pull/56',
+      number: 56,
+      branch: 'cloudblocks/update',
+    });
+
+    render(<GitHubPR />);
+    expect(screen.getByText('Recent PR:')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Create Pull Request' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Recent PR:')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show recent PR banner when lastPrResult is absent (#888)', () => {
+    render(<GitHubPR />);
+    expect(screen.queryByText('Recent PR:')).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -25,7 +25,9 @@ function GitHubPRContent() {
   const isAuthenticated = useAuthStore((s) => s.status) === 'authenticated';
   const authStatus = useAuthStore((s) => s.status);
   const workspace = useArchitectureStore((s) => s.workspace);
+  const setLastPrResult = useArchitectureStore((s) => s.setLastPrResult);
   const hasBackendWorkspaceLink = Boolean(workspace.backendWorkspaceId);
+  const lastPrResult = workspace.lastPrResult;
 
   const [title, setTitle] = useState('Update cloud architecture');
   const [body, setBody] = useState('');
@@ -87,6 +89,12 @@ function GitHubPRContent() {
         }
       );
       setResult(response);
+      setLastPrResult(workspace.id, {
+        url: response.pull_request_url,
+        number: response.number,
+        branch: response.branch,
+        createdAt: new Date().toISOString(),
+      });
     } catch (err) {
       setError(getApiErrorMessage(err, 'Failed to create pull request.'));
     } finally {
@@ -153,6 +161,18 @@ function GitHubPRContent() {
             Base branch: <code>{baseBranch}</code>
             {workspace.githubRepo ? <> · Repo: <code>{workspace.githubRepo}</code></> : null}
           </div>
+
+          {lastPrResult && !result && (
+            <div className="github-pr-recent-pr">
+              <span className="github-pr-recent-pr-label">Recent PR:</span>
+              {' '}
+              <a href={lastPrResult.url} target="_blank" rel="noreferrer">
+                #{lastPrResult.number}
+              </a>
+              {' · '}Branch: <code>{lastPrResult.branch}</code>
+              {' · '}{new Date(lastPrResult.createdAt).toLocaleDateString()}
+            </div>
+          )}
 
           <label className="github-pr-label" htmlFor="github-pr-title">
             Title


### PR DESCRIPTION
## Summary
- Add `lastPrResult` field to `Workspace` interface (URL, number, branch, timestamp) for per-workspace PR persistence via localStorage
- Add `setLastPrResult` store action in workspaceSlice following the `setGithubRepo` pattern
- On successful PR submission, persist the result to the workspace store
- Show a "Recent PR" banner in the GitHubPR panel when the workspace has a previous PR (hidden when a fresh PR result is displayed)
- 4 new tests: persistence on submit, banner shown, banner hidden after new result, banner absent when no lastPrResult

## Issues
Fixes #887, #888

## Test Results
- 1756 tests passed, 0 failures
- Branch coverage: 90.05% (≥ 90% threshold)
- Build: ✅ | Lint: ✅ | LSP diagnostics: 0 errors