### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 ---
 
+
+## [v0.19.0] — 2026-03-22
+
+**Milestone 19 — Resource Category Realignment + Cleanup**
+
+Unified Plate/Block into a single ResourceNode model with 7 categories, removed the minifigure worker system, fixed provider label bugs, added demo resilience mode, and hardened CI with build-output secret scanning.
+
+### Resource Model Unification (Epic #1099)
+- Unified `Plate` + `Block` into single `ResourceNode` type with `kind: "container" | "resource"` (#1100)
+- Realigned 10 resource categories → 7: Network, Security, Edge, Compute, Data, Messaging, Operations (#1102)
+- Migrated architectureStore from `plates[] + blocks[]` to unified `nodes[]` array (#1101)
+- Updated all UI components, templates, scenarios, generators, and validation engine (#1103–#1105)
+- Updated 121+ source/test files across `apps/web`, `packages/schema`, `packages/cloudblocks-domain`
+- Regenerated Python Pydantic models from TypeScript schema (#1108)
+- Updated DOMAIN_MODEL.md and RESOURCE_CATEGORY_STRATEGY.md (#1109)
+
+### Minifigure Removal (Epic #1088)
+- Deleted minifigure character module and workerStore (#1090)
+- Stripped all worker references from source files (#1091)
+- Added CreationGrid as default CommandCard mode (#1092)
+- Hidden connection rendering from canvas and CommandCard (#1093)
+- Updated tests and documentation (#1094, #1095)
+
+### Bug Fixes
+- Fixed provider-prefixed resource names in CreationGrid ("Azure SQL" → "SQL Database") (#1096)
+- Fixed diff mode state not clearing on workspace switch (#706)
+- Unified panel naming conventions and expanded onboarding tour to 7 steps (#1110)
+
+### Demo Resilience Mode (#478)
+- Frontend gracefully handles backend-unavailable state without error storms
+- `isApiConfigured()` check + network error normalization in API client
+- "Demo Mode" indicator in menu bar when backend is unreachable
+- Backend status tracking in uiStore (`unknown → not_configured | available | unavailable`)
+
+### Security & CI (#479)
+- Added `scripts/check-build-secrets.sh` — scans build output for leaked credentials
+- Integrated secret scanning into `ci.yml`, `pages.yml`, and `deploy.yml`
+- VITE_* env var audit ensures only `VITE_API_URL` reaches the frontend bundle
+
+### Retrospective
+M19 was scoped as a 1-day milestone — resource model unification, minifigure removal, provider label fixes, demo resilience, and CI hardening. All 28 issues closed. The ResourceNode unification touched 121+ files but preserved all existing test coverage (1811 tests passing, 90.27% branch coverage).
+
 ## [v0.18.0] — 2026-03-22
 
 **Milestone 18 — DevOps UX**

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cd apps/api && pip install -e ".[dev]" && uvicorn app.main:app --reload
 | v0.16.0 | Documentation Architecture | ✅ |
 | v0.17.0 | Product Structure | ✅ |
 | v0.18.0 | DevOps UX | ✅ |
-| v0.19.0 | Resource Category Realignment + Cleanup | 🔜 |
+| v0.19.0 | Resource Category Realignment + Cleanup | ✅ |
 | v0.20.0 | Resource Category UI + Pipeline Migration | |
 | v0.21.0 | Azure v1 Resource Catalog | |
 | v0.22.0 | Generator UX Abstraction | |

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -89,7 +89,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 app = FastAPI(
     title="CloudBlocks API",
     description="Thin orchestration backend for CloudBlocks Platform",
-    version="0.16.0",
+    version="0.19.0",
     lifespan=lifespan,
 )
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloudblocks-api"
-version = "0.16.0"
+version = "0.19.0"
 description = "CloudBlocks API — orchestration backend for auth, GitHub integration, and code generation"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudblocks/web",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.19.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Architecture compiler that converts visual infrastructure designs into Terraform, Bicep, and Pulumi code",
   "type": "module",
   "repository": {

--- a/packages/cloudblocks-domain/package.json
+++ b/packages/cloudblocks-domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/domain",
-  "version": "0.16.0",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/schema",
-  "version": "0.16.0",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump all package versions to `0.19.0` (root, apps/web, packages/schema, packages/domain, apps/api)
- Add CHANGELOG entry for Milestone 19 — Resource Category Realignment + Cleanup
- Update README roadmap to mark v0.19.0 as ✅

## Milestone 19 Highlights (28 issues closed)
- **ResourceNode unification**: Plate + Block → single `ResourceNode` type, 10→7 categories, 121+ files migrated
- **Minifigure removal**: Deleted worker system, added CreationGrid as default
- **Bug fixes**: Provider label prefix, diff state cleanup, panel naming
- **Demo resilience**: Graceful frontend behavior when backend is unavailable
- **CI hardening**: Build output secret scanning in all deployment pipelines