### PR TITLE
feat(web): add infrastructure settings with Apply to Properties panel (#1039)

### DIFF
--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -21,6 +21,7 @@ type DomainSlice = Pick<
   | 'duplicateBlock'
   | 'removeBlock'
   | 'renameBlock'
+  | 'updateBlockConfig'
   | 'renamePlate'
   | 'moveBlock'
   | 'setPlateProfile'
@@ -296,6 +297,26 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         ...arch,
         blocks: arch.blocks.map((candidate) =>
           candidate.id === blockId ? { ...candidate, name: newName } : candidate
+        ),
+      });
+    });
+  },
+
+  updateBlockConfig: (blockId, config) => {
+    set((state) => {
+      const arch = state.workspace.architecture;
+      const block = arch.blocks.find((candidate) => candidate.id === blockId);
+
+      if (!block) {
+        return state;
+      }
+
+      return withHistory(state, {
+        ...arch,
+        blocks: arch.blocks.map((candidate) =>
+          candidate.id === blockId
+            ? { ...candidate, config: { ...candidate.config, ...config } }
+            : candidate
         ),
       });
     });

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -36,6 +36,7 @@ export interface ArchitectureState {
   duplicateBlock: (blockId: string) => void;
   removeBlock: (id: string) => void;
   renameBlock: (blockId: string, newName: string) => void;
+  updateBlockConfig: (blockId: string, config: Record<string, unknown>) => void;
   renamePlate: (plateId: string, newName: string) => void;
   moveBlock: (blockId: string, newPlacementId: string) => void;
   setPlateProfile: (plateId: string, profileId: PlateProfileId) => void;

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.css
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.css
@@ -303,3 +303,61 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
+
+/* ─── Infrastructure Settings ────────────────────────────── */
+
+.detail-infra-settings {
+  padding: 8px 12px;
+}
+
+.detail-infra-title {
+  margin: 0 0 8px 0;
+  font-size: 11px;
+  font-weight: 700;
+  color: #665500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.detail-property-input {
+  width: 80px;
+  padding: 3px 6px;
+  border: 2px solid #D4B200;
+  border-radius: 4px;
+  background: #FFFDE7;
+  color: #333;
+  font-size: 11px;
+  font-family: 'Fredoka', system-ui, sans-serif;
+  font-weight: 600;
+}
+
+.detail-property-input:focus {
+  outline: none;
+  border-color: #FFD500;
+  box-shadow: 0 0 0 2px rgba(255, 213, 0, 0.3);
+}
+
+.detail-infra-apply-btn {
+  margin-top: 8px;
+  padding: 6px 16px;
+  border-radius: 6px;
+  border: 2px solid #00591D;
+  background: #00852B;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: 'Fredoka', system-ui, sans-serif;
+  transition: all 0.1s ease;
+  box-shadow: inset 0 2px 0 rgba(255,255,255,0.3), 0 2px 0 0 #00591D;
+}
+
+.detail-infra-apply-btn:hover:not(:disabled) {
+  background: #00a335;
+  transform: translateY(-1px);
+}
+
+.detail-infra-apply-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -218,6 +218,119 @@ function BlockDetail({ block, className }: { block: Block; className: string }) 
           </span>
         </div>
       </div>
+
+      <div className="detail-divider" />
+
+      <InfraSettings block={block} />
+    </div>
+  );
+}
+
+// ─── Infrastructure Settings ──────────────────────────────
+
+/** Category-specific infrastructure setting definitions. */
+const INFRA_SETTING_DEFS: Record<string, { key: string; label: string; type: 'select' | 'number'; options?: string[] }[]> = {
+  compute: [
+    { key: 'tier', label: 'Tier / SKU', type: 'select', options: ['Basic', 'Standard', 'Premium'] },
+    { key: 'vcpus', label: 'vCPUs', type: 'number' },
+    { key: 'memoryGb', label: 'Memory (GB)', type: 'number' },
+  ],
+  database: [
+    { key: 'tier', label: 'Tier', type: 'select', options: ['Basic', 'Standard', 'Premium'] },
+    { key: 'storageSizeGb', label: 'Storage (GB)', type: 'number' },
+  ],
+  function: [
+    { key: 'tier', label: 'Plan', type: 'select', options: ['Consumption', 'Premium', 'Dedicated'] },
+  ],
+  gateway: [
+    { key: 'tier', label: 'Tier', type: 'select', options: ['Basic', 'Standard', 'Premium'] },
+  ],
+  storage: [
+    { key: 'replication', label: 'Replication', type: 'select', options: ['LRS', 'GRS', 'ZRS', 'GZRS'] },
+    { key: 'storageSizeGb', label: 'Size (GB)', type: 'number' },
+  ],
+};
+
+function InfraSettings({ block }: { block: Block }) {
+  const updateBlockConfig = useArchitectureStore((s) => s.updateBlockConfig);
+  const [draft, setDraft] = useState<Record<string, string>>({});
+  const [hasChanges, setHasChanges] = useState(false);
+
+  const settings = INFRA_SETTING_DEFS[block.category] ?? [];
+
+  // Reset draft when block changes
+  useEffect(() => {
+    const initial: Record<string, string> = {};
+    for (const setting of settings) {
+      initial[setting.key] = String(block.config?.[setting.key] ?? '');
+    }
+    setDraft(initial);
+    setHasChanges(false);
+  }, [block.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (settings.length === 0) {
+    return null;
+  }
+
+  const handleChange = (key: string, value: string) => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+    setHasChanges(true);
+  };
+
+  const handleApply = () => {
+    const config: Record<string, unknown> = {};
+    for (const setting of settings) {
+      const value = draft[setting.key];
+      if (value !== '') {
+        config[setting.key] = setting.type === 'number' ? Number(value) : value;
+      }
+    }
+    updateBlockConfig(block.id, config);
+    setHasChanges(false);
+  };
+
+  return (
+    <div className="detail-infra-settings">
+      <h4 className="detail-infra-title">Infrastructure Settings</h4>
+      {settings.map((setting) => (
+        <div key={setting.key} className="detail-property">
+          <label className="detail-property-label" htmlFor={`infra-${block.id}-${setting.key}`}>
+            {setting.label}
+          </label>
+          <span className="detail-property-value">
+            {setting.type === 'select' && setting.options ? (
+              <select
+                id={`infra-${block.id}-${setting.key}`}
+                className="detail-property-select"
+                value={draft[setting.key] ?? ''}
+                onChange={(e) => handleChange(setting.key, e.target.value)}
+              >
+                <option value="">—</option>
+                {setting.options.map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                id={`infra-${block.id}-${setting.key}`}
+                type="number"
+                className="detail-property-input"
+                value={draft[setting.key] ?? ''}
+                onChange={(e) => handleChange(setting.key, e.target.value)}
+                min={0}
+              />
+            )}
+          </span>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="detail-infra-apply-btn"
+        onClick={handleApply}
+        disabled={!hasChanges}
+      >
+        Apply
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Part of Epic #1035.

Add infrastructure settings section to the block detail panel:
- Tier/SKU selection (compute, database, function, gateway)
- vCPU and memory settings (compute)
- Storage size and replication (storage, database)
- Apply button saves to Block.config via new updateBlockConfig action

## Test plan
- [x] typecheck, lint, 1792 tests pass

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)