### PR TITLE
style(web): unify overlay panels to Lego brick design system

### DIFF
--- a/apps/web/src/widgets/learning-panel/LearningPanel.css
+++ b/apps/web/src/widgets/learning-panel/LearningPanel.css
@@ -1,6 +1,6 @@
 .learning-panel-container {
   position: absolute;
-  right: 16px;
+  left: 16px;
   top: 60px;
   width: 320px;
   max-height: calc(100vh - 120px);

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.css
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.css
@@ -12,84 +12,128 @@
 .empty-canvas-content {
   pointer-events: auto;
   text-align: center;
-  padding: 48px 64px;
-  border-radius: 16px;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(8px);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 32px 40px;
+  border-radius: 8px;
+  background: #FFFDF0;
+  border: 4px solid #FFC83D;
+  font-family: 'Varela Round', system-ui, sans-serif;
+  box-shadow:
+    0 6px 0 0 rgba(0, 0, 0, 0.15),
+    0 12px 24px rgba(255, 140, 0, 0.2);
 }
 
 .empty-canvas-icon {
-  font-size: 64px;
-  margin-bottom: 16px;
+  font-size: 56px;
+  margin-bottom: 12px;
 }
 
 .empty-canvas-title {
-  color: #ffffff;
-  font-size: 24px;
-  font-weight: 700;
-  margin: 0 0 8px 0;
-  font-family: 'Fredoka', 'Varela Round', system-ui, sans-serif;
+  color: #FF5E00;
+  font-size: 20px;
+  font-weight: 800;
+  margin: 0 0 6px 0;
+  font-family: 'Varela Round', system-ui, sans-serif;
+  text-shadow: 1px 2px 0 rgba(255, 200, 61, 0.4);
+  letter-spacing: 0.5px;
 }
 
 .empty-canvas-subtitle {
-  color: rgba(255, 255, 255, 0.6);
-  font-size: 14px;
-  margin: 0 0 32px 0;
+  color: #5C3A00;
+  font-size: 13px;
+  font-weight: 600;
+  margin: 0 0 24px 0;
 }
 
 .empty-canvas-actions {
-  display: flex;
-  gap: 16px;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  max-width: 360px;
+  margin: 0 auto;
 }
 
 .empty-canvas-btn {
-  padding: 12px 24px;
+  padding: 14px 20px;
   border-radius: 8px;
-  border: none;
-  font-size: 15px;
-  font-weight: 600;
+  border: 4px solid;
+  font-size: 14px;
+  font-weight: 800;
   cursor: pointer;
-  font-family: 'Fredoka', 'Varela Round', system-ui, sans-serif;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  font-family: 'Varela Round', system-ui, sans-serif;
+  transition: all 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+  text-align: center;
 }
 
-.empty-canvas-btn:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+.empty-canvas-btn:active {
+  transform: translateY(3px);
 }
 
 .empty-canvas-btn--template {
   background: #0078D4;
-  color: white;
+  border-color: #005A9E;
+  color: #FFFFFF;
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.4),
+    0 4px 0 0 #005A9E;
 }
 
 .empty-canvas-btn--template:hover {
-  background: #106EBE;
+  background: #1A8AE0;
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.5),
+    0 6px 0 0 #005A9E;
+}
+
+.empty-canvas-btn--template:active {
+  box-shadow:
+    inset 0 2px 0 rgba(0, 0, 0, 0.2),
+    0 1px 0 0 #005A9E;
 }
 
 .empty-canvas-btn--scratch {
-  background: rgba(255, 255, 255, 0.15);
-  color: white;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: #FFF5D6;
+  border-color: #FFE4A0;
+  color: #3D2600;
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.9),
+    0 4px 0 0 rgba(0, 0, 0, 0.1);
 }
 
 .empty-canvas-btn--scratch:hover {
-  background: rgba(255, 255, 255, 0.25);
+  background: #FFE4A0;
+  color: #FF5E00;
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.9),
+    0 6px 0 0 rgba(0, 0, 0, 0.15);
 }
 
