### PR TITLE
fix(web): hide NotificationCenter to fix infinite loop crash

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -49,9 +49,6 @@ vi.mock('../widgets/github-sync/GitHubSync', () => ({
 vi.mock('../widgets/github-pr/GitHubPR', () => ({
   GitHubPR: () => <div data-testid="github-pr" />,
 }));
-vi.mock('../widgets/notification-center/NotificationCenter', () => ({
-  NotificationCenter: () => <div data-testid="notification-center" />,
-}));
 
 vi.mock('../widgets/promote-dialog/PromoteDialog', () => ({
   PromoteDialog: () => <div data-testid="promote-dialog" />,
@@ -429,10 +426,8 @@ describe('App', () => {
   });
 
   it('renders ops widgets when their show flags are true', async () => {
-    const { useNotificationStore } = await import('../entities/store/notificationStore');
     const { usePromoteStore } = await import('../entities/store/promoteStore');
 
-    useNotificationStore.setState({ showNotificationCenter: true });
     usePromoteStore.setState({
       showPromoteDialog: true,
       showRollbackDialog: true,
@@ -441,7 +436,6 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(await screen.findByTestId('notification-center')).toBeInTheDocument();
     expect(await screen.findByTestId('promote-dialog')).toBeInTheDocument();
     expect(await screen.findByTestId('rollback-dialog')).toBeInTheDocument();
     expect(await screen.findByTestId('promote-history')).toBeInTheDocument();

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -10,7 +10,7 @@ import { ValidationPanel } from '../widgets/validation-panel/ValidationPanel';
 import { useArchitectureStore } from '../entities/store/architectureStore';
 import { useAuthStore } from '../entities/store/authStore';
 import { useUIStore } from '../entities/store/uiStore';
-import { useNotificationStore } from '../entities/store/notificationStore';
+
 
 import { usePromoteStore } from '../entities/store/promoteStore';
 import { registerBuiltinTemplates } from '../features/templates/builtin';
@@ -34,7 +34,6 @@ const GitHubSync = lazy(() => import('../widgets/github-sync/GitHubSync').then(m
 const GitHubPR = lazy(() => import('../widgets/github-pr/GitHubPR').then(m => ({ default: m.GitHubPR })));
 const DiffPanel = lazy(() => import('../widgets/diff-panel/DiffPanel').then(m => ({ default: m.DiffPanel })));
 
-const NotificationCenter = lazy(() => import('../widgets/notification-center/NotificationCenter').then(m => ({ default: m.NotificationCenter })));
 
 const PromoteDialog = lazy(() => import('../widgets/promote-dialog/PromoteDialog').then(m => ({ default: m.PromoteDialog })));
 const RollbackDialog = lazy(() => import('../widgets/rollback-dialog/RollbackDialog').then(m => ({ default: m.RollbackDialog })));
@@ -63,7 +62,6 @@ function App() {
   const showScenarioGallery = useUIStore((s) => s.showScenarioGallery);
 
   const workspaceId = useArchitectureStore((s) => s.workspace.id);
-  const showNotificationCenter = useNotificationStore((s) => s.showNotificationCenter);
 
   const showPromoteDialog = usePromoteStore((s) => s.showPromoteDialog);
   const showRollbackDialog = usePromoteStore((s) => s.showRollbackDialog);
@@ -76,7 +74,6 @@ function App() {
     showGitHubLogin ||
     showGitHubRepos ||
     showGitHubPR ||
-    showNotificationCenter ||
     showPromoteDialog ||
     showRollbackDialog;
   const rightPanelClass = isWideRightPanel
@@ -198,8 +195,6 @@ function App() {
             {showGitHubPR && <GitHubPR key={`pr-${workspaceId}`} />}
             <DiffPanel />
             {showScenarioGallery && <ScenarioGallery />}
-            {showNotificationCenter && <NotificationCenter />}
-
             {showPromoteDialog && <PromoteDialog />}
             {showRollbackDialog && <RollbackDialog />}
             {showPromoteHistory && <PromoteHistory />}

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -974,46 +974,6 @@ describe('MenuBar', () => {
     expect(usePromoteStore.getState().showPromoteHistory).toBe(true);
   });
 
-  it('notification bell shows badge when unread count > 0', async () => {
-    const { useNotificationStore } = await import('../../entities/store/notificationStore');
-    useNotificationStore.getState().addNotification({
-      level: 'info',
-      category: 'system',
-      title: 'Test',
-      message: 'msg',
-    });
-    render(<MenuBar />);
-
-    const badge = screen.getByText('1');
-    expect(badge).toHaveClass('notification-badge');
-  });
-
-  it('notification bell click toggles notification center', async () => {
-    const { container } = render(<MenuBar />);
-
-    const bellButton = container.querySelector('.notification-bell-btn') as HTMLElement;
-    await userEvent.setup().click(bellButton);
-
-    const { useNotificationStore } = await import('../../entities/store/notificationStore');
-    expect(useNotificationStore.getState().showNotificationCenter).toBe(true);
-  });
-
-  it('notification bell closes other panels when opening', async () => {
-    const { useNotificationStore } = await import('../../entities/store/notificationStore');
-    useNotificationStore.setState({ showNotificationCenter: false });
-    useUIStore.setState({
-      showCodePreview: true,
-      showGitHubRepos: true,
-    });
-    const { container } = render(<MenuBar />);
-
-    const bellButton = container.querySelector('.notification-bell-btn') as HTMLElement;
-    await userEvent.setup().click(bellButton);
-
-    expect(useUIStore.getState().showCodePreview).toBe(false);
-    expect(useUIStore.getState().showGitHubRepos).toBe(false);
-  });
-
   it('show learning panel toggles off when already shown', async () => {
     useUIStore.setState({ showLearningPanel: true });
     const user = userEvent.setup();

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -5,7 +5,7 @@ import { useLearningStore } from '../../entities/store/learningStore';
 import { validateArchitectureShape } from '../../entities/store/slices';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import { useNotificationStore, selectUnreadCount } from '../../entities/store/notificationStore';
+
 
 import { usePromoteStore } from '../../entities/store/promoteStore';
 import { computeArchitectureDiff } from '../../features/diff/engine';
@@ -53,13 +53,9 @@ export function MenuBar() {
   const toggleSound = useUIStore((s) => s.toggleSound);
   const playSound = (name: SoundName) => { if (!isSoundMuted) audioService.playSound(name); };
 
-  const unreadCount = useNotificationStore(selectUnreadCount);
-
   const togglePromoteDialog = usePromoteStore((s) => s.togglePromoteDialog);
   const toggleRollbackDialog = usePromoteStore((s) => s.toggleRollbackDialog);
   const togglePromoteHistory = usePromoteStore((s) => s.togglePromoteHistory);
-  const toggleNotificationCenter = useNotificationStore((s) => s.toggleNotificationCenter);
-  const showNotificationCenter = useNotificationStore((s) => s.showNotificationCenter);
 
   const isAuthenticated = useAuthStore((s) => s.status) === 'authenticated';
   const authStatus = useAuthStore((s) => s.status);
@@ -228,18 +224,6 @@ export function MenuBar() {
   const handleToggleSound = () => {
     toggleSound();
     audioService.setMuted(!isSoundMuted);
-  };
-
-  const handleToggleNotifications = () => {
-    // Close other right panels when opening notification center
-    if (!showNotificationCenter) {
-      const ui = useUIStore.getState();
-      if (ui.showCodePreview) ui.toggleCodePreview();
-      if (ui.showGitHubRepos) ui.toggleGitHubRepos();
-      if (ui.showGitHubPR) ui.toggleGitHubPR();
-
-    }
-    toggleNotificationCenter();
   };
 
   const handleCompareWithGitHub = async () => {
@@ -507,17 +491,6 @@ export function MenuBar() {
           💾
         </button>
 
-        <button
-          type="button"
-          className="quick-btn notification-bell-btn"
-          onClick={handleToggleNotifications}
-          title="Notifications"
-        >
-          🔔
-          {unreadCount > 0 && (
-            <span className="notification-badge">{unreadCount > 99 ? '99+' : unreadCount}</span>
-          )}
-        </button>
         <button
           type="button"
           className="quick-btn"


### PR DESCRIPTION
## Summary
- Hide NotificationCenter from UI to fix `Maximum update depth exceeded` crash
- Root cause: `selectFilteredNotifications` returns a new array every render, triggering infinite `useSyncExternalStore` re-renders
- NotificationCenter is part of OpsCenter (deferred to M20+), so hiding is the correct fix
- Removes lazy import, render gate, notification bell button, and 3 related tests
- Store and component files preserved for M20+ reactivation

## Verification
- ✅ 1823 tests passed (3 notification tests correctly removed)
- ✅ Lint clean
- ✅ Build successful (bundle -1.76KB)