### PR TITLE
fix(web): raise z-index for overlay panels above BottomPanel

### DIFF
--- a/apps/web/src/widgets/learning-panel/LearningPanel.css
+++ b/apps/web/src/widgets/learning-panel/LearningPanel.css
@@ -4,7 +4,7 @@
   top: 60px;
   width: 320px;
   max-height: calc(100vh - 120px);
-  z-index: 15;
+  z-index: 200;
   background: #FFFDF0;
   border: 4px solid #FFC83D;
   border-radius: 8px;

--- a/apps/web/src/widgets/scenario-gallery/ScenarioGallery.css
+++ b/apps/web/src/widgets/scenario-gallery/ScenarioGallery.css
@@ -11,7 +11,7 @@
   padding: 16px;
   color: #3D2600;
   font-family: 'Varela Round', system-ui, sans-serif;
-  z-index: 20;
+  z-index: 200;
   display: flex;
   flex-direction: column;
   overflow: hidden;

--- a/apps/web/src/widgets/template-gallery/TemplateGallery.css
+++ b/apps/web/src/widgets/template-gallery/TemplateGallery.css
@@ -11,7 +11,7 @@
   padding: 12px;
   color: #e0e0e0;
   font-family: 'Segoe UI', system-ui, sans-serif;
-  z-index: 20;
+  z-index: 200;
   display: flex;
   flex-direction: column;
   overflow: hidden;


### PR DESCRIPTION
## Summary

- Raises z-index for ScenarioGallery, TemplateGallery, and LearningPanel from 20/20/15 to 200
- These panels were rendering behind BottomPanel (z-index: 100) and ResourceBar (z-index: 50)
- New value (200) sits above BottomPanel tabs (140) and below MenuBar dropdown (1000)

## Files Changed

| File | Change |
|---|---|
| `ScenarioGallery.css` | z-index: 20 → 200 |
| `TemplateGallery.css` | z-index: 20 → 200 |
| `LearningPanel.css` | z-index: 15 → 200 |

Fixes #985