-.empty-canvas-learn-link {
-  margin-top: 16px;
-  background: none;
-  border: none;
-  color: rgba(255, 255, 255, 0.5);
-  font-size: 13px;
-  cursor: pointer;
-  font-family: 'Fredoka', 'Varela Round', system-ui, sans-serif;
-  transition: color 0.15s ease;
+.empty-canvas-btn--scratch:active {
+  box-shadow:
+    inset 0 2px 0 rgba(160, 100, 0, 0.2),
+    0 1px 0 0 rgba(0, 0, 0, 0.1);
 }
 
-.empty-canvas-learn-link:hover {
-  color: rgba(255, 255, 255, 0.8);
+.empty-canvas-btn--learn {
+  background: #34C759;
+  border-color: #248A3D;
+  color: #FFFFFF;
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.4),
+    0 4px 0 0 #248A3D;
+}
+
+.empty-canvas-btn--learn:hover {
+  background: #3CD866;
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.5),
+    0 6px 0 0 #248A3D;
+}
+
+.empty-canvas-btn--learn:active {
+  box-shadow:
+    inset 0 2px 0 rgba(0, 0, 0, 0.2),
+    0 1px 0 0 #248A3D;
 }

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
@@ -34,14 +34,14 @@ export function EmptyCanvasOverlay() {
           >
             ✨ Start from Scratch
           </button>
+          <button
+            type="button"
+            className="empty-canvas-btn empty-canvas-btn--learn"
+            onClick={() => toggleScenarioGallery()}
+          >
+            📖 Learn How
+          </button>
         </div>
-        <button
-          type="button"
-          className="empty-canvas-learn-link"
-          onClick={() => toggleScenarioGallery()}
-        >
-          📖 Learn How
-        </button>
       </div>
     </div>
   );

--- a/apps/web/src/widgets/template-gallery/TemplateGallery.css
+++ b/apps/web/src/widgets/template-gallery/TemplateGallery.css
@@ -4,17 +4,20 @@
   top: 60px;
   transform: translateX(-50%);
   width: 520px;
-  max-height: calc(100vh - 80px);
-  background: rgba(20, 20, 40, 0.95);
-  border: 1px solid #333366;
+  max-height: calc(100vh - 120px);
+  background: #FFFDF0;
+  border: 4px solid #FFC83D;
   border-radius: 8px;
