### PR TITLE
fix(web): adapt learning scenario content for active cloud provider

### DIFF
--- a/apps/web/src/features/learning/scenario-engine.ts
+++ b/apps/web/src/features/learning/scenario-engine.ts
@@ -2,6 +2,7 @@ import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useLearningStore } from '../../entities/store/learningStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { getScenario } from './scenarios/registry';
+import { formatScenarioForProvider } from './scenario-formatter';
 import { startHintSubscription, startHintTimer, stopHintSubscription } from './hint-engine';
 import { evaluateRules } from './step-validator';
 import type { ValidationResult } from './step-validator';
@@ -29,10 +30,13 @@ function syncCurrentStepCompletion(): ValidationResult {
 }
 
 export function startLearningScenario(scenarioId: string): void {
-  const scenario = getScenario(scenarioId);
-  if (!scenario) {
+  const rawScenario = getScenario(scenarioId);
+  if (!rawScenario) {
     throw new Error(`Scenario not found: ${scenarioId}`);
   }
+
+  const provider = useUIStore.getState().activeProvider;
+  const scenario = formatScenarioForProvider(rawScenario, provider);
 
   preLearningSnapshot = JSON.parse(
     JSON.stringify(useArchitectureStore.getState().workspace.architecture),

--- a/apps/web/src/features/learning/scenario-formatter.test.ts
+++ b/apps/web/src/features/learning/scenario-formatter.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import type { Scenario, ScenarioStep, ArchitectureSnapshot } from '../../shared/types/learning';
+import { formatScenarioForProvider } from './scenario-formatter';
+
+// ─── Test Fixtures ───────────────────────────────────────
+
+const createSnapshot = (plateName = 'VNet'): ArchitectureSnapshot => ({
+  name: 'Test Architecture',
+  version: '1',
+  plates: [
+    {
+      id: 'plate-vnet',
+      name: plateName,
+      type: 'region',
+      parentId: null,
+      children: ['plate-public'],
+      position: { x: 0, y: 0, z: 0 },
+      size: { width: 12, height: 0.3, depth: 10 },
+      metadata: {},
+    },
+    {
+      id: 'plate-public',
+      name: 'Public Subnet',
+      type: 'subnet',
+      subnetAccess: 'public',
+      parentId: 'plate-vnet',
+      children: [],
+      position: { x: -3, y: 0.3, z: 0 },
+      size: { width: 5, height: 0.2, depth: 8 },
+      metadata: {},
+    },
+  ],
+  blocks: [],
+  connections: [],
+  externalActors: [],
+});
+
+const createStep = (overrides: Partial<ScenarioStep> = {}): ScenarioStep => ({
+  id: 'step-1',
+  order: 1,
+  title: 'Create a VNet',
+  instruction: 'Place a Virtual Network (VNet) plate on the canvas.',
+  hints: [
+    'Look for the VNet option in the palette.',
+    'A VNet provides network isolation for your resources.',
+  ],
+  validationRules: [{ type: 'plate-exists', plateType: 'region' }],
+  ...overrides,
+});
+
+const createScenario = (overrides: Partial<Scenario> = {}): Scenario => ({
+  id: 'test-scenario',
+  name: 'Test Scenario',
+  description: 'Learn to build a VNet with subnets.',
+  difficulty: 'beginner',
+  category: 'web-application',
+  tags: ['networking'],
+  estimatedMinutes: 10,
+  steps: [createStep()],
+  initialArchitecture: createSnapshot(),
+  ...overrides,
+});
+
+// ─── Tests ───────────────────────────────────────────────
+
+describe('formatScenarioForProvider', () => {
+  describe('azure provider (passthrough)', () => {
+    it('returns the scenario unchanged', () => {
+      const scenario = createScenario();
+      const result = formatScenarioForProvider(scenario, 'azure');
+      expect(result).toBe(scenario); // reference equality — no cloning
+    });
+  });
+
+  describe('aws provider', () => {
+    it('substitutes VNet → VPC in description', () => {
+      const result = formatScenarioForProvider(createScenario(), 'aws');
+      expect(result.description).toBe('Learn to build a VPC with subnets.');
+    });
+
+    it('substitutes long-form "Virtual Network (VNet)" → "Virtual Private Cloud (VPC)" in instructions', () => {
+      const result = formatScenarioForProvider(createScenario(), 'aws');
+      expect(result.steps[0].instruction).toBe(
+        'Place a Virtual Private Cloud (VPC) plate on the canvas.',
+      );
+    });
+
+    it('substitutes VNet in step title', () => {
+      const result = formatScenarioForProvider(createScenario(), 'aws');
+      expect(result.steps[0].title).toBe('Create a VPC');
+    });
+
+    it('substitutes VNet in hints', () => {
+      const result = formatScenarioForProvider(createScenario(), 'aws');
+      expect(result.steps[0].hints[0]).toBe('Look for the VPC option in the palette.');
+      expect(result.steps[0].hints[1]).toBe('A VPC provides network isolation for your resources.');
+    });
+
+    it('adapts plate names in initialArchitecture snapshot', () => {
+      const result = formatScenarioForProvider(createScenario(), 'aws');
+      expect(result.initialArchitecture.plates[0].name).toBe('VPC');
+      // Non-VNet plate names should remain unchanged
+      expect(result.initialArchitecture.plates[1].name).toBe('Public Subnet');
+    });
+
+    it('adapts plate names in step checkpoint snapshots', () => {
+      const scenario = createScenario({
+        steps: [createStep({ checkpoint: createSnapshot() })],
+      });
+      const result = formatScenarioForProvider(scenario, 'aws');
+      expect(result.steps[0].checkpoint?.plates[0].name).toBe('VPC');
+    });
+
+    it('preserves plate IDs (internal identifiers unchanged)', () => {
+      const result = formatScenarioForProvider(createScenario(), 'aws');
+      expect(result.initialArchitecture.plates[0].id).toBe('plate-vnet');
+    });
+
+    it('does NOT modify validation rules', () => {
+      const scenario = createScenario();
+      const result = formatScenarioForProvider(scenario, 'aws');
+      expect(result.steps[0].validationRules).toEqual(scenario.steps[0].validationRules);
+    });
+  });
+
+  describe('gcp provider', () => {
+    it('substitutes VNet → VPC in description', () => {
+      const result = formatScenarioForProvider(createScenario(), 'gcp');
+      expect(result.description).toBe('Learn to build a VPC with subnets.');
+    });
+
+    it('substitutes long-form "Virtual Network (VNet)" → "VPC Network" in instructions', () => {
+      const result = formatScenarioForProvider(createScenario(), 'gcp');
+      expect(result.steps[0].instruction).toBe(
+        'Place a VPC Network plate on the canvas.',
+      );
+    });
+
+    it('substitutes VNet in step title', () => {
+      const result = formatScenarioForProvider(createScenario(), 'gcp');
+      expect(result.steps[0].title).toBe('Create a VPC');
+    });
+
+    it('adapts plate names in initialArchitecture snapshot', () => {
+      const result = formatScenarioForProvider(createScenario(), 'gcp');
+      expect(result.initialArchitecture.plates[0].name).toBe('VPC');
+    });
+
+    it('does NOT modify validation rules', () => {
+      const scenario = createScenario();
+      const result = formatScenarioForProvider(scenario, 'gcp');
+      expect(result.steps[0].validationRules).toEqual(scenario.steps[0].validationRules);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles "a virtual network" (lowercase) substitution for AWS', () => {
+      const scenario = createScenario({
+        description: 'Deploy resources inside a virtual network.',
+      });
+      const result = formatScenarioForProvider(scenario, 'aws');
+      expect(result.description).toBe('Deploy resources inside a VPC.');
+    });
+
+    it('handles steps without checkpoints', () => {
+      const scenario = createScenario({
+        steps: [createStep({ checkpoint: undefined })],
+      });
+      const result = formatScenarioForProvider(scenario, 'aws');
+      expect(result.steps[0].checkpoint).toBeUndefined();
+    });
+
+    it('handles multiple VNet references in a single string', () => {
+      const scenario = createScenario({
+        description: 'Create a VNet, add subnets to the VNet, then verify the VNet.',
+      });
+      const result = formatScenarioForProvider(scenario, 'aws');
+      expect(result.description).toBe(
+        'Create a VPC, add subnets to the VPC, then verify the VPC.',
+      );
+    });
+
+    it('preserves non-VNet text unchanged', () => {
+      const scenario = createScenario({
+        description: 'Add a compute block to the subnet.',
+      });
+      const result = formatScenarioForProvider(scenario, 'aws');
+      expect(result.description).toBe('Add a compute block to the subnet.');
+    });
+
+    it('preserves scenario metadata (id, name, difficulty, etc.)', () => {
+      const scenario = createScenario();
+      const result = formatScenarioForProvider(scenario, 'aws');
+      expect(result.id).toBe(scenario.id);
+      expect(result.name).toBe(scenario.name);
+      expect(result.difficulty).toBe(scenario.difficulty);
+      expect(result.category).toBe(scenario.category);
+      expect(result.tags).toEqual(scenario.tags);
+      expect(result.estimatedMinutes).toBe(scenario.estimatedMinutes);
+    });
+  });
+});

--- a/apps/web/src/features/learning/scenario-formatter.ts
+++ b/apps/web/src/features/learning/scenario-formatter.ts
@@ -1,0 +1,59 @@
+import type { ProviderType } from '@cloudblocks/schema';
+import type {
+  ArchitectureSnapshot,
+  Scenario,
+  ScenarioStep,
+} from '../../shared/types/learning';
+
+const NETWORK_TERMS: Record<ProviderType, { vnet: string; vnetLong: string }> = {
+  azure: { vnet: 'VNet', vnetLong: 'Virtual Network (VNet)' },
+  aws: { vnet: 'VPC', vnetLong: 'Virtual Private Cloud (VPC)' },
+  gcp: { vnet: 'VPC', vnetLong: 'VPC Network' },
+};
+
+function substituteText(text: string, provider: ProviderType): string {
+  const terms = NETWORK_TERMS[provider];
+  let result = text.replace(/Virtual Network \(VNet\)/g, terms.vnetLong);
+  result = result.replace(/\bVNet\b/g, terms.vnet);
+  result = result.replace(/a virtual network/gi, `a ${terms.vnet}`);
+  return result;
+}
+
+function adaptSnapshot(
+  snapshot: ArchitectureSnapshot,
+  provider: ProviderType,
+): ArchitectureSnapshot {
+  const terms = NETWORK_TERMS[provider];
+  return {
+    ...snapshot,
+    plates: snapshot.plates.map((plate) => ({
+      ...plate,
+      name: plate.name === 'VNet' ? terms.vnet : plate.name,
+    })),
+  };
+}
+
+function adaptStep(step: ScenarioStep, provider: ProviderType): ScenarioStep {
+  return {
+    ...step,
+    title: substituteText(step.title, provider),
+    instruction: substituteText(step.instruction, provider),
+    hints: step.hints.map((hint) => substituteText(hint, provider)),
+    checkpoint: step.checkpoint
+      ? adaptSnapshot(step.checkpoint, provider)
+      : undefined,
+  };
+}
+
+export function formatScenarioForProvider(
+  scenario: Scenario,
+  provider: ProviderType,
+): Scenario {
+  if (provider === 'azure') return scenario;
+  return {
+    ...scenario,
+    description: substituteText(scenario.description, provider),
+    steps: scenario.steps.map((step) => adaptStep(step, provider)),
+    initialArchitecture: adaptSnapshot(scenario.initialArchitecture, provider),
+  };
+}


### PR DESCRIPTION
## Summary
- Add `scenario-formatter.ts` that substitutes Azure-centric terminology (VNet, Virtual Network) with provider-appropriate equivalents (VPC for AWS, VPC Network for GCP) in all user-facing scenario text and architecture snapshots
- Wire `formatScenarioForProvider()` into `scenario-engine.ts` so learning scenarios adapt to the currently active cloud provider
- Validation rules remain unchanged (they are category-based, not provider-specific)

## Changes
- **New**: `apps/web/src/features/learning/scenario-formatter.ts` — Provider-aware text substitution + snapshot adaptation
- **New**: `apps/web/src/features/learning/scenario-formatter.test.ts` — 19 tests covering Azure passthrough, AWS/GCP substitution, edge cases
- **Modified**: `apps/web/src/features/learning/scenario-engine.ts` — Import formatter, apply to scenario before passing to learning store

Fixes #1067