### PR TITLE
feat(web): implement brick-style connection rendering

### DIFF
--- a/apps/web/src/entities/connection/BrickConnector.test.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.test.tsx
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { BrickConnector } from './BrickConnector';
+import { useUIStore } from '../store/uiStore';
+import { useArchitectureStore } from '../store/architectureStore';
+import { getEndpointWorldPosition } from '../../shared/utils/position';
+import { worldToScreen } from '../../shared/utils/isometric';
+import { getDiffState } from '../../features/diff/engine';
+import type { Connection } from '@cloudblocks/schema';
+import type { DiffDelta } from '../../shared/types/diff';
+
+vi.mock('../../shared/utils/position', () => ({
+  getEndpointWorldPosition: vi.fn(),
+}));
+
+vi.mock('../../shared/utils/isometric', () => ({
+  worldToScreen: vi.fn(),
+}));
+
+vi.mock('../../features/diff/engine', () => ({
+  getDiffState: vi.fn(),
+}));
+
+const connection: Connection = {
+  id: 'conn-1',
+  sourceId: 'source-1',
+  targetId: 'target-1',
+  type: 'dataflow',
+  metadata: {},
+};
+
+describe('BrickConnector', () => {
+  const initialUIState = useUIStore.getState();
+  const initialArchitectureState = useArchitectureStore.getState();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useUIStore.setState(initialUIState, true);
+    useArchitectureStore.setState(initialArchitectureState, true);
+    useUIStore.setState({
+      diffMode: false,
+      diffDelta: null,
+      selectedId: null,
+      toolMode: 'select',
+    });
+  });
+
+  it('returns null when source endpoint position is missing', () => {
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce([3, 0, 4]);
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          externalActors={[]}
+          originX={100}
+          originY={200}
+        />
+      </svg>,
+    );
+
+    expect(container.querySelector('g')).toBeNull();
+  });
+
+  it('returns null when target endpoint position is missing', () => {
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce(null);
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          externalActors={[]}
+          originX={100}
+          originY={200}
+        />
+      </svg>,
+    );
+
+    expect(container.querySelector('g')).toBeNull();
+  });
+
+  it('renders svg group with polygons and ellipses when endpoints exist', () => {
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 120, y: 220 })
+      .mockReturnValueOnce({ x: 280, y: 320 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          externalActors={[]}
+          originX={100}
+          originY={200}
+        />
+      </svg>,
+    );
+
+    expect(container.querySelector('g')).toBeInTheDocument();
+    const polygons = container.querySelectorAll('polygon');
+    expect(polygons.length).toBeGreaterThanOrEqual(4);
+    const ellipses = container.querySelectorAll('ellipse');
+    expect(ellipses.length).toBe(6);
+  });
+
+  it('renders hit area with data-testid', () => {
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    expect(container.querySelector('[data-testid="connection-hit-area"]')).toBeInTheDocument();
+  });
+
+  it('click in select mode sets selectedId to connection id', () => {
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    fireEvent.click(container.querySelector('g') as SVGGElement);
+    expect(useUIStore.getState().selectedId).toBe(connection.id);
+  });
+
+  it('click in delete mode removes the connection', () => {
+    const removeConnectionMock = vi.fn();
+    useUIStore.setState({ toolMode: 'delete' });
+    useArchitectureStore.setState({ removeConnection: removeConnectionMock });
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    fireEvent.click(container.querySelector('g') as SVGGElement);
+    expect(removeConnectionMock).toHaveBeenCalledWith(connection.id);
+  });
+
+  it('stops propagation when clicking a connection', () => {
+    const parentClick = vi.fn();
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg onClick={parentClick}><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={0} originY={0} />
+      </svg>,
+    );
+
+    fireEvent.click(container.querySelector('g') as SVGGElement);
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it('uses diff colors when diff state is added', () => {
+    useUIStore.setState({ diffMode: true, diffDelta: {} as unknown as DiffDelta });
+    vi.mocked(getDiffState).mockReturnValue('added');
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    const topFace = container.querySelectorAll('polygon')[2];
+    expect(topFace?.getAttribute('fill')).toBe('#22c55e');
+    expect(container.querySelector('g')?.getAttribute('opacity')).toBe('1');
+  });
+
+  it('uses removed diff opacity when diff state is removed', () => {
+    useUIStore.setState({ diffMode: true, diffDelta: {} as unknown as DiffDelta });
+    vi.mocked(getDiffState).mockReturnValue('removed');
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    expect(container.querySelector('g')?.getAttribute('opacity')).toBe('0.4');
+  });
+
+  it('renders selection glow when connection is selected', () => {
+    useUIStore.setState({ selectedId: connection.id });
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    const glowPath = container.querySelectorAll('path')[0];
+    expect(glowPath?.getAttribute('stroke')).toBe('#ffffff');
+    expect(glowPath?.getAttribute('stroke-opacity')).toBe('0.5');
+  });
+
+  it('renders studs at source and target endpoints', () => {
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 200, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    const ellipses = container.querySelectorAll('ellipse');
+    expect(ellipses).toHaveLength(6);
+
+    expect(ellipses[0]?.getAttribute('rx')).toBe('12');
+    expect(ellipses[0]?.getAttribute('ry')).toBe('6');
+    expect(ellipses[2]?.getAttribute('rx')).toBe('7.2');
+    expect(ellipses[2]?.getAttribute('ry')).toBe('3.6');
+  });
+
+  it('renders different pattern for http connection type', () => {
+    const httpConnection: Connection = {
+      ...connection,
+      id: 'conn-http',
+      type: 'http',
+    };
+
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 250, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={httpConnection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    const lines = container.querySelectorAll('line');
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders dashed pattern for internal connection type', () => {
+    const internalConnection: Connection = {
+      ...connection,
+      id: 'conn-int',
+      type: 'internal',
+    };
+
+    vi.mocked(getEndpointWorldPosition)
+      .mockReturnValueOnce([1, 0, 2])
+      .mockReturnValueOnce([3, 0, 4]);
+    vi.mocked(worldToScreen)
+      .mockReturnValueOnce({ x: 100, y: 100 })
+      .mockReturnValueOnce({ x: 250, y: 200 });
+
+    const { container } = render(
+      <svg><title>Test</title>
+        <BrickConnector connection={internalConnection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
+      </svg>,
+    );
+
+    const lines = container.querySelectorAll('line');
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    expect(lines[0]?.getAttribute('stroke-dasharray')).toBe('4 3');
+  });
+});

--- a/apps/web/src/entities/connection/BrickConnector.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.tsx
@@ -1,0 +1,311 @@
+import { memo, useState, useMemo } from 'react';
+import type { Connection, Block, Plate, ExternalActor } from '@cloudblocks/schema';
+import { getDiffState } from '../../features/diff/engine';
+import { getEndpointWorldPosition } from '../../shared/utils/position';
+import { worldToScreen } from '../../shared/utils/isometric';
+import type { ScreenPoint } from '../../shared/utils/isometric';
+import { useUIStore } from '../store/uiStore';
+import { useArchitectureStore } from '../store/architectureStore';
+import { STUD_RX, STUD_RY, STUD_HEIGHT, STUD_INNER_RX, STUD_INNER_RY, STUD_INNER_OPACITY } from '../../shared/tokens/designTokens';
+import { CONNECTOR_THEMES, DIFF_THEMES, lightenColor } from './connectorTheme';
+import { computeRoute, segmentAngle, segmentLength } from './routing';
+import type { ConnectorTheme } from './connectorTheme';
+import type { RouteSegment } from './routing';
+
+interface BrickConnectorProps {
+  connection: Connection;
+  blocks: Block[];
+  plates: Plate[];
+  externalActors: ExternalActor[];
+  originX: number;
+  originY: number;
+}
+
+const TILE_HALF_WIDTH = 8;
+const TILE_THICKNESS = 3;
+const ARROW_LENGTH = 12;
+const HIT_AREA_WIDTH = 16;
+
+function getColors(
+  theme: ConnectorTheme,
+  diffState: string,
+  isHighlighted: boolean,
+): { tile: string; shadow: string; dark: string; accent: string; opacity: number } {
+  const diffOverride = diffState !== 'unchanged' ? DIFF_THEMES[diffState] : null;
+
+  const baseTile = diffOverride?.tile ?? theme.tile;
+  const baseShadow = diffOverride?.shadow ?? theme.shadow;
+  const baseDark = diffOverride?.dark ?? theme.dark;
+  const baseOpacity = diffOverride?.opacity ?? 1.0;
+  const accent = diffState !== 'unchanged' ? '#ffffff' : theme.accent;
+
+  if (isHighlighted) {
+    return {
+      tile: lightenColor(baseTile, 0.15),
+      shadow: lightenColor(baseShadow, 0.1),
+      dark: lightenColor(baseDark, 0.1),
+      accent,
+      opacity: baseOpacity,
+    };
+  }
+
+  return { tile: baseTile, shadow: baseShadow, dark: baseDark, accent, opacity: baseOpacity };
+}
+
+function buildTilePoints(
+  start: ScreenPoint,
+  end: ScreenPoint,
+  halfWidth: number,
+): { top: string; rightSide: string; frontSide: string } {
+  const angle = Math.atan2(end.y - start.y, end.x - start.x);
+  const perpX = -Math.sin(angle) * halfWidth;
+  const perpY = Math.cos(angle) * halfWidth;
+
+  const p1 = { x: start.x + perpX, y: start.y + perpY };
+  const p2 = { x: start.x - perpX, y: start.y - perpY };
+  const p3 = { x: end.x - perpX, y: end.y - perpY };
+  const p4 = { x: end.x + perpX, y: end.y + perpY };
+
+  const top = `${p1.x},${p1.y} ${p4.x},${p4.y} ${p3.x},${p3.y} ${p2.x},${p2.y}`;
+
+  const rightSide = [
+    `${p4.x},${p4.y}`,
+    `${p3.x},${p3.y}`,
+    `${p3.x},${p3.y + TILE_THICKNESS}`,
+    `${p4.x},${p4.y + TILE_THICKNESS}`,
+  ].join(' ');
+
+  const frontSide = [
+    `${p2.x},${p2.y}`,
+    `${p3.x},${p3.y}`,
+    `${p3.x},${p3.y + TILE_THICKNESS}`,
+    `${p2.x},${p2.y + TILE_THICKNESS}`,
+  ].join(' ');
+
+  return { top, rightSide, frontSide };
+}
+
+function buildArrowPoints(
+  end: ScreenPoint,
+  angle: number,
+  halfWidth: number,
+): string {
+  const tipX = end.x + Math.cos(angle) * ARROW_LENGTH;
+  const tipY = end.y + Math.sin(angle) * ARROW_LENGTH;
+  const perpX = -Math.sin(angle) * halfWidth;
+  const perpY = Math.cos(angle) * halfWidth;
+  const baseLeft = { x: end.x + perpX, y: end.y + perpY };
+  const baseRight = { x: end.x - perpX, y: end.y - perpY };
+
+  return `${baseLeft.x},${baseLeft.y} ${tipX},${tipY} ${baseRight.x},${baseRight.y}`;
+}
+
+function buildHitPath(segments: RouteSegment[]): string {
+  if (segments.length === 0) return '';
+  let d = `M ${segments[0].start.x} ${segments[0].start.y}`;
+  for (const seg of segments) {
+    d += ` L ${seg.end.x} ${seg.end.y}`;
+  }
+  return d;
+}
+
+function renderPattern(
+  pattern: ConnectorTheme['pattern'],
+  start: ScreenPoint,
+  end: ScreenPoint,
+  accent: string,
+  segId: string,
+): React.ReactNode {
+  if (pattern === 'solid') return null;
+
+  const len = segmentLength({ start, end });
+  if (len < 10) return null;
+
+  const angle = Math.atan2(end.y - start.y, end.x - start.x);
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+
+  const inset = 4;
+  const sx = start.x + cos * inset;
+  const sy = start.y + sin * inset;
+  const ex = end.x - cos * inset;
+  const ey = end.y - sin * inset;
+
+  const commonProps = {
+    stroke: accent,
+    strokeWidth: 1,
+    opacity: 0.5,
+    fill: 'none' as const,
+  };
+
+  switch (pattern) {
+    case 'double': {
+      const off = 2;
+      const px = -sin * off;
+      const py = cos * off;
+      return (
+        <g key={segId}>
+          <line x1={sx + px} y1={sy + py} x2={ex + px} y2={ey + py} {...commonProps} />
+          <line x1={sx - px} y1={sy - py} x2={ex - px} y2={ey - py} {...commonProps} />
+        </g>
+      );
+    }
+    case 'dashed':
+      return <line key={segId} x1={sx} y1={sy} x2={ex} y2={ey} {...commonProps} strokeDasharray="4 3" />;
+    case 'dotted':
+      return <line key={segId} x1={sx} y1={sy} x2={ex} y2={ey} {...commonProps} strokeDasharray="2 3" />;
+    case 'zigzag': {
+      const steps = Math.max(2, Math.floor(len / 8));
+      const pts: string[] = [];
+      for (let i = 0; i <= steps; i++) {
+        const t = i / steps;
+        const bx = sx + (ex - sx) * t;
+        const by = sy + (ey - sy) * t;
+        const zigOff = (i % 2 === 0 ? 2.5 : -2.5);
+        pts.push(`${bx + (-sin) * zigOff},${by + cos * zigOff}`);
+      }
+      return <polyline key={segId} points={pts.join(' ')} {...commonProps} />;
+    }
+    default:
+      return null;
+  }
+}
+
+function renderStud(
+  cx: number,
+  cy: number,
+  colors: { tile: string; shadow: string; accent: string },
+  id: string,
+): React.ReactNode {
+  return (
+    <g key={id}>
+      <ellipse cx={cx} cy={cy} rx={STUD_RX} ry={STUD_RY} fill={colors.shadow} />
+      <ellipse cx={cx} cy={cy - STUD_HEIGHT} rx={STUD_RX} ry={STUD_RY} fill={colors.tile} />
+      <ellipse cx={cx} cy={cy - STUD_HEIGHT} rx={STUD_INNER_RX} ry={STUD_INNER_RY} fill={colors.accent} opacity={STUD_INNER_OPACITY} />
+    </g>
+  );
+}
+
+export const BrickConnector = memo(function BrickConnector({
+  connection,
+  blocks,
+  plates,
+  externalActors,
+  originX,
+  originY,
+}: BrickConnectorProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const selectedId = useUIStore((s) => s.selectedId);
+  const setSelectedId = useUIStore((s) => s.setSelectedId);
+  const toolMode = useUIStore((s) => s.toolMode);
+  const diffMode = useUIStore((s) => s.diffMode);
+  const diffDelta = useUIStore((s) => s.diffDelta);
+  const removeConnection = useArchitectureStore((s) => s.removeConnection);
+
+  const src = getEndpointWorldPosition(connection.sourceId, blocks, plates, externalActors);
+  const tgt = getEndpointWorldPosition(connection.targetId, blocks, plates, externalActors);
+
+  const theme = CONNECTOR_THEMES[connection.type];
+  const diffState = diffMode && diffDelta ? getDiffState(connection.id, diffDelta) : 'unchanged';
+  const isSelected = selectedId === connection.id;
+  const isHighlighted = isHovered || isSelected;
+
+  const route = useMemo(() => {
+    if (!src || !tgt) return null;
+    const srcScreen = worldToScreen(src[0], src[1], src[2], originX, originY);
+    const tgtScreen = worldToScreen(tgt[0], tgt[1], tgt[2], originX, originY);
+    return { srcScreen, tgtScreen, ...computeRoute(srcScreen, tgtScreen) };
+  }, [src, tgt, originX, originY]);
+
+  if (!src || !tgt || !route) return null;
+
+  const colors = getColors(theme, diffState, isHighlighted);
+  const hitPath = buildHitPath(route.segments);
+
+  const lastSeg = route.segments[route.segments.length - 1];
+  const arrowAngle = segmentAngle(lastSeg);
+  const arrowPoints = buildArrowPoints(lastSeg.end, arrowAngle, TILE_HALF_WIDTH);
+
+  const handleClick = (e: React.MouseEvent<SVGGElement>) => {
+    e.stopPropagation();
+    if (toolMode === 'delete') {
+      removeConnection(connection.id);
+      return;
+    }
+    setSelectedId(connection.id);
+  };
+
+  return (
+    <g
+      opacity={colors.opacity}
+      style={{ cursor: 'pointer' }}
+      onClick={handleClick}
+    >
+      {isSelected && (
+        <path
+          d={hitPath}
+          stroke="#ffffff"
+          strokeWidth={TILE_HALF_WIDTH * 2 + 4}
+          strokeOpacity={0.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+          pointerEvents="none"
+        />
+      )}
+
+      <path
+        d={hitPath}
+        stroke="transparent"
+        strokeWidth={HIT_AREA_WIDTH}
+        fill="none"
+        pointerEvents="stroke"
+        data-testid="connection-hit-area"
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      />
+
+      {route.segments.map((seg, i) => {
+        const pts = buildTilePoints(seg.start, seg.end, TILE_HALF_WIDTH);
+        return (
+          <g key={`seg-${connection.id}-${i}`} pointerEvents="none">
+            <polygon points={pts.frontSide} fill={colors.dark} />
+            <polygon points={pts.rightSide} fill={colors.shadow} />
+            <polygon points={pts.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+            {renderPattern(theme.pattern, seg.start, seg.end, colors.accent, `pat-${connection.id}-${i}`)}
+          </g>
+        );
+      })}
+
+      {route.elbows.map((elbow, i) => {
+        const elbowPts = [
+          `${elbow.x - TILE_HALF_WIDTH},${elbow.y}`,
+          `${elbow.x},${elbow.y - TILE_HALF_WIDTH / 2}`,
+          `${elbow.x + TILE_HALF_WIDTH},${elbow.y}`,
+          `${elbow.x},${elbow.y + TILE_HALF_WIDTH / 2}`,
+        ].join(' ');
+        return (
+          <polygon
+            key={`elbow-${connection.id}-${i}`}
+            points={elbowPts}
+            fill={colors.tile}
+            stroke={colors.shadow}
+            strokeWidth={0.5}
+            pointerEvents="none"
+          />
+        );
+      })}
+
+      <polygon
+        points={arrowPoints}
+        fill={colors.tile}
+        stroke={colors.shadow}
+        strokeWidth={0.5}
+        pointerEvents="none"
+      />
+
+      {renderStud(route.srcScreen.x, route.srcScreen.y, colors, `stud-src-${connection.id}`)}
+      {renderStud(route.tgtScreen.x, route.tgtScreen.y, colors, `stud-tgt-${connection.id}`)}
+    </g>
+  );
+});

--- a/apps/web/src/entities/connection/connectorTheme.test.ts
+++ b/apps/web/src/entities/connection/connectorTheme.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { lightenColor, CONNECTOR_THEMES, DIFF_THEMES } from './connectorTheme';
+
+describe('lightenColor', () => {
+  it('returns same color when amount is 0', () => {
+    expect(lightenColor('#000000', 0)).toBe('#000000');
+    expect(lightenColor('#ff0000', 0)).toBe('#ff0000');
+  });
+
+  it('returns white when amount is 1', () => {
+    expect(lightenColor('#000000', 1)).toBe('#ffffff');
+    expect(lightenColor('#334155', 1)).toBe('#ffffff');
+  });
+
+  it('lightens a color by partial amount', () => {
+    expect(lightenColor('#000000', 0.5)).toBe('#808080');
+  });
+
+  it('lightens non-black color correctly', () => {
+    const result = lightenColor('#64748b', 0.15);
+    expect(result).toMatch(/^#[0-9a-f]{6}$/);
+    const r = parseInt(result.slice(1, 3), 16);
+    expect(r).toBeGreaterThan(0x64);
+  });
+
+  it('clamps at 255', () => {
+    const result = lightenColor('#fefefe', 0.5);
+    expect(result).toBe('#ffffff');
+  });
+});
+
+describe('CONNECTOR_THEMES', () => {
+  it('defines themes for all 5 connection types', () => {
+    expect(Object.keys(CONNECTOR_THEMES)).toEqual(['dataflow', 'http', 'internal', 'data', 'async']);
+  });
+
+  it('each theme has required properties', () => {
+    for (const theme of Object.values(CONNECTOR_THEMES)) {
+      expect(theme).toHaveProperty('tile');
+      expect(theme).toHaveProperty('shadow');
+      expect(theme).toHaveProperty('dark');
+      expect(theme).toHaveProperty('accent');
+      expect(theme).toHaveProperty('pattern');
+    }
+  });
+
+  it('each pattern is unique across types', () => {
+    const patterns = Object.values(CONNECTOR_THEMES).map((t) => t.pattern);
+    expect(new Set(patterns).size).toBe(5);
+  });
+});
+
+describe('DIFF_THEMES', () => {
+  it('defines themes for added, removed, and modified', () => {
+    expect(DIFF_THEMES).toHaveProperty('added');
+    expect(DIFF_THEMES).toHaveProperty('removed');
+    expect(DIFF_THEMES).toHaveProperty('modified');
+  });
+
+  it('removed state has reduced opacity', () => {
+    expect(DIFF_THEMES.removed.opacity).toBeLessThan(1);
+  });
+});

--- a/apps/web/src/entities/connection/connectorTheme.ts
+++ b/apps/web/src/entities/connection/connectorTheme.ts
@@ -1,0 +1,87 @@
+import type { ConnectionType } from '@cloudblocks/schema';
+
+// ─── Connector Color Themes ─────────────────────────────────
+// See BRICK_CONNECTOR_SPEC.md §3.1
+
+export interface ConnectorTheme {
+  /** Top face / tile color */
+  tile: string;
+  /** Shadow / side face color */
+  shadow: string;
+  /** Front face (darkest) */
+  dark: string;
+  /** Accent for patterns and stud inner ring */
+  accent: string;
+  /** SVG pattern type */
+  pattern: 'solid' | 'double' | 'dashed' | 'dotted' | 'zigzag';
+}
+
+export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
+  dataflow: {
+    tile: '#64748b',
+    shadow: '#475569',
+    dark: '#334155',
+    accent: '#94a3b8',
+    pattern: 'solid',
+  },
+  http: {
+    tile: '#3b82f6',
+    shadow: '#2563eb',
+    dark: '#1d4ed8',
+    accent: '#60a5fa',
+    pattern: 'double',
+  },
+  internal: {
+    tile: '#8b5cf6',
+    shadow: '#7c3aed',
+    dark: '#6d28d9',
+    accent: '#a78bfa',
+    pattern: 'dashed',
+  },
+  data: {
+    tile: '#f59e0b',
+    shadow: '#d97706',
+    dark: '#b45309',
+    accent: '#fbbf24',
+    pattern: 'dotted',
+  },
+  async: {
+    tile: '#10b981',
+    shadow: '#059669',
+    dark: '#047857',
+    accent: '#34d399',
+    pattern: 'zigzag',
+  },
+};
+
+// ─── Diff-Aware Overrides ───────────────────────────────────
+// See BRICK_CONNECTOR_SPEC.md §6
+
+export interface DiffTheme {
+  tile: string;
+  shadow: string;
+  dark: string;
+  opacity: number;
+}
+
+export const DIFF_THEMES: Record<string, DiffTheme> = {
+  added: { tile: '#22c55e', shadow: '#166534', dark: '#14532d', opacity: 1.0 },
+  removed: { tile: '#ef4444', shadow: '#991b1b', dark: '#7f1d1d', opacity: 0.4 },
+  modified: { tile: '#eab308', shadow: '#854d0e', dark: '#713f12', opacity: 1.0 },
+};
+
+/**
+ * Lighten a hex color by a percentage (0–1).
+ * Used for hover/selection brightness boost.
+ */
+export function lightenColor(hex: string, amount: number): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+
+  const lr = Math.min(255, Math.round(r + (255 - r) * amount));
+  const lg = Math.min(255, Math.round(g + (255 - g) * amount));
+  const lb = Math.min(255, Math.round(b + (255 - b) * amount));
+
+  return `#${lr.toString(16).padStart(2, '0')}${lg.toString(16).padStart(2, '0')}${lb.toString(16).padStart(2, '0')}`;
+}

--- a/apps/web/src/entities/connection/routing.test.ts
+++ b/apps/web/src/entities/connection/routing.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { computeRoute, segmentAngle, segmentLength } from './routing';
+
+describe('computeRoute', () => {
+  it('returns single segment for aligned points', () => {
+    const route = computeRoute({ x: 0, y: 0 }, { x: 100, y: 0 });
+    expect(route.segments).toHaveLength(1);
+    expect(route.elbows).toHaveLength(0);
+    expect(route.segments[0].start).toEqual({ x: 0, y: 0 });
+    expect(route.segments[0].end).toEqual({ x: 100, y: 0 });
+  });
+
+  it('returns single segment for vertically aligned points', () => {
+    const route = computeRoute({ x: 50, y: 0 }, { x: 50, y: 100 });
+    expect(route.segments).toHaveLength(1);
+    expect(route.elbows).toHaveLength(0);
+  });
+
+  it('returns L-shaped route with elbow for diagonal points', () => {
+    const route = computeRoute({ x: 0, y: 0 }, { x: 100, y: 80 });
+    expect(route.segments).toHaveLength(2);
+    expect(route.elbows).toHaveLength(1);
+    expect(route.elbows[0]).toEqual({ x: 100, y: 0 });
+  });
+
+  it('returns single segment for very close points', () => {
+    const route = computeRoute({ x: 0, y: 0 }, { x: 3, y: 3 });
+    expect(route.segments).toHaveLength(1);
+    expect(route.elbows).toHaveLength(0);
+  });
+});
+
+describe('segmentAngle', () => {
+  it('returns 0 for horizontal right', () => {
+    const angle = segmentAngle({ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } });
+    expect(angle).toBeCloseTo(0);
+  });
+
+  it('returns PI/2 for vertical down', () => {
+    const angle = segmentAngle({ start: { x: 0, y: 0 }, end: { x: 0, y: 10 } });
+    expect(angle).toBeCloseTo(Math.PI / 2);
+  });
+});
+
+describe('segmentLength', () => {
+  it('returns correct length for horizontal segment', () => {
+    const len = segmentLength({ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } });
+    expect(len).toBeCloseTo(10);
+  });
+
+  it('returns correct length for diagonal segment', () => {
+    const len = segmentLength({ start: { x: 0, y: 0 }, end: { x: 3, y: 4 } });
+    expect(len).toBeCloseTo(5);
+  });
+});

