### PR TITLE
feat(web): add demo resilience mode for backend-unavailable state

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -20,6 +20,7 @@ import { LearningPanel } from '../widgets/learning-panel/LearningPanel';
 import { registerBuiltinScenarios } from '../features/learning/scenarios/builtin';
 import { audioService } from '../shared/utils/audioService';
 import { SOUND_ASSETS } from '../shared/assets/sounds';
+import { isApiConfigured } from '../shared/api/client';
 import type { ContainerNode, LeafNode } from '@cloudblocks/schema';
 import './App.css';
 import './LearnMode.css';
@@ -99,6 +100,9 @@ function App() {
   }, [loadFromStorage]);
 
   useEffect(() => {
+    if (!isApiConfigured()) {
+      useUIStore.getState().setBackendStatus('not_configured');
+    }
     void useAuthStore.getState().checkSession();
   }, []);
 

--- a/apps/web/src/entities/store/authStore.test.ts
+++ b/apps/web/src/entities/store/authStore.test.ts
@@ -2,15 +2,29 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ApiUser } from '../../shared/types/api';
 
 vi.mock('../../shared/api/client', () => ({
+  ApiError: class ApiError extends Error {
+    status: number;
+    body: string;
+
+    constructor(message: string, status: number, body: string) {
+      super(message);
+      this.name = 'ApiError';
+      this.status = status;
+      this.body = body;
+    }
+  },
   apiGet: vi.fn(),
   apiPost: vi.fn(),
+  isApiConfigured: vi.fn(),
 }));
 
-import { apiGet, apiPost } from '../../shared/api/client';
+import { ApiError, apiGet, apiPost, isApiConfigured } from '../../shared/api/client';
 import { useAuthStore } from './authStore';
+import { useUIStore } from './uiStore';
 
 const mockApiGet = vi.mocked(apiGet);
 const mockApiPost = vi.mocked(apiPost);
