### PR TITLE
chore(web): hide OpsCenter and AI features from UI (defer to M20+)

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -52,9 +52,7 @@ vi.mock('../widgets/github-pr/GitHubPR', () => ({
 vi.mock('../widgets/notification-center/NotificationCenter', () => ({
   NotificationCenter: () => <div data-testid="notification-center" />,
 }));
-vi.mock('../widgets/ops-center/OpsCenter', () => ({
-  OpsCenter: () => <div data-testid="ops-center" />,
-}));
+
 vi.mock('../widgets/promote-dialog/PromoteDialog', () => ({
   PromoteDialog: () => <div data-testid="promote-dialog" />,
 }));
@@ -432,25 +430,18 @@ describe('App', () => {
 
   it('renders ops widgets when their show flags are true', async () => {
     const { useNotificationStore } = await import('../entities/store/notificationStore');
-    const { useOpsStore } = await import('../entities/store/opsStore');
     const { usePromoteStore } = await import('../entities/store/promoteStore');
 
     useNotificationStore.setState({ showNotificationCenter: true });
-    useOpsStore.setState({ showOpsCenter: true });
     usePromoteStore.setState({
       showPromoteDialog: true,
       showRollbackDialog: true,
       showPromoteHistory: true,
     });
-    useUIStore.setState({
-      showSuggestionsPanel: true,
-      showCostPanel: true,
-    });
 
     render(<App />);
 
     expect(await screen.findByTestId('notification-center')).toBeInTheDocument();
-    expect(await screen.findByTestId('ops-center')).toBeInTheDocument();
     expect(await screen.findByTestId('promote-dialog')).toBeInTheDocument();
     expect(await screen.findByTestId('rollback-dialog')).toBeInTheDocument();
     expect(await screen.findByTestId('promote-history')).toBeInTheDocument();

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -11,7 +11,7 @@ import { useArchitectureStore } from '../entities/store/architectureStore';
 import { useAuthStore } from '../entities/store/authStore';
 import { useUIStore } from '../entities/store/uiStore';
 import { useNotificationStore } from '../entities/store/notificationStore';
-import { useOpsStore } from '../entities/store/opsStore';
+
 import { usePromoteStore } from '../entities/store/promoteStore';
 import { registerBuiltinTemplates } from '../features/templates/builtin';
 import { FlowDiagram } from '../widgets/flow-diagram/FlowDiagram';
@@ -33,10 +33,9 @@ const GitHubRepos = lazy(() => import('../widgets/github-repos/GitHubRepos').the
 const GitHubSync = lazy(() => import('../widgets/github-sync/GitHubSync').then(m => ({ default: m.GitHubSync })));
 const GitHubPR = lazy(() => import('../widgets/github-pr/GitHubPR').then(m => ({ default: m.GitHubPR })));
 const DiffPanel = lazy(() => import('../widgets/diff-panel/DiffPanel').then(m => ({ default: m.DiffPanel })));
-const SuggestionsPanel = lazy(() => import('../features/ai/components/SuggestionsPanel').then(m => ({ default: m.SuggestionsPanel })));
-const CostPanel = lazy(() => import('../features/ai/components/CostPanel').then(m => ({ default: m.CostPanel })));
+
 const NotificationCenter = lazy(() => import('../widgets/notification-center/NotificationCenter').then(m => ({ default: m.NotificationCenter })));
-const OpsCenter = lazy(() => import('../widgets/ops-center/OpsCenter').then(m => ({ default: m.OpsCenter })));
+
 const PromoteDialog = lazy(() => import('../widgets/promote-dialog/PromoteDialog').then(m => ({ default: m.PromoteDialog })));
 const RollbackDialog = lazy(() => import('../widgets/rollback-dialog/RollbackDialog').then(m => ({ default: m.RollbackDialog })));
 const PromoteHistory = lazy(() => import('../widgets/promote-history/PromoteHistory').then(m => ({ default: m.PromoteHistory })));
@@ -63,24 +62,21 @@ function App() {
   const showGitHubPR = useUIStore((s) => s.showGitHubPR);
   const showTemplateGallery = useUIStore((s) => s.showTemplateGallery);
   const showScenarioGallery = useUIStore((s) => s.showScenarioGallery);
-  const showSuggestionsPanel = useUIStore((s) => s.showSuggestionsPanel);
-  const showCostPanel = useUIStore((s) => s.showCostPanel);
+
   const workspaceId = useArchitectureStore((s) => s.workspace.id);
   const showNotificationCenter = useNotificationStore((s) => s.showNotificationCenter);
-  const showOpsCenter = useOpsStore((s) => s.showOpsCenter);
+
   const showPromoteDialog = usePromoteStore((s) => s.showPromoteDialog);
   const showRollbackDialog = usePromoteStore((s) => s.showRollbackDialog);
   const showPromoteHistory = usePromoteStore((s) => s.showPromoteHistory);
 
   // Determine right-panel CSS class so canvas viewport shrinks accordingly
-  const isWideRightPanel = showOpsCenter || showPromoteHistory;
+  const isWideRightPanel = showPromoteHistory;
   const isNarrowRightPanel =
     showCodePreview ||
     showGitHubLogin ||
     showGitHubRepos ||
     showGitHubPR ||
-    showSuggestionsPanel ||
-    showCostPanel ||
     showNotificationCenter ||
     showPromoteDialog ||
     showRollbackDialog;
@@ -203,10 +199,8 @@ function App() {
             {showGitHubPR && <GitHubPR key={`pr-${workspaceId}`} />}
             <DiffPanel />
             {showScenarioGallery && <ScenarioGallery />}
-            {showSuggestionsPanel && <SuggestionsPanel />}
-            {showCostPanel && <CostPanel />}
             {showNotificationCenter && <NotificationCenter />}
-            {showOpsCenter && <OpsCenter />}
+
             {showPromoteDialog && <PromoteDialog />}
             {showRollbackDialog && <RollbackDialog />}
             {showPromoteHistory && <PromoteHistory />}

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -590,13 +590,6 @@ describe('MenuBar', () => {
     await user.click(within(buildDropdown).getByRole('button', { name: /Browse Templates/ }));
     expect(useUIStore.getState().showTemplateGallery).toBe(true);
 
-    buildDropdown = await openMenu(user, 'Build');
-    await user.click(within(buildDropdown).getByRole('button', { name: /AI Suggestions/ }));
-    expect(useUIStore.getState().showSuggestionsPanel).toBe(true);
-
-    buildDropdown = await openMenu(user, 'Build');
-    await user.click(within(buildDropdown).getByRole('button', { name: /Cost Estimate/ }));
-    expect(useUIStore.getState().showCostPanel).toBe(true);
   }, 15000);
 
   it('routes Show Learning Panel to scenario gallery when no scenario is active', async () => {
@@ -948,55 +941,6 @@ describe('MenuBar', () => {
     expect(toast.error).toHaveBeenCalledWith('pull failed');
   });
 
-  it('submits AI prompt via AiPromptBar and calls generate', async () => {
-    const user = userEvent.setup();
-    const generateMock = vi.fn().mockResolvedValue(undefined);
-    const { useAiStore } = await import('../../features/ai/store');
-    useAiStore.setState({ generate: generateMock, generateLoading: false, generateError: null });
-    render(<MenuBar />);
-
-    const promptInput = screen.getByPlaceholderText(/describe your cloud architecture/i);
-    await user.type(promptInput, 'Create a 3-tier web app');
-    await user.click(screen.getByTitle('Generate Architecture'));
-
-    expect(generateMock).toHaveBeenCalledWith('Create a 3-tier web app', 'azure');
-  });
-
-  it('shows validation badge with Valid text when validationResult is valid', async () => {
-    const user = userEvent.setup();
-    useArchitectureStore.setState({
-      validationResult: { valid: true, errors: [], warnings: [] },
-    });
-    render(<MenuBar />);
-
-    const buildDropdown = await openMenu(user, 'Build');
-    const badge = within(buildDropdown).getByText('Valid');
-    expect(badge).toHaveClass('menu-badge-valid');
-  });
-
-  it('shows validation badge with Errors text when validationResult is invalid', async () => {
-    const user = userEvent.setup();
-    useArchitectureStore.setState({
-      validationResult: { valid: false, errors: [{ ruleId: 'test', message: 'err', severity: 'error', targetId: 'block-1' }], warnings: [] },
-    });
-    render(<MenuBar />);
-
-    const buildDropdown = await openMenu(user, 'Build');
-    const badge = within(buildDropdown).getByText('Errors');
-    expect(badge).toHaveClass('menu-badge-invalid');
-  });
-
-  it('Ops Center button toggles ops center visibility', async () => {
-    const user = userEvent.setup();
-    render(<MenuBar />);
-
-    const buildDropdown = await openMenu(user, 'Build');
-    await user.click(within(buildDropdown).getByRole('button', { name: /Ops Center/ }));
-
-    const { useOpsStore } = await import('../../entities/store/opsStore');
-    expect(useOpsStore.getState().showOpsCenter).toBe(true);
-  });
-
   it('Promote to Production button toggles promote dialog', async () => {
     const user = userEvent.setup();
     render(<MenuBar />);
@@ -1030,26 +974,6 @@ describe('MenuBar', () => {
     expect(usePromoteStore.getState().showPromoteHistory).toBe(true);
   });
 
-  it('AI Suggestions button toggles suggestions panel', async () => {
-    const user = userEvent.setup();
-    render(<MenuBar />);
-
-    const buildDropdown = await openMenu(user, 'Build');
-    await user.click(within(buildDropdown).getByRole('button', { name: /AI Suggestions/ }));
-
-    expect(useUIStore.getState().showSuggestionsPanel).toBe(true);
-  });
-
-  it('Cost Estimate button toggles cost panel', async () => {
-    const user = userEvent.setup();
-    render(<MenuBar />);
-
-    const buildDropdown = await openMenu(user, 'Build');
-    await user.click(within(buildDropdown).getByRole('button', { name: /Cost Estimate/ }));
-
-    expect(useUIStore.getState().showCostPanel).toBe(true);
-  });
-
   it('notification bell shows badge when unread count > 0', async () => {
     const { useNotificationStore } = await import('../../entities/store/notificationStore');
     useNotificationStore.getState().addNotification({
@@ -1080,8 +1004,6 @@ describe('MenuBar', () => {
     useUIStore.setState({
       showCodePreview: true,
       showGitHubRepos: true,
-      showSuggestionsPanel: true,
-      showCostPanel: true,
     });
     const { container } = render(<MenuBar />);
 
@@ -1090,8 +1012,6 @@ describe('MenuBar', () => {
 
     expect(useUIStore.getState().showCodePreview).toBe(false);
     expect(useUIStore.getState().showGitHubRepos).toBe(false);
-    expect(useUIStore.getState().showSuggestionsPanel).toBe(false);
-    expect(useUIStore.getState().showCostPanel).toBe(false);
   });
 
   it('show learning panel toggles off when already shown', async () => {

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -1,6 +1,4 @@
 import { useState, useEffect, useRef } from 'react';
-import { AiPromptBar } from '../../features/ai';
-import { useAiStore } from '../../features/ai/store';
 import { toast } from 'react-hot-toast';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useLearningStore } from '../../entities/store/learningStore';
@@ -8,7 +6,7 @@ import { validateArchitectureShape } from '../../entities/store/slices';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { useNotificationStore, selectUnreadCount } from '../../entities/store/notificationStore';
-import { useOpsStore } from '../../entities/store/opsStore';
+
 import { usePromoteStore } from '../../entities/store/promoteStore';
 import { computeArchitectureDiff } from '../../features/diff/engine';
 import { apiPost, getApiErrorMessage } from '../../shared/api/client';
@@ -46,8 +44,6 @@ export function MenuBar() {
   const toggleGitHubRepos = useUIStore((s) => s.toggleGitHubRepos);
   const toggleGitHubSync = useUIStore((s) => s.toggleGitHubSync);
   const toggleGitHubPR = useUIStore((s) => s.toggleGitHubPR);
-  const toggleSuggestionsPanel = useUIStore((s) => s.toggleSuggestionsPanel);
-  const toggleCostPanel = useUIStore((s) => s.toggleCostPanel);
   const diffMode = useUIStore((s) => s.diffMode);
   const toggleScenarioGallery = useUIStore((s) => s.toggleScenarioGallery);
   const toggleLearningPanel = useUIStore((s) => s.toggleLearningPanel);
@@ -58,7 +54,7 @@ export function MenuBar() {
   const playSound = (name: SoundName) => { if (!isSoundMuted) audioService.playSound(name); };
 
   const unreadCount = useNotificationStore(selectUnreadCount);
-  const toggleOpsCenter = useOpsStore((s) => s.toggleOpsCenter);
+
   const togglePromoteDialog = usePromoteStore((s) => s.togglePromoteDialog);
   const toggleRollbackDialog = usePromoteStore((s) => s.toggleRollbackDialog);
   const togglePromoteHistory = usePromoteStore((s) => s.togglePromoteHistory);
@@ -241,8 +237,7 @@ export function MenuBar() {
       if (ui.showCodePreview) ui.toggleCodePreview();
       if (ui.showGitHubRepos) ui.toggleGitHubRepos();
       if (ui.showGitHubPR) ui.toggleGitHubPR();
-      if (ui.showSuggestionsPanel) ui.toggleSuggestionsPanel();
-      if (ui.showCostPanel) ui.toggleCostPanel();
+
     }
     toggleNotificationCenter();
   };
@@ -266,14 +261,6 @@ export function MenuBar() {
       toast.error(getApiErrorMessage(err, 'Failed to fetch remote architecture'));
     }
   };
-
-  const handleAiSubmit = (prompt: string, provider: string) => {
-    useAiStore.getState().generate(prompt, provider);
-  };
-
-  const aiLoading = useAiStore((s) => s.generateLoading);
-  const aiError = useAiStore((s) => s.generateError);
-  const aiResult = useAiStore((s) => s.generateResult);
 
   const handleToggleDiffMode = () => {
     if (diffMode) {
@@ -415,15 +402,7 @@ export function MenuBar() {
             <button type="button" className="menu-item" onClick={() => handleAction(toggleTemplateGallery)}>
               <span className="menu-item-left">📦 Browse Templates</span>
             </button>
-            <button type="button" className="menu-item" onClick={() => handleAction(toggleSuggestionsPanel)}>
-              <span className="menu-item-left">🤖 AI Suggestions</span>
-            </button>
-            <button type="button" className="menu-item" onClick={() => handleAction(toggleCostPanel)}>
-              <span className="menu-item-left">💰 Cost Estimate</span>
-            </button>
-            <button type="button" className="menu-item" onClick={() => handleAction(toggleOpsCenter)}>
-              <span className="menu-item-left">&#9881; Ops Center</span>
-            </button>
+
             <div className="menu-separator" />
             <button type="button" className="menu-item" onClick={() => handleAction(togglePromoteDialog)}>
               <span className="menu-item-left">&#x2B06; Promote to Production</span>
@@ -478,8 +457,6 @@ export function MenuBar() {
       
       </nav>
 
-      <AiPromptBar onSubmit={handleAiSubmit} isLoading={aiLoading} provider={activeProvider} error={aiError ?? undefined} explanation={aiResult?.explanation} warnings={aiResult?.warnings} />
-
       <div className="menu-bar-divider" />
 
       <div className="provider-section" role="tablist" aria-label="Cloud provider">
@@ -529,14 +506,7 @@ export function MenuBar() {
         >
           💾
         </button>
-        <button
-          type="button"
-          className="quick-btn"
-          onClick={toggleOpsCenter}
-          title="Ops Center"
-        >
-          &#9881;
-        </button>
+
         <button
           type="button"
           className="quick-btn notification-bell-btn"


### PR DESCRIPTION
## Summary

- Hide OpsCenter widget and AI features (SuggestionsPanel, CostPanel, AiPromptBar) from the UI
- Preserve all underlying code (`widgets/ops-center/`, `features/ai/`, `entities/store/opsStore.ts`) for re-enablement in M20+
- Update tests to remove references to hidden features

Fixes #1065