--- a/apps/web/src/entities/connection/routing.ts
+++ b/apps/web/src/entities/connection/routing.ts
@@ -1,0 +1,51 @@
+import type { ScreenPoint } from '../../shared/utils/isometric';
+
+export interface RouteSegment {
+  start: ScreenPoint;
+  end: ScreenPoint;
+}
+
+export interface ConnectorRoute {
+  segments: RouteSegment[];
+  elbows: ScreenPoint[];
+}
+
+const ELBOW_THRESHOLD = 8;
+
+export function computeRoute(src: ScreenPoint, tgt: ScreenPoint): ConnectorRoute {
+  const dx = Math.abs(tgt.x - src.x);
+  const dy = Math.abs(tgt.y - src.y);
+
+  if (dx < ELBOW_THRESHOLD && dy < ELBOW_THRESHOLD) {
+    return {
+      segments: [{ start: src, end: tgt }],
+      elbows: [],
+    };
+  }
+
+  if (dx < ELBOW_THRESHOLD || dy < ELBOW_THRESHOLD) {
+    return {
+      segments: [{ start: src, end: tgt }],
+      elbows: [],
+    };
+  }
+
+  const elbow: ScreenPoint = { x: tgt.x, y: src.y };
+  return {
+    segments: [
+      { start: src, end: elbow },
+      { start: elbow, end: tgt },
+    ],
+    elbows: [elbow],
+  };
+}
+
+export function segmentAngle(seg: RouteSegment): number {
+  return Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
+}
+
+export function segmentLength(seg: RouteSegment): number {
+  const dx = seg.end.x - seg.start.x;
+  const dy = seg.end.y - seg.start.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../../shared/utils/audioService', () => ({
 }));
 vi.mock('../../entities/plate/PlateSprite', () => ({ PlateSprite: () => null }));
 vi.mock('../../entities/block/BlockSprite', () => ({ BlockSprite: () => null }));
-vi.mock('../../entities/connection/ConnectionPath', () => ({ ConnectionPath: () => null }));
+vi.mock('../../entities/connection/BrickConnector', () => ({ BrickConnector: () => null }));
 vi.mock('../../entities/connection/ExternalActorSprite', () => ({ ExternalActorSprite: () => null }));
 vi.mock('../../entities/character', () => ({ MinifigureSvg: () => null, MinifigureSprite: () => null }));
 vi.mock('./EmptyCanvasOverlay', () => ({ EmptyCanvasOverlay: () => null }));

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -10,7 +10,7 @@ import type { SoundName } from '../../shared/utils/audioService';
 
 import { PlateSprite } from '../../entities/plate/PlateSprite';
 import { BlockSprite } from '../../entities/block/BlockSprite';
-import { ConnectionPath } from '../../entities/connection/ConnectionPath';
+import { BrickConnector } from '../../entities/connection/BrickConnector';
 import { ExternalActorSprite } from '../../entities/connection/ExternalActorSprite';
 import { MinifigureSprite } from '../../entities/character';
 import { EmptyCanvasOverlay } from './EmptyCanvasOverlay';
@@ -211,7 +211,7 @@ export function SceneCanvas() {
         <svg className="connection-layer" style={{ width: 1, height: 1 }}>
           <title>Connections</title>
           {architecture.connections.map((conn) => (
-            <ConnectionPath
+            <BrickConnector
               key={conn.id}
               connection={conn}
               blocks={architecture.blocks}

--- a/docs/design/BRICK_CONNECTOR_SPEC.md
+++ b/docs/design/BRICK_CONNECTOR_SPEC.md
@@ -1,0 +1,311 @@
+# Brick Connector Design Specification
+
+**Status**: Active  
+**Date**: 2026-03-21  
+**Related issues**: #1014 (Epic), #1015, #1016, #1017, #1018, #1019  
+**Related**: [CLOUDBLOCKS_SPEC_V2.md §11](./CLOUDBLOCKS_SPEC_V2.md), [BRICK_DESIGN_SPEC.md §0](./BRICK_DESIGN_SPEC.md) (stud standard reference)
+
+---
+
+## 1. Problem Statement
+
+Connections between blocks currently render as thin SVG bezier curves — generic diagram-tool lines that break the Lego visual metaphor. Plates and blocks look like Lego bricks with studs, but connections look like arrows from a flowchart tool. This visual inconsistency undermines the entire brick-based design language.
+
+### Current Implementation
+
+```
+ConnectionPath.tsx:
+- SVG <path> with quadratic bezier curve (M ... Q ...)
+- Two-layer stroke: 4px dark background + 2px colored foreground
+- Arrow markers at end for direction
+- 14px transparent hit area for click/hover
+- 5 connection types differentiated by stroke dash pattern only
+```
+
+### Goal
+
+Replace bezier lines with **Lego Technic flat-tile style connectors** that:
+- Conform to the Universal Stud Standard
+- Render correctly in 2.5D isometric projection
+- Visually distinguish 5 connection types
+- Preserve all existing interactions and diff-aware coloring
+
+---
+
+## 2. Design Decisions
+
+### 2.1 Connector Shape: Flat Tile (1×N×⅓)
+
+Connectors use the **Lego flat tile** metaphor — thin rectangular pieces (⅓ brick height) that lie flat on the isometric plane. This was chosen over Technic beams because:
+
+- **Simpler geometry** — fewer SVG elements per connector, better performance with 20+ connections
+- **Less visual clutter** — thin tiles don't compete with blocks for attention
+- **Natural at any angle** — tiles can be rotated to follow connection paths without looking broken
+- **Clear hierarchy** — blocks are tall (full bricks), connectors are flat (tiles), maintaining visual depth
+
+Each connector is composed of **segments** — individual flat tile pieces that chain together from source to target.
+
+### 2.2 Segment Geometry (Isometric)
+
+A single connector segment in isometric view:
+
+```
+Segment width:  16px screen (≈0.5 CU)
+Segment height: 3px screen (≈⅓ of stud height)
+```
+
+The segment renders as a parallelogram in isometric projection:
+
+```svg
+<!-- Single segment along X-axis (simplified) -->
+<g>
+  <!-- Top face (flat tile surface) -->
+  <path d="M x1,y1 L x2,y2 L x3,y3 L x4,y4 Z" fill="{tile-color}" />
+  <!-- Right edge (thin side face) -->
+  <path d="M x2,y2 L x3,y3 L x3,y3+3 L x2,y2+3 Z" fill="{shadow-color}" />
+  <!-- Front edge (thin front face) -->
+  <path d="M x3,y3 L x4,y4 L x4,y4+3 L x3,y3+3 Z" fill="{dark-color}" />
+</g>
+```
+
+### 2.3 Stud Placement on Connectors
+
+To maintain the Universal Stud Standard, connectors include **one stud at each endpoint** (source and target attachment points). Mid-segment studs are omitted to keep connectors visually clean and distinguishable from blocks.
+
+Endpoint studs use the canonical dimensions:
+- rx=12, ry=6, height=5, 3-layer structure
+- Color matches the connection type palette
+
+### 2.4 Routing Strategy: Direct Segmented
+
+**Phase 1 (M18)**: Direct point-to-point with up to 3 segments.
+
+```
+Source ──[segment]──[elbow]──[segment]──[elbow]──[segment]── Target
+```
+
+The path from source to target is computed as:
+1. If source and target share the same X or Z axis: **single straight segment**
+2. Otherwise: **L-shaped path** with one elbow joint (2 segments)
+3. Elbow joints render as small square connector pieces (like Lego Technic angle connectors)
+
+The routing algorithm projects screen-space endpoints back to world coordinates, then routes along world X and Z axes (which render as isometric diagonals on screen).
+
+**Phase 2 (future)**: Orthogonal Manhattan routing with collision avoidance.
+
+---
+
+## 3. Connection Type Visual Language
+
+Each of the 5 connection types is differentiated by **color** and **surface pattern**. The flat tile metaphor makes color the primary differentiator, with a subtle SVG pattern overlay for accessibility.
+
+### 3.1 Color Palette
+
+| Type | Tile Color | Shadow Color | Accent | Pattern |
+|------|-----------|-------------|--------|---------|
+| `dataflow` | `#64748b` (slate) | `#475569` | `#94a3b8` | Solid — no pattern |
+| `http` | `#3b82f6` (blue) | `#2563eb` | `#60a5fa` | Double line — ═ |
+| `internal` | `#8b5cf6` (violet) | `#7c3aed` | `#a78bfa` | Dashed — ┄ |
+| `data` | `#f59e0b` (amber) | `#d97706` | `#fbbf24` | Dotted — ··· |
+| `async` | `#10b981` (emerald) | `#059669` | `#34d399` | Zigzag — ⚡ |
+
+### 3.2 Pattern Implementation
+
+Patterns are rendered as thin SVG lines/shapes on the tile's top face:
+
+```svg
+<!-- dataflow: solid (no pattern overlay) -->
+
+<!-- http: double parallel line -->
+<line x1="..." y1="..." x2="..." y2="..." stroke="{accent}" stroke-width="1" opacity="0.5" />
+<line x1="..." y1="..." x2="..." y2="..." stroke="{accent}" stroke-width="1" opacity="0.5" />
+
+<!-- internal: dashed center line -->
+<line ... stroke-dasharray="4 3" stroke="{accent}" stroke-width="1" opacity="0.5" />
+
+<!-- data: dotted center line -->
+<line ... stroke-dasharray="2 3" stroke="{accent}" stroke-width="1" opacity="0.5" />
+
+<!-- async: zigzag line (via polyline) -->
+<polyline points="..." stroke="{accent}" stroke-width="1" fill="none" opacity="0.5" />
+```
+
+---
+
+## 4. Directional Indicator
+
+Direction is indicated by an **asymmetric end piece** at the target end of the connector:
+
+- **Source end**: Flat tile terminates flush (square end)
+- **Target end**: Arrow-shaped point — the tile narrows to a triangular tip
+
+```
+Source ═════════════════════▷ Target
+  [flat]                   [arrow]
+```
+
+The arrow tip is a simple triangular polygon appended to the last segment, using the same color palette as the connection type.
+
+---
+
+## 5. Interaction Model
+
+### 5.1 Hit Area
+
+A transparent stroke along the connector path provides the clickable area, matching the current 14px hit zone:
+
+```svg
+<path d="{connector-path}" stroke="transparent" stroke-width="14" fill="none" pointer-events="stroke" />
+```
+
+### 5.2 Selection State
+
+When selected, the connector receives:
+- **Outline glow**: 2px outer stroke in white at 50% opacity around the entire connector
+- **Brightness boost**: Tile color lightened by 15%
+- Consistent with block selection visual (blue glow ring)
+
+### 5.3 Hover State
+
+On hover:
+- **Brightness boost**: Tile color lightened by 10%
+- **Cursor**: `pointer`
+
+### 5.4 Delete
+
+- Delete mode (tool mode = 'delete'): Click removes connection
+- Keyboard: Del key removes selected connection
+- Same behavior as current implementation
+
+---
+
+## 6. Diff-Aware Coloring
+
+When diff mode is active, connector colors override the type-based palette:
+
+| Diff State | Tile Color | Shadow | Opacity |
+|-----------|-----------|--------|---------|
+| `added` | `#22c55e` | `#166534` | 1.0 |
+| `removed` | `#ef4444` | `#991b1b` | 0.4 |
+| `modified` | `#eab308` | `#854d0e` | 1.0 |
+| `unchanged` | Type default | Type default | 1.0 |
+
+The surface pattern (§3.2) is still rendered in diff mode, using white at 30% opacity for contrast.
+
+---
+
+## 7. External Actor Connections
+
+External actors (Internet → Gateway) use the same brick connector rendering. The connector originates from the external actor's world position and terminates at the target block.
+
+No special geometry changes — external actor connections render identically to block-to-block connections, preserving visual consistency.
+
+---
+
+## 8. Performance Considerations
+
+| Concern | Mitigation |
+|---------|-----------|
+| SVG complexity per connector | Flat tiles use 3-4 paths per segment (top + 2 edges + optional pattern). ~10 SVG elements per connection. |
+| 20+ connections | React `memo` on connector component. SVG `<defs>` for shared patterns and stud symbols. |
+| Re-render on pan/zoom | Connectors use world coordinates projected to screen — same as blocks. No extra calculation. |
+| Hit area accuracy | Transparent stroke path follows actual connector geometry. |
+
+Target: **<16ms frame time** with 30 simultaneous connections.
+
+---
+
+## 9. Implementation Plan
+
+| Issue | Deliverable | Dependencies |
+|-------|------------|-------------|
+| #1015 | This design spec document | None |
+| #1016 | `BrickConnector.tsx` — SVG component with 5 type visuals | #1015 |
+| #1017 | `routing.ts` — path computation (direct + L-shaped) | #1015 |
+| #1018 | Interaction migration (select, hover, delete) | #1016 |
+| #1019 | Diff-aware coloring + external actor support | #1016 |
+
+### File Structure
+
+```
+src/entities/connection/
+├── BrickConnector.tsx          # Main component (replaces ConnectionPath.tsx)
+├── BrickConnector.css          # Styles
+├── BrickConnector.test.tsx     # Tests
+├── routing.ts                  # Path computation algorithm
+├── routing.test.ts             # Routing tests
+├── connectorTheme.ts           # Color palettes and pattern definitions
+├── ConnectionPath.tsx          # DEPRECATED — kept for rollback
+└── ConnectionPath.test.tsx     # Existing tests (kept)
+```
+
+---
+
+## 10. SVG Reference: Flat Tile Connector Segment
+
+Complete SVG for a single isometric flat tile segment along the world X-axis:
+
+```svg
+<!-- 
+  Flat tile segment at world position, projected to isometric.
+  Width: 0.5 CU along X-axis
+  Height: 3px (⅓ stud height) 
+-->
+<g class="connector-segment" data-type="dataflow">
+  <!-- Top face (isometric parallelogram) -->
+  <polygon 
+    points="{p1x},{p1y} {p2x},{p2y} {p3x},{p3y} {p4x},{p4y}"
+    fill="#64748b" 
+    stroke="#475569" 
+    stroke-width="0.5"
+  />
+  <!-- Right side face (3px tall) -->
+  <polygon 
+    points="{p2x},{p2y} {p3x},{p3y} {p3x},{p3y+3} {p2x},{p2y+3}"
+    fill="#475569"
+  />
+  <!-- Front face (3px tall) -->
+  <polygon 
+    points="{p3x},{p3y} {p4x},{p4y} {p4x},{p4y+3} {p3x},{p3y+3}"
+    fill="#334155"
+  />
+</g>
+```
+
+### Elbow Joint (Corner Piece)
+
+```svg
+<!-- Square connector piece at bend point -->
+<g class="connector-elbow">
+  <polygon 
+    points="{top-face-diamond}" 
+    fill="{tile-color}" 
+    stroke="{shadow-color}" 
+    stroke-width="0.5"
+  />
+  <!-- side faces omitted for brevity — same pattern as segment -->
+</g>
+```
+
+### Endpoint Stud (Source/Target)
+
+```svg
+<!-- Universal Stud Standard at connector endpoint -->
+<g class="connector-stud">
+  <ellipse cx="{cx}" cy="{cy}" rx="12" ry="6" fill="{shadow-color}" />
+  <ellipse cx="{cx}" cy="{cy-5}" rx="12" ry="6" fill="{tile-color}" />
+  <ellipse cx="{cx}" cy="{cy-5}" rx="7.2" ry="3.6" fill="{accent}" opacity="0.3" />
+</g>
+```
+
+### Arrow Tip (Target End)
+
+```svg
+<!-- Directional arrow at target endpoint -->
+<polygon 
+  points="{tip-triangle}" 
+  fill="{tile-color}" 
+  stroke="{shadow-color}" 
+  stroke-width="0.5"
+/>
+```


### PR DESCRIPTION
## Summary

- Replace `ConnectionPath` with `BrickConnector` SVG component that renders connections as flat tile segments with 3D depth, directional arrows, and Universal Stud Standard endpoint studs
- Implement L-shaped routing algorithm (`routing.ts`) with single-elbow paths for non-aligned endpoints
- Add 5 visual patterns mapped to connection types: solid (dataflow), double-line (http), dashed (internal), dotted (data), zigzag (async)
- Add diff-aware coloring with green/red/yellow overrides for architecture diff mode
- Add selection glow (white stroke at 50% opacity) and hover brightness boost via `lightenColor`
- Add design spec document (`BRICK_CONNECTOR_SPEC.md`) covering geometry, color themes, routing, interactions, and performance

## Test Coverage

- 13 BrickConnector tests (null endpoints, rendering, click/delete, diff colors, selection glow, studs, patterns)
- 10 connectorTheme tests (lightenColor edge cases, theme completeness, pattern uniqueness, diff themes)
- 7 routing tests (direct/L-shaped routes, segment angle/length)
- All 1823 tests pass, 0 failures

## Files Changed

| File | Change |
|------|--------|
| `docs/design/BRICK_CONNECTOR_SPEC.md` | NEW — Design specification |
| `apps/web/src/entities/connection/BrickConnector.tsx` | NEW — Main SVG component |
| `apps/web/src/entities/connection/BrickConnector.test.tsx` | NEW — 13 tests |
| `apps/web/src/entities/connection/connectorTheme.ts` | NEW — Color palettes |
| `apps/web/src/entities/connection/connectorTheme.test.ts` | NEW — 10 tests |
| `apps/web/src/entities/connection/routing.ts` | NEW — Route computation |
| `apps/web/src/entities/connection/routing.test.ts` | NEW — 7 tests |
| `apps/web/src/widgets/scene-canvas/SceneCanvas.tsx` | MOD — Swap ConnectionPath → BrickConnector |
| `apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx` | MOD — Update mock |

Closes #1014, closes #1015, closes #1016, closes #1017, closes #1018, closes #1019