### PR TITLE
fix(web): remove Azure prefix from provider-neutral resource labels

### DIFF
--- a/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
@@ -272,7 +272,7 @@ describe('CommandCard', () => {
     const { unmount } = render(<CommandCard />);
 
     const networkButton = screen.getByTitle('Create Network (VNet)');
-    const firewallButton = screen.getByTitle('Create Azure Firewall');
+    const firewallButton = screen.getByTitle('Create Firewall');
 
     const networkListeners = draggableListeners.get(networkButton);
     const vmListeners = draggableListeners.get(firewallButton);
@@ -284,7 +284,7 @@ describe('CommandCard', () => {
     vmListeners?.move?.({ target: firewallButton });
     expect(firewallButton).toHaveClass('is-dragging');
     expect(useUIStore.getState().draggedBlockCategory).toBe('edge');
-    expect(useUIStore.getState().draggedResourceName).toBe('Azure Firewall');
+    expect(useUIStore.getState().draggedResourceName).toBe('Firewall');
 
     vmListeners?.end?.({ target: firewallButton });
     expect(firewallButton).not.toHaveClass('is-dragging');
@@ -726,7 +726,7 @@ describe('CommandCard', () => {
     await user.click(screen.getByRole('button', { name: /Deploy/ }));
     expect(screen.getByTitle('Create Public Subnet (Q)')).toBeInTheDocument();
     expect(screen.getByTitle('Create Private Subnet (W)')).toBeInTheDocument();
-    expect(screen.queryByTitle('Create Azure SQL (W)')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Create SQL Database (W)')).not.toBeInTheDocument();
 
     act(() => {
       useUIStore.setState({ selectedId: 'subnet-public-1' });
@@ -747,7 +747,7 @@ describe('CommandCard', () => {
     await user.click(screen.getByRole('button', { name: /Deploy/ }));
     expect(screen.getByTitle('Create DNS Zone (W)')).toBeInTheDocument();
     expect(screen.getByTitle('Create Virtual Machine (S)')).toBeInTheDocument();
-    expect(screen.queryByTitle('Create Azure SQL (W)')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Create SQL Database (W)')).not.toBeInTheDocument();
 
     act(() => {
       useUIStore.setState({ selectedId: 'subnet-private-1' });
@@ -766,7 +766,7 @@ describe('CommandCard', () => {
     });
     rerender(<CommandCard />);
     await user.click(screen.getByRole('button', { name: /Deploy/ }));
-    expect(screen.getByTitle('Create Azure SQL (W)')).toBeInTheDocument();
+    expect(screen.getByTitle('Create SQL Database (W)')).toBeInTheDocument();
     expect(screen.queryByTitle('Create Public Subnet (Q)')).not.toBeInTheDocument();
   });
 
@@ -1066,9 +1066,9 @@ describe('CommandCard', () => {
     await user.click(screen.getByRole('button', { name: /Deploy/ }));
 
     // Now in PlateCreationMode — create SQL
-    await user.click(screen.getByTitle('Create Azure SQL (W)'));
+    await user.click(screen.getByTitle('Create SQL Database (W)'));
 
-    expect(addBlockMock).toHaveBeenCalledWith('data', 'Azure SQL 1', 'subnet-private-1', 'azure');
+    expect(addBlockMock).toHaveBeenCalledWith('data', 'SQL Database 1', 'subnet-private-1', 'azure');
   });
 
   it('creates private subnet via Deploy on network plate', async () => {

--- a/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
@@ -135,10 +135,10 @@ describe('useTechTree constants', () => {
         category: 'always',
         blockCategory: 'edge',
       },
-      sql: { id: 'sql', label: 'Azure SQL', shortLabel: 'SQL', icon: '🗄️', category: 'vnet-optional', blockCategory: 'data' },
+      sql: { id: 'sql', label: 'SQL Database', shortLabel: 'SQL', icon: '🗄️', category: 'vnet-optional', blockCategory: 'data' },
       function: {
         id: 'function',
-        label: 'Azure Functions',
+        label: 'Functions',
         shortLabel: 'Func',
         icon: '⚡',
         category: 'vnet-optional',
@@ -204,7 +204,7 @@ describe('useTechTree constants', () => {
       },
       firewall: {
         id: 'firewall',
-        label: 'Azure Firewall',
+        label: 'Firewall',
         shortLabel: 'FW',
         icon: '🛡️',
         category: 'vnet-required',
@@ -220,7 +220,7 @@ describe('useTechTree constants', () => {
       },
       bastion: {
         id: 'bastion',
-        label: 'Azure Bastion',
+        label: 'Bastion',
         shortLabel: 'Bastion',
         icon: '🏰',
         category: 'vnet-required',

--- a/apps/web/src/widgets/bottom-panel/useTechTree.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.ts
@@ -100,7 +100,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
   // VNet optional (public-first, can add private later)
   sql: {
     id: 'sql',
-    label: 'Azure SQL',
+    label: 'SQL Database',
     shortLabel: 'SQL',
     icon: '🗄️',
     category: 'vnet-optional',
@@ -108,7 +108,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
   },
   function: {
     id: 'function',
-    label: 'Azure Functions',
+    label: 'Functions',
     shortLabel: 'Func',
     icon: '⚡',
     category: 'vnet-optional',
@@ -193,7 +193,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
   },
   firewall: {
     id: 'firewall',
-    label: 'Azure Firewall',
+    label: 'Firewall',
     shortLabel: 'FW',
     icon: '🛡️',
     category: 'vnet-required',
@@ -211,7 +211,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
   },
   bastion: {
     id: 'bastion',
-    label: 'Azure Bastion',
+    label: 'Bastion',
     shortLabel: 'Bastion',
     icon: '🏰',
     category: 'vnet-required',


### PR DESCRIPTION
## Summary
- Remove hardcoded "Azure" prefix from 4 default resource labels in `useTechTree.ts`: `Azure SQL` → `SQL Database`, `Azure Functions` → `Functions`, `Azure Firewall` → `Firewall`, `Azure Bastion` → `Bastion`
- Update corresponding test expectations in `useTechTree.test.ts` and `CommandCard.test.tsx`

## Why
Default labels should be provider-neutral since `PROVIDER_LABELS` already handles provider-specific display name overrides for AWS/GCP.

## Changed Files
- `apps/web/src/widgets/bottom-panel/useTechTree.ts` — 4 label fixes
- `apps/web/src/widgets/bottom-panel/useTechTree.test.ts` — 4 expected values updated
- `apps/web/src/widgets/bottom-panel/CommandCard.test.tsx` — 7 references updated

## Verification
- ✅ Build passes
- ✅ Lint passes
- ✅ All 1804 tests pass (101 test files)

Fixes #1096