### PR TITLE
feat(web): unify panel naming, expand onboarding tour, fix learn-mode layout

### DIFF
--- a/apps/web/src/app/App.css
+++ b/apps/web/src/app/App.css
@@ -27,7 +27,7 @@
 }
 
 .canvas-container.learn-mode-active {
-  padding-right: 320px;
+  padding-right: 380px;
   transition: padding-right 0.3s ease;
 }
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -90,6 +90,10 @@ interface UIState {
   ) => void;
   clearDiffState: () => void;
 
+  // ── Onboarding ──
+  showOnboarding: boolean;
+  setShowOnboarding: (show: boolean) => void;
+
   // ── Sound preference ──
   isSoundMuted: boolean;
   toggleSound: () => void;
@@ -290,6 +294,9 @@ export const useUIStore = create<UIState>((set) => ({
 
   isSoundMuted: true,
   toggleSound: () => set((s) => ({ isSoundMuted: !s.isSoundMuted })),
+
+  showOnboarding: false,
+  setShowOnboarding: (show) => set({ showOnboarding: show }),
 
   upgradingBlockId: null,
   triggerUpgradeAnimation: (blockId) => {

--- a/apps/web/src/widgets/bottom-panel/BottomPanel.css
+++ b/apps/web/src/widgets/bottom-panel/BottomPanel.css
@@ -55,14 +55,7 @@
   border-right: none;
 }
 
-/* Learn mode: offset CommandCard sidebar so it doesn't overlap LearningPanel (320px + 16px margin) */
-.learn-mode-active .bottom-panel--command-open {
-  right: 716px;
-}
 
-.learn-mode-active .bottom-panel--command-open .bottom-panel-command {
-  right: 336px;
-}
 
 /* Responsive behavior — VISUAL_DESIGN_SPEC.md §7.8 */
 

--- a/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
@@ -110,7 +110,7 @@ describe('CommandCard', () => {
 
   // --- Creation Grid (default mode) ---
 
-  it('renders creation grid with "Create Resource" header when nothing is selected', () => {
+  it('renders creation grid with "Command Panel" header when nothing is selected', () => {
     useArchitectureStore.setState({
       workspace: {
         id: 'ws-1',
@@ -126,7 +126,7 @@ describe('CommandCard', () => {
 
     render(<CommandCard />);
 
-    expect(screen.getByText('Create Resource')).toBeInTheDocument();
+    expect(screen.getByText('Command Panel')).toBeInTheDocument();
     expect(screen.queryByText(/Select a block/)).not.toBeInTheDocument();
   });
 
@@ -146,7 +146,7 @@ describe('CommandCard', () => {
 
     render(<CommandCard />);
 
-    expect(screen.getByText('Create Resource')).toBeInTheDocument();
+    expect(screen.getByText('Command Panel')).toBeInTheDocument();
     const resourceButtons = screen.getAllByRole('button');
     expect(resourceButtons.length).toBeGreaterThan(0);
   });
@@ -154,7 +154,7 @@ describe('CommandCard', () => {
   it('shows disabled resource buttons when no VNet exists', () => {
     render(<CommandCard />);
 
-    expect(screen.getByText('Create Resource')).toBeInTheDocument();
+    expect(screen.getByText('Command Panel')).toBeInTheDocument();
     const disabledButtons = screen.getAllByRole('button', { name: /Needs:/ });
     expect(disabledButtons.length).toBeGreaterThan(0);
     for (const btn of disabledButtons) {
@@ -482,7 +482,7 @@ describe('CommandCard', () => {
     });
 
     const { rerender } = render(<CommandCard />);
-    expect(screen.getByText('Create Resource')).toBeInTheDocument();
+    expect(screen.getByText('Command Panel')).toBeInTheDocument();
 
     act(() => {
       useUIStore.setState({ selectedId: 'block-1' });
@@ -500,6 +500,6 @@ describe('CommandCard', () => {
       useUIStore.setState({ selectedId: null });
     });
     rerender(<CommandCard />);
-    expect(screen.getByText('Create Resource')).toBeInTheDocument();
+    expect(screen.getByText('Command Panel')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/widgets/bottom-panel/CommandCard.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.tsx
@@ -94,7 +94,7 @@ export function CommandCard({ className = '' }: CommandCardProps) {
     ? 'Block Actions'
     : selectedPlate
       ? 'Plate Actions'
-      : 'Create Resource';
+      : 'Command Panel';
 
   const modeContent = selectedBlock
     ? <BlockMode />

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -680,21 +680,21 @@ describe('MenuBar', () => {
     expect(useUIStore.getState().showValidation).toBe(true);
   });
 
-  it('handles View menu toggle for Block Palette', async () => {
+  it('handles View menu toggle for Resource Counter', async () => {
     const user = userEvent.setup();
     render(<MenuBar />);
 
     const viewDropdown = await openMenu(user, 'View');
-    await user.click(within(viewDropdown).getByRole('button', { name: /Block Palette/ }));
+    await user.click(within(viewDropdown).getByRole('button', { name: /Resource Counter/ }));
     expect(useUIStore.getState().showBlockPalette).toBe(false);
   });
 
-  it('handles View menu toggle for Properties Panel', async () => {
+  it('handles View menu toggle for Inspector', async () => {
     const user = userEvent.setup();
     render(<MenuBar />);
 
     const viewDropdown = await openMenu(user, 'View');
-    await user.click(within(viewDropdown).getByRole('button', { name: /Properties Panel/ }));
+    await user.click(within(viewDropdown).getByRole('button', { name: /Inspector/ }));
     expect(useUIStore.getState().showProperties).toBe(false);
   });
 

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -418,10 +418,10 @@ export function MenuBar() {
           </button>
           <div className={`menu-dropdown ${openMenu === 'view' ? 'show' : ''}`}>
             <button type="button" className="menu-item" onClick={() => handleAction(toggleBlockPalette)}>
-              <span className="menu-item-left">{showBlockPalette ? '✓ ' : '  '}🧰 Block Palette</span>
+              <span className="menu-item-left">{showBlockPalette ? '✓ ' : '  '}📊 Resource Counter</span>
             </button>
             <button type="button" className="menu-item" onClick={() => handleAction(toggleProperties)}>
-              <span className="menu-item-left">{showProperties ? '✓ ' : '  '}⚙️ Properties Panel</span>
+              <span className="menu-item-left">{showProperties ? '✓ ' : '  '}🔎 Inspector</span>
             </button>
             <div className="menu-separator" />
             <button type="button" className="menu-item" onClick={() => handleAction(toggleValidation)}>

--- a/apps/web/src/widgets/onboarding-tour/OnboardingTour.css
+++ b/apps/web/src/widgets/onboarding-tour/OnboardingTour.css
@@ -1,0 +1,119 @@
+.onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: auto;
+}
+
+.onboarding-overlay--visible {
+  opacity: 1;
+}
+
+.onboarding-spotlight {
+  position: fixed;
+  border-radius: 8px;
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.6);
+  transition: top 0.3s ease, left 0.3s ease, width 0.3s ease, height 0.3s ease;
+  pointer-events: none;
+}
+
+.onboarding-tooltip {
+  position: fixed;
+  background: #1a1a2e;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  padding: 20px 24px;
+  max-width: 340px;
+  width: 340px;
+  color: #e0e0e0;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  transition: top 0.3s ease, left 0.3s ease;
+  z-index: 10001;
+}
+
+.onboarding-tooltip-title {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #fff;
+}
+
+.onboarding-tooltip-desc {
+  font-size: 14px;
+  line-height: 1.5;
+  color: #b0b0b0;
+}
+
+.onboarding-skip {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  color: #666;
+  font-size: 13px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 4px 8px;
+}
+
+.onboarding-skip:hover {
+  color: #999;
+}
+
+.onboarding-dots {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  margin-top: 14px;
+}
+
+.onboarding-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.2);
+  transition: background 0.2s ease;
+}
+
+.onboarding-dot--active {
+  background: #3b82f6;
+}
+
+.onboarding-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 16px;
+}
+
+.onboarding-btn {
+  cursor: pointer;
+  border-radius: 6px;
+  padding: 6px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  transition: background 0.15s ease, opacity 0.15s ease;
+}
+
+.onboarding-btn--primary {
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+}
+
+.onboarding-btn--primary:hover {
+  background: #2563eb;
+}
+
+.onboarding-btn--secondary {
+  background: transparent;
+  color: #999;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.onboarding-btn--secondary:hover {
+  color: #ccc;
+  border-color: rgba(255, 255, 255, 0.2);
+}

--- a/apps/web/src/widgets/onboarding-tour/OnboardingTour.test.tsx
+++ b/apps/web/src/widgets/onboarding-tour/OnboardingTour.test.tsx
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { OnboardingTour } from './OnboardingTour';
+import { useUIStore } from '../../entities/store/uiStore';
+
+const STORAGE_KEY = 'cloudblocks:onboarding-completed';
+
+let targetElements: HTMLElement[] = [];
+
+function createTargetElements() {
+  const selectors = [
+    'empty-canvas-overlay',
+    'command-card',
+    'resource-bar',
+    'menu-bar-nav',
+    'scene-canvas',
+    'bottom-panel-minimap',
+    'bottom-panel-detail',
+    'validation-panel',
+    'bottom-panel',
+  ];
+  for (const cls of selectors) {
+    const el = document.createElement('div');
+    el.className = cls;
+    document.body.appendChild(el);
+    targetElements.push(el);
+  }
+}
+
+function removeTargetElements() {
+  for (const el of targetElements) {
+    el.remove();
+  }
+  targetElements = [];
+}
+
+function mockGetBoundingClientRect() {
+  const original = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    return {
+      top: 100,
+      left: 100,
+      width: 300,
+      height: 200,
+      right: 400,
+      bottom: 300,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    };
+  };
+  return () => {
+    Element.prototype.getBoundingClientRect = original;
+  };
+}
+
+describe('OnboardingTour', () => {
+  let restoreRect: () => void;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    useUIStore.setState({ showOnboarding: false });
+    createTargetElements();
+    restoreRect = mockGetBoundingClientRect();
+  });
+
+  afterEach(() => {
+    removeTargetElements();
+    restoreRect();
+  });
+
+  it('renders nothing when showOnboarding is false', () => {
+    useUIStore.setState({ showOnboarding: false });
+    render(<OnboardingTour />);
+    expect(screen.queryByTestId('onboarding-tour')).not.toBeInTheDocument();
+  });
+
+  it('renders tour when showOnboarding is true', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByTestId('onboarding-tour')).toBeInTheDocument();
+  });
+
+  it('shows step 1 content initially', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByText('Welcome to CloudBlocks!')).toBeInTheDocument();
+  });
+
+  it('advances to step 2 on Next click', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    fireEvent.click(screen.getByText('Next'));
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByText('Command Panel')).toBeInTheDocument();
+  });
+
+  it('goes back to previous step on Back click', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    fireEvent.click(screen.getByText('Next'));
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    fireEvent.click(screen.getByText('Back'));
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.getByText('Welcome to CloudBlocks!')).toBeInTheDocument();
+  });
+
+  it('does not show Back button on step 1', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    expect(screen.queryByText('Back')).not.toBeInTheDocument();
+  });
+
+  it('shows Finish on last step', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    for (let i = 0; i < 6; i++) {
+      fireEvent.click(screen.getByText('Next'));
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r));
+      });
+    }
+
+    expect(screen.getByText('Finish')).toBeInTheDocument();
+    expect(screen.queryByText('Next')).not.toBeInTheDocument();
+  });
+
+  it('sets localStorage and hides tour on Skip', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    fireEvent.click(screen.getByText('Skip'));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    expect(useUIStore.getState().showOnboarding).toBe(false);
+  });
+
+  it('sets localStorage on Finish', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    for (let i = 0; i < 6; i++) {
+      fireEvent.click(screen.getByText('Next'));
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r));
+      });
+    }
+
+    fireEvent.click(screen.getByText('Finish'));
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    expect(useUIStore.getState().showOnboarding).toBe(false);
+  });
+
+  it('Escape key skips tour', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+    expect(useUIStore.getState().showOnboarding).toBe(false);
+  });
+
+  it('shows step 4 content: Minimap', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText('Next'));
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r));
+      });
+    }
+
+    expect(screen.getByText('Minimap')).toBeInTheDocument();
+  });
+
+  it('shows step 7 content: Menu Bar', async () => {
+    useUIStore.setState({ showOnboarding: true });
+    render(<OnboardingTour />);
+
+    await act(async () => {
+      await new Promise((r) => requestAnimationFrame(r));
+    });
+
+    for (let i = 0; i < 6; i++) {
+      fireEvent.click(screen.getByText('Next'));
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r));
+      });
+    }
+
+    expect(screen.getByText('Menu Bar')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/widgets/onboarding-tour/OnboardingTour.tsx
+++ b/apps/web/src/widgets/onboarding-tour/OnboardingTour.tsx
@@ -1,0 +1,306 @@
+import { useState, useEffect, useCallback, useRef, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+import { useUIStore } from '../../entities/store/uiStore';
+import './OnboardingTour.css';
+
+const STORAGE_KEY = 'cloudblocks:onboarding-completed';
+
+interface TourStep {
+  selector: string;
+  fallbackSelector: string;
+  title: string;
+  description: string;
+}
+
+const STEPS: TourStep[] = [
+  {
+    selector: '.empty-canvas-overlay',
+    fallbackSelector: '.scene-canvas',
+    title: 'Welcome to CloudBlocks!',
+    description:
+      'Start by creating a Network plate \u2014 click "Start from Scratch" or pick a template.',
+  },
+  {
+    selector: '.command-card-header',
+    fallbackSelector: '.command-card',
+    title: 'Command Panel',
+    description:
+      'Context-sensitive action grid. Create resources, edit properties, or delete elements depending on your selection.',
+  },
+  {
+    selector: '.resource-bar',
+    fallbackSelector: '.resource-bar',
+    title: 'Resource Counter',
+    description:
+      'Displays real-time counts of plates, blocks, and connections in your architecture.',
+  },
+  {
+    selector: '.bottom-panel-minimap',
+    fallbackSelector: '.bottom-panel',
+    title: 'Minimap',
+    description:
+      'Bird\u2019s-eye view of your entire architecture. Quickly orient yourself in large designs.',
+  },
+  {
+    selector: '.bottom-panel-detail',
+    fallbackSelector: '.bottom-panel',
+    title: 'Inspector',
+    description:
+      'View detailed properties of the selected plate or block. Shows metadata, placement, and configuration.',
+  },
+  {
+    selector: '.validation-panel',
+    fallbackSelector: '.scene-canvas',
+    title: 'Validation Results',
+    description:
+      'Run validation from the Build menu to check placement rules and connection constraints in real time.',
+  },
+  {
+    selector: '.menu-bar-nav',
+    fallbackSelector: '.menu-bar-nav',
+    title: 'Menu Bar',
+    description:
+      'Access File, Edit, Build, and View menus. Validate architecture, generate IaC, and toggle panels.',
+  },
+];
+
+interface SpotlightRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const PADDING = 8;
+
+function getTargetElement(step: TourStep): Element | null {
+  return (
+    document.querySelector(step.selector) ??
+    document.querySelector(step.fallbackSelector)
+  );
+}
+
+function getTargetRect(step: TourStep): SpotlightRect | null {
+  const el = getTargetElement(step);
+  if (!el) return null;
+  const rect = el.getBoundingClientRect();
+  return {
+    top: rect.top - PADDING,
+    left: rect.left - PADDING,
+    width: rect.width + PADDING * 2,
+    height: rect.height + PADDING * 2,
+  };
+}
+
+const ELEVATED_Z = '10000';
+const ELEVATED_ATTR = 'data-onboarding-elevated';
+
+function elevateTarget(step: TourStep): (() => void) | null {
+  const el = getTargetElement(step) as HTMLElement | null;
+  if (!el) return null;
+
+  const prevZ = el.style.zIndex;
+  const prevPos = el.style.position;
+  const prevRelative = el.style.position === '' || el.style.position === 'static';
+
+  el.style.zIndex = ELEVATED_Z;
+  if (prevRelative) el.style.position = 'relative';
+  el.setAttribute(ELEVATED_ATTR, 'true');
+
+  return () => {
+    el.style.zIndex = prevZ;
+    if (prevRelative) el.style.position = prevPos;
+    el.removeAttribute(ELEVATED_ATTR);
+  };
+}
+
+function getTooltipPosition(
+  spotlight: SpotlightRect,
+): { top: number; left: number; placement: 'above' | 'below' } {
+  const tooltipWidth = 340;
+  const tooltipEstimatedHeight = 180;
+  const gap = 12;
+
+  const spaceBelow = window.innerHeight - (spotlight.top + spotlight.height);
+  const placement: 'above' | 'below' =
+    spaceBelow > tooltipEstimatedHeight + gap ? 'below' : 'above';
+
+  const top =
+    placement === 'below'
+      ? spotlight.top + spotlight.height + gap
+      : spotlight.top - tooltipEstimatedHeight - gap;
+
+  let left = spotlight.left + spotlight.width / 2 - tooltipWidth / 2;
+  left = Math.max(12, Math.min(left, window.innerWidth - tooltipWidth - 12));
+
+  return { top: Math.max(12, top), left, placement };
+}
+
+let readyFlag = false;
+const readyListeners = new Set<() => void>();
+function subscribeReady(cb: () => void) {
+  readyListeners.add(cb);
+  return () => { readyListeners.delete(cb); };
+}
+function getReadySnapshot() { return readyFlag; }
+
+export function OnboardingTour() {
+  const showOnboarding = useUIStore((s) => s.showOnboarding);
+  const setShowOnboarding = useUIStore((s) => s.setShowOnboarding);
+
+  const [currentStep, setCurrentStep] = useState(0);
+  const [spotlight, setSpotlight] = useState<SpotlightRect | null>(null);
+  const rafRef = useRef(0);
+  const ready = useSyncExternalStore(subscribeReady, getReadySnapshot);
+
+  const updateSpotlight = useCallback(() => {
+    if (!showOnboarding) return;
+    const rect = getTargetRect(STEPS[currentStep]);
+    setSpotlight(rect);
+  }, [showOnboarding, currentStep]);
+
+  useEffect(() => {
+    if (!showOnboarding) {
+      readyFlag = false;
+      for (const cb of readyListeners) cb();
+      return;
+    }
+
+    const frameId = requestAnimationFrame(() => {
+      updateSpotlight();
+      readyFlag = true;
+      for (const cb of readyListeners) cb();
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, [showOnboarding, updateSpotlight]);
+
+  useEffect(() => {
+    if (!showOnboarding) return;
+
+    const handleResize = () => {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(updateSpotlight);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, [showOnboarding, updateSpotlight]);
+
+  useEffect(() => {
+    if (!showOnboarding) return;
+    const restore = elevateTarget(STEPS[currentStep]);
+    return () => { restore?.(); };
+  }, [showOnboarding, currentStep]);
+
+  const completeTour = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    setCurrentStep(0);
+    setShowOnboarding(false);
+  }, [setShowOnboarding]);
+
+  useEffect(() => {
+    if (!showOnboarding) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        completeTour();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showOnboarding, completeTour]);
+
+  const handleNext = useCallback(() => {
+    if (currentStep < STEPS.length - 1) {
+      setCurrentStep((s) => s + 1);
+    } else {
+      completeTour();
+    }
+  }, [currentStep, completeTour]);
+
+  const handleBack = useCallback(() => {
+    if (currentStep > 0) {
+      setCurrentStep((s) => s - 1);
+    }
+  }, [currentStep]);
+
+  if (!showOnboarding || !ready) return null;
+
+  const step = STEPS[currentStep];
+
+  const tooltipPos = spotlight
+    ? getTooltipPosition(spotlight)
+    : { top: window.innerHeight / 2 - 90, left: window.innerWidth / 2 - 170, placement: 'below' as const };
+
+  const isLastStep = currentStep === STEPS.length - 1;
+
+  return createPortal(
+    <div
+      className="onboarding-overlay onboarding-overlay--visible"
+      data-testid="onboarding-tour"
+    >
+      {spotlight && (
+        <div
+          className="onboarding-spotlight"
+          style={{
+            top: spotlight.top,
+            left: spotlight.left,
+            width: spotlight.width,
+            height: spotlight.height,
+          }}
+        />
+      )}
+
+      <div
+        className={`onboarding-tooltip onboarding-tooltip--${tooltipPos.placement}`}
+        style={{ top: tooltipPos.top, left: tooltipPos.left }}
+      >
+        <button
+          type="button"
+          className="onboarding-skip"
+          onClick={completeTour}
+        >
+          Skip
+        </button>
+
+        <div className="onboarding-tooltip-title">{step.title}</div>
+        <div className="onboarding-tooltip-desc">{step.description}</div>
+
+        <div className="onboarding-dots">
+          {STEPS.map((s, i) => (
+            <span
+              key={s.selector}
+              className={`onboarding-dot${i === currentStep ? ' onboarding-dot--active' : ''}`}
+            />
+          ))}
+        </div>
+
+        <div className="onboarding-nav">
+          {currentStep > 0 ? (
+            <button
+              type="button"
+              className="onboarding-btn onboarding-btn--secondary"
+              onClick={handleBack}
+            >
+              Back
+            </button>
+          ) : (
+            <span />
+          )}
+          <button
+            type="button"
+            className="onboarding-btn onboarding-btn--primary"
+            onClick={handleNext}
+          >
+            {isLastStep ? 'Finish' : 'Next'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/widgets/resource-bar/ResourceBar.css
+++ b/apps/web/src/widgets/resource-bar/ResourceBar.css
@@ -1,7 +1,7 @@
 .resource-bar {
   position: absolute;
   top: 12px;
-  right: 12px;
+  right: 392px; /* 380px CommandCard sidebar + 12px gap */
   z-index: 50;
   display: flex;
   align-items: center;
@@ -64,4 +64,10 @@
   background-color: rgba(255, 255, 255, 0.15);
   box-shadow: 1px 0 0 rgba(0, 0, 0, 0.3);
   z-index: 1;
+}
+
+@media (max-width: 899px) {
+  .resource-bar {
+    right: 12px;
+  }
 }


### PR DESCRIPTION
## Summary

- Unify panel names to canonical naming convention: CommandCard → "Command Panel", View menu → "Resource Counter" / "Inspector"
- Expand OnboardingTour from 4 → 7 steps covering all major panels (Command Panel, Resource Counter, Minimap, Inspector, Validation Results, Menu Bar)
- Fix Command Panel not anchored to right edge in Learn Mode — removed stale CSS offsets (LearningPanel is already left-positioned via `left: 16px`)
- Position ResourceBar (counter badge) to the left of CommandCard sidebar

## Changes

| File | Change |
|------|--------|
| `CommandCard.tsx` | Header: "Create Resource" → "Command Panel" |
| `MenuBar.tsx` | View menu: "Block Palette" → "Resource Counter", "Properties Panel" → "Inspector" |
| `OnboardingTour.tsx` | New 7-step tour component |
| `OnboardingTour.test.tsx` | Full test coverage for tour |
| `OnboardingTour.css` | Tour styling |
| `uiStore.ts` | Added `showOnboarding` / `setShowOnboarding` |
| `BottomPanel.css` | Removed learn-mode CommandCard offset rules |
| `App.css` | Learn mode `padding-right`: 320px → 380px |
| `ResourceBar.css` | `right: 12px` → `392px` + responsive fallback |
| Tests | Updated CommandCard, MenuBar test assertions |

## Verification

- ✅ Build passes
- ✅ Lint passes  
- ✅ 1773 tests pass (97 files)
- ✅ User confirmed learn-mode layout fix

Fixes #1110