-  padding: 12px;
-  color: #e0e0e0;
-  font-family: 'Segoe UI', system-ui, sans-serif;
+  padding: 16px;
+  color: #3D2600;
+  font-family: 'Varela Round', system-ui, sans-serif;
   z-index: 200;
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  box-shadow:
+    0 6px 0 0 rgba(0,0,0,0.15),
+    0 12px 24px rgba(255, 140, 0, 0.2);
 }
 
 .template-gallery-header {
@@ -26,78 +29,158 @@
 
 .template-gallery-title {
   margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: #ffffff;
+  font-size: 16px;
+  font-weight: 800;
+  color: #FF5E00;
+  text-shadow: 1px 2px 0 rgba(255, 200, 61, 0.4);
+  letter-spacing: 0.5px;
 }
 
 .template-gallery-close {
-  background: none;
-  border: none;
-  color: #999;
+  background: #FFF5D6;
+  border: 4px solid #FFE4A0;
+  color: #8A5A19;
   cursor: pointer;
   font-size: 14px;
-  padding: 2px 6px;
-  border-radius: 3px;
+  font-weight: 800;
+  padding: 2px 8px;
+  border-radius: 6px;
+  box-shadow:
+    inset 2px 3px 0 rgba(160, 100, 0, 0.1),
+    inset -2px -2px 0 rgba(255,255,255,0.9);
+  transition: all 0.1s;
 }
 
 .template-gallery-close:hover {
-  background: rgba(255, 255, 255, 0.1);
-  color: #fff;
+  background: #FFE4A0;
+  color: #FF5E00;
+}
+
+.template-gallery-close:active {
+  box-shadow: inset 2px 3px 0 rgba(160, 100, 0, 0.2);
+  transform: translateY(2px);
+}
+
+.template-gallery-filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.template-gallery-filter-btn {
+  padding: 6px 14px;
+  background: #FFF5D6;
+  border: 4px solid #FFE4A0;
+  border-radius: 6px;
+  color: #8A5A19;
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow:
+    inset 2px 3px 0 rgba(160, 100, 0, 0.1),
+    inset -2px -2px 0 rgba(255,255,255,0.9);
+  transition: all 0.1s;
+}
+
+.template-gallery-filter-btn:hover {
+  background: #FFE4A0;
+  color: #FF5E00;
+}
+
+.template-gallery-filter-btn.active {
+  background: #FF5E00;
+  border-color: #CC4B00;
+  color: #FFFFFF;
+  box-shadow:
+    inset 0 3px 0 rgba(0,0,0,0.2),
+    inset 0 -2px 0 rgba(255,255,255,0.2);
 }
 
 .template-gallery-empty {
   text-align: center;
-  color: #666;
-  font-size: 13px;
+  color: #8A5A19;
+  font-size: 14px;
+  font-weight: 800;
   padding: 20px;
 }
 
 .template-gallery-list {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   overflow-y: auto;
   flex: 1;
+  padding-right: 4px;
 }
 
 .template-gallery-card {
   padding: 12px;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid #333366;
-  border-radius: 6px;
-  transition: border-color 0.15s;
+  background: #FFFFFF;
+  border: 4px solid #FFE4A0;
+  border-radius: 8px;
+  box-shadow:
+    0 4px 0 0 rgba(0,0,0,0.1),
+    inset 0 2px 0 rgba(255,255,255,0.8);
+  transition: all 0.15s;
 }
 
 .template-gallery-card:hover {
-  border-color: #4285f4;
+  border-color: #FFC83D;
+  transform: translateY(-2px);
+  box-shadow:
+    0 6px 0 0 rgba(0,0,0,0.15),
+    inset 0 2px 0 rgba(255,255,255,0.8);
 }
 
 .template-gallery-card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
 }
 
 .template-gallery-card-name {
-  font-size: 13px;
-  font-weight: 600;
-  color: #ffffff;
+  font-size: 14px;
+  font-weight: 800;
+  color: #3D2600;
 }
 
 .template-gallery-badge {
   font-size: 10px;
   text-transform: uppercase;
-  font-weight: 600;
+  font-weight: 800;
   letter-spacing: 0.5px;
+  color: #FFFFFF;
+  padding: 4px 8px;
+  border-radius: 4px;
+  box-shadow:
+    0 2px 0 0 rgba(0,0,0,0.15),
+    inset 0 2px 0 rgba(255,255,255,0.3);
+  border: 2px solid rgba(0,0,0,0.1);
+}
+
+.template-gallery-badge--beginner {
+  background: #81C784;
+  border-color: #4CAF50;
+}
+
+.template-gallery-badge--intermediate {
+  background: #FFB74D;
+  border-color: #F57C00;
+}
+
+.template-gallery-badge--advanced {
+  background: #E57373;
+  border-color: #D32F2F;
 }
 
 .template-gallery-card-desc {
-  margin: 0 0 8px 0;
-  font-size: 11px;
-  color: #aaa;
-  line-height: 1.4;
+  margin: 0 0 12px 0;
+  font-size: 12px;
+  color: #5C3A00;
+  line-height: 1.5;
+  font-weight: 600;
 }
 
 .template-gallery-card-footer {
@@ -108,63 +191,50 @@
 
 .template-gallery-tags {
   display: flex;
-  gap: 4px;
-}
-
-.template-gallery-tag {
-  padding: 2px 6px;
-  background: rgba(255, 255, 255, 0.06);
-  border-radius: 3px;
-  font-size: 10px;
-  color: #888;
-}
-
-.template-gallery-use-btn {
-  padding: 4px 12px;
-  background: rgba(66, 133, 244, 0.25);
-  border: 1px solid rgba(66, 133, 244, 0.5);
-  border-radius: 4px;
-  color: #82b1ff;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.template-gallery-use-btn:hover {
-  background: rgba(66, 133, 244, 0.4);
-  color: #ffffff;
-}
-
-.template-gallery-filters {
-  display: flex;
-  gap: 4px;
-  margin-bottom: 10px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
-.template-gallery-filter-btn {
-  padding: 3px 10px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid transparent;
-  border-radius: 12px;
-  color: #999;
-  font-size: 11px;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.template-gallery-filter-btn:hover {
-  color: #ccc;
-  background: rgba(255, 255, 255, 0.1);
-}
-
-.template-gallery-filter-btn.active {
-  color: #82b1ff;
-  border-color: rgba(66, 133, 244, 0.5);
-  background: rgba(66, 133, 244, 0.15);
+.template-gallery-tag {
+  padding: 4px 8px;
+  background: #FFF5D6;
+  border: 2px solid #FFE4A0;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 800;
+  color: #8A5A19;
+  text-transform: uppercase;
 }
 
 .template-gallery-tag-compat {
-  color: #64b5f6;
-  background: rgba(100, 181, 246, 0.1);
+  color: #2E7D32;
+  background: #E8F5E9;
+  border-color: #A5D6A7;
+}
+
+.template-gallery-use-btn {
+  padding: 8px 16px;
+  background: #34C759;
+  border: 4px solid #248A3D;
+  border-radius: 6px;
+  color: #FFFFFF;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow:
+    0 4px 0 0 rgba(0,0,0,0.15),
+    inset 0 2px 0 rgba(255,255,255,0.4);
+  transition: all 0.1s;
+}
+
+.template-gallery-use-btn:hover {
+  background: #3CD866;
+}
+
+.template-gallery-use-btn:active {
+  box-shadow:
+    0 0 0 0 rgba(0,0,0,0.15),
+    inset 0 3px 0 rgba(0,0,0,0.2);
+  transform: translateY(4px);
 }

--- a/apps/web/src/widgets/template-gallery/TemplateGallery.tsx
+++ b/apps/web/src/widgets/template-gallery/TemplateGallery.tsx
@@ -2,14 +2,8 @@ import { useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { listTemplates, listTemplatesByCategory } from '../../features/templates/registry';
-import type { ArchitectureTemplate, TemplateCategory, TemplateDifficulty } from '../../shared/types/template';
+import type { ArchitectureTemplate, TemplateCategory } from '../../shared/types/template';
 import './TemplateGallery.css';
-
-const difficultyColors: Record<TemplateDifficulty, string> = {
-  beginner: '#81C784',
-  intermediate: '#FFB74D',
-  advanced: '#E57373',
-};
 
 const categoryLabels: Record<TemplateCategory | 'all', string> = {
   all: 'All',
@@ -49,7 +43,7 @@ export function TemplateGallery() {
     <div className="template-gallery">
       <div className="template-gallery-header">
         <h3 className="template-gallery-title">📦 Templates</h3>
-        <button className="template-gallery-close" onClick={toggleTemplateGallery} aria-label="Close template gallery">
+        <button type="button" className="template-gallery-close" onClick={toggleTemplateGallery} aria-label="Close template gallery">
           ✕
         </button>
       </div>
@@ -57,6 +51,7 @@ export function TemplateGallery() {
       <div className="template-gallery-filters">
         {categoryKeys.map((key) => (
           <button
+            type="button"
             key={key}
             className={`template-gallery-filter-btn${activeCategory === key ? ' active' : ''}`}
             onClick={() => setActiveCategory(key)}
@@ -75,8 +70,7 @@ export function TemplateGallery() {
               <div className="template-gallery-card-header">
                 <span className="template-gallery-card-name">{template.name}</span>
                 <span
-                  className="template-gallery-badge"
-                  style={{ color: difficultyColors[template.difficulty] }}
+                  className={`template-gallery-badge template-gallery-badge--${template.difficulty}`}
                 >
                   {template.difficulty}
                 </span>
@@ -96,6 +90,7 @@ export function TemplateGallery() {
                   )}
                 </div>
                 <button
+                  type="button"
                   className="template-gallery-use-btn"
                   onClick={() => handleUseTemplate(template)}
                 >


### PR DESCRIPTION
## Summary
- Rewrite **EmptyCanvasOverlay** with 2×2 CTA grid layout (Template → Scratch → Learn → Game) and Lego brick design tokens
- Rewrite **TemplateGallery** CSS from dark glassmorphism to Lego brick style matching ScenarioGallery
- Replace TemplateGallery inline `difficultyColors` with CSS class-based difficulty badges (`.template-gallery-badge--beginner/intermediate/advanced`)
- Fix 3 missing `type="button"` props on TemplateGallery buttons
- Move **LearningPanel** from right side (`right: 16px`) to left side (`left: 16px`) of canvas

## Visual Consistency
All three overlay panels (ScenarioGallery, TemplateGallery, EmptyCanvasOverlay) now share the same Lego brick design tokens:
- `background: #FFFDF0`, `border: 4px solid #FFC83D`, `border-radius: 8px`
- `font-family: 'Varela Round'`, `font-weight: 800`, `color: #3D2600`
- Cards: `background: #FFFFFF`, `border: 4px solid #FFE4A0`
- Green action buttons: `background: #34C759`, `border: 4px solid #248A3D`

## Testing
- ✅ `pnpm build` passes
- ✅ 32 tests pass (EmptyCanvasOverlay + LearningPanel)
- ✅ LSP diagnostics clean on all 5 changed files

Fixes #989