### PR TITLE
feat(web): redesign connectors with Lego-faithful Technic Beam style (§12)

### DIFF
--- a/apps/web/src/entities/connection/BrickConnector.test.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.test.tsx
@@ -15,6 +15,28 @@ vi.mock('../../shared/utils/position', () => ({
 
 vi.mock('../../shared/utils/isometric', () => ({
   worldToScreen: vi.fn(),
+  TILE_W: 64,
+  TILE_H: 32,
+  TILE_Z: 32,
+}));
+
+vi.mock('../../shared/tokens/designTokens', () => ({
+  TILE_W: 64,
+  TILE_H: 32,
+  TILE_Z: 32,
+  RENDER_SCALE: 32,
+  BEAM_WIDTH_CU: 0.5,
+  BEAM_THICKNESS_CU: 1 / 3,
+  BEAM_THICKNESS_PX: 32 * (1 / 3),
+  PIN_HOLE_SPACING_CU: 1.0,
+  PIN_HOLE_RX: 32 * 3 / 20,
+  PIN_HOLE_RY: (32 * 3 / 20) / 2,
+  STUD_RX: 12,
+  STUD_RY: 6,
+  STUD_HEIGHT: 5,
+  STUD_INNER_RX: 7.2,
+  STUD_INNER_RY: 3.6,
+  STUD_INNER_OPACITY: 0.3,
 }));
 
 vi.mock('../../features/diff/engine', () => ({
@@ -29,13 +51,14 @@ const connection: Connection = {
   metadata: {},
 };
 
-function setupEndpoints(srcScreen = { x: 120, y: 220 }, tgtScreen = { x: 280, y: 320 }) {
+function setupEndpoints(srcWorld: [number, number, number] = [1, 0, 2], tgtWorld: [number, number, number] = [3, 0, 4]) {
   vi.mocked(getEndpointWorldPosition)
-    .mockReturnValueOnce([1, 0, 2])
-    .mockReturnValueOnce([3, 0, 4]);
-  vi.mocked(worldToScreen)
-    .mockReturnValueOnce(srcScreen)
-    .mockReturnValueOnce(tgtScreen);
+    .mockReturnValueOnce(srcWorld)
+    .mockReturnValueOnce(tgtWorld);
+  vi.mocked(worldToScreen).mockImplementation((wx: number, wy: number, wz: number, ox = 0, oy = 0) => ({
+    x: ox + (wx - wz) * 32,
+    y: oy + (wx + wz) * 16 - wy * 32,
+  }));
 }
 
 function renderConnector(conn: Connection = connection) {
@@ -87,20 +110,18 @@ describe('BrickConnector', () => {
     expect(container.querySelector('g')).toBeNull();
   });
 
-  it('renders svg group with polygons and ellipses when endpoints exist', () => {
+  it('renders svg group with polygons when endpoints exist', () => {
     setupEndpoints();
 
     const { container } = renderConnector();
 
     expect(container.querySelector('g')).toBeInTheDocument();
     const polygons = container.querySelectorAll('polygon');
-    expect(polygons.length).toBeGreaterThanOrEqual(4);
-    const ellipses = container.querySelectorAll('ellipse');
-    expect(ellipses).toHaveLength(6);
+    expect(polygons.length).toBeGreaterThanOrEqual(3);
   });
 
   it('renders hit area with data-testid', () => {
-    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
+    setupEndpoints();
 
     const { container } = renderConnector();
 
@@ -108,7 +129,7 @@ describe('BrickConnector', () => {
   });
 
   it('click in select mode sets selectedId to connection id', () => {
-    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
+    setupEndpoints();
 
     const { container } = renderConnector();
 
@@ -120,7 +141,7 @@ describe('BrickConnector', () => {
     const removeConnectionMock = vi.fn();
     useUIStore.setState({ toolMode: 'delete' });
     useArchitectureStore.setState({ removeConnection: removeConnectionMock });
-    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
+    setupEndpoints();
 
     const { container } = renderConnector();
 
@@ -133,9 +154,10 @@ describe('BrickConnector', () => {
     vi.mocked(getEndpointWorldPosition)
       .mockReturnValueOnce([1, 0, 2])
       .mockReturnValueOnce([3, 0, 4]);
-    vi.mocked(worldToScreen)
-      .mockReturnValueOnce({ x: 100, y: 100 })
-      .mockReturnValueOnce({ x: 200, y: 200 });
+    vi.mocked(worldToScreen).mockImplementation((wx: number, wy: number, wz: number, ox = 0, oy = 0) => ({
+      x: ox + (wx - wz) * 32,
+      y: oy + (wx + wz) * 16 - wy * 32,
+    }));
 
     const { container } = render(
       <svg onClick={parentClick}><title>Test</title>
@@ -150,20 +172,21 @@ describe('BrickConnector', () => {
   it('uses diff colors when diff state is added', () => {
     useUIStore.setState({ diffMode: true, diffDelta: {} as unknown as DiffDelta });
     vi.mocked(getDiffState).mockReturnValue('added');
-    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
+    setupEndpoints([1, 0, 1], [1, 0, 4]);
 
     const { container } = renderConnector();
 
     const polygons = container.querySelectorAll('polygon');
-    const topFace = polygons[2];
-    expect(topFace?.getAttribute('fill')).toBe('#22c55e');
+    expect(polygons.length).toBeGreaterThanOrEqual(1);
+    const topFaces = Array.from(polygons).filter(p => p.getAttribute('fill') === '#22c55e');
+    expect(topFaces.length).toBeGreaterThanOrEqual(1);
     expect(container.querySelector('g')?.getAttribute('opacity')).toBe('1');
   });
 
   it('uses removed diff opacity when diff state is removed', () => {
     useUIStore.setState({ diffMode: true, diffDelta: {} as unknown as DiffDelta });
     vi.mocked(getDiffState).mockReturnValue('removed');
-    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
+    setupEndpoints([1, 0, 1], [1, 0, 4]);
 
     const { container } = renderConnector();
 
@@ -172,7 +195,7 @@ describe('BrickConnector', () => {
 
   it('renders selection glow when connection is selected', () => {
     useUIStore.setState({ selectedId: connection.id });
-    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
+    setupEndpoints();
 
     const { container } = renderConnector();
 
@@ -182,127 +205,116 @@ describe('BrickConnector', () => {
   });
 
   it('renders studs at source and target endpoints', () => {
-    setupEndpoints({ x: 100, y: 100 }, { x: 200, y: 200 });
+    setupEndpoints();
 
     const { container } = renderConnector();
 
     const ellipses = container.querySelectorAll('ellipse');
-    expect(ellipses).toHaveLength(6);
+    expect(ellipses.length).toBeGreaterThanOrEqual(6);
 
-    expect(ellipses[0]?.getAttribute('rx')).toBe('12');
-    expect(ellipses[0]?.getAttribute('ry')).toBe('6');
-    expect(ellipses[2]?.getAttribute('rx')).toBe('7.2');
-    expect(ellipses[2]?.getAttribute('ry')).toBe('3.6');
+    const studEllipses = Array.from(ellipses).filter(e => e.getAttribute('rx') === '12');
+    expect(studEllipses.length).toBeGreaterThanOrEqual(2);
   });
 
-  describe('beam shapes', () => {
-    const beamShapeMap: Record<ConnectionType, string> = {
-      dataflow: 'standard',
-      http: 'doubleRail',
-      internal: 'segmented',
-      data: 'wide',
-      async: 'zigzag',
+  describe('connector types', () => {
+    const typeMap: Record<ConnectionType, string> = {
+      dataflow: 'dataflow',
+      http: 'http',
+      internal: 'internal',
+      data: 'data',
+      async: 'async',
     };
 
-    for (const [type, beamShape] of Object.entries(beamShapeMap)) {
-      it(`renders ${beamShape} beam for ${type} connection type`, () => {
+    for (const [type, expected] of Object.entries(typeMap)) {
+      it(`renders ${type} connection type with correct data attribute`, () => {
         const conn: Connection = {
           ...connection,
           id: `conn-${type}`,
           type: type as ConnectionType,
         };
-        setupEndpoints({ x: 100, y: 100 }, { x: 250, y: 200 });
+        setupEndpoints();
 
         const { container } = renderConnector(conn);
 
         const rootGroup = container.querySelector('g');
         expect(rootGroup).toBeInTheDocument();
-        expect(rootGroup?.getAttribute('data-beam-shape')).toBe(beamShape);
+        expect(rootGroup?.getAttribute('data-connector-type')).toBe(expected);
       });
     }
+  });
 
-    it('standard beam renders 3 polygons per segment (top + 2 sides)', () => {
-      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
+  describe('liftarm segments', () => {
+    it('renders iso-aligned segments with data-connector-segment attribute', () => {
+      setupEndpoints([1, 0, 1], [1, 0, 5]);
 
-      const { container } = renderConnector({
-        ...connection,
-        type: 'dataflow',
-      });
+      const { container } = renderConnector();
 
-      const standardBeam = container.querySelector('[data-beam="standard"]');
-      expect(standardBeam).toBeInTheDocument();
-      expect(standardBeam?.querySelectorAll('polygon')).toHaveLength(3);
+      const segments = container.querySelectorAll('[data-connector-segment]');
+      expect(segments.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('doubleRail beam renders 6 polygons per segment (3 per rail × 2)', () => {
-      const conn: Connection = { ...connection, id: 'conn-http', type: 'http' };
-      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
+    it('segment has axis data attribute', () => {
+      setupEndpoints([1, 0, 1], [4, 0, 1]);
 
-      const { container } = renderConnector(conn);
+      const { container } = renderConnector();
 
-      const railBeam = container.querySelector('[data-beam="doubleRail"]');
-      expect(railBeam).toBeInTheDocument();
-      expect(railBeam?.querySelectorAll('polygon')).toHaveLength(6);
+      const segment = container.querySelector('[data-connector-segment]');
+      expect(segment).toBeInTheDocument();
+      expect(segment?.getAttribute('data-axis')).toBe('x');
     });
 
-    it('segmented beam renders multiple chunks with gaps', () => {
-      const conn: Connection = { ...connection, id: 'conn-int', type: 'internal' };
-      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 300 });
+    it('renders at least 3 polygons per segment (top + side + front + optional pin markers)', () => {
+      setupEndpoints([1, 0, 1], [1, 0, 4]);
 
-      const { container } = renderConnector(conn);
+      const { container } = renderConnector();
 
-      const segmentedBeam = container.querySelector('[data-beam="segmented"]');
-      expect(segmentedBeam).toBeInTheDocument();
-      const chunkGroups = segmentedBeam?.querySelectorAll('g');
-      expect(chunkGroups?.length).toBeGreaterThanOrEqual(2);
-    });
-
-    it('wide beam renders wider polygons than standard', () => {
-      const conn: Connection = { ...connection, id: 'conn-data', type: 'data' };
-      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
-
-      const { container } = renderConnector(conn);
-
-      const wideBeam = container.querySelector('[data-beam="wide"]');
-      expect(wideBeam).toBeInTheDocument();
-      expect(wideBeam?.querySelectorAll('polygon')).toHaveLength(3);
-    });
-
-    it('zigzag beam renders multiple zig-zag sub-segments', () => {
-      const conn: Connection = { ...connection, id: 'conn-async', type: 'async' };
-      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 300 });
-
-      const { container } = renderConnector(conn);
-
-      const zigzagBeam = container.querySelector('[data-beam="zigzag"]');
-      expect(zigzagBeam).toBeInTheDocument();
-      const zigGroups = zigzagBeam?.querySelectorAll('g');
-      expect(zigGroups?.length).toBeGreaterThanOrEqual(2);
+      const segment = container.querySelector('[data-connector-segment]');
+      expect(segment).toBeInTheDocument();
+      const polygons = segment?.querySelectorAll('polygon');
+      expect(polygons?.length).toBeGreaterThanOrEqual(3);
     });
   });
 
   describe('elbow joints', () => {
-    it('renders 3D elbow with side faces at bend points', () => {
-      setupEndpoints({ x: 100, y: 100 }, { x: 300, y: 250 });
+    it('renders elbow with data-connector-elbow for L-shaped routes', () => {
+      setupEndpoints([1, 0, 1], [4, 0, 5]);
 
       const { container } = renderConnector();
 
-      const elbowGroups = container.querySelectorAll('[data-elbow]');
-      const elbowPolygons = Array.from(elbowGroups).flatMap((g) =>
-        Array.from(g.querySelectorAll('polygon')),
-      );
-      expect(elbowPolygons.length).toBeGreaterThanOrEqual(3);
+      const elbows = container.querySelectorAll('[data-connector-elbow]');
+      expect(elbows).toHaveLength(1);
+    });
+
+    it('elbow has 3 polygons (diamond top + 2 side faces)', () => {
+      setupEndpoints([1, 0, 1], [4, 0, 5]);
+
+      const { container } = renderConnector();
+
+      const elbow = container.querySelector('[data-connector-elbow]');
+      expect(elbow).toBeInTheDocument();
+      expect(elbow?.querySelectorAll('polygon')).toHaveLength(3);
+    });
+
+    it('does not render elbow for axis-aligned connections', () => {
+      setupEndpoints([1, 0, 1], [1, 0, 5]);
+
+      const { container } = renderConnector();
+
+      const elbows = container.querySelectorAll('[data-connector-elbow]');
+      expect(elbows).toHaveLength(0);
     });
   });
 
-  describe('arrow tip', () => {
-    it('renders arrow with side face for 3D effect', () => {
-      setupEndpoints({ x: 100, y: 100 }, { x: 100, y: 250 });
+  describe('pin holes', () => {
+    it('renders pin holes along segments for long enough connections', () => {
+      setupEndpoints([0, 0, 0], [0, 0, 5]);
 
       const { container } = renderConnector();
 
-      const allPolygons = container.querySelectorAll('polygon');
-      expect(allPolygons.length).toBeGreaterThanOrEqual(5);
+      const segment = container.querySelector('[data-connector-segment]');
+      expect(segment).toBeInTheDocument();
+      const pinElements = segment?.querySelectorAll('ellipse, line, polygon');
+      expect(pinElements?.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/apps/web/src/entities/connection/BrickConnector.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.tsx
@@ -6,11 +6,16 @@ import { worldToScreen } from '../../shared/utils/isometric';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
-import { STUD_RX, STUD_RY, STUD_HEIGHT, STUD_INNER_RX, STUD_INNER_RY, STUD_INNER_OPACITY } from '../../shared/tokens/designTokens';
+import {
+  TILE_W, TILE_H,
+  BEAM_WIDTH_CU, BEAM_THICKNESS_PX,
+  PIN_HOLE_SPACING_CU, PIN_HOLE_RX, PIN_HOLE_RY,
+  STUD_RX, STUD_RY, STUD_HEIGHT, STUD_INNER_RX, STUD_INNER_RY, STUD_INNER_OPACITY,
+} from '../../shared/tokens/designTokens';
 import { CONNECTOR_THEMES, DIFF_THEMES, lightenColor } from './connectorTheme';
-import { computeRoute, segmentAngle, segmentLength } from './routing';
-import type { ConnectorTheme, BeamShape } from './connectorTheme';
-import type { RouteSegment } from './routing';
+import { computeWorldRoute, worldSegmentToScreen, worldSegmentLengthCU } from './routing';
+import type { ConnectorTheme, PinHoleStyle } from './connectorTheme';
+import type { WorldSegment } from './routing';
 
 interface BrickConnectorProps {
   connection: Connection;
@@ -29,16 +34,8 @@ interface BeamColors {
   opacity: number;
 }
 
-const BEAM_HALF_WIDTH = 8;
-const BEAM_THICKNESS = 6;
-const WIDE_HALF_WIDTH = 12;
-const RAIL_HALF_WIDTH = 3;
-const RAIL_GAP = 4;
-const SEGMENT_CHUNK_LENGTH = 20;
-const SEGMENT_GAP = 4;
-const ZIGZAG_AMPLITUDE = 6;
-const ZIGZAG_WAVELENGTH = 16;
-const ARROW_LENGTH = 12;
+const BEAM_HALF_W_X = TILE_W / 2 * BEAM_WIDTH_CU / 2;
+const BEAM_HALF_W_Y = TILE_H / 2 * BEAM_WIDTH_CU / 2;
 const HIT_AREA_WIDTH = 20;
 
 function getColors(
@@ -67,247 +64,201 @@ function getColors(
   return { tile: baseTile, shadow: baseShadow, dark: baseDark, accent, opacity: baseOpacity };
 }
 
-function buildBeamFaces(
-  start: ScreenPoint,
-  end: ScreenPoint,
-  halfWidth: number,
+function buildIsoBeamTopFace(
+  startScreen: ScreenPoint,
+  endScreen: ScreenPoint,
+  axis: 'x' | 'z',
+): string {
+  const hw = axis === 'x'
+    ? { dx: 0, dy: -BEAM_HALF_W_Y, dx2: 0, dy2: BEAM_HALF_W_Y }
+    : { dx: -BEAM_HALF_W_X, dy: 0, dx2: BEAM_HALF_W_X, dy2: 0 };
+
+  const p1 = { x: startScreen.x + hw.dx, y: startScreen.y + hw.dy };
+  const p2 = { x: startScreen.x + hw.dx2, y: startScreen.y + hw.dy2 };
+  const p3 = { x: endScreen.x + hw.dx2, y: endScreen.y + hw.dy2 };
+  const p4 = { x: endScreen.x + hw.dx, y: endScreen.y + hw.dy };
+
+  return `${p1.x},${p1.y} ${p4.x},${p4.y} ${p3.x},${p3.y} ${p2.x},${p2.y}`;
+}
+
+function buildIsoBeamSideFace(
+  startScreen: ScreenPoint,
+  endScreen: ScreenPoint,
+  axis: 'x' | 'z',
   thickness: number,
-): { top: string; rightSide: string; frontSide: string } {
-  const angle = Math.atan2(end.y - start.y, end.x - start.x);
-  const perpX = -Math.sin(angle) * halfWidth;
-  const perpY = Math.cos(angle) * halfWidth;
+): string {
+  if (axis === 'x') {
+    const p1 = { x: startScreen.x, y: startScreen.y + BEAM_HALF_W_Y };
+    const p2 = { x: endScreen.x, y: endScreen.y + BEAM_HALF_W_Y };
+    return `${p1.x},${p1.y} ${p2.x},${p2.y} ${p2.x},${p2.y + thickness} ${p1.x},${p1.y + thickness}`;
+  }
+  const p1 = { x: startScreen.x + BEAM_HALF_W_X, y: startScreen.y };
+  const p2 = { x: endScreen.x + BEAM_HALF_W_X, y: endScreen.y };
+  return `${p1.x},${p1.y} ${p2.x},${p2.y} ${p2.x},${p2.y + thickness} ${p1.x},${p1.y + thickness}`;
+}
 
-  const p1 = { x: start.x + perpX, y: start.y + perpY };
-  const p2 = { x: start.x - perpX, y: start.y - perpY };
-  const p3 = { x: end.x - perpX, y: end.y - perpY };
-  const p4 = { x: end.x + perpX, y: end.y + perpY };
+function buildIsoBeamFrontFace(
+  endScreen: ScreenPoint,
+  axis: 'x' | 'z',
+  thickness: number,
+): string {
+  if (axis === 'x') {
+    const left = { x: endScreen.x, y: endScreen.y - BEAM_HALF_W_Y };
+    const right = { x: endScreen.x, y: endScreen.y + BEAM_HALF_W_Y };
+    return `${left.x},${left.y} ${right.x},${right.y} ${right.x},${right.y + thickness} ${left.x},${left.y + thickness}`;
+  }
+  const left = { x: endScreen.x - BEAM_HALF_W_X, y: endScreen.y };
+  const right = { x: endScreen.x + BEAM_HALF_W_X, y: endScreen.y };
+  return `${left.x},${left.y} ${right.x},${right.y} ${right.x},${right.y + thickness} ${left.x},${left.y + thickness}`;
+}
 
-  const top = `${p1.x},${p1.y} ${p4.x},${p4.y} ${p3.x},${p3.y} ${p2.x},${p2.y}`;
+function renderPinHole(
+  cx: number,
+  cy: number,
+  style: PinHoleStyle,
+  accent: string,
+  id: string,
+): React.ReactNode {
+  const opacity = 0.4;
+  switch (style) {
+    case 'open':
+      return (
+        <ellipse key={id} cx={cx} cy={cy} rx={PIN_HOLE_RX} ry={PIN_HOLE_RY}
+          fill="none" stroke={accent} strokeWidth={1} opacity={opacity} />
+      );
+    case 'filled':
+      return (
+        <ellipse key={id} cx={cx} cy={cy} rx={PIN_HOLE_RX} ry={PIN_HOLE_RY}
+          fill={accent} opacity={opacity} />
+      );
+    case 'cross':
+      return (
+        <g key={id} opacity={opacity}>
+          <line x1={cx - PIN_HOLE_RX} y1={cy} x2={cx + PIN_HOLE_RX} y2={cy}
+            stroke={accent} strokeWidth={1} />
+          <line x1={cx} y1={cy - PIN_HOLE_RY} x2={cx} y2={cy + PIN_HOLE_RY}
+            stroke={accent} strokeWidth={1} />
+        </g>
+      );
+    case 'double':
+      return (
+        <g key={id} opacity={opacity}>
+          <ellipse cx={cx} cy={cy} rx={PIN_HOLE_RX} ry={PIN_HOLE_RY}
+            fill="none" stroke={accent} strokeWidth={1} />
+          <ellipse cx={cx} cy={cy} rx={PIN_HOLE_RX * 0.5} ry={PIN_HOLE_RY * 0.5}
+            fill="none" stroke={accent} strokeWidth={0.5} />
+        </g>
+      );
+    case 'dashed':
+      return (
+        <ellipse key={id} cx={cx} cy={cy} rx={PIN_HOLE_RX} ry={PIN_HOLE_RY}
+          fill="none" stroke={accent} strokeWidth={1} strokeDasharray="2 2" opacity={opacity} />
+      );
+  }
+}
+
+function renderDirectionMarker(
+  cx: number,
+  cy: number,
+  accent: string,
+  id: string,
+): React.ReactNode {
+  const size = PIN_HOLE_RX * 0.8;
+  return (
+    <polygon key={id}
+      points={`${cx},${cy - size} ${cx + size},${cy + size * 0.5} ${cx - size},${cy + size * 0.5}`}
+      fill={accent} opacity={0.5} />
+  );
+}
+
+function getPinHolePositions(
+  seg: WorldSegment,
+  startScreen: ScreenPoint,
+  endScreen: ScreenPoint,
+): ScreenPoint[] {
+  const lengthCU = worldSegmentLengthCU(seg);
+  if (lengthCU < PIN_HOLE_SPACING_CU) return [];
+
+  const holeCount = Math.floor(lengthCU / PIN_HOLE_SPACING_CU);
+  const positions: ScreenPoint[] = [];
+
+  for (let i = 1; i <= holeCount; i++) {
+    const t = (i * PIN_HOLE_SPACING_CU) / lengthCU;
+    positions.push({
+      x: startScreen.x + (endScreen.x - startScreen.x) * t,
+      y: startScreen.y + (endScreen.y - startScreen.y) * t,
+    });
+  }
+
+  return positions;
+}
+
+function renderLiftarmSegment(
+  seg: WorldSegment,
+  colors: BeamColors,
+  pinHoleStyle: PinHoleStyle,
+  originX: number,
+  originY: number,
+  segId: string,
+  isLastSegment: boolean,
+): React.ReactNode {
+  const { start: startScreen, end: endScreen } = worldSegmentToScreen(seg, originX, originY);
+
+  const topFace = buildIsoBeamTopFace(startScreen, endScreen, seg.axis);
+  const sideFace = buildIsoBeamSideFace(startScreen, endScreen, seg.axis, BEAM_THICKNESS_PX);
+  const frontFace = buildIsoBeamFrontFace(endScreen, seg.axis, BEAM_THICKNESS_PX);
+
+  const pinHoles = getPinHolePositions(seg, startScreen, endScreen);
+
+  return (
+    <g key={segId} pointerEvents="none" data-connector-segment data-axis={seg.axis}>
+      <polygon points={sideFace} fill={colors.dark} />
+      <polygon points={frontFace} fill={colors.shadow} />
+      <polygon points={topFace} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+      {pinHoles.map((pos, i) => {
+        const isLast = isLastSegment && i === pinHoles.length - 1;
+        if (isLast) {
+          return renderDirectionMarker(pos.x, pos.y, colors.accent, `${segId}-dir`);
+        }
+        return renderPinHole(pos.x, pos.y, pinHoleStyle, colors.accent, `${segId}-hole-${i}`);
+      })}
+    </g>
+  );
+}
+
+function renderElbowJoint(
+  elbowScreen: ScreenPoint,
+  colors: BeamColors,
+  pinHoleStyle: PinHoleStyle,
+  id: string,
+): React.ReactNode {
+  const hw = TILE_W / 2 * 0.5;
+  const hh = TILE_H / 2 * 0.5;
+
+  const diamond = `${elbowScreen.x},${elbowScreen.y - hh} ${elbowScreen.x + hw},${elbowScreen.y} ${elbowScreen.x},${elbowScreen.y + hh} ${elbowScreen.x - hw},${elbowScreen.y}`;
 
   const rightSide = [
-    `${p4.x},${p4.y}`,
-    `${p3.x},${p3.y}`,
-    `${p3.x},${p3.y + thickness}`,
-    `${p4.x},${p4.y + thickness}`,
+    `${elbowScreen.x + hw},${elbowScreen.y}`,
+    `${elbowScreen.x},${elbowScreen.y + hh}`,
+    `${elbowScreen.x},${elbowScreen.y + hh + BEAM_THICKNESS_PX}`,
+    `${elbowScreen.x + hw},${elbowScreen.y + BEAM_THICKNESS_PX}`,
   ].join(' ');
 
   const frontSide = [
-    `${p2.x},${p2.y}`,
-    `${p3.x},${p3.y}`,
-    `${p3.x},${p3.y + thickness}`,
-    `${p2.x},${p2.y + thickness}`,
+    `${elbowScreen.x},${elbowScreen.y + hh}`,
+    `${elbowScreen.x - hw},${elbowScreen.y}`,
+    `${elbowScreen.x - hw},${elbowScreen.y + BEAM_THICKNESS_PX}`,
+    `${elbowScreen.x},${elbowScreen.y + hh + BEAM_THICKNESS_PX}`,
   ].join(' ');
 
-  return { top, rightSide, frontSide };
-}
-
-function renderStandardBeam(
-  seg: RouteSegment,
-  colors: BeamColors,
-  segId: string,
-): React.ReactNode {
-  const faces = buildBeamFaces(seg.start, seg.end, BEAM_HALF_WIDTH, BEAM_THICKNESS);
   return (
-    <g key={segId} pointerEvents="none" data-beam="standard">
-      <polygon points={faces.frontSide} fill={colors.dark} />
-      <polygon points={faces.rightSide} fill={colors.shadow} />
-      <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+    <g key={id} pointerEvents="none" data-connector-elbow>
+      <polygon points={frontSide} fill={colors.dark} />
+      <polygon points={rightSide} fill={colors.shadow} />
+      <polygon points={diamond} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+      {renderPinHole(elbowScreen.x, elbowScreen.y, pinHoleStyle, colors.accent, `${id}-hole`)}
     </g>
   );
-}
-
-function renderDoubleRailBeam(
-  seg: RouteSegment,
-  colors: BeamColors,
-  segId: string,
-): React.ReactNode {
-  const angle = Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
-  const perpX = -Math.sin(angle);
-  const perpY = Math.cos(angle);
-  const offset = RAIL_GAP + RAIL_HALF_WIDTH;
-
-  const rail1Start = { x: seg.start.x + perpX * offset, y: seg.start.y + perpY * offset };
-  const rail1End = { x: seg.end.x + perpX * offset, y: seg.end.y + perpY * offset };
-  const rail2Start = { x: seg.start.x - perpX * offset, y: seg.start.y - perpY * offset };
-  const rail2End = { x: seg.end.x - perpX * offset, y: seg.end.y - perpY * offset };
-
-  const faces1 = buildBeamFaces(rail1Start, rail1End, RAIL_HALF_WIDTH, BEAM_THICKNESS);
-  const faces2 = buildBeamFaces(rail2Start, rail2End, RAIL_HALF_WIDTH, BEAM_THICKNESS);
-
-  return (
-    <g key={segId} pointerEvents="none" data-beam="doubleRail">
-      <polygon points={faces1.frontSide} fill={colors.dark} />
-      <polygon points={faces1.rightSide} fill={colors.shadow} />
-      <polygon points={faces1.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
-      <polygon points={faces2.frontSide} fill={colors.dark} />
-      <polygon points={faces2.rightSide} fill={colors.shadow} />
-      <polygon points={faces2.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
-    </g>
-  );
-}
-
-function renderSegmentedBeam(
-  seg: RouteSegment,
-  colors: BeamColors,
-  segId: string,
-): React.ReactNode {
-  const len = segmentLength(seg);
-  if (len < 1) return null;
-
-  const angle = Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
-  const cos = Math.cos(angle);
-  const sin = Math.sin(angle);
-
-  const chunkCount = Math.max(1, Math.round(len / SEGMENT_CHUNK_LENGTH));
-  const totalGaps = Math.max(0, chunkCount - 1) * SEGMENT_GAP;
-  const chunkLen = (len - totalGaps) / chunkCount;
-  const chunks: React.ReactNode[] = [];
-
-  let cursor = 0;
-  for (let i = 0; i < chunkCount; i++) {
-    const chunkStart = {
-      x: seg.start.x + cos * cursor,
-      y: seg.start.y + sin * cursor,
-    };
-    const chunkEnd = {
-      x: seg.start.x + cos * (cursor + chunkLen),
-      y: seg.start.y + sin * (cursor + chunkLen),
-    };
-    const faces = buildBeamFaces(chunkStart, chunkEnd, BEAM_HALF_WIDTH, BEAM_THICKNESS);
-    chunks.push(
-      <g key={`${segId}-chunk-${i}`}>
-        <polygon points={faces.frontSide} fill={colors.dark} />
-        <polygon points={faces.rightSide} fill={colors.shadow} />
-        <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
-      </g>,
-    );
-    cursor += chunkLen + SEGMENT_GAP;
-  }
-
-  return (
-    <g key={segId} pointerEvents="none" data-beam="segmented">
-      {chunks}
-    </g>
-  );
-}
-
-function renderWideBeam(
-  seg: RouteSegment,
-  colors: BeamColors,
-  segId: string,
-): React.ReactNode {
-  const faces = buildBeamFaces(seg.start, seg.end, WIDE_HALF_WIDTH, BEAM_THICKNESS);
-  return (
-    <g key={segId} pointerEvents="none" data-beam="wide">
-      <polygon points={faces.frontSide} fill={colors.dark} />
-      <polygon points={faces.rightSide} fill={colors.shadow} />
-      <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
-    </g>
-  );
-}
-
-function renderZigzagBeam(
-  seg: RouteSegment,
-  colors: BeamColors,
-  segId: string,
-): React.ReactNode {
-  const len = segmentLength(seg);
-  if (len < 1) return null;
-
-  const angle = Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
-  const cos = Math.cos(angle);
-  const sin = Math.sin(angle);
-  const perpX = -sin;
-  const perpY = cos;
-
-  const steps = Math.max(2, Math.floor(len / ZIGZAG_WAVELENGTH) * 2);
-  const zigSegments: React.ReactNode[] = [];
-
-  for (let i = 0; i < steps; i++) {
-    const t0 = i / steps;
-    const t1 = (i + 1) / steps;
-    const offset0 = (i % 2 === 0 ? 1 : -1) * ZIGZAG_AMPLITUDE;
-    const offset1 = (i % 2 === 0 ? -1 : 1) * ZIGZAG_AMPLITUDE;
-
-    const zStart = {
-      x: seg.start.x + cos * len * t0 + perpX * offset0,
-      y: seg.start.y + sin * len * t0 + perpY * offset0,
-    };
-    const zEnd = {
-      x: seg.start.x + cos * len * t1 + perpX * offset1,
-      y: seg.start.y + sin * len * t1 + perpY * offset1,
-    };
-
-    const faces = buildBeamFaces(zStart, zEnd, RAIL_HALF_WIDTH, BEAM_THICKNESS);
-    zigSegments.push(
-      <g key={`${segId}-zig-${i}`}>
-        <polygon points={faces.frontSide} fill={colors.dark} />
-        <polygon points={faces.rightSide} fill={colors.shadow} />
-        <polygon points={faces.top} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
-      </g>,
-    );
-  }
-
-  return (
-    <g key={segId} pointerEvents="none" data-beam="zigzag">
-      {zigSegments}
-    </g>
-  );
-}
-
-function renderBeamSegment(
-  beamShape: BeamShape,
-  seg: RouteSegment,
-  colors: BeamColors,
-  segId: string,
-): React.ReactNode {
-  switch (beamShape) {
-    case 'standard':
-      return renderStandardBeam(seg, colors, segId);
-    case 'doubleRail':
-      return renderDoubleRailBeam(seg, colors, segId);
-    case 'segmented':
-      return renderSegmentedBeam(seg, colors, segId);
-    case 'wide':
-      return renderWideBeam(seg, colors, segId);
-    case 'zigzag':
-      return renderZigzagBeam(seg, colors, segId);
-  }
-}
-
-function getBeamHalfWidth(beamShape: BeamShape): number {
-  switch (beamShape) {
-    case 'wide':
-      return WIDE_HALF_WIDTH;
-    case 'doubleRail':
-      return RAIL_GAP + RAIL_HALF_WIDTH * 2;
-    default:
-      return BEAM_HALF_WIDTH;
-  }
-}
-
-function buildArrowPoints(
-  end: ScreenPoint,
-  angle: number,
-  halfWidth: number,
-): string {
-  const tipX = end.x + Math.cos(angle) * ARROW_LENGTH;
-  const tipY = end.y + Math.sin(angle) * ARROW_LENGTH;
-  const perpX = -Math.sin(angle) * halfWidth;
-  const perpY = Math.cos(angle) * halfWidth;
-  const baseLeft = { x: end.x + perpX, y: end.y + perpY };
-  const baseRight = { x: end.x - perpX, y: end.y - perpY };
-
-  return `${baseLeft.x},${baseLeft.y} ${tipX},${tipY} ${baseRight.x},${baseRight.y}`;
-}
-
-function buildHitPath(segments: RouteSegment[]): string {
-  if (segments.length === 0) return '';
-  let d = `M ${segments[0].start.x} ${segments[0].start.y}`;
-  for (const seg of segments) {
-    d += ` L ${seg.end.x} ${seg.end.y}`;
-  }
-  return d;
 }
 
 function renderStud(
@@ -323,6 +274,21 @@ function renderStud(
       <ellipse cx={cx} cy={cy - STUD_HEIGHT} rx={STUD_INNER_RX} ry={STUD_INNER_RY} fill={colors.accent} opacity={STUD_INNER_OPACITY} />
     </g>
   );
+}
+
+function buildHitPath(
+  route: ReturnType<typeof computeWorldRoute>,
+  originX: number,
+  originY: number,
+): string {
+  if (route.segments.length === 0) return '';
+  const first = worldSegmentToScreen(route.segments[0], originX, originY);
+  let d = `M ${first.start.x} ${first.start.y}`;
+  for (const seg of route.segments) {
+    const screen = worldSegmentToScreen(seg, originX, originY);
+    d += ` L ${screen.end.x} ${screen.end.y}`;
+  }
+  return d;
 }
 
 export const BrickConnector = memo(function BrickConnector({
@@ -351,20 +317,17 @@ export const BrickConnector = memo(function BrickConnector({
 
   const route = useMemo(() => {
     if (!src || !tgt) return null;
-    const srcScreen = worldToScreen(src[0], src[1], src[2], originX, originY);
-    const tgtScreen = worldToScreen(tgt[0], tgt[1], tgt[2], originX, originY);
-    return { srcScreen, tgtScreen, ...computeRoute(srcScreen, tgtScreen) };
+    return computeWorldRoute(src, tgt, originX, originY);
   }, [src, tgt, originX, originY]);
 
   if (!src || !tgt || !route) return null;
 
   const colors = getColors(theme, diffState, isHighlighted);
-  const hitPath = buildHitPath(route.segments);
-  const beamHW = getBeamHalfWidth(theme.beamShape);
+  const hitPath = buildHitPath(route, originX, originY);
 
-  const lastSeg = route.segments[route.segments.length - 1];
-  const arrowAngle = segmentAngle(lastSeg);
-  const arrowPoints = buildArrowPoints(lastSeg.end, arrowAngle, beamHW);
+  const elbowScreen = route.elbow
+    ? worldToScreen(route.elbow.worldX, route.elbow.worldY, route.elbow.worldZ, originX, originY)
+    : null;
 
   const handleClick = (e: React.MouseEvent<SVGGElement>) => {
     e.stopPropagation();
@@ -380,13 +343,13 @@ export const BrickConnector = memo(function BrickConnector({
       opacity={colors.opacity}
       style={{ cursor: 'pointer' }}
       onClick={handleClick}
-      data-beam-shape={theme.beamShape}
+      data-connector-type={connection.type}
     >
       {isSelected && (
         <path
           d={hitPath}
           stroke="#ffffff"
-          strokeWidth={beamHW * 2 + 4}
+          strokeWidth={BEAM_HALF_W_X * 2 + 4}
           strokeOpacity={0.5}
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -407,70 +370,23 @@ export const BrickConnector = memo(function BrickConnector({
       />
 
       {route.segments.map((seg, i) =>
-        renderBeamSegment(
-          theme.beamShape,
+        renderLiftarmSegment(
           seg,
           colors,
+          theme.pinHoleStyle,
+          originX,
+          originY,
           `seg-${connection.id}-${i}`,
+          i === route.segments.length - 1,
         ),
       )}
 
-      {route.elbows.map((elbow, i) => {
-        const elbowPts = [
-          `${elbow.x - beamHW},${elbow.y}`,
-          `${elbow.x},${elbow.y - beamHW / 2}`,
-          `${elbow.x + beamHW},${elbow.y}`,
-          `${elbow.x},${elbow.y + beamHW / 2}`,
-        ].join(' ');
-        return (
-          <g key={`elbow-${connection.id}-${i}`} pointerEvents="none" data-elbow>
-            <polygon
-              points={elbowPts}
-              fill={colors.tile}
-              stroke={colors.shadow}
-              strokeWidth={0.5}
-            />
-            <polygon
-              points={[
-                `${elbow.x + beamHW},${elbow.y}`,
-                `${elbow.x},${elbow.y + beamHW / 2}`,
-                `${elbow.x},${elbow.y + beamHW / 2 + BEAM_THICKNESS}`,
-                `${elbow.x + beamHW},${elbow.y + BEAM_THICKNESS}`,
-              ].join(' ')}
-              fill={colors.shadow}
-            />
-            <polygon
-              points={[
-                `${elbow.x},${elbow.y + beamHW / 2}`,
-                `${elbow.x - beamHW},${elbow.y}`,
-                `${elbow.x - beamHW},${elbow.y + BEAM_THICKNESS}`,
-                `${elbow.x},${elbow.y + beamHW / 2 + BEAM_THICKNESS}`,
-              ].join(' ')}
-              fill={colors.dark}
-            />
-          </g>
-        );
-      })}
-
-      <g pointerEvents="none">
-        <polygon
-          points={arrowPoints}
-          fill={colors.tile}
-          stroke={colors.shadow}
-          strokeWidth={0.5}
-        />
-        <polygon
-          points={(() => {
-            const tipX = lastSeg.end.x + Math.cos(arrowAngle) * ARROW_LENGTH;
-            const tipY = lastSeg.end.y + Math.sin(arrowAngle) * ARROW_LENGTH;
-            const perpX = -Math.sin(arrowAngle) * beamHW;
-            const perpY = Math.cos(arrowAngle) * beamHW;
-            const baseRight = { x: lastSeg.end.x - perpX, y: lastSeg.end.y - perpY };
-            return `${baseRight.x},${baseRight.y} ${tipX},${tipY} ${tipX},${tipY + BEAM_THICKNESS} ${baseRight.x},${baseRight.y + BEAM_THICKNESS}`;
-          })()}
-          fill={colors.shadow}
-        />
-      </g>
+      {elbowScreen && renderElbowJoint(
+        elbowScreen,
+        colors,
+        theme.pinHoleStyle,
+        `elbow-${connection.id}`,
+      )}
 
       {renderStud(route.srcScreen.x, route.srcScreen.y, colors, `stud-src-${connection.id}`)}
       {renderStud(route.tgtScreen.x, route.tgtScreen.y, colors, `stud-tgt-${connection.id}`)}

--- a/apps/web/src/entities/connection/connectorTheme.test.ts
+++ b/apps/web/src/entities/connection/connectorTheme.test.ts
@@ -40,25 +40,19 @@ describe('CONNECTOR_THEMES', () => {
       expect(theme).toHaveProperty('shadow');
       expect(theme).toHaveProperty('dark');
       expect(theme).toHaveProperty('accent');
-      expect(theme).toHaveProperty('pattern');
-      expect(theme).toHaveProperty('beamShape');
+      expect(theme).toHaveProperty('pinHoleStyle');
     }
   });
 
-  it('each pattern is unique across types', () => {
-    const patterns = Object.values(CONNECTOR_THEMES).map((t) => t.pattern);
-    expect(new Set(patterns).size).toBe(5);
+  it('each pinHoleStyle is unique across types', () => {
+    const styles = Object.values(CONNECTOR_THEMES).map((t) => t.pinHoleStyle);
+    expect(new Set(styles).size).toBe(5);
   });
 
-  it('each beamShape is unique across types', () => {
-    const shapes = Object.values(CONNECTOR_THEMES).map((t) => t.beamShape);
-    expect(new Set(shapes).size).toBe(5);
-  });
-
-  it('beamShape values are valid BeamShape literals', () => {
-    const validShapes = new Set(['standard', 'doubleRail', 'segmented', 'wide', 'zigzag']);
+  it('pinHoleStyle values are valid literals', () => {
+    const validStyles = new Set(['open', 'filled', 'cross', 'double', 'dashed']);
     for (const theme of Object.values(CONNECTOR_THEMES)) {
-      expect(validShapes.has(theme.beamShape)).toBe(true);
+      expect(validStyles.has(theme.pinHoleStyle)).toBe(true);
     }
   });
 });

--- a/apps/web/src/entities/connection/connectorTheme.ts
+++ b/apps/web/src/entities/connection/connectorTheme.ts
@@ -1,24 +1,13 @@
 import type { ConnectionType } from '@cloudblocks/schema';
 
-// ─── Connector Color Themes ─────────────────────────────────
-// See BRICK_CONNECTOR_SPEC.md §3.1
-
-/** Physically distinct beam shapes — each connection type uses a unique shape */
-export type BeamShape = 'standard' | 'doubleRail' | 'segmented' | 'wide' | 'zigzag';
+export type PinHoleStyle = 'open' | 'filled' | 'cross' | 'double' | 'dashed';
 
 export interface ConnectorTheme {
-  /** Top face / tile color */
   tile: string;
-  /** Shadow / side face color */
   shadow: string;
-  /** Front face (darkest) */
   dark: string;
-  /** Accent for patterns and stud inner ring */
   accent: string;
-  /** SVG pattern type rendered on the beam surface */
-  pattern: 'solid' | 'double' | 'dashed' | 'dotted' | 'zigzag';
-  /** Physical beam shape — determines the geometry of the connector */
-  beamShape: BeamShape;
+  pinHoleStyle: PinHoleStyle;
 }
 
 export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
@@ -27,45 +16,37 @@ export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
     shadow: '#475569',
     dark: '#334155',
     accent: '#94a3b8',
-    pattern: 'solid',
-    beamShape: 'standard',
+    pinHoleStyle: 'open',
   },
   http: {
     tile: '#3b82f6',
     shadow: '#2563eb',
     dark: '#1d4ed8',
     accent: '#60a5fa',
-    pattern: 'double',
-    beamShape: 'doubleRail',
+    pinHoleStyle: 'filled',
   },
   internal: {
     tile: '#8b5cf6',
     shadow: '#7c3aed',
     dark: '#6d28d9',
     accent: '#a78bfa',
-    pattern: 'dashed',
-    beamShape: 'segmented',
+    pinHoleStyle: 'cross',
   },
   data: {
     tile: '#f59e0b',
     shadow: '#d97706',
     dark: '#b45309',
     accent: '#fbbf24',
-    pattern: 'dotted',
-    beamShape: 'wide',
+    pinHoleStyle: 'double',
   },
   async: {
     tile: '#10b981',
     shadow: '#059669',
     dark: '#047857',
     accent: '#34d399',
-    pattern: 'zigzag',
-    beamShape: 'zigzag',
+    pinHoleStyle: 'dashed',
   },
 };
-
-// ─── Diff-Aware Overrides ───────────────────────────────────
-// See BRICK_CONNECTOR_SPEC.md §6
 
 export interface DiffTheme {
   tile: string;
@@ -80,10 +61,6 @@ export const DIFF_THEMES: Record<string, DiffTheme> = {
   modified: { tile: '#eab308', shadow: '#854d0e', dark: '#713f12', opacity: 1.0 },
 };
 
-/**
- * Lighten a hex color by a percentage (0–1).
- * Used for hover/selection brightness boost.
- */
 export function lightenColor(hex: string, amount: number): string {
   const r = parseInt(hex.slice(1, 3), 16);
   const g = parseInt(hex.slice(3, 5), 16);

--- a/apps/web/src/entities/connection/routing.test.ts
+++ b/apps/web/src/entities/connection/routing.test.ts
@@ -1,55 +1,97 @@
 import { describe, it, expect } from 'vitest';
-import { computeRoute, segmentAngle, segmentLength } from './routing';
+import { computeWorldRoute, worldSegmentToScreen, worldSegmentLengthCU } from './routing';
 
-describe('computeRoute', () => {
-  it('returns single segment for aligned points', () => {
-    const route = computeRoute({ x: 0, y: 0 }, { x: 100, y: 0 });
+describe('computeWorldRoute', () => {
+  const originX = 400;
+  const originY = 300;
+
+  it('returns single segment for same-X-axis aligned points', () => {
+    const route = computeWorldRoute([2, 0, 3], [5, 0, 3], originX, originY);
     expect(route.segments).toHaveLength(1);
-    expect(route.elbows).toHaveLength(0);
-    expect(route.segments[0].start).toEqual({ x: 0, y: 0 });
-    expect(route.segments[0].end).toEqual({ x: 100, y: 0 });
+    expect(route.elbow).toBeNull();
+    expect(route.segments[0].axis).toBe('x');
+    expect(route.segments[0].start.worldX).toBe(2);
+    expect(route.segments[0].end.worldX).toBe(5);
   });
 
-  it('returns single segment for vertically aligned points', () => {
-    const route = computeRoute({ x: 50, y: 0 }, { x: 50, y: 100 });
+  it('returns single segment for same-Z-axis aligned points', () => {
+    const route = computeWorldRoute([3, 0, 1], [3, 0, 4], originX, originY);
     expect(route.segments).toHaveLength(1);
-    expect(route.elbows).toHaveLength(0);
+    expect(route.elbow).toBeNull();
+    expect(route.segments[0].axis).toBe('z');
   });
 
-  it('returns L-shaped route with elbow for diagonal points', () => {
-    const route = computeRoute({ x: 0, y: 0 }, { x: 100, y: 80 });
+  it('returns L-shaped route with X-first elbow for diagonal points', () => {
+    const route = computeWorldRoute([1, 0, 2], [4, 0, 5], originX, originY);
     expect(route.segments).toHaveLength(2);
-    expect(route.elbows).toHaveLength(1);
-    expect(route.elbows[0]).toEqual({ x: 100, y: 0 });
+    expect(route.elbow).not.toBeNull();
+    expect(route.segments[0].axis).toBe('x');
+    expect(route.segments[1].axis).toBe('z');
+    expect(route.elbow!.worldX).toBe(4);
+    expect(route.elbow!.worldZ).toBe(2);
   });
 
-  it('returns single segment for very close points', () => {
-    const route = computeRoute({ x: 0, y: 0 }, { x: 3, y: 3 });
+  it('returns Z-first route when source is below target on screen', () => {
+    const route = computeWorldRoute([5, 0, 8], [2, 0, 1], originX, originY);
+    expect(route.segments).toHaveLength(2);
+    expect(route.elbow).not.toBeNull();
+    expect(route.segments[0].axis).toBe('z');
+    expect(route.segments[1].axis).toBe('x');
+    expect(route.elbow!.worldX).toBe(5);
+    expect(route.elbow!.worldZ).toBe(1);
+  });
+
+  it('returns single segment for coincident points', () => {
+    const route = computeWorldRoute([3, 0, 3], [3, 0, 3], originX, originY);
     expect(route.segments).toHaveLength(1);
-    expect(route.elbows).toHaveLength(0);
+    expect(route.elbow).toBeNull();
+  });
+
+  it('includes screen coordinates for source and target', () => {
+    const route = computeWorldRoute([0, 0, 0], [2, 0, 1], originX, originY);
+    expect(route.srcScreen).toBeDefined();
+    expect(route.tgtScreen).toBeDefined();
+    expect(typeof route.srcScreen.x).toBe('number');
+    expect(typeof route.srcScreen.y).toBe('number');
+  });
+
+  it('handles elevated endpoints', () => {
+    const route = computeWorldRoute([1, 2, 3], [4, 2, 6], originX, originY);
+    expect(route.segments).toHaveLength(2);
+    expect(route.segments[0].start.worldY).toBe(2);
   });
 });
 
-describe('segmentAngle', () => {
-  it('returns 0 for horizontal right', () => {
-    const angle = segmentAngle({ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } });
-    expect(angle).toBeCloseTo(0);
-  });
-
-  it('returns PI/2 for vertical down', () => {
-    const angle = segmentAngle({ start: { x: 0, y: 0 }, end: { x: 0, y: 10 } });
-    expect(angle).toBeCloseTo(Math.PI / 2);
+describe('worldSegmentToScreen', () => {
+  it('converts world segment endpoints to screen coordinates', () => {
+    const seg = {
+      start: { worldX: 0, worldZ: 0, worldY: 0 },
+      end: { worldX: 2, worldZ: 0, worldY: 0 },
+      axis: 'x' as const,
+    };
+    const result = worldSegmentToScreen(seg, 400, 300);
+    expect(result.start.x).toBe(400);
+    expect(result.start.y).toBe(300);
+    expect(result.end.x).toBeGreaterThan(result.start.x);
   });
 });
 
-describe('segmentLength', () => {
-  it('returns correct length for horizontal segment', () => {
-    const len = segmentLength({ start: { x: 0, y: 0 }, end: { x: 10, y: 0 } });
-    expect(len).toBeCloseTo(10);
+describe('worldSegmentLengthCU', () => {
+  it('returns X-axis length for x segments', () => {
+    const seg = {
+      start: { worldX: 1, worldZ: 3, worldY: 0 },
+      end: { worldX: 4, worldZ: 3, worldY: 0 },
+      axis: 'x' as const,
+    };
+    expect(worldSegmentLengthCU(seg)).toBe(3);
   });
 
-  it('returns correct length for diagonal segment', () => {
-    const len = segmentLength({ start: { x: 0, y: 0 }, end: { x: 3, y: 4 } });
-    expect(len).toBeCloseTo(5);
+  it('returns Z-axis length for z segments', () => {
+    const seg = {
+      start: { worldX: 3, worldZ: 1, worldY: 0 },
+      end: { worldX: 3, worldZ: 5, worldY: 0 },
+      axis: 'z' as const,
+    };
+    expect(worldSegmentLengthCU(seg)).toBe(4);
   });
 });

--- a/apps/web/src/entities/connection/routing.ts
+++ b/apps/web/src/entities/connection/routing.ts
@@ -1,51 +1,125 @@
+import { TILE_W, TILE_H, TILE_Z } from '../../shared/tokens/designTokens';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 
-export interface RouteSegment {
-  start: ScreenPoint;
-  end: ScreenPoint;
+export interface WorldPoint {
+  worldX: number;
+  worldZ: number;
+  worldY: number;
+}
+
+export interface WorldSegment {
+  start: WorldPoint;
+  end: WorldPoint;
+  axis: 'x' | 'z';
 }
 
 export interface ConnectorRoute {
-  segments: RouteSegment[];
-  elbows: ScreenPoint[];
+  segments: WorldSegment[];
+  elbow: WorldPoint | null;
+  srcScreen: ScreenPoint;
+  tgtScreen: ScreenPoint;
 }
 
-const ELBOW_THRESHOLD = 8;
+const SAME_AXIS_TOLERANCE = 0.1;
 
-export function computeRoute(src: ScreenPoint, tgt: ScreenPoint): ConnectorRoute {
-  const dx = Math.abs(tgt.x - src.x);
-  const dy = Math.abs(tgt.y - src.y);
-
-  if (dx < ELBOW_THRESHOLD && dy < ELBOW_THRESHOLD) {
-    return {
-      segments: [{ start: src, end: tgt }],
-      elbows: [],
-    };
-  }
-
-  if (dx < ELBOW_THRESHOLD || dy < ELBOW_THRESHOLD) {
-    return {
-      segments: [{ start: src, end: tgt }],
-      elbows: [],
-    };
-  }
-
-  const elbow: ScreenPoint = { x: tgt.x, y: src.y };
+function worldToScreen(
+  wp: WorldPoint,
+  originX: number,
+  originY: number,
+): ScreenPoint {
   return {
-    segments: [
-      { start: src, end: elbow },
-      { start: elbow, end: tgt },
-    ],
-    elbows: [elbow],
+    x: originX + (wp.worldX - wp.worldZ) * TILE_W / 2,
+    y: originY + (wp.worldX + wp.worldZ) * TILE_H / 2 - wp.worldY * TILE_Z,
   };
 }
 
-export function segmentAngle(seg: RouteSegment): number {
-  return Math.atan2(seg.end.y - seg.start.y, seg.end.x - seg.start.x);
+export function computeWorldRoute(
+  srcWorld: [number, number, number],
+  tgtWorld: [number, number, number],
+  originX: number,
+  originY: number,
+): ConnectorRoute {
+  const src: WorldPoint = { worldX: srcWorld[0], worldZ: srcWorld[2], worldY: srcWorld[1] };
+  const tgt: WorldPoint = { worldX: tgtWorld[0], worldZ: tgtWorld[2], worldY: tgtWorld[1] };
+
+  const srcScreen = worldToScreen(src, originX, originY);
+  const tgtScreen = worldToScreen(tgt, originX, originY);
+
+  const dx = Math.abs(tgt.worldX - src.worldX);
+  const dz = Math.abs(tgt.worldZ - src.worldZ);
+
+  // Same position or nearly same — single degenerate segment
+  if (dx < SAME_AXIS_TOLERANCE && dz < SAME_AXIS_TOLERANCE) {
+    return {
+      segments: [{ start: src, end: tgt, axis: 'x' }],
+      elbow: null,
+      srcScreen,
+      tgtScreen,
+    };
+  }
+
+  // Aligned on X — single Z segment
+  if (dx < SAME_AXIS_TOLERANCE) {
+    return {
+      segments: [{ start: src, end: tgt, axis: 'z' }],
+      elbow: null,
+      srcScreen,
+      tgtScreen,
+    };
+  }
+
+  // Aligned on Z — single X segment
+  if (dz < SAME_AXIS_TOLERANCE) {
+    return {
+      segments: [{ start: src, end: tgt, axis: 'x' }],
+      elbow: null,
+      srcScreen,
+      tgtScreen,
+    };
+  }
+
+  const srcBelow = srcScreen.y > tgtScreen.y;
+
+  if (srcBelow) {
+    const elbow: WorldPoint = { worldX: src.worldX, worldZ: tgt.worldZ, worldY: src.worldY };
+    return {
+      segments: [
+        { start: src, end: elbow, axis: 'z' },
+        { start: elbow, end: tgt, axis: 'x' },
+      ],
+      elbow,
+      srcScreen,
+      tgtScreen,
+    };
+  }
+
+  const elbow: WorldPoint = { worldX: tgt.worldX, worldZ: src.worldZ, worldY: src.worldY };
+
+  return {
+    segments: [
+      { start: src, end: elbow, axis: 'x' },
+      { start: elbow, end: tgt, axis: 'z' },
+    ],
+    elbow,
+    srcScreen,
+    tgtScreen,
+  };
 }
 
-export function segmentLength(seg: RouteSegment): number {
-  const dx = seg.end.x - seg.start.x;
-  const dy = seg.end.y - seg.start.y;
-  return Math.sqrt(dx * dx + dy * dy);
+export function worldSegmentToScreen(
+  seg: WorldSegment,
+  originX: number,
+  originY: number,
+): { start: ScreenPoint; end: ScreenPoint } {
+  return {
+    start: worldToScreen(seg.start, originX, originY),
+    end: worldToScreen(seg.end, originX, originY),
+  };
+}
+
+export function worldSegmentLengthCU(seg: WorldSegment): number {
+  if (seg.axis === 'x') {
+    return Math.abs(seg.end.worldX - seg.start.worldX);
+  }
+  return Math.abs(seg.end.worldZ - seg.start.worldZ);
 }

--- a/apps/web/src/shared/tokens/designTokens.ts
+++ b/apps/web/src/shared/tokens/designTokens.ts
@@ -31,6 +31,17 @@ export const EDGE_HIGHLIGHT_STROKE_WIDTH = 2;
 export const EDGE_HIGHLIGHT_OPACITY = 0.3;
 export const EDGE_HIGHLIGHT_COLOR = '#ffffff';
 
+// -- Technic Liftarm (Connector Beam) --
+// Derived from Lego Technic liftarm proportions.
+// Real Lego: stud pitch 8mm, plate height 3.2mm (= ⅓ brick), liftarm width ≈ 1 stud.
+// We use a thin liftarm (0.5 CU wide) for visual clarity at our render scale.
+export const BEAM_WIDTH_CU = 0.5;                                // beam is half a stud wide
+export const BEAM_THICKNESS_CU = 1 / 3;                          // plate height = ⅓ brick
+export const BEAM_THICKNESS_PX = RENDER_SCALE * BEAM_THICKNESS_CU; // ~11px
+export const PIN_HOLE_SPACING_CU = 1.0;                          // 1 hole per stud pitch
+export const PIN_HOLE_RX = RENDER_SCALE * 3 / 20;                // 4.8 (iso X radius)
+export const PIN_HOLE_RY = PIN_HOLE_RX / 2;                      // 2.4 (iso Y radius)
+
 // -- Face Stroke --
 export const TOP_FACE_STROKE_WIDTH = 1;
 export const TOP_FACE_STROKE_OPACITY = 0.6;

--- a/apps/web/src/shared/utils/position.test.ts
+++ b/apps/web/src/shared/utils/position.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Block, ExternalActor, Plate } from '../types/index';
 import {
+  EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET,
   EXTERNAL_ACTOR_LABEL_POSITION,
   EXTERNAL_ACTOR_POSITION,
   GRID_CELL,
@@ -76,7 +77,7 @@ describe('position utilities', () => {
 
     const endpoint = getEndpointWorldPosition(actor.id, [], [], [actor]);
 
-    expect(endpoint).toEqual([42, 1, -7]);
+    expect(endpoint).toEqual([42, 1 + EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET, -7]);
   });
 
   it('falls back to external actor when block exists but parent plate is missing', () => {
@@ -91,7 +92,7 @@ describe('position utilities', () => {
 
     const endpoint = getEndpointWorldPosition(id, [block], [], [actor]);
 
-    expect(endpoint).toEqual([-2, 3, 4]);
+    expect(endpoint).toEqual([-2, 3 + EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET, 4]);
   });
 
   it('falls back to default external actor position for legacy actor payloads', () => {
@@ -99,7 +100,11 @@ describe('position utilities', () => {
 
     const endpoint = getEndpointWorldPosition(legacyActor.id, [], [], [legacyActor]);
 
-    expect(endpoint).toEqual(EXTERNAL_ACTOR_POSITION);
+    expect(endpoint).toEqual([
+      EXTERNAL_ACTOR_POSITION[0],
+      EXTERNAL_ACTOR_POSITION[1] + EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET,
+      EXTERNAL_ACTOR_POSITION[2],
+    ]);
   });
 
   it('returns null when endpoint id cannot be resolved', () => {

--- a/apps/web/src/shared/utils/position.ts
+++ b/apps/web/src/shared/utils/position.ts
@@ -8,6 +8,19 @@ export { GRID_CELL } from './isometric';
 /** Fixed world position for ExternalActor entities (above and behind the scene). */
 export const EXTERNAL_ACTOR_POSITION: [number, number, number] = [-3, 0, 5];
 
+/**
+ * World-Y offset so that connection endpoints land on the visual center
+ * of the ExternalActorSprite globe rather than its world-coordinate anchor.
+ *
+ * The sprite is rendered with CSS `translate(-50%, 58%)` on a 132×117 px
+ * element whose SVG globe center sits at 51.4% of its height.
+ * Total screen-Y displacement from the anchor = 117×0.58 + 117×(72/140) ≈ 128 px.
+ * Converting to world units: 128 / TILE_Z(32) = 4.
+ * Subtracting worldY pushes the screen position *down* (screenY increases),
+ * so we apply −4 to shift the endpoint down to the globe's visual center.
+ */
+export const EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET = -4;
+
 /** Label position offset above ExternalActor (y + 1 from actor position). */
 export const EXTERNAL_ACTOR_LABEL_POSITION: [number, number, number] = [
   EXTERNAL_ACTOR_POSITION[0],
@@ -55,14 +68,11 @@ export function getEndpointWorldPosition(
     }
   }
 
-  // Check external actors (fixed position above the scene)
   const actor = externalActors.find((a) => a.id === id);
   if (actor) {
-    if (actor.position) {
-      return toTuple(actor.position);
-    }
-
-    return [...EXTERNAL_ACTOR_POSITION];
+    const base = actor.position ? toTuple(actor.position) : [...EXTERNAL_ACTOR_POSITION] as [number, number, number];
+    base[1] += EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET;
+    return base;
   }
 
   return null;

--- a/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
@@ -3,6 +3,7 @@ import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { useRafCallback } from '../../shared/hooks/useRafCallback';
 import { worldToScreen } from '../../shared/utils/isometric';
+import { EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET } from '../../shared/utils/position';
 
 interface ConnectionPreviewProps {
   originX: number;
@@ -66,7 +67,7 @@ export function ConnectionPreview({ originX, originY }: ConnectionPreviewProps) 
     }
 
     const { x: worldX, y: worldY, z: worldZ } = sourceExternalActor.position;
-    return worldToScreen(worldX, worldY, worldZ, originX, originY);
+    return worldToScreen(worldX, worldY + EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET, worldZ, originX, originY);
   }, [blocks, connectionSource, externalActors, interactionState, originX, originY, plates]);
 
   useEffect(() => {

--- a/docs/design/BRICK_CONNECTOR_SPEC.md
+++ b/docs/design/BRICK_CONNECTOR_SPEC.md
@@ -415,3 +415,284 @@ Beam-shape-specific tests validate:
 - `beamShape` values are unique across all 5 connection types
 - Elbow joints have `data-elbow` attribute and 3-polygon structure
 - Arrow tip renders with side face
+
+---
+
+## 12. Lego-Faithful Connector Redesign (Supersedes §11)
+
+**Date**: 2026-03-21  
+**Status**: Active — supersedes §11 (Technic Beam Redesign)  
+**Problem**: §11 produced connectors that look like dark pillars and pipes — nothing like real Lego. The routing used screen-space coordinates instead of isometric axes, and beam proportions were arbitrary rather than grounded in actual Lego measurements.
+
+### 12.1 Real Lego Measurement System
+
+All connector dimensions derive from the **official Lego measurement system**, translated into our coordinate system. This is the single source of truth.
+
+#### 12.1.1 Lego Physical Dimensions (Reference)
+
+```
+Stud pitch (center-to-center):     8.0 mm
+Stud diameter:                     4.8 mm  (= 0.6 × pitch)
+Stud height:                       1.7 mm
+Brick height (with stud):          9.6 mm  (= 1.2 × pitch)
+Brick height (without stud):       7.8 mm
+Plate height:                      3.2 mm  (= ⅓ brick height)
+Brick wall thickness:              1.5 mm
+Technic beam thickness (thick):    7.8 mm  (≈ 1 stud width, 7:8 aspect)
+Technic beam thickness (thin):     3.9 mm  (= ½ thick beam)
+Technic pin hole diameter:         4.8 mm  (same as stud diameter)
+Technic pin hole spacing:          8.0 mm  (= stud pitch)
+```
+
+#### 12.1.2 Key Lego Ratios
+
+```
+brick height : stud pitch     = 6:5  (9.6:8.0)
+plate height : brick height   = 1:3  (3.2:9.6)
+stud diameter : stud pitch    = 3:5  (4.8:8.0)
+beam thickness : stud pitch   = ~1:1 (7.8:8.0)
+thin beam : thick beam        = 1:2  (3.9:7.8)
+pin hole : stud pitch         = 3:5  (4.8:8.0)
+```
+
+#### 12.1.3 Mapping to CloudBlocks Coordinate System
+
+CloudBlocks uses `RENDER_SCALE = 32` where 1 CU (Cloud Unit) = 1 stud pitch.
+
+```
+1 CU = 1 stud pitch
+TILE_W = 64px (isometric tile width = 2 × RENDER_SCALE)
+TILE_H = 32px (isometric tile height = RENDER_SCALE)
+TILE_Z = 32px (elevation per CU)
+```
+
+The isometric projection is 2:1 dimetric:
+```
+screenX = originX + (worldX - worldZ) × TILE_W / 2
+screenY = originY + (worldX + worldZ) × TILE_H / 2 - worldY × TILE_Z
+```
+
+**Connector dimensions, derived from Lego ratios:**
+
+| Lego Concept | Lego mm | CU Equivalent | Screen px (approx) |
+|---|---|---|---|
+| Beam width (1 stud) | 8.0 | 1.0 CU | 32 iso-X or 16 iso-Y |
+| Beam thickness (plate height) | 3.2 | 0.4 CU | 13 elevation |
+| Pin hole spacing | 8.0 | 1.0 CU | 1 grid cell |
+| Pin hole diameter | 4.8 | 0.6 CU | ~19 iso-X |
+| Stud on beam | 4.8 dia | — | Standard stud (STUD_RX=12) |
+
+### 12.2 Design: Technic Liftarm (Flat Beam with Pin Holes)
+
+Connectors use the **Lego Technic Liftarm** metaphor — flat beams with visible pin holes at regular intervals. This is what makes them instantly recognizable as Lego.
+
+#### 12.2.1 Why Liftarms
+
+Real Lego Technic liftarms are:
+- **Flat** — 1 plate height thick (3.2mm), lying on the isometric ground plane
+- **Studless** — no studs on top, only pin holes along the beam
+- **Rounded ends** — semi-circular terminations at both ends
+- **Pin holes visible** — evenly spaced holes are the defining visual feature
+
+This contrasts with §11's approach which used arbitrary extrusions with no Lego-recognizable features.
+
+#### 12.2.2 Liftarm Cross-Section in Isometric
+
+```
+   Top view (isometric diamond):
+   ╭─── beam width (0.5 CU) ───╮
+   ◇ ○ ─── ○ ─── ○ ─── ○ ─── ◇   ← pin holes at 1 CU intervals
+   ╰───────────────────────────╯
+
+   Side view (isometric):
+   ┌─────────────────────────────┐  ← top face (tile color)
+   │  ○     ○     ○     ○     ○ │  ← pin holes (accent circles)
+   ├─────────────────────────────┤  ← side face (shadow color, plate height thick)
+   └─────────────────────────────┘
+```
+
+### 12.3 World-Space Isometric Routing (Critical Fix)
+
+**§11 Bug**: Routing computed elbows in screen-space (`{ x: tgt.x, y: src.y }`) which produces non-isometric diagonals. Beams must follow isometric grid axes to look like physical Lego pieces.
+
+#### 12.3.1 Algorithm
+
+1. Convert source and target screen positions back to **world coordinates** using `screenToWorld()`
+2. Route along **world X-axis** first, then **world Z-axis** (L-shaped)
+3. Convert each route point back to **screen coordinates** for rendering
+4. Each segment aligns with an isometric axis — no arbitrary screen-space angles
+
+```
+World-space routing:
+
+Source (wx1, wz1)
+  │
+  ├── Segment 1: walk along world X to (wx2, wz1)    ← renders as ╲ or ╱
+  │
+  Elbow (wx2, wz1)
+  │
+  ├── Segment 2: walk along world Z to (wx2, wz2)    ← renders as ╱ or ╲
+  │
+Target (wx2, wz2)
+```
+
+In isometric projection, world X-axis renders as a line going **right-down** (slope +0.5), and world Z-axis renders as a line going **left-down** (slope -0.5). This produces clean, recognizable isometric paths.
+
+#### 12.3.2 Elbow Selection
+
+Two possible L-shapes for any source→target pair:
+- **X-first**: walk X, then Z (elbow at `(tgt.worldX, src.worldZ)`)
+- **Z-first**: walk Z, then X (elbow at `(src.worldX, tgt.worldZ)`)
+
+Default: **X-first**. Future: pick the path with less visual occlusion.
+
+#### 12.3.3 Straight Segments
+
+If source and target share the same world X or Z coordinate (within tolerance), use a single straight segment along the shared axis.
+
+### 12.4 Beam Geometry Constants (Derived from Lego)
+
+All values derived from `RENDER_SCALE` and Lego ratios:
+
+```typescript
+// Beam is 0.5 CU wide (half a stud pitch — thin liftarm)
+const BEAM_HALF_WIDTH_CU = 0.25;
+const BEAM_HALF_WIDTH_X = TILE_W / 2 * BEAM_HALF_WIDTH_CU;   // 8px in iso-X
+const BEAM_HALF_WIDTH_Y = TILE_H / 2 * BEAM_HALF_WIDTH_CU;   // 4px in iso-Y
+
+// Beam thickness = 1 plate height = 0.33 CU
+const BEAM_THICKNESS_CU = 1 / 3;
+const BEAM_THICKNESS_PX = TILE_Z * BEAM_THICKNESS_CU;         // ~11px elevation
+
+// Pin hole spacing = 1 CU (= 1 stud pitch)
+const PIN_HOLE_SPACING_CU = 1.0;
+
+// Pin hole radius = 0.3 CU (= 0.6 × stud pitch / 2)
+const PIN_HOLE_RADIUS_CU = 0.3;
+
+// Rounded end radius = beam half-width
+const END_RADIUS_CU = BEAM_HALF_WIDTH_CU;
+```
+
+### 12.5 Connection Type Differentiation
+
+Types are differentiated by **beam color** (primary) and **pin hole style** (secondary). Beam shape is uniform — all types use the same liftarm geometry. This matches real Lego where the same beam part comes in different colors.
+
+| Type | Beam Color | Pin Hole Style | Lego Analogy |
+|---|---|---|---|
+| `dataflow` | Slate gray `#64748b` | Open circle | Standard liftarm |
+| `http` | Blue `#3b82f6` | Filled dot (pin inserted) | Beam with pins |
+| `internal` | Violet `#8b5cf6` | Cross (axle hole) | Beam with axle holes |
+| `data` | Amber `#f59e0b` | Double circle | Wide beam (2-stud) |
+| `async` | Emerald `#10b981` | Dashed circle | Thin beam (half-height) |
+
+**Color is the primary differentiator.** Pin hole style adds secondary recognition at close zoom but is not required for identification.
+
+### 12.6 Rendering Pipeline
+
+#### 12.6.1 Per-Segment Rendering
+
+Each segment renders as a **3D isometric liftarm piece** along one world axis:
+
+```svg
+<g data-connector-segment data-axis="x|z">
+  <!-- 1. Side face (plate-height thick, drawn first for depth) -->
+  <polygon points="{side-face}" fill="{dark}" />
+
+  <!-- 2. Top face (isometric parallelogram, beam width × segment length) -->
+  <polygon points="{top-face}" fill="{tile}" stroke="{shadow}" stroke-width="0.5" />
+
+  <!-- 3. Pin holes along beam (1 per CU of length) -->
+  <ellipse cx="..." cy="..." rx="{hole-rx}" ry="{hole-ry}"
+           fill="{accent}" opacity="0.4" />
+  <!-- repeat per hole -->
+</g>
+```
+
+The parallelogram direction depends on which world axis the segment follows:
+- **World X segment**: top face is a parallelogram slanting right-down
+- **World Z segment**: top face is a parallelogram slanting left-down
+
+#### 12.6.2 Elbow Joint
+
+At the bend point, a **square connector piece** (1×1 CU) joins the two segments:
+
+```svg
+<g data-connector-elbow>
+  <!-- Isometric diamond (1 CU × 1 CU top face) -->
+  <polygon points="{diamond}" fill="{tile}" stroke="{shadow}" stroke-width="0.5" />
+  <!-- Right side face -->
+  <polygon points="{right-side}" fill="{shadow}" />
+  <!-- Front side face -->
+  <polygon points="{front-side}" fill="{dark}" />
+  <!-- Center pin hole -->
+  <ellipse cx="..." cy="..." rx="{hole-rx}" ry="{hole-ry}"
+           fill="{accent}" opacity="0.4" />
+</g>
+```
+
+#### 12.6.3 Directional Arrow
+
+Direction is indicated by the **last pin hole being a filled triangle** (arrow shape) instead of a circle. No protruding arrow tip — the beam terminates flush, with only the pin hole shape changing.
+
+This is more Lego-faithful than a protruding arrow — real Lego pieces don't have arrows.
+
+#### 12.6.4 Endpoint Studs
+
+Source and target endpoints render the **Universal Stud Standard** stud on top of the beam at the connection point. This represents the stud that "plugs into" the block's anti-stud.
+
+### 12.7 Rendering Order
+
+To avoid the "pillar through block" artifact from §11:
+
+1. Connectors render at **layer 0.5** — between plates (layer 0) and blocks (layer 2)
+2. Connector segments get depth keys based on their world position: `depthKey(worldX, worldZ, 0, 0.5)`
+3. Segments closer to the camera (higher worldX + worldZ) render later (painter's algorithm)
+
+### 12.8 Performance
+
+| Concern | Mitigation |
+|---|---|
+| Pin holes add SVG elements | Max ~5 holes per segment. Clipped to visible viewport. |
+| World↔screen conversions | Pre-computed at route time, cached in `useMemo`. |
+| 30+ connections | `React.memo` on component. Route only recomputes on endpoint change. |
+| Rendering order | Depth key computation is O(1) per segment. |
+
+Target: **<16ms frame time** with 30 simultaneous connections.
+
+### 12.9 Design Token Additions
+
+New tokens added to `designTokens.ts`, all derived from `RENDER_SCALE`:
+
+```typescript
+// -- Technic Liftarm (Connector Beam) --
+// Derived from Lego Technic liftarm proportions
+export const BEAM_WIDTH_CU = 0.5;                              // beam is half a stud wide
+export const BEAM_THICKNESS_CU = 1 / 3;                        // plate height = ⅓ brick
+export const BEAM_THICKNESS_PX = RENDER_SCALE * BEAM_THICKNESS_CU; // ~11px
+export const PIN_HOLE_SPACING_CU = 1.0;                        // 1 hole per stud pitch
+export const PIN_HOLE_RX = RENDER_SCALE * 3 / 20;              // 4.8 (iso X radius)
+export const PIN_HOLE_RY = PIN_HOLE_RX / 2;                    // 2.4 (iso Y radius)
+```
+
+### 12.10 Migration from §11
+
+| §11 Artifact | §12 Replacement |
+|---|---|
+| `buildBeamFaces()` — screen-space polygon | `buildIsoBeamFaces()` — axis-aligned isometric parallelogram |
+| `computeRoute()` — screen-space elbow | `computeWorldRoute()` — world-space X/Z routing |
+| 5 beam shape renderers | 1 universal liftarm renderer with pin hole style variants |
+| `BEAM_HALF_WIDTH = 8` (magic number) | `BEAM_WIDTH_CU = 0.5` (derived from Lego ratio) |
+| `BEAM_THICKNESS = 6` (magic number) | `BEAM_THICKNESS_CU = 1/3` (= plate height ratio) |
+| Protruding arrow tip | Flush end with directional pin hole |
+| Screen-space hit path | World-space routed hit path |
+
+### 12.11 Acceptance Criteria
+
+- [ ] Connectors visually resemble Lego Technic liftarms with visible pin holes
+- [ ] All segments align with isometric X or Z axes — no screen-space diagonals
+- [ ] Beam proportions match Lego ratios (width = 0.5 CU, thickness = plate height)
+- [ ] 5 connection types differentiated by color (pin hole style is bonus)
+- [ ] No "pillar through block" artifacts — correct depth ordering
+- [ ] All existing interactions preserved (select, hover, delete, diff)
+- [ ] Tests pass, lint clean, build succeeds


### PR DESCRIPTION
## Summary
- Redesign connector rendering based on real Lego Technic liftarm dimensions (§12 spec)
- Rewrite BrickConnector SVG renderer with proper 3D isometric beam faces and pin holes
- Add adaptive L-route direction (Z-first when source below target on screen)
- Fix external actor endpoint Y offset so connections land on globe visual center

## Changes
- **Spec**: Added §12 to `BRICK_CONNECTOR_SPEC.md` with real Lego dimensional ratios
- **Tokens**: New beam design tokens (width, thickness, pin-hole spacing/radii)
- **Theme**: Replaced `BeamShape` with `PinHoleStyle` — 5 distinct styles per connection type
- **Renderer**: Full BrickConnector rewrite — 3-face beam body + elliptical pin holes + direction markers
- **Routing**: Adaptive X-first/Z-first L-route based on source-target screen position
- **Endpoint**: `EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET = -4` compensates CSS transform on actor sprites

## Verification
- ✅ 1826 tests passed
- ✅ Lint clean
- ✅ Build successful

Fixes #1069