### PR TITLE
fix(web): hide provider badge and add resource design doc (#1026)

### DIFF
--- a/apps/web/src/entities/block/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/BlockSvg.test.tsx
@@ -3,33 +3,27 @@ import { render } from '@testing-library/react';
 import { BlockSvg } from './BlockSvg';
 
 describe('BlockSvg', () => {
-  it('renders without provider badge when provider is not set', () => {
-    const { container } = render(<BlockSvg category="compute" />);
+  it('does not render provider badge in single-provider mode', () => {
+    const { container } = render(<BlockSvg category="compute" provider="azure" />);
 
     expect(container.querySelector('[data-testid="provider-badge"]')).toBeNull();
   });
 
-  it('renders provider badge with Az label for azure', () => {
-    const { container } = render(<BlockSvg category="compute" provider="azure" />);
-
-    const badge = container.querySelector('[data-testid="provider-badge"]');
-    expect(badge).not.toBeNull();
-    expect(badge?.querySelector('text')?.textContent).toBe('Az');
-  });
-
-  it('renders provider badge with AW label for aws', () => {
+  it('does not render provider badge for aws', () => {
     const { container } = render(<BlockSvg category="compute" provider="aws" />);
 
-    const badge = container.querySelector('[data-testid="provider-badge"]');
-    expect(badge).not.toBeNull();
-    expect(badge?.querySelector('text')?.textContent).toBe('AW');
+    expect(container.querySelector('[data-testid="provider-badge"]')).toBeNull();
   });
 
-  it('renders provider badge with GC label for gcp', () => {
+  it('does not render provider badge for gcp', () => {
     const { container } = render(<BlockSvg category="compute" provider="gcp" />);
 
-    const badge = container.querySelector('[data-testid="provider-badge"]');
-    expect(badge).not.toBeNull();
-    expect(badge?.querySelector('text')?.textContent).toBe('GC');
+    expect(container.querySelector('[data-testid="provider-badge"]')).toBeNull();
+  });
+
+  it('renders without provider badge when provider is not set', () => {
+    const { container } = render(<BlockSvg category="compute" />);
+
+    expect(container.querySelector('[data-testid="provider-badge"]')).toBeNull();
   });
 });

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -25,18 +25,6 @@ interface BlockSvgProps {
   roles?: BlockRole[];        // v2.0 §9 — visual-only role indicators
 }
 
-const PROVIDER_BADGE_LABELS: Record<string, string> = {
-  azure: 'Az',
-  aws: 'AW',
-  gcp: 'GC',
-};
-
-const PROVIDER_BADGE_COLORS: Record<string, { bg: string; text: string }> = {
-  azure: { bg: '#0078D4', text: '#FFFFFF' },
-  aws: { bg: '#FF9900', text: '#000000' },
-  gcp: { bg: '#4285F4', text: '#FFFFFF' },
-};
-
 export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, name, aggregationCount, roles }: BlockSvgProps) {
   // ─── v2.0: CU-based dimension resolution ───────────────────
   const cu = getBlockDimensions(category, provider, subtype);
@@ -194,30 +182,7 @@ export const BlockSvg = memo(function BlockSvg({ category, provider, subtype, na
         </g>
       )}
 
-      {provider && (
-        <g data-testid="provider-badge">
-          <rect
-            x={screenWidth - 22}
-            y={svgHeight - 16}
-            width={20}
-            height={14}
-            rx={3}
-            fill={PROVIDER_BADGE_COLORS[provider]?.bg ?? '#666'}
-            fillOpacity={0.9}
-          />
-          <text
-            x={screenWidth - 12}
-            y={svgHeight - 5}
-            fontFamily="system-ui, -apple-system, sans-serif"
-            fontSize={8}
-            fontWeight="700"
-            fill={PROVIDER_BADGE_COLORS[provider]?.text ?? '#FFF'}
-            textAnchor="middle"
-          >
-            {PROVIDER_BADGE_LABELS[provider] ?? '??'}
-          </text>
-        </g>
-      )}
+      {/* Provider badge hidden in single-provider mode. Multi-cloud support planned for M20+. */}
 
     </svg>
   );

--- a/docs/design/PROVIDER_RESOURCES.md
+++ b/docs/design/PROVIDER_RESOURCES.md
@@ -1,0 +1,189 @@
+# Provider-Specific Resource System — Design Document
+
+> Covers: block palette labels, icons, subtypes, and provider badge behavior across Azure/AWS/GCP.
+
+## 1. Current Problems
+
+### P1: All providers show Azure resource names
+`RESOURCE_DEFINITIONS` hardcodes Azure-specific labels ("Azure SQL", "Azure Functions", "AKS"). `PROVIDER_RESOURCE_ALLOWLIST` maps all three providers to the same set. Switching provider tab has no effect on the block palette.
+
+### P2: Wrong icon mappings
+| Resource | Icon file used | Correct icon |
+|----------|---------------|-------------|
+| `function` category | `logic-apps.svg` | Should use a functions icon (doesn't exist yet) |
+| `app-service` (subtype) | `logic-apps.svg` (via function category) | `app-service.svg` exists but is unused |
+| `identity` (key-vault) | `storage-account.svg` | Needs dedicated icon |
+| `analytics` | `virtual-machine.svg` | Needs dedicated icon |
+| `observability` | `event-hub.svg` | Needs dedicated icon |
+
+### P3: Provider badge always shows
+`BlockSvg` renders "Az"/"AW"/"GC" badge on every block unconditionally. When working with a single provider, the badge is noise. It should only appear when the architecture contains blocks from multiple providers.
+
+### P4: `_subtype` parameter ignored in icon resolution
+`getBlockIconUrl(provider, category, _subtype)` ignores subtype entirely. App Service and Azure Functions both resolve to the `function` category icon. With subtype-aware resolution, `app-service.svg` could be used for App Service.
+
+### P5: AWS/GCP icons are Azure fallback
+`PROVIDER_BLOCK_ICONS` for AWS and GCP spread Azure icons. No AWS or GCP icon packs exist.
+
+## 2. Design
+
+### 2.1 Provider Label Map
+
+Replace the flat `RESOURCE_DEFINITIONS` labels with a provider-indexed map:
+
+```typescript
+// useTechTree.ts
+
+interface ProviderLabel {
+  label: string;       // "Amazon RDS"
+  shortLabel: string;  // "RDS"
+}
+
+const PROVIDER_LABELS: Record<ProviderType, Record<ResourceType, ProviderLabel>> = {
+  azure: {
+    network:     { label: 'Virtual Network (VNet)', shortLabel: 'VNet' },
+    storage:     { label: 'Blob Storage',           shortLabel: 'Storage' },
+    sql:         { label: 'Azure SQL',              shortLabel: 'SQL' },
+    function:    { label: 'Azure Functions',         shortLabel: 'Func' },
+    'app-service': { label: 'App Service',          shortLabel: 'AppSvc' },
+    vm:          { label: 'Virtual Machine',         shortLabel: 'VM' },
+    aks:         { label: 'Kubernetes (AKS)',        shortLabel: 'AKS' },
+    // ... (all 20 resources)
+  },
+  aws: {
+    network:     { label: 'VPC',                    shortLabel: 'VPC' },
+    storage:     { label: 'S3',                     shortLabel: 'S3' },
+    sql:         { label: 'Amazon RDS',             shortLabel: 'RDS' },
+    function:    { label: 'Lambda',                 shortLabel: 'Lambda' },
+    'app-service': { label: 'Elastic Beanstalk',   shortLabel: 'EB' },
+    vm:          { label: 'EC2',                    shortLabel: 'EC2' },
+    aks:         { label: 'EKS',                    shortLabel: 'EKS' },
+    // ...
+  },
+  gcp: {
+    network:     { label: 'VPC Network',            shortLabel: 'VPC' },
+    storage:     { label: 'Cloud Storage',          shortLabel: 'GCS' },
+    sql:         { label: 'Cloud SQL',              shortLabel: 'CloudSQL' },
+    function:    { label: 'Cloud Functions',         shortLabel: 'GCF' },
+    'app-service': { label: 'App Engine',           shortLabel: 'GAE' },
+    vm:          { label: 'Compute Engine',          shortLabel: 'GCE' },
+    aks:         { label: 'GKE',                    shortLabel: 'GKE' },
+    // ...
+  },
+};
+```
+
+`RESOURCE_DEFINITIONS` keeps only provider-agnostic fields: `id`, `icon`, `category`, `blockCategory`, `disabledReason`. Labels come from `PROVIDER_LABELS[activeProvider][resourceType]`.
+
+### 2.2 Icon Resolution Fix
+
+Update `iconResolver.ts`:
+
+```typescript
+// Subtype-specific overrides (provider-agnostic)
+const SUBTYPE_ICON_OVERRIDES: Record<string, string> = {
+  'app-service': appServiceIcon,   // use existing app-service.svg
+};
+
+export function getBlockIconUrl(provider, category, subtype?) {
+  // 1. Check subtype override first
+  if (subtype && SUBTYPE_ICON_OVERRIDES[subtype]) {
+    return SUBTYPE_ICON_OVERRIDES[subtype];
+  }
+  // 2. Provider + category
+  return PROVIDER_BLOCK_ICONS[provider]?.[category] ?? AZURE_BLOCK_ICONS[category];
+}
+```
+
+Also fix the `function` category mapping: `logic-apps.svg` → a proper functions icon. Since no `azure-functions.svg` exists, we have two options:
+- **Option A**: Create a simple Azure Functions SVG icon
+- **Option B**: Use `logic-apps.svg` but rename it to `functions.svg` for clarity
+
+Recommend **Option A** for accuracy.
+
+### 2.3 Provider Badge Rules
+
+Show provider badge only when architecture has **multiple providers**:
+
+```typescript
+// BlockSvg.tsx
+const showProviderBadge = allProviders.size > 1;
+```
+
+Where `allProviders` is derived from the architecture's blocks. This requires passing a `showBadge` prop or reading the architecture store.
+
+Simpler approach: always show badge **except** when all blocks share the same provider as the active provider tab. This avoids reading the entire architecture in every BlockSvg render.
+
+### 2.4 Subtype Storage
+
+When a block is created via CommandCard, `Block.subtype` stores the `ResourceType` ID (e.g., `'sql'`, `'app-service'`, `'vm'`). This is already working — `def.id` is passed as subtype in `addBlock()`.
+
+No change needed here, but the subtype should also be provider-aware for future use:
+- Store: `subtype = resourceType` (e.g., `'sql'`)
+- The provider field already distinguishes Azure SQL from RDS
+- Display label comes from `PROVIDER_LABELS[block.provider][block.subtype]`
+
+## 3. Full Resource Mapping
+
+### Plates
+
+| ID | Azure | AWS | GCP |
+|----|-------|-----|-----|
+| `network` | Virtual Network (VNet) | VPC | VPC Network |
+| `public-subnet` | Public Subnet | Public Subnet | Public Subnet |
+| `private-subnet` | Private Subnet | Private Subnet | Private Subnet |
+
+### Always-available (edge/global)
+
+| ID | Cat | Azure | AWS | GCP |
+|----|-----|-------|-----|-----|
+| `storage` | storage | Blob Storage | S3 | Cloud Storage |
+| `dns` | gateway | DNS Zone | Route 53 | Cloud DNS |
+| `cdn` | gateway | CDN Profile | CloudFront | Cloud CDN |
+| `front-door` | gateway | Front Door | Global Accelerator | Cloud Load Balancing |
+
+### VNet-optional
+
+| ID | Cat | Azure | AWS | GCP |
+|----|-----|-------|-----|-----|
+| `sql` | database | Azure SQL | Amazon RDS | Cloud SQL |
+| `function` | function | Azure Functions | Lambda | Cloud Functions |
+| `queue` | queue | Queue Storage | SQS | Cloud Tasks |
+| `event` | event | Event Hub | EventBridge | Pub/Sub |
+| `app-service` | function | App Service | Elastic Beanstalk | App Engine |
+| `container-instances` | compute | Container Instances | ECS Fargate | Cloud Run |
+| `cosmos-db` | database | Cosmos DB | DynamoDB | Firestore |
+| `key-vault` | identity | Key Vault | Secrets Manager | Secret Manager |
+
+### VNet-required
+
+| ID | Cat | Azure | AWS | GCP |
+|----|-----|-------|-----|-----|
+| `vm` | compute | Virtual Machine | EC2 | Compute Engine |
+| `aks` | compute | Kubernetes (AKS) | EKS | GKE |
+| `internal-lb` | gateway | Internal LB | Internal ALB | Internal LB |
+| `firewall` | gateway | Azure Firewall | Network Firewall | Cloud Firewall |
+| `nsg` | gateway | NSG | Security Group | Firewall Rules |
+| `bastion` | gateway | Azure Bastion | Session Manager | IAP Tunnel |
+
+## 4. Implementation Issues
+
+### Issue 1: Provider-specific resource labels (#1023)
+- Add `PROVIDER_LABELS` to `useTechTree.ts`
+- Update `CommandCard` to read labels from provider map
+- Files: `useTechTree.ts`, `CommandCard.tsx`
+
+### Issue 2: Fix wrong icon mappings
+- Use `app-service.svg` for app-service subtype
+- Create/source proper icons for functions, identity, analytics, observability
+- Make `getBlockIconUrl` subtype-aware
+- Files: `iconResolver.ts`, `assets/azure-icons/`
+
+### Issue 3: Provider badge conditional display
+- Only show "Az"/"AW"/"GC" badge when multi-provider blocks exist
+- Files: `BlockSvg.tsx`
+
+### Issue 4: AWS/GCP icon packs (future)
+- Out of scope for this iteration
+- AWS/GCP will continue using Azure icon fallbacks with correct labels
+- Icon packs can be added later without code changes (just add SVGs + update `PROVIDER_BLOCK_ICONS`)


### PR DESCRIPTION
## Summary
- Hide the always-visible provider badge ("Az"/"AW"/"GC") from BlockSvg — in single-provider mode it's visual noise
- Add `docs/design/PROVIDER_RESOURCES.md` — comprehensive design for provider-specific resources covering:
  - Provider label mapping (Azure/AWS/GCP equivalents for all 20 resources)
  - Icon mapping fixes needed (function uses wrong icon, app-service.svg unused)
  - Badge display rules (hidden now, multi-cloud in M20+)
  - Migration path from hardcoded Azure to provider-aware system

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 1797 tests pass

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)