+const mockIsApiConfigured = vi.mocked(isApiConfigured);
 
 const mockUser: ApiUser = {
   id: 'user-1',
@@ -24,12 +38,15 @@ describe('useAuthStore', () => {
   beforeEach(() => {
     mockApiGet.mockReset();
     mockApiPost.mockReset();
+    mockIsApiConfigured.mockReset();
+    mockIsApiConfigured.mockReturnValue(true);
     useAuthStore.setState({
       status: 'unknown',
       user: null,
       hydrated: false,
       error: null,
     });
+    useUIStore.setState({ backendStatus: 'unknown' });
   });
 
   it('has expected initial state', () => {
@@ -79,6 +96,7 @@ describe('useAuthStore', () => {
     expect(state.user).toEqual(mockUser);
     expect(state.hydrated).toBe(true);
     expect(state.error).toBe(null);
+    expect(useUIStore.getState().backendStatus).toBe('available');
   });
 
   it('checkSession sets anonymous state on 401', async () => {
@@ -92,10 +110,24 @@ describe('useAuthStore', () => {
     expect(state.user).toBe(null);
     expect(state.hydrated).toBe(true);
     expect(state.error).toBe(null);
+    expect(useUIStore.getState().backendStatus).toBe('available');
   });
 
-  it('checkSession clears auth on network error', async () => {
-    mockApiGet.mockRejectedValueOnce(new Error('Network error'));
+  it('checkSession returns anonymous without API calls when backend is not configured', async () => {
+    mockIsApiConfigured.mockReturnValue(false);
+
+    await useAuthStore.getState().checkSession();
+
+    expect(mockApiGet).not.toHaveBeenCalled();
+    const state = useAuthStore.getState();
+    expect(state.status).toBe('anonymous');
+    expect(state.user).toBe(null);
+    expect(state.hydrated).toBe(true);
+    expect(state.error).toBe(null);
+  });
+
+  it('checkSession clears auth silently on network ApiError', async () => {
+    mockApiGet.mockRejectedValueOnce(new ApiError('Network request failed', 0, ''));
 
     await useAuthStore.getState().checkSession();
 
@@ -103,7 +135,21 @@ describe('useAuthStore', () => {
     expect(state.status).toBe('anonymous');
     expect(state.user).toBe(null);
     expect(state.hydrated).toBe(true);
-    expect(state.error).toBe('Session check failed');
+    expect(state.error).toBe(null);
+    expect(useUIStore.getState().backendStatus).toBe('unavailable');
+  });
+
+  it('checkSession clears auth silently on fetch TypeError', async () => {
+    mockApiGet.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    await useAuthStore.getState().checkSession();
+
+    const state = useAuthStore.getState();
+    expect(state.status).toBe('anonymous');
+    expect(state.user).toBe(null);
+    expect(state.hydrated).toBe(true);
+    expect(state.error).toBe(null);
+    expect(useUIStore.getState().backendStatus).toBe('unavailable');
   });
 
   it('checkSession clears stale authenticated state on non-401 error', async () => {
@@ -122,6 +168,7 @@ describe('useAuthStore', () => {
     expect(state.status).toBe('anonymous');
     expect(state.user).toBe(null);
     expect(state.error).toBe('Session check failed');
+    expect(useUIStore.getState().backendStatus).toBe('available');
   });
 
   it('checkSession ignores stale success response when another call follows', async () => {

--- a/apps/web/src/entities/store/authStore.ts
+++ b/apps/web/src/entities/store/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
-import { apiGet, apiPost } from '../../shared/api/client';
+import { ApiError, apiGet, apiPost, isApiConfigured } from '../../shared/api/client';
 import type { ApiUser, SessionUserResponse } from '../../shared/types/api';
+import { useUIStore } from './uiStore';
 
 type AuthStatus = 'unknown' | 'authenticated' | 'anonymous';
 
@@ -35,11 +36,17 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ error }),
 
   checkSession: async () => {
+    if (!isApiConfigured()) {
+      set({ status: 'anonymous', user: null, hydrated: true, error: null });
+      return;
+    }
+
     const seq = ++_checkSessionSeq;
     try {
       const user = await apiGet<SessionUserResponse>('/api/v1/auth/session');
       if (seq !== _checkSessionSeq) return; // stale response
       set({ status: 'authenticated', user, hydrated: true, error: null });
+      useUIStore.getState().setBackendStatus('available');
     } catch (err: unknown) {
       if (seq !== _checkSessionSeq) return; // stale response
       // 401 = clear session quietly; other errors = set anonymous with error message
@@ -47,10 +54,18 @@ export const useAuthStore = create<AuthState>((set) => ({
         err instanceof Error &&
         'status' in err &&
         (err as { status: number }).status === 401;
+      const isNetworkError =
+        (err instanceof ApiError && err.status === 0) ||
+        err instanceof TypeError;
       if (isUnauthorized) {
         set({ status: 'anonymous', user: null, hydrated: true, error: null });
+        useUIStore.getState().setBackendStatus('available');
+      } else if (isNetworkError) {
+        set({ status: 'anonymous', user: null, hydrated: true, error: null });
+        useUIStore.getState().setBackendStatus('unavailable');
       } else {
         set({ status: 'anonymous', user: null, hydrated: true, error: 'Session check failed' });
+        useUIStore.getState().setBackendStatus('available');
       }
     }
   },

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -6,6 +6,7 @@ import type { ArchitectureModel } from '@cloudblocks/schema';
 
 export type ToolMode = 'select' | 'connect' | 'delete';
 export type InteractionState = 'idle' | 'selecting' | 'dragging' | 'placing' | 'connecting';
+export type BackendStatus = 'unknown' | 'not_configured' | 'available' | 'unavailable';
 export type { EditorMode } from '../../shared/types/learning';
 
 interface UIState {
@@ -65,6 +66,9 @@ interface UIState {
   toggleSuggestionsPanel: () => void;
   showCostPanel: boolean;
   toggleCostPanel: () => void;
+
+  backendStatus: BackendStatus;
+  setBackendStatus: (status: BackendStatus) => void;
 
   // ── Editor mode ──
   editorMode: EditorMode;
@@ -261,6 +265,9 @@ export const useUIStore = create<UIState>((set) => ({
       showCostPanel: !s.showCostPanel,
       ...(!s.showCostPanel ? closeOtherRightPanels('showCostPanel') : {}),
     })),
+
+  backendStatus: 'unknown',
+  setBackendStatus: (status) => set({ backendStatus: status }),
 
   editorMode: 'build',
   setEditorMode: (mode) => set({ editorMode: mode }),

--- a/apps/web/src/shared/api/__tests__/client.test.ts
+++ b/apps/web/src/shared/api/__tests__/client.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('isApiConfigured', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('returns false when VITE_API_URL is empty', async () => {
+    vi.stubEnv('VITE_API_URL', '');
+    const { isApiConfigured } = await import('../client');
+
+    expect(isApiConfigured()).toBe(false);
+  });
+
+  it('returns true when VITE_API_URL is set', async () => {
+    vi.stubEnv('VITE_API_URL', 'https://api.example.com');
+    const { isApiConfigured } = await import('../client');
+
+    expect(isApiConfigured()).toBe(true);
+  });
+});

--- a/apps/web/src/shared/api/client.test.ts
+++ b/apps/web/src/shared/api/client.test.ts
@@ -107,6 +107,17 @@ describe('api client', () => {
     });
   });
 
+  it('throws ApiError with status 0 on fetch network failure', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+    await expect(apiGet('/api/v1/test')).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'Network request failed',
+      status: 0,
+      body: '',
+    });
+  });
+
   it('uses FastAPI detail message for ApiError message', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ detail: 'Repository not linked' }, 400));
 

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -16,6 +16,10 @@ export function normalizeApiBaseUrl(rawBaseUrl: string): string {
 
 const API_BASE_URL = normalizeApiBaseUrl(RAW_API_BASE_URL);
 
+export function isApiConfigured(): boolean {
+  return Boolean(API_BASE_URL?.trim());
+}
+
 export class ApiError extends Error {
   status: number;
   body: string;
@@ -98,12 +102,17 @@ export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> 
   }
   const body = normalizeBody(init?.body, headers);
 
-  const response = await fetch(`${API_BASE_URL}${path}`, {
-    ...init,
-    headers,
-    body,
-    credentials: 'include',
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE_URL}${path}`, {
+      ...init,
+      headers,
+      body,
+      credentials: 'include',
+    });
+  } catch {
+    throw new ApiError('Network request failed', 0, '');
+  }
 
   if (!response.ok) {
     const responseBody = await parseResponseBody(response);

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -269,6 +269,7 @@ describe('MenuBar', () => {
       showGitHubRepos: false,
       showGitHubSync: false,
       showGitHubPR: false,
+      backendStatus: 'available',
       connectionSource: null,
       draggedBlockCategory: null,
       activeProvider: 'azure',
@@ -329,6 +330,24 @@ describe('MenuBar', () => {
 
     rerender(<MenuBar />);
     expect(screen.getByRole('button', { name: /octocat/ })).toBeInTheDocument();
+  });
+
+  it('shows demo mode button when backend is not available for anonymous users', () => {
+    useUIStore.setState({ backendStatus: 'not_configured' });
+
+    render(<MenuBar />);
+
+    const demoButton = screen.getByRole('button', { name: /Demo Mode/ });
+    expect(demoButton).toBeDisabled();
+    expect(demoButton).toHaveAttribute('title', 'Backend API required for GitHub features. Run the backend server to enable.');
+  });
+
+  it('keeps loading state when backend status is unknown', () => {
+    useUIStore.setState({ backendStatus: 'unknown' });
+
+    render(<MenuBar />);
+
+    expect(screen.getByTitle('Checking authentication...')).toBeDisabled();
   });
 
   it('toggles workspace manager from Workspaces button', async () => {

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -13,6 +13,7 @@ import { apiPost, getApiErrorMessage } from '../../shared/api/client';
 import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import type { PullResponse } from '../../shared/types/api';
 import type { ArchitectureModel, ProviderType } from '@cloudblocks/schema';
+import type { BackendStatus } from '../../entities/store/uiStore';
 import { audioService } from '../../shared/utils/audioService';
 import type { SoundName } from '../../shared/utils/audioService';
 import './MenuBar.css';
@@ -59,6 +60,8 @@ export function MenuBar() {
 
   const isAuthenticated = useAuthStore((s) => s.status) === 'authenticated';
   const authStatus = useAuthStore((s) => s.status);
+  const backendStatus: BackendStatus = useUIStore((s) => s.backendStatus);
+  const backendAvailable = backendStatus === 'available';
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
 
@@ -506,16 +509,7 @@ export function MenuBar() {
       <div className="menu-bar-divider" />
 
       <div className="github-section menu-dropdown-container">
-        {authStatus === 'unknown' ? (
-          <button
-            type="button"
-            className="github-btn"
-            disabled
-            title="Checking authentication..."
-          >
-            🔐 ...
-          </button>
-        ) : isAuthenticated ? (
+        {isAuthenticated ? (
           <>
             <button
               type="button"
@@ -562,6 +556,24 @@ export function MenuBar() {
               </button>
             </div>
           </>
+        ) : authStatus === 'unknown' || backendStatus === 'unknown' ? (
+          <button
+            type="button"
+            className="github-btn"
+            disabled
+            title="Checking authentication..."
+          >
+            🔐 ...
+          </button>
+        ) : !backendAvailable ? (
+          <button
+            type="button"
+            className="github-btn"
+            disabled
+            title="Backend API required for GitHub features. Run the backend server to enable."
+          >
+            🔐 Demo Mode
+          </button>
         ) : (
           <button
             type="button"


### PR DESCRIPTION
## Summary
- Add silent demo mode when backend API is unavailable (no error messages, no failed network calls)
- Show disabled "🔐 Demo Mode" button in MenuBar with tooltip when backend is unreachable
- Normalize network errors in API client (status=0 sentinel for fetch failures)
- Gate `checkSession()` to skip API calls when `VITE_API_URL` is unset

## Changes
| File | Change |
|------|--------|
| `client.ts` | Add `isApiConfigured()`, wrap fetch in try/catch for network errors |
| `uiStore.ts` | Add `BackendStatus` type and `backendStatus`/`setBackendStatus` state |
| `authStore.ts` | Early return when API unconfigured, silent network error handling, set backendStatus |
| `App.tsx` | Set `not_configured` on mount when API URL is empty |
| `MenuBar.tsx` | Show "Demo Mode" disabled button when backend unavailable |
| Tests | 7 new tests across client, authStore, and MenuBar |

## How It Works
1. On mount, if `VITE_API_URL` is empty → `backendStatus = 'not_configured'`, auth hydrates as anonymous silently
2. If `VITE_API_URL` is set but backend unreachable → `backendStatus = 'unavailable'` (detected via network error)
3. If backend responds (200 or 401) → `backendStatus = 'available'`
4. GitHub menu adapts: authenticated → full menu, unknown → loading, unavailable → "Demo Mode", available+anonymous → "Sign In"

## Verification
- ✅ Build passes
- ✅ Lint passes  
- ✅ All 1811 tests pass (102 test files)
- ✅ LSP diagnostics clean on all changed files

Fixes #478