### PR TITLE
feat(web): auto-open Properties, add Copy/Delete to detail panels (#1037, #1038)

### DIFF
--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -124,7 +124,11 @@ function closeOtherRightPanels(except: RightPanelKey): Partial<UIState> {
 
 export const useUIStore = create<UIState>((set) => ({
   selectedId: null,
-  setSelectedId: (id) => set({ selectedId: id }),
+  setSelectedId: (id) => set({
+    selectedId: id,
+    // Auto-open properties panel when a block/plate is selected
+    ...(id && id !== 'worker-default' ? { showProperties: true } : {}),
+  }),
 
   toolMode: 'select',
   setToolMode: (mode) =>

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.css
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.css
@@ -303,3 +303,52 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
+
+/* ─── Action Buttons ─────────────────────────────────────── */
+
+.detail-actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+}
+
+.detail-action-btn {
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 2px solid #D4B200;
+  background: #FFD500;
+  color: #333;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'Fredoka', system-ui, sans-serif;
+  transition: all 0.1s ease;
+  box-shadow: inset 0 2px 0 rgba(255,255,255,0.4), 0 2px 0 0 #D4B200;
+}
+
+.detail-action-btn:hover {
+  background: #FFE44D;
+  transform: translateY(-1px);
+  box-shadow: inset 0 2px 0 rgba(255,255,255,0.5), 0 3px 0 0 #D4B200;
+}
+
+.detail-action-btn:active {
+  transform: translateY(1px);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2), 0 1px 0 0 #D4B200;
+}
+
+.detail-action-btn--danger {
+  background: #E3000B;
+  color: #fff;
+  border-color: #B80009;
+  box-shadow: inset 0 2px 0 rgba(255,255,255,0.3), 0 2px 0 0 #B80009;
+}
+
+.detail-action-btn--danger:hover {
+  background: #FF3333;
+  box-shadow: inset 0 2px 0 rgba(255,255,255,0.4), 0 3px 0 0 #B80009;
+}
+
+.detail-action-btn--danger:active {
+  box-shadow: inset 0 1px 0 rgba(255,255,255,0.2), 0 1px 0 0 #B80009;
+}

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -19,6 +19,7 @@ import type { PlateProfileId } from '../../shared/types/index';
 import type { Block, Plate } from '@cloudblocks/schema';
 import { getBlockColor } from '../../entities/block/blockFaceColors';
 import { getBlockIconUrl, getPlateIconUrl } from '../../shared/utils/iconResolver';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import './DetailPanel.css';
 
 interface DetailPanelProps {
@@ -104,6 +105,9 @@ function BlockDetail({ block, className }: { block: Block; className: string }) 
   const inputRef = useRef<HTMLInputElement>(null);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
   const renameBlock = useArchitectureStore((s) => s.renameBlock);
+  const removeBlock = useArchitectureStore((s) => s.removeBlock);
+  const duplicateBlock = useArchitectureStore((s) => s.duplicateBlock);
+  const setSelectedId = useUIStore((s) => s.setSelectedId);
 
   useEffect(() => {
     if (isRenaming && inputRef.current) {
@@ -218,6 +222,36 @@ function BlockDetail({ block, className }: { block: Block; className: string }) 
           </span>
         </div>
       </div>
+
+      <div className="detail-divider" />
+
+      <div className="detail-actions">
+        <button
+          type="button"
+          className="detail-action-btn"
+          onClick={() => duplicateBlock(block.id)}
+          title="Duplicate this block"
+        >
+          📋 Copy
+        </button>
+        <button
+          type="button"
+          className="detail-action-btn detail-action-btn--danger"
+          onClick={async () => {
+            const confirmed = await confirmDialog(
+              `Delete "${block.name}"? This cannot be undone.`,
+              'Delete Block',
+            );
+            if (confirmed) {
+              removeBlock(block.id);
+              setSelectedId(null);
+            }
+          }}
+          title="Delete this block"
+        >
+          🗑️ Delete
+        </button>
+      </div>
     </div>
   );
 }
@@ -227,6 +261,28 @@ function BlockDetail({ block, className }: { block: Block; className: string }) 
 function PlateDetail({ plate, className }: { plate: Plate; className: string }) {
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
   const setPlateProfile = useArchitectureStore((s) => s.setPlateProfile);
+  const renamePlate = useArchitectureStore((s) => s.renamePlate);
+  const removePlate = useArchitectureStore((s) => s.removePlate);
+  const setSelectedId = useUIStore((s) => s.setSelectedId);
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [newPlateName, setNewPlateName] = useState(plate.name);
+  const plateInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isRenaming && plateInputRef.current) {
+      plateInputRef.current.focus();
+      plateInputRef.current.select();
+    }
+  }, [isRenaming]);
+
+  const handlePlateRename = useCallback(() => {
+    const trimmed = newPlateName.trim();
+    if (trimmed && trimmed !== plate.name) {
+      renamePlate(plate.id, trimmed);
+      setNewPlateName(trimmed);
+    }
+    setIsRenaming(false);
+  }, [newPlateName, plate.id, plate.name, renamePlate]);
 
   const profileId = plate.profileId && isPlateProfileId(plate.profileId)
     ? plate.profileId
@@ -259,7 +315,30 @@ function PlateDetail({ plate, className }: { plate: Plate; className: string }) 
           alt={altText}
           className="detail-header-icon-img"
         />
-        <span className="detail-header-name">{plate.name}</span>
+        {isRenaming ? (
+          <input
+            ref={plateInputRef}
+            type="text"
+            className="detail-header-input"
+            value={newPlateName}
+            onChange={(e) => setNewPlateName(e.target.value)}
+            onBlur={handlePlateRename}
+            onKeyDown={(e) => e.key === 'Enter' && handlePlateRename()}
+          />
+        ) : (
+          <span className="detail-header-name">{plate.name}</span>
+        )}
+        <button
+          type="button"
+          className="detail-rename-btn"
+          onClick={() => {
+            setNewPlateName(plate.name);
+            setIsRenaming(true);
+          }}
+          title="Rename"
+        >
+          Rename
+        </button>
       </div>
 
       <div className="detail-divider" />
@@ -321,6 +400,28 @@ function PlateDetail({ plate, className }: { plate: Plate; className: string }) 
             {childPlates.length > 0 && `, ${childPlates.length} subnet${childPlates.length !== 1 ? 's' : ''}`}
           </span>
         </div>
+      </div>
+
+      <div className="detail-divider" />
+
+      <div className="detail-actions">
+        <button
+          type="button"
+          className="detail-action-btn detail-action-btn--danger"
+          onClick={async () => {
+            const confirmed = await confirmDialog(
+              `Delete "${plate.name}"? All blocks inside will also be removed.`,
+              'Delete Plate',
+            );
+            if (confirmed) {
+              removePlate(plate.id);
+              setSelectedId(null);
+            }
+          }}
+          title="Delete this plate"
+        >
+          🗑️ Delete
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Part of Epic #1035 (Minifigure Worker Role Implementation).

### #1037: Properties auto-open
- Selecting a block/plate automatically opens Properties panel

### #1038: Copy and Delete in Properties
- BlockDetail: Copy + Delete with confirmation
- PlateDetail: Rename + Delete with confirmation
- LEGO brick-styled action buttons

## Test plan
- [x] typecheck, lint, 1792 tests pass

Closes #1037, #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)