### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,63 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 ---
 
+## [v0.18.0] — 2026-03-22
+
+**Milestone 18 — DevOps UX**
+
+Introduced Lego Technic Beam connectors, fixed provider-specific UX issues, and clarified product direction by removing features that didn't fit the "architecture compiler" identity. Several originally planned features (OpsCenter, Notification System, AI panel) were deferred after evaluation showed they added complexity without immediate user value.
+
+### Brick-Style Connectors (Area E)
+- Redesigned connection lines as Lego Technic liftarm beams with pin holes, side faces, and typed color differentiation
+- Screen-space orthogonal routing: all beams are strictly horizontal or vertical on screen with clean right-angle elbows
+- Height normalization: L-routes connect at the topmost endpoint height
+- BRICK_CONNECTOR_SPEC.md §12 written with full geometry, routing algorithm, and design token documentation
+- 5 connection types differentiated by beam color (dataflow, http, internal, data, async)
+
+### Provider & Block Fixes
+- Provider-specific resource names in block palette when switching Azure/AWS/GCP (#1023)
+- Correct icon mappings with subtype-aware resolution (#1025)
+- Hide provider badge on blocks in single-provider mode (#1026)
+- Learning mode adapts scenario content to active cloud provider (#1067)
+- Plate overlap prevention on add and move (#1057)
+
+### UI Cleanup & Simplification
+- Unified overlay panels to Lego brick design system (#1021)
+- EmptyCanvasOverlay CTA buttons consolidated into 2×2 grid (#989)
+- Portrait panel removed; canvas viewport adjusts for right-side panels (#1033)
+- OpsCenter and AI features hidden from UI — deferred to M20+ (#1066)
+- NotificationCenter hidden to fix infinite re-render loop — deferred to M20+ (#1071)
+- Overlay z-index fix above BottomPanel (#987)
+
+### GitHub Integration Fixes
+- 24 bug fixes across diff engine, GitHub widgets, and store helpers (#816, #866, #890, #891, #892)
+- Contextual info added to GitHub widgets (repo status, sync state, PR context)
+- PR result persistence per workspace
+
+### Worker Role (Implemented then Removed)
+- Minifigure worker role designed, documented (SCV_ROLE_BOUNDARIES.md), and partially implemented
+- CommandCard modes, store actions, and plate creation animation built
+- **Decision: minifigure concept removed entirely** — CloudBlocks is a design tool (SimCity/ArchiCAD paradigm), not an RTS (StarCraft paradigm). Workers add complexity without value. 7 related issues closed, full removal tracked in #1088 (M19)
+
+### Infrastructure
+- GitHub Actions CI optimized to reduce storage and cost (#1059)
+- 24 code quality findings addressed from M18 review (#991)
+
+### Deferred to Future Milestones
+- Ops Control Center dashboard (M20+)
+- Deploy promote/rollback UX (M20+)
+- Notification system (M20+)
+- AI features UI (M20+)
+- Minifigure code removal (#1088, M19)
+
+### Retrospective
+This milestone revealed the cost of scope inflation in agentic coding: 324 issues closed but most exit criteria unmet. Connectors were rewritten 3 times before arriving at the correct screen-space approach. The minifigure concept was built before validating product fit. Key lesson: validate direction before executing at scale.
+
+### Stats
+- 47 commits, 23 merged PRs, 1854 tests passing, branch coverage ~90%
+
+---
+
 ## [v0.17.0] — 2026-03-21
 
 **Milestone 17 — Product Structure**

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ cd apps/api && pip install -e ".[dev]" && uvicorn app.main:app --reload
 | v0.15.0 | v2.0 Specification Implementation | ✅ |
 | v0.16.0 | Documentation Architecture | ✅ |
 | v0.17.0 | Product Structure | ✅ |
-| v0.18.0 | DevOps UX | 🔄 |
+| v0.18.0 | DevOps UX | ✅ |
 
 See [CHANGELOG.md](CHANGELOG.md) for release details and [full roadmap](docs/concept/ROADMAP.md) for milestone breakdown.
 

--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -950,7 +950,7 @@ Scope:
 
 ---
 
-## Milestone 18 — DevOps UX
+## Milestone 18 — DevOps UX ✅
 
 Goal:
 Add operational control capabilities to CloudBlocks. Introduce an Ops Control Center, standardize deployment terminology, build environment promotion/rollback UX, add a notification system, and replace SVG connection lines with brick-style connector pieces.
@@ -971,14 +971,27 @@ Scope:
 - Estimated effort: 8–10 weeks
 
 ### Exit Criteria
-- [ ] Ops Control Center shows real-time deployment status for `local`, `staging`, and `production`
-- [ ] Deploy/promote/rollback terminology consistent across all docs, workflows, and UI
-- [ ] Promote flow works end-to-end: staging to production with pre-promotion checklist
-- [ ] Rollback to a previous version works from Ops Control Center
-- [ ] Cost estimation displayed before deployment confirmation
-- [ ] Notification system shows deployment lifecycle events in-app
-- [ ] Deployment history log records all deploys, promotions, and rollbacks
-- [ ] Connections render as brick-style connector pieces matching the Lego visual language
+- [ ] Ops Control Center shows real-time deployment status for `local`, `staging`, and `production` — **deferred to M20+**
+- [ ] Deploy/promote/rollback terminology consistent across all docs, workflows, and UI — **partially done (docs only)**
+- [ ] Promote flow works end-to-end: staging to production with pre-promotion checklist — **deferred to M20+**
+- [ ] Rollback to a previous version works from Ops Control Center — **deferred to M20+**
+- [ ] Cost estimation displayed before deployment confirmation — **deferred to M20+**
+- [ ] Notification system shows deployment lifecycle events in-app — **deferred to M20+ (infinite loop bug)**
+- [ ] Deployment history log records all deploys, promotions, and rollbacks — **deferred to M20+**
+- [x] Connections render as brick-style connector pieces matching the Lego visual language
+
+### Delivered (not in original exit criteria)
+- [x] Screen-space orthogonal connector routing with height normalization
+- [x] BRICK_CONNECTOR_SPEC.md §12 with full geometry and algorithm documentation
+- [x] Provider-specific block palette, icon mappings, and learning mode content
+- [x] Plate overlap prevention
+- [x] 24+ GitHub integration bug fixes
+- [x] UI simplification: OpsCenter, AI, NotificationCenter hidden; Portrait panel removed
+- [x] Minifigure worker concept evaluated and removed (paradigm mismatch)
+- [x] CI cost optimization
+
+### Retrospective
+Scope inflation with agentic coding led to most exit criteria being deferred. The milestone's primary value was the brick-style connector system and clarifying product direction (design tool, not RTS). See CHANGELOG v0.18.0 for details.
 
 ### Dependencies
 - Milestone 17 complete
@@ -1138,6 +1151,13 @@ Milestone 17 (Complete)
 - 30 bug fixes across domain model, workspace persistence, dialogs, and code generation
 - Version alignment policy enforced
 
+Milestone 18 (Complete)
+- Brick-style Technic Beam connectors with screen-space orthogonal routing
+- Provider-specific block palette and learning mode fixes
+- Product direction clarified: design tool identity (minifigure worker removed)
+- UI simplified: OpsCenter, AI, NotificationCenter deferred to M20+
+- 47 commits, 23 PRs, 1854 tests passing
+
 ---
 
 ## Summary
@@ -1176,7 +1196,7 @@ The roadmap evolves CloudBlocks from:
 
 → Product Structure (Milestone 17) ✅
 
-→ DevOps UX (Milestone 18)
+→ DevOps UX (Milestone 18) ✅
 
 → MVP Polish & Launch (Milestone 19)
 
@@ -1193,7 +1213,7 @@ Milestone 8 (Complete) ✅
     │                       └── Milestone 15 (v2.0 Spec) ✅
     │                               └── Milestone 16 (Doc Architecture) ✅
     │                                       └── Milestone 17 (Product Structure) ✅
-    │                                               └── Milestone 18 (DevOps UX)
+    │                                               └── Milestone 18 (DevOps UX) ✅
     │                                                       └── Milestone 19 (MVP Polish & Launch)
     │               └── Milestone 14 (AI Roadmap) ✅ ←── also benefits from Milestone 13
     └── Milestone 11 (Brick Design) ✅ ──── parallel with Milestone 9

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Architecture compiler that converts visual infrastructure designs into Terraform, Bicep, and Pulumi code",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump version `0.17.0` → `0.18.0` in `package.json`
- Add v0.18.0 CHANGELOG section covering connectors, provider fixes, UI cleanup, worker role retrospective, and infrastructure
- Mark M18 complete in ROADMAP.md with exit criteria status and retrospective
- Update README.md roadmap table (🔄 → ✅)

## Release Notes

**Milestone 18 — DevOps UX**

Key deliverables: Lego Technic Beam connectors with screen-space routing, provider-specific block fixes, UI simplification (OpsCenter/AI/NotificationCenter deferred), GitHub integration fixes (24 bug fixes), CI cost optimization.

Product direction clarified: minifigure worker concept evaluated and removed — CloudBlocks follows SimCity/ArchiCAD design-tool paradigm, not StarCraft RTS paradigm. Full code removal tracked in #1088 (M19).

47 commits, 23 merged PRs, 1854 tests passing.