### PR TITLE
feat(web): implement Technic Beam connector redesign

### DIFF
--- a/apps/web/src/entities/connection/BrickConnector.test.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.test.tsx
@@ -6,7 +6,7 @@ import { useArchitectureStore } from '../store/architectureStore';
 import { getEndpointWorldPosition } from '../../shared/utils/position';
 import { worldToScreen } from '../../shared/utils/isometric';
 import { getDiffState } from '../../features/diff/engine';
-import type { Connection } from '@cloudblocks/schema';
+import type { Connection, ConnectionType } from '@cloudblocks/schema';
 import type { DiffDelta } from '../../shared/types/diff';
 
 vi.mock('../../shared/utils/position', () => ({
@@ -29,6 +29,30 @@ const connection: Connection = {
   metadata: {},
 };
 
+function setupEndpoints(srcScreen = { x: 120, y: 220 }, tgtScreen = { x: 280, y: 320 }) {
+  vi.mocked(getEndpointWorldPosition)
+    .mockReturnValueOnce([1, 0, 2])
+    .mockReturnValueOnce([3, 0, 4]);
+  vi.mocked(worldToScreen)
+    .mockReturnValueOnce(srcScreen)
+    .mockReturnValueOnce(tgtScreen);
+}
+
+function renderConnector(conn: Connection = connection) {
+  return render(
+    <svg><title>Test</title>
+      <BrickConnector
+        connection={conn}
+        blocks={[]}
+        plates={[]}
+        externalActors={[]}
+        originX={100}
+        originY={200}
+      />
+    </svg>,
+  );
+}
+
 describe('BrickConnector', () => {
   const initialUIState = useUIStore.getState();
   const initialArchitectureState = useArchitectureStore.getState();
@@ -50,19 +74,7 @@ describe('BrickConnector', () => {
       .mockReturnValueOnce(null)
       .mockReturnValueOnce([3, 0, 4]);
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector
-          connection={connection}
-          blocks={[]}
-          plates={[]}
-          externalActors={[]}
-          originX={100}
-          originY={200}
-        />
-      </svg>,
-    );
-
+    const { container } = renderConnector();
     expect(container.querySelector('g')).toBeNull();
   });
 
@@ -71,80 +83,34 @@ describe('BrickConnector', () => {
       .mockReturnValueOnce([1, 0, 2])
       .mockReturnValueOnce(null);
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector
-          connection={connection}
-          blocks={[]}
-          plates={[]}
-          externalActors={[]}
-          originX={100}
-          originY={200}
-        />
-      </svg>,
-    );
-
+    const { container } = renderConnector();
     expect(container.querySelector('g')).toBeNull();
   });
 
   it('renders svg group with polygons and ellipses when endpoints exist', () => {
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 120, y: 220 })
-      .mockReturnValueOnce({ x: 280, y: 320 });
+    setupEndpoints();
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector
-          connection={connection}
-          blocks={[]}
-          plates={[]}
-          externalActors={[]}
-          originX={100}
-          originY={200}
-        />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
     expect(container.querySelector('g')).toBeInTheDocument();
     const polygons = container.querySelectorAll('polygon');
     expect(polygons.length).toBeGreaterThanOrEqual(4);
     const ellipses = container.querySelectorAll('ellipse');
-    expect(ellipses.length).toBe(6);
+    expect(ellipses).toHaveLength(6);
   });
 
   it('renders hit area with data-testid', () => {
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
     expect(container.querySelector('[data-testid="connection-hit-area"]')).toBeInTheDocument();
   });
 
   it('click in select mode sets selectedId to connection id', () => {
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
     fireEvent.click(container.querySelector('g') as SVGGElement);
     expect(useUIStore.getState().selectedId).toBe(connection.id);
@@ -154,18 +120,9 @@ describe('BrickConnector', () => {
     const removeConnectionMock = vi.fn();
     useUIStore.setState({ toolMode: 'delete' });
     useArchitectureStore.setState({ removeConnection: removeConnectionMock });
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
     fireEvent.click(container.querySelector('g') as SVGGElement);
     expect(removeConnectionMock).toHaveBeenCalledWith(connection.id);
@@ -193,20 +150,12 @@ describe('BrickConnector', () => {
   it('uses diff colors when diff state is added', () => {
     useUIStore.setState({ diffMode: true, diffDelta: {} as unknown as DiffDelta });
     vi.mocked(getDiffState).mockReturnValue('added');
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
-    const topFace = container.querySelectorAll('polygon')[2];
+    const polygons = container.querySelectorAll('polygon');
+    const topFace = polygons[2];
     expect(topFace?.getAttribute('fill')).toBe('#22c55e');
     expect(container.querySelector('g')?.getAttribute('opacity')).toBe('1');
   });
@@ -214,36 +163,18 @@ describe('BrickConnector', () => {
   it('uses removed diff opacity when diff state is removed', () => {
     useUIStore.setState({ diffMode: true, diffDelta: {} as unknown as DiffDelta });
     vi.mocked(getDiffState).mockReturnValue('removed');
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
     expect(container.querySelector('g')?.getAttribute('opacity')).toBe('0.4');
   });
 
   it('renders selection glow when connection is selected', () => {
     useUIStore.setState({ selectedId: connection.id });
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
     const glowPath = container.querySelectorAll('path')[0];
     expect(glowPath?.getAttribute('stroke')).toBe('#ffffff');
@@ -251,18 +182,9 @@ describe('BrickConnector', () => {
   });
 
   it('renders studs at source and target endpoints', () => {
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={connection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+    const { container } = renderConnector();
 
     const ellipses = container.querySelectorAll('ellipse');
     expect(ellipses).toHaveLength(6);
@@ -273,52 +195,114 @@ describe('BrickConnector', () => {
     expect(ellipses[2]?.getAttribute('ry')).toBe('3.6');
   });
 
-  it('renders different pattern for http connection type', () => {
-    const httpConnection: Connection = {
-      ...connection,
-      id: 'conn-http',
-      type: 'http',
+  describe('beam shapes', () => {
+    const beamShapeMap: Record<ConnectionType, string> = {
+      dataflow: 'standard',
+      http: 'doubleRail',
+      internal: 'segmented',
+      data: 'wide',
+      async: 'zigzag',
     };
 
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 250, y: 200 });
+    for (const [type, beamShape] of Object.entries(beamShapeMap)) {
+      it(`renders ${beamShape} beam for ${type} connection type`, () => {
+        const conn: Connection = {
+          ...connection,
+          id: `conn-${type}`,
+          type: type as ConnectionType,
+        };
+        setupEndpoints({ x: 100, y: 100 }, { x: 250, y: 200 });
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={httpConnection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+        const { container } = renderConnector(conn);
 
-    const lines = container.querySelectorAll('line');
-    expect(lines.length).toBeGreaterThanOrEqual(2);
+        const rootGroup = container.querySelector('g');
+        expect(rootGroup).toBeInTheDocument();
+        expect(rootGroup?.getAttribute('data-beam-shape')).toBe(beamShape);
+      });
+    }
+
+    it('standard beam renders 3 polygons per segment (top + 2 sides)', () => {
+      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
+
+      const { container } = renderConnector({
+        ...connection,
+        type: 'dataflow',
+      });
+
+      const standardBeam = container.querySelector('[data-beam="standard"]');
+      expect(standardBeam).toBeInTheDocument();
+      expect(standardBeam?.querySelectorAll('polygon')).toHaveLength(3);
+    });
+
+    it('doubleRail beam renders 6 polygons per segment (3 per rail × 2)', () => {
+      const conn: Connection = { ...connection, id: 'conn-http', type: 'http' };
+      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
+
+      const { container } = renderConnector(conn);
+
+      const railBeam = container.querySelector('[data-beam="doubleRail"]');
+      expect(railBeam).toBeInTheDocument();
+      expect(railBeam?.querySelectorAll('polygon')).toHaveLength(6);
+    });
+
+    it('segmented beam renders multiple chunks with gaps', () => {
+      const conn: Connection = { ...connection, id: 'conn-int', type: 'internal' };
+      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 300 });
+
+      const { container } = renderConnector(conn);
+
+      const segmentedBeam = container.querySelector('[data-beam="segmented"]');
+      expect(segmentedBeam).toBeInTheDocument();
+      const chunkGroups = segmentedBeam?.querySelectorAll('g');
+      expect(chunkGroups?.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('wide beam renders wider polygons than standard', () => {
+      const conn: Connection = { ...connection, id: 'conn-data', type: 'data' };
+      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
+
+      const { container } = renderConnector(conn);
+
+      const wideBeam = container.querySelector('[data-beam="wide"]');
+      expect(wideBeam).toBeInTheDocument();
+      expect(wideBeam?.querySelectorAll('polygon')).toHaveLength(3);
+    });
+
+    it('zigzag beam renders multiple zig-zag sub-segments', () => {
+      const conn: Connection = { ...connection, id: 'conn-async', type: 'async' };
+      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 300 });
+
+      const { container } = renderConnector(conn);
+
+      const zigzagBeam = container.querySelector('[data-beam="zigzag"]');
+      expect(zigzagBeam).toBeInTheDocument();
+      const zigGroups = zigzagBeam?.querySelectorAll('g');
+      expect(zigGroups?.length).toBeGreaterThanOrEqual(2);
+    });
   });
 
-  it('renders dashed pattern for internal connection type', () => {
-    const internalConnection: Connection = {
-      ...connection,
-      id: 'conn-int',
-      type: 'internal',
-    };
+  describe('elbow joints', () => {
+    it('renders 3D elbow with side faces at bend points', () => {
+      setupEndpoints({ x: 100, y: 100 }, { x: 300, y: 250 });
 
-    vi.mocked(getEndpointWorldPosition)
-      .mockReturnValueOnce([1, 0, 2])
-      .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 250, y: 200 });
+      const { container } = renderConnector();
 
-    const { container } = render(
-      <svg><title>Test</title>
-        <BrickConnector connection={internalConnection} blocks={[]} plates={[]} externalActors={[]} originX={100} originY={200} />
-      </svg>,
-    );
+      const elbowGroups = container.querySelectorAll('[data-elbow]');
+      const elbowPolygons = Array.from(elbowGroups).flatMap((g) =>
+        Array.from(g.querySelectorAll('polygon')),
+      );
+      expect(elbowPolygons.length).toBeGreaterThanOrEqual(3);
+    });
+  });
 
-    const lines = container.querySelectorAll('line');
-    expect(lines.length).toBeGreaterThanOrEqual(1);
-    expect(lines[0]?.getAttribute('stroke-dasharray')).toBe('4 3');
+  describe('arrow tip', () => {
+    it('renders arrow with side face for 3D effect', () => {
+      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
+
+      const { container } = renderConnector();
+
+      const allPolygons = container.querySelectorAll('polygon');
+      expect(allPolygons.length).toBeGreaterThanOrEqual(5);
+    });
   });
 });

--- a/apps/web/src/entities/connection/BrickConnector.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.tsx
@@ -9,7 +9,7 @@ import { useArchitectureStore } from '../store/architectureStore';
 import { STUD_RX, STUD_RY, STUD_HEIGHT, STUD_INNER_RX, STUD_INNER_RY, STUD_INNER_OPACITY } from '../../shared/tokens/designTokens';
 import { CONNECTOR_THEMES, DIFF_THEMES, lightenColor } from './connectorTheme';
 import { computeRoute, segmentAngle, segmentLength } from './routing';
-import type { ConnectorTheme } from './connectorTheme';
+import type { ConnectorTheme, BeamShape } from './connectorTheme';
 import type { RouteSegment } from './routing';
 
 interface BrickConnectorProps {
@@ -21,16 +21,31 @@ interface BrickConnectorProps {
   originY: number;
 }
 
-const TILE_HALF_WIDTH = 8;
-const TILE_THICKNESS = 3;
+interface BeamColors {
+  tile: string;
+  shadow: string;
+  dark: string;
+  accent: string;
+  opacity: number;
+}
+
+const BEAM_HALF_WIDTH = 8;
+const BEAM_THICKNESS = 6;
+const WIDE_HALF_WIDTH = 12;
+const RAIL_HALF_WIDTH = 3;
+const RAIL_GAP = 4;
+const SEGMENT_CHUNK_LENGTH = 20;
+const SEGMENT_GAP = 4;
+const ZIGZAG_AMPLITUDE = 6;
+const ZIGZAG_WAVELENGTH = 16;
 const ARROW_LENGTH = 12;
-const HIT_AREA_WIDTH = 16;
+const HIT_AREA_WIDTH = 20;
 
 function getColors(
   theme: ConnectorTheme,
   diffState: string,
   isHighlighted: boolean,
-): { tile: string; shadow: string; dark: string; accent: string; opacity: number } {
+): BeamColors {
   const diffOverride = diffState !== 'unchanged' ? DIFF_THEMES[diffState] : null;
 
   const baseTile = diffOverride?.tile ?? theme.tile;
@@ -52,10 +67,11 @@ function getColors(
   return { tile: baseTile, shadow: baseShadow, dark: baseDark, accent, opacity: baseOpacity };
 }
 
-function buildTilePoints(
+function buildBeamFaces(
   start: ScreenPoint,
   end: ScreenPoint,
   halfWidth: number,
+  thickness: number,
 ): { top: string; rightSide: string; frontSide: string } {
   const angle = Math.atan2(end.y - start.y, end.x - start.x);
   const perpX = -Math.sin(angle) * halfWidth;
@@ -71,18 +87,203 @@ function buildTilePoints(
   const rightSide = [
     `${p4.x},${p4.y}`,
     `${p3.x},${p3.y}`,
-    `${p3.x},${p3.y + TILE_THICKNESS}`,
-    `${p4.x},${p4.y + TILE_THICKNESS}`,
+    `${p3.x},${p3.y + thickness}`,
+    `${p4.x},${p4.y + thickness}`,
   ].join(' ');
 
   const frontSide = [
     `${p2.x},${p2.y}`,
     `${p3.x},${p3.y}`,
-    `${p3.x},${p3.y + TILE_THICKNESS}`,
-    `${p2.x},${p2.y + TILE_THICKNESS}`,
+    `${p3.x},${p3.y + thickness}`,
+    `${p2.x},${p2.y + thickness}`,
   ].join(' ');
 
   return { top, rightSide, frontSide };
+}
+
+function renderStandardBeam(
+  seg: RouteSegment,
+  colors: BeamColors,
+  segId: string,
+): React.ReactNode {
+  const faces = buildBeamFaces(seg.start, seg.end, BEAM_HALF_WIDTH, BEAM_THICKNESS);
+  return (
+    <g key={segId} pointerEvents="none" data-beam="standard">
+      <polygon points={faces.frontSide} fill={colors.dark} />
+      <polygon points={faces.rightSide} fill={colors.shadow} />
+      <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+    </g>
+  );
+}
+
+function renderDoubleRailBeam(
+  seg: RouteSegment,
+  colors: BeamColors,
+  segId: string,
+): React.ReactNode {
+  const angle = Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
+  const perpX = -Math.sin(angle);
+  const perpY = Math.cos(angle);
+  const offset = RAIL_GAP + RAIL_HALF_WIDTH;
+
+  const rail1Start = { x: seg.start.x + perpX * offset, y: seg.start.y + perpY * offset };
+  const rail1End = { x: seg.end.x + perpX * offset, y: seg.end.y + perpY * offset };
+  const rail2Start = { x: seg.start.x - perpX * offset, y: seg.start.y - perpY * offset };
+  const rail2End = { x: seg.end.x - perpX * offset, y: seg.end.y - perpY * offset };
+
+  const faces1 = buildBeamFaces(rail1Start, rail1End, RAIL_HALF_WIDTH, BEAM_THICKNESS);
+  const faces2 = buildBeamFaces(rail2Start, rail2End, RAIL_HALF_WIDTH, BEAM_THICKNESS);
+
+  return (
+    <g key={segId} pointerEvents="none" data-beam="doubleRail">
+      <polygon points={faces1.frontSide} fill={colors.dark} />
+      <polygon points={faces1.rightSide} fill={colors.shadow} />
+      <polygon points={faces1.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+      <polygon points={faces2.frontSide} fill={colors.dark} />
+      <polygon points={faces2.rightSide} fill={colors.shadow} />
+      <polygon points={faces2.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+    </g>
+  );
+}
+
+function renderSegmentedBeam(
+  seg: RouteSegment,
+  colors: BeamColors,
+  segId: string,
+): React.ReactNode {
+  const len = segmentLength(seg);
+  if (len < 1) return null;
+
+  const angle = Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+
+  const chunkCount = Math.max(1, Math.round(len / SEGMENT_CHUNK_LENGTH));
+  const totalGaps = Math.max(0, chunkCount - 1) * SEGMENT_GAP;
+  const chunkLen = (len - totalGaps) / chunkCount;
+  const chunks: React.ReactNode[] = [];
+
+  let cursor = 0;
+  for (let i = 0; i < chunkCount; i++) {
+    const chunkStart = {
+      x: seg.start.x + cos * cursor,
+      y: seg.start.y + sin * cursor,
+    };
+    const chunkEnd = {
+      x: seg.start.x + cos * (cursor + chunkLen),
+      y: seg.start.y + sin * (cursor + chunkLen),
+    };
+    const faces = buildBeamFaces(chunkStart, chunkEnd, BEAM_HALF_WIDTH, BEAM_THICKNESS);
+    chunks.push(
+      <g key={`${segId}-chunk-${i}`}>
+        <polygon points={faces.frontSide} fill={colors.dark} />
+        <polygon points={faces.rightSide} fill={colors.shadow} />
+        <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+      </g>,
+    );
+    cursor += chunkLen + SEGMENT_GAP;
+  }
+
+  return (
+    <g key={segId} pointerEvents="none" data-beam="segmented">
+      {chunks}
+    </g>
+  );
+}
+
+function renderWideBeam(
+  seg: RouteSegment,
+  colors: BeamColors,
+  segId: string,
+): React.ReactNode {
+  const faces = buildBeamFaces(seg.start, seg.end, WIDE_HALF_WIDTH, BEAM_THICKNESS);
+  return (
+    <g key={segId} pointerEvents="none" data-beam="wide">
+      <polygon points={faces.frontSide} fill={colors.dark} />
+      <polygon points={faces.rightSide} fill={colors.shadow} />
+      <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+    </g>
+  );
+}
+
+function renderZigzagBeam(
+  seg: RouteSegment,
+  colors: BeamColors,
+  segId: string,
+): React.ReactNode {
+  const len = segmentLength(seg);
+  if (len < 1) return null;
+
+  const angle = Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  const perpX = -sin;
+  const perpY = cos;
+
+  const steps = Math.max(2, Math.floor(len / ZIGZAG_WAVELENGTH) * 2);
+  const zigSegments: React.ReactNode[] = [];
+
+  for (let i = 0; i < steps; i++) {
+    const t0 = i / steps;
+    const t1 = (i + 1) / steps;
+    const offset0 = (i % 2 === 0 ? 1 : -1) * ZIGZAG_AMPLITUDE;
+    const offset1 = (i % 2 === 0 ? -1 : 1) * ZIGZAG_AMPLITUDE;
+
+    const zStart = {
+      x: seg.start.x + cos * len * t0 + perpX * offset0,
+      y: seg.start.y + sin * len * t0 + perpY * offset0,
+    };
+    const zEnd = {
+      x: seg.start.x + cos * len * t1 + perpX * offset1,
+      y: seg.start.y + sin * len * t1 + perpY * offset1,
+    };
+
+    const faces = buildBeamFaces(zStart, zEnd, RAIL_HALF_WIDTH, BEAM_THICKNESS);
+    zigSegments.push(
+      <g key={`${segId}-zig-${i}`}>
+        <polygon points={faces.frontSide} fill={colors.dark} />
+        <polygon points={faces.rightSide} fill={colors.shadow} />
+        <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+      </g>,
+    );
+  }
+
+  return (
+    <g key={segId} pointerEvents="none" data-beam="zigzag">
+      {zigSegments}
+    </g>
+  );
+}
+
+function renderBeamSegment(
+  beamShape: BeamShape,
+  seg: RouteSegment,
+  colors: BeamColors,
+  segId: string,
+): React.ReactNode {
+  switch (beamShape) {
+    case 'standard':
+      return renderStandardBeam(seg, colors, segId);
+    case 'doubleRail':
+      return renderDoubleRailBeam(seg, colors, segId);
+    case 'segmented':
+      return renderSegmentedBeam(seg, colors, segId);
+    case 'wide':
+      return renderWideBeam(seg, colors, segId);
+    case 'zigzag':
+      return renderZigzagBeam(seg, colors, segId);
+  }
+}
+
+function getBeamHalfWidth(beamShape: BeamShape): number {
+  switch (beamShape) {
+    case 'wide':
+      return WIDE_HALF_WIDTH;
+    case 'doubleRail':
+      return RAIL_GAP + RAIL_HALF_WIDTH * 2;
+    default:
+      return BEAM_HALF_WIDTH;
+  }
 }
 
 function buildArrowPoints(
@@ -107,68 +308,6 @@ function buildHitPath(segments: RouteSegment[]): string {
     d += ` L ${seg.end.x} ${seg.end.y}`;
   }
   return d;
-}
-
-function renderPattern(
-  pattern: ConnectorTheme['pattern'],
-  start: ScreenPoint,
-  end: ScreenPoint,
-  accent: string,
-  segId: string,
-): React.ReactNode {
-  if (pattern === 'solid') return null;
-
-  const len = segmentLength({ start, end });
-  if (len < 10) return null;
-
-  const angle = Math.atan2(end.y - start.y, end.x - start.x);
-  const cos = Math.cos(angle);
-  const sin = Math.sin(angle);
-
-  const inset = 4;
-  const sx = start.x + cos * inset;
-  const sy = start.y + sin * inset;
-  const ex = end.x - cos * inset;
-  const ey = end.y - sin * inset;
-
-  const commonProps = {
-    stroke: accent,
-    strokeWidth: 1,
-    opacity: 0.5,
-    fill: 'none' as const,
-  };
-
-  switch (pattern) {
-    case 'double': {
-      const off = 2;
-      const px = -sin * off;
-      const py = cos * off;
-      return (
-        <g key={segId}>
-          <line x1={sx + px} y1={sy + py} x2={ex + px} y2={ey + py} {...commonProps} />
-          <line x1={sx - px} y1={sy - py} x2={ex - px} y2={ey - py} {...commonProps} />
-        </g>
-      );
-    }
-    case 'dashed':
-      return <line key={segId} x1={sx} y1={sy} x2={ex} y2={ey} {...commonProps} strokeDasharray="4 3" />;
-    case 'dotted':
-      return <line key={segId} x1={sx} y1={sy} x2={ex} y2={ey} {...commonProps} strokeDasharray="2 3" />;
-    case 'zigzag': {
-      const steps = Math.max(2, Math.floor(len / 8));
-      const pts: string[] = [];
-      for (let i = 0; i <= steps; i++) {
-        const t = i / steps;
-        const bx = sx + (ex - sx) * t;
-        const by = sy + (ey - sy) * t;
-        const zigOff = (i % 2 === 0 ? 2.5 : -2.5);
-        pts.push(`${bx + (-sin) * zigOff},${by + cos * zigOff}`);
-      }
-      return <polyline key={segId} points={pts.join(' ')} {...commonProps} />;
-    }
-    default:
-      return null;
-  }
 }
 
 function renderStud(
@@ -221,10 +360,11 @@ export const BrickConnector = memo(function BrickConnector({
 
   const colors = getColors(theme, diffState, isHighlighted);
   const hitPath = buildHitPath(route.segments);
+  const beamHW = getBeamHalfWidth(theme.beamShape);
 
   const lastSeg = route.segments[route.segments.length - 1];
   const arrowAngle = segmentAngle(lastSeg);
-  const arrowPoints = buildArrowPoints(lastSeg.end, arrowAngle, TILE_HALF_WIDTH);
+  const arrowPoints = buildArrowPoints(lastSeg.end, arrowAngle, beamHW);
 
   const handleClick = (e: React.MouseEvent<SVGGElement>) => {
     e.stopPropagation();
@@ -240,12 +380,13 @@ export const BrickConnector = memo(function BrickConnector({
       opacity={colors.opacity}
       style={{ cursor: 'pointer' }}
       onClick={handleClick}
+      data-beam-shape={theme.beamShape}
     >
       {isSelected && (
         <path
           d={hitPath}
           stroke="#ffffff"
-          strokeWidth={TILE_HALF_WIDTH * 2 + 4}
+          strokeWidth={beamHW * 2 + 4}
           strokeOpacity={0.5}
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -265,44 +406,71 @@ export const BrickConnector = memo(function BrickConnector({
         onMouseLeave={() => setIsHovered(false)}
       />
 
-      {route.segments.map((seg, i) => {
-        const pts = buildTilePoints(seg.start, seg.end, TILE_HALF_WIDTH);
+      {route.segments.map((seg, i) =>
+        renderBeamSegment(
+          theme.beamShape,
+          seg,
+          colors,
+          `seg-${connection.id}-${i}`,
+        ),
+      )}
+
+      {route.elbows.map((elbow, i) => {
+        const elbowPts = [
+          `${elbow.x - beamHW},${elbow.y}`,
+          `${elbow.x},${elbow.y - beamHW / 2}`,
+          `${elbow.x + beamHW},${elbow.y}`,
+          `${elbow.x},${elbow.y + beamHW / 2}`,
+        ].join(' ');
         return (
-          <g key={`seg-${connection.id}-${i}`} pointerEvents="none">
-            <polygon points={pts.frontSide} fill={colors.dark} />
-            <polygon points={pts.rightSide} fill={colors.shadow} />
-            <polygon points={pts.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
-            {renderPattern(theme.pattern, seg.start, seg.end, colors.accent, `pat-${connection.id}-${i}`)}
+          <g key={`elbow-${connection.id}-${i}`} pointerEvents="none" data-elbow>
+            <polygon
+              points={elbowPts}
+              fill={colors.tile}
+              stroke={colors.shadow}
+              strokeWidth={0.5}
+            />
+            <polygon
+              points={[
+                `${elbow.x + beamHW},${elbow.y}`,
+                `${elbow.x},${elbow.y + beamHW / 2}`,
+                `${elbow.x},${elbow.y + beamHW / 2 + BEAM_THICKNESS}`,
+                `${elbow.x + beamHW},${elbow.y + BEAM_THICKNESS}`,
+              ].join(' ')}
+              fill={colors.shadow}
+            />
+            <polygon
+              points={[
+                `${elbow.x},${elbow.y + beamHW / 2}`,
+                `${elbow.x - beamHW},${elbow.y}`,
+                `${elbow.x - beamHW},${elbow.y + BEAM_THICKNESS}`,
+                `${elbow.x},${elbow.y + beamHW / 2 + BEAM_THICKNESS}`,
+              ].join(' ')}
+              fill={colors.dark}
+            />
           </g>
         );
       })}
 
-      {route.elbows.map((elbow, i) => {
-        const elbowPts = [
-          `${elbow.x - TILE_HALF_WIDTH},${elbow.y}`,
-          `${elbow.x},${elbow.y - TILE_HALF_WIDTH / 2}`,
-          `${elbow.x + TILE_HALF_WIDTH},${elbow.y}`,
-          `${elbow.x},${elbow.y + TILE_HALF_WIDTH / 2}`,
-        ].join(' ');
-        return (
-          <polygon
-            key={`elbow-${connection.id}-${i}`}
-            points={elbowPts}
-            fill={colors.tile}
-            stroke={colors.shadow}
-            strokeWidth={0.5}
-            pointerEvents="none"
-          />
-        );
-      })}
-
-      <polygon
-        points={arrowPoints}
-        fill={colors.tile}
-        stroke={colors.shadow}
-        strokeWidth={0.5}
-        pointerEvents="none"
-      />
+      <g pointerEvents="none">
+        <polygon
+          points={arrowPoints}
+          fill={colors.tile}
+          stroke={colors.shadow}
+          strokeWidth={0.5}
+        />
+        <polygon
+          points={(() => {
+            const tipX = lastSeg.end.x + Math.cos(arrowAngle) * ARROW_LENGTH;
+            const tipY = lastSeg.end.y + Math.sin(arrowAngle) * ARROW_LENGTH;
+            const perpX = -Math.sin(arrowAngle) * beamHW;
+            const perpY = Math.cos(arrowAngle) * beamHW;
+            const baseRight = { x: lastSeg.end.x - perpX, y: lastSeg.end.y - perpY };
+            return `${baseRight.x},${baseRight.y} ${tipX},${tipY} ${tipX},${tipY + BEAM_THICKNESS} ${baseRight.x},${baseRight.y + BEAM_THICKNESS}`;
+          })()}
+          fill={colors.shadow}
+        />
+      </g>
 
       {renderStud(route.srcScreen.x, route.srcScreen.y, colors, `stud-src-${connection.id}`)}
       {renderStud(route.tgtScreen.x, route.tgtScreen.y, colors, `stud-tgt-${connection.id}`)}

--- a/apps/web/src/entities/connection/connectorTheme.test.ts
+++ b/apps/web/src/entities/connection/connectorTheme.test.ts
@@ -41,12 +41,25 @@ describe('CONNECTOR_THEMES', () => {
       expect(theme).toHaveProperty('dark');
       expect(theme).toHaveProperty('accent');
       expect(theme).toHaveProperty('pattern');
+      expect(theme).toHaveProperty('beamShape');
     }
   });
 
   it('each pattern is unique across types', () => {
     const patterns = Object.values(CONNECTOR_THEMES).map((t) => t.pattern);
     expect(new Set(patterns).size).toBe(5);
+  });
+
+  it('each beamShape is unique across types', () => {
+    const shapes = Object.values(CONNECTOR_THEMES).map((t) => t.beamShape);
+    expect(new Set(shapes).size).toBe(5);
+  });
+
+  it('beamShape values are valid BeamShape literals', () => {
+    const validShapes = new Set(['standard', 'doubleRail', 'segmented', 'wide', 'zigzag']);
+    for (const theme of Object.values(CONNECTOR_THEMES)) {
+      expect(validShapes.has(theme.beamShape)).toBe(true);
+    }
   });
 });
 

--- a/apps/web/src/entities/connection/connectorTheme.ts
+++ b/apps/web/src/entities/connection/connectorTheme.ts
@@ -3,6 +3,9 @@ import type { ConnectionType } from '@cloudblocks/schema';
 // ─── Connector Color Themes ─────────────────────────────────
 // See BRICK_CONNECTOR_SPEC.md §3.1
 
+/** Physically distinct beam shapes — each connection type uses a unique shape */
+export type BeamShape = 'standard' | 'doubleRail' | 'segmented' | 'wide' | 'zigzag';
+
 export interface ConnectorTheme {
   /** Top face / tile color */
   tile: string;
@@ -12,8 +15,10 @@ export interface ConnectorTheme {
   dark: string;
   /** Accent for patterns and stud inner ring */
   accent: string;
-  /** SVG pattern type */
+  /** SVG pattern type rendered on the beam surface */
   pattern: 'solid' | 'double' | 'dashed' | 'dotted' | 'zigzag';
+  /** Physical beam shape — determines the geometry of the connector */
+  beamShape: BeamShape;
 }
 
 export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
@@ -23,6 +28,7 @@ export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
     dark: '#334155',
     accent: '#94a3b8',
     pattern: 'solid',
+    beamShape: 'standard',
   },
   http: {
     tile: '#3b82f6',
@@ -30,6 +36,7 @@ export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
     dark: '#1d4ed8',
     accent: '#60a5fa',
     pattern: 'double',
+    beamShape: 'doubleRail',
   },
   internal: {
     tile: '#8b5cf6',
@@ -37,6 +44,7 @@ export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
     dark: '#6d28d9',
     accent: '#a78bfa',
     pattern: 'dashed',
+    beamShape: 'segmented',
   },
   data: {
     tile: '#f59e0b',
@@ -44,6 +52,7 @@ export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
     dark: '#b45309',
     accent: '#fbbf24',
     pattern: 'dotted',
+    beamShape: 'wide',
   },
   async: {
     tile: '#10b981',
@@ -51,6 +60,7 @@ export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
     dark: '#047857',
     accent: '#34d399',
     pattern: 'zigzag',
+    beamShape: 'zigzag',
   },
 };
 

--- a/docs/design/BRICK_CONNECTOR_SPEC.md
+++ b/docs/design/BRICK_CONNECTOR_SPEC.md
@@ -309,3 +309,109 @@ Complete SVG for a single isometric flat tile segment along the world X-axis:
   stroke-width="0.5"
 />
 ```
+
+---
+
+## 11. Technic Beam Redesign (M18)
+
+**Date**: 2026-03-21  
+**Issue**: #1060
+
+### 11.1 Motivation
+
+The original flat tile design (§2.1) used surface pattern overlays (§3.2) to distinguish connection types. While functionally correct, the thin lines and dash patterns were subtle and hard to read at typical zoom levels. The Technic Beam redesign replaces pattern overlays with **physically distinct beam geometries** — each connection type now has a unique 3D shape, making them instantly recognizable.
+
+This follows the Lego Technic principle: different beam pieces are physically different shapes, not painted-on decorations.
+
+### 11.2 BeamShape Type
+
+A new `BeamShape` type is added to `connectorTheme.ts`:
+
+```typescript
+type BeamShape = 'standard' | 'doubleRail' | 'segmented' | 'wide' | 'zigzag';
+```
+
+Each connector theme gains a `beamShape` field. The mapping is:
+
+| Connection Type | BeamShape | Visual Description |
+|----------------|-----------|-------------------|
+| `dataflow` | `standard` | Classic smooth beam — single 3D extrusion |
+| `http` | `doubleRail` | Two parallel track beams — rail pair |
+| `internal` | `segmented` | Beam with visible gaps — dashed physical form |
+| `data` | `wide` | 1.5× width beam — broad data pipe |
+| `async` | `zigzag` | Sawtooth path — physically jagged beam |
+
+### 11.3 Beam Geometry Constants
+
+```
+BEAM_HALF_WIDTH  = 8     (half-width of standard beam, screen px)
+BEAM_THICKNESS   = 6     (3D depth, up from 3px flat tiles)
+WIDE_HALF_WIDTH  = 12    (1.5× for 'data' type)
+RAIL_HALF_WIDTH  = 3     (each rail in double-rail)
+RAIL_GAP         = 4     (gap between rails)
+SEGMENT_CHUNK    = 20    (chunk length before gap)
+SEGMENT_GAP      = 4     (gap between chunks)
+ZIGZAG_AMPLITUDE = 6     (zigzag offset)
+ZIGZAG_WAVELENGTH= 16    (zigzag period)
+ARROW_LENGTH     = 12    (unchanged)
+HIT_AREA_WIDTH   = 20    (widened from 16px for easier clicking)
+```
+
+### 11.4 Beam Renderers
+
+Each beam shape has a dedicated renderer function:
+
+1. **`renderStandardBeam`** — 3 polygons per segment (top face + right side + front side). Identical geometry to the original flat tile but thicker (6px vs 3px).
+
+2. **`renderDoubleRailBeam`** — 6 polygons per segment (3 per rail × 2). Two parallel beams with `RAIL_GAP` spacing, each using `RAIL_HALF_WIDTH`.
+
+3. **`renderSegmentedBeam`** — Variable polygon count. Beam is split into chunks of `SEGMENT_CHUNK` length with `SEGMENT_GAP` gaps. Each chunk is a standard 3-polygon beam piece.
+
+4. **`renderWideBeam`** — 3 polygons per segment using `WIDE_HALF_WIDTH` (12px vs standard 8px). Visually reads as a wider data channel.
+
+5. **`renderZigzagBeam`** — Multiple sub-segments per route segment. The beam path zigzags with `ZIGZAG_AMPLITUDE` offset at `ZIGZAG_WAVELENGTH` intervals. Each zig/zag is a standard 3-polygon piece.
+
+### 11.5 3D Elbow Joints
+
+Elbow joints (bend points) are upgraded from single-polygon diamonds to **3-polygon 3D pieces**:
+
+```svg
+<g data-elbow pointer-events="none">
+  <!-- Top face: diamond -->
+  <polygon points="{top-diamond}" fill="{tile}" stroke="{shadow}" stroke-width="0.5" />
+  <!-- Right side face -->
+  <polygon points="{right-side}" fill="{shadow}" />
+  <!-- Front side face -->
+  <polygon points="{front-side}" fill="{dark}" />
+</g>
+```
+
+Elbow size scales with beam width via `getBeamHalfWidth(beamShape)`.
+
+### 11.6 3D Arrow Tip
+
+The directional arrow at the target end now includes a side face for 3D depth:
+
+```svg
+<g pointer-events="none">
+  <!-- Top face: triangle -->
+  <polygon points="{tip-triangle}" fill="{tile}" stroke="{shadow}" stroke-width="0.5" />
+  <!-- Side face: parallelogram -->
+  <polygon points="{side-face}" fill="{shadow}" />
+</g>
+```
+
+### 11.7 Pattern Overlay Removal
+
+The `renderPattern` function from the original implementation is **removed**. Pattern differentiation is now achieved through beam geometry alone — no SVG line overlays are needed.
+
+The `pattern` field in `ConnectorTheme` is **retained** for backward compatibility and documentation reference, but is not rendered visually.
+
+### 11.8 Test Coverage
+
+Beam-shape-specific tests validate:
+- Each connection type renders with the correct `data-beam-shape` attribute
+- Each beam type produces the expected SVG structure (polygon counts, group nesting)
+- `beamShape` values are unique across all 5 connection types
+- Elbow joints have `data-elbow` attribute and 3-polygon structure
+- Arrow tip renders with side face


### PR DESCRIPTION
## Summary
- Replace flat-tile pattern overlays with 5 physically distinct Technic Beam geometries: `standard` (dataflow), `doubleRail` (http), `segmented` (internal), `wide` (data), `zigzag` (async)
- Upgrade elbow joints and arrow tips with 3D side faces for depth
- Update BRICK_CONNECTOR_SPEC.md with new §11 documenting beam shapes, constants, and renderers

## Changes
- `connectorTheme.ts` — Added `BeamShape` type and `beamShape` field to all 5 themes
- `BrickConnector.tsx` — 5 dedicated beam renderers, 3D elbows with `data-elbow` attribute, 3D arrow tip, removed `renderPattern` overlay
- `BrickConnector.test.tsx` — Beam-shape-specific tests (23 tests)
- `connectorTheme.test.ts` — `beamShape` uniqueness and validity tests
- `BRICK_CONNECTOR_SPEC.md` — §11 Technic Beam Redesign specification

## Verification
- 88/88 connection tests passing
- Build clean (tsc + vite)
- Lint clean

Fixes #1060