### PR TITLE
docs: update README, create DESIGN.md, update AGENTS.md for v0.19.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@
 - `CONTRIBUTING.md`
 
 ## Working Rules
-- Preserve the existing visual-model vocabulary: plates, blocks, connections, templates.
+- **Always work on latest code**: Before starting any work, always sync with the remote. Run `git pull origin main` (or rebase onto `main` if on a feature branch) to ensure you are working against the latest codebase. Stale code causes merge conflicts and wasted effort.
+- Preserve the existing visual-model vocabulary: nodes (ContainerNode, LeafNode), connections, templates. The legacy terms "plate" and "block" may appear in historical documents and UI labels but the data model uses `ResourceNode` (see `DESIGN.md §2`).
 - Keep frontend behavior, docs, and any domain model changes synchronized.
 - Treat `apps/web` as the primary production surface unless the task explicitly targets `apps/api`.
 - Avoid incidental refactors in areas that already have unrelated user changes.
@@ -16,7 +17,7 @@
 - **English only**: All documentation, code comments, UI strings, and commit messages must be written in English. Do not introduce Korean or any other non-English text. An i18n system (`react-i18next`) is planned for future localization — until then, English is the single source language.
 - **Historical documents are immutable**: Do NOT edit documents marked "Historical (Superseded)" — including `BRICK_DESIGN_SPEC.md`, `VISUAL_DESIGN_SPEC.md`, and `BRICK_GUIDEBOOK.md`. ADRs (`docs/decisions/ADR-*.md`) are also immutable once merged; create a new ADR to supersede an old one.
 - **SVG asset rules**: All SVG sprites live in `apps/web/src/shared/assets/`. New SVG files must comply with the Universal Stud Standard. Use consistent naming: lowercase kebab-case (e.g., `internet.svg`, `compute-block.svg`). Every SVG must include a `viewBox` attribute and avoid inline `style` elements — use attributes or CSS classes instead.
-- **Zustand store boundaries**: Three stores exist — `architectureStore` (domain model: plates, blocks, connections, external actors), `uiStore` (UI state: tool mode, panel visibility, selection), and `authStore` (auth: GitHub OAuth, session). Add new state to the store that owns the domain. Do not create new stores without discussion.
+- **Zustand store boundaries**: Three stores exist — `architectureStore` (domain model: nodes, connections, external actors), `uiStore` (UI state: tool mode, panel visibility, selection), and `authStore` (auth: GitHub OAuth, session). Add new state to the store that owns the domain. Do not create new stores without discussion.
 - **Test expectations**: New features should include tests. Branch coverage must stay ≥ 90%. Do not delete or skip failing tests to make CI pass — fix the root cause instead.
 
 ## Git Conventions

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,135 @@
+# CloudBlocks Design
+
+---
+
+## 1. Philosophy
+
+Cloud infrastructure is unnecessarily complex.
+
+CloudBlocks simplifies it with a single principle:
+
+> Everything is a resource node
+
+---
+
+## 2. Evolution
+
+### Before (Legacy Model)
+
+- **Plate** — Layout abstraction for boundaries
+- **Block** — Resource abstraction for cloud services
+- Separate structures led to increasing complexity
+
+### After (Current Model — v0.19.0)
+
+Unified Node Model:
+
+- **ContainerNode** — Logical grouping (global, edge, region, zone, subnet)
+- **LeafNode** — Actual cloud resource (7 categories)
+
+```typescript
+interface ArchitectureModel {
+  nodes: ResourceNode[];    // ContainerNode | LeafNode
+  connections: Connection[];
+  externalActors: ExternalActor[];
+}
+```
+
+### Key Changes
+
+1. **Plate removed** — Layout abstraction eliminated; replaced by ContainerNode with `parentId`-based hierarchy
+2. **Block removed** — Resource abstraction unified as LeafNode
+3. **Single data structure** — `plates[] + blocks[]` consolidated into `nodes[]`
+4. **Category realignment** — 10 categories consolidated to 7: network, security, edge, compute, data, messaging, operations
+
+---
+
+## 3. Key Design Decisions
+
+### Lego-Style Composition
+
+Every visual element follows the Universal Stud Standard — uniform dimensions
+across all studs so any piece can connect to any other piece.
+This is the core constraint that keeps the system composable.
+
+### Architecture-First, Not Diagram-First
+
+Most tools work **code to diagram** (visualize existing infra).
+CloudBlocks works **architecture to code** (model visually, compile to IaC).
+The visual model is the source of truth, not a byproduct.
+
+### Validation Before Generation
+
+A real-time rule engine enforces placement and connection constraints.
+Invalid architectures cannot produce code — validation gates generation.
+
+### Multi-Generator Output
+
+One architecture model compiles to multiple IaC targets:
+Terraform (HCL), Bicep (ARM), and Pulumi (TypeScript).
+The generation pipeline is provider-aware and extensible.
+
+### Three-Store State Architecture
+
+State is split into three Zustand stores with clear boundaries:
+
+| Store | Owns |
+|-------|------|
+| `architectureStore` | Domain model — nodes, connections, external actors |
+| `uiStore` | UI state — tool mode, panel visibility, selection |
+| `authStore` | Auth state — GitHub OAuth, session |
+
+---
+
+## 4. Agentic Development
+
+This project is developed using **agentic coding workflows** where AI agents
+handle implementation, testing, code review, and documentation under human direction.
+
+### How It Works
+
+- A human architect defines goals, constraints, and design direction
+- AI agents decompose tasks, write code, run tests, and create PRs
+- Agent orchestration manages parallel workstreams across the monorepo
+- All changes go through CI validation before merge
+
+### What This Means for the Codebase
+
+- Early milestones have exploratory, noisy commit history from rapid iteration
+- The current architecture is stabilized and production-quality
+- Code quality is enforced by automated linting, type checking, and 90%+ branch coverage
+- Focus on the current structure rather than early commits
+
+---
+
+## 5. Current Architecture
+
+```
+apps/web          — React 19 + TypeScript SPA (visual editor, validation, code generation)
+apps/api          — FastAPI backend (GitHub OAuth, AI proxy, workspace sync)
+packages/schema   — Canonical architecture model types, enums, JSON Schema
+packages/domain   — Shared domain helpers (hierarchy rules, labels, validation)
+```
+
+The frontend owns the full architecture lifecycle:
+model → validate → generate → export.
+The backend handles external integrations (GitHub, AI).
+
+---
+
+## 6. Future Direction
+
+- Resource category UI migration (Milestone 20)
+- Azure v1 resource catalog with real subtypes
+- Generator UX abstraction
+- Community launch with onboarding + demo flow
+- Internationalization (i18n)
+
+---
+
+## 7. Design Principles
+
+- **Simple > Accurate** — Capture intent, not every cloud detail
+- **Visual > Textual** — Design by composing, not by writing config
+- **Composable > Monolithic** — Small pieces that snap together
+- **Learnable > Complete** — Approachable first, comprehensive later

--- a/README.md
+++ b/README.md
@@ -1,56 +1,70 @@
 # CloudBlocks
 
+> Learn Cloud Architecture by Building It
+
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CI](https://github.com/yeongseon/cloudblocks/actions/workflows/ci.yml/badge.svg)](https://github.com/yeongseon/cloudblocks/actions/workflows/ci.yml)
 [![Version](https://img.shields.io/github/v/release/yeongseon/cloudblocks?label=version)](https://github.com/yeongseon/cloudblocks/releases/latest)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev/)
-[![Python](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.110+-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://yeongseon.github.io/cloudblocks/)
 
-<p align="center">
-  <img src="docs/images/hero.png" alt="CloudBlocks — visual cloud architecture builder" width="720" />
-</p>
+---
 
-**CloudBlocks is an architecture compiler that converts visual infrastructure designs into infrastructure-as-code.**
+## Overview
 
-Design cloud infrastructure by placing blocks on plates, connect components, validate against real-world rules, and generate Terraform, Bicep, or Pulumi — all from the browser. No YAML. No HCL. Just place, connect, validate, generate.
+CloudBlocks is a visual platform for learning and designing cloud architecture
+by composing infrastructure as interactive building blocks.
 
-> **[▶ Try the Live Demo](https://yeongseon.github.io/cloudblocks/)** — Frontend-only playground. Visual builder, code generation, and templates work instantly. AI and GitHub features require the backend ([setup guide](docs/guides/TUTORIALS.md)).
+> **[Try the Live Demo](https://yeongseon.github.io/cloudblocks/)** — Visual builder, code generation, and templates work instantly.
 
-## Monorepo Layout
+---
 
-CloudBlocks uses a monorepo with one frontend app, one backend app, and shared TypeScript packages:
+## Core Idea
 
-| Path | Package | Current role |
-|--|--|--|
-| `apps/web` | `@cloudblocks/web` | Frontend SPA. Owns validation engine, generation pipeline, and template system. |
-| `apps/api` | - | FastAPI backend. Handles GitHub OAuth/session auth, workspace/repo operations, and AI integration proxying. |
-| `packages/schema` | `@cloudblocks/schema` | Canonical architecture model types/enums and JSON Schema output. |
-| `packages/cloudblocks-domain` | `@cloudblocks/domain` | Shared domain helpers (hierarchy rules, labels, validation types). |
+> Everything is a resource node
 
-The frontend imports architecture/domain types from `@cloudblocks/schema` and `@cloudblocks/domain` instead of defining local model types.
-Python models in `apps/api/app/models/generated/` are auto-generated from the TypeScript schema (`packages/schema/dist/architecture-model.schema.json`).
+All infrastructure is represented in a unified node structure:
 
-## Why CloudBlocks?
+- **ContainerNode** — Logical groupings (global, edge, region, zone, subnet)
+- **LeafNode** — Actual cloud resources (7 categories: network, security, edge, compute, data, messaging, operations)
 
-Most IaC tools work **code → diagram** (visualize existing infra). CloudBlocks works **architecture → code** (model visually, compile to infra).
+```typescript
+nodes: ResourceNode[]   // ContainerNode | LeafNode
+connections: Connection[]
+```
 
-| | Diagram Tool | CloudBlocks |
-|--|-------------|-------------|
-| Output | Static image | Architecture model + IaC code |
-| Validation | None | Rule engine enforces constraints |
-| Semantics | Visual only | Every element maps to a real resource |
+Containers nest. Resources sit inside containers. Connections wire resources together.
+The result is an architecture model that compiles directly to infrastructure-as-code.
 
-## Features
+---
 
-- 🧱 **Lego-style modeling** — Plates (boundaries) + Blocks (resources) + typed Connections
-- ⚡ **Architecture compiler** — Visual designs compile to Terraform, Bicep, and Pulumi
-- ✅ **Validation engine** — Real-time rule checking for placement and connections
-- 📦 **7 resource categories** — Network, security, edge, compute, data, messaging, operations
-- 🔗 **GitHub integration** — OAuth login, repo sync, PR creation, architecture diff (backend API)
-- 📚 **Learning mode** — Guided scenarios to learn cloud architecture patterns
+## Agentic Development
+
+This project is developed using **agentic coding workflows** —
+AI agents handle implementation, code review, testing, and documentation
+under human direction.
+
+During early milestones, rapid iteration and exploratory commits produced
+noisy history. The current architecture represents a stabilized,
+production-quality system refined through 19 milestone cycles.
+
+> Focus on the current structure rather than early commits.
+
+---
+
+## Current Status
+
+| Area | Status |
+|------|--------|
+| Unified node model (ResourceNode) | Complete (v0.19.0) |
+| Visual builder + validation engine | Complete |
+| Multi-generator (Terraform, Bicep, Pulumi) | Complete |
+| GitHub integration (OAuth, sync, PR) | Complete |
+| Learning mode (guided scenarios) | Complete |
+| Resource category UI migration | In progress (Milestone 20) |
+
+---
 
 ## Quick Start
 
@@ -58,84 +72,60 @@ Most IaC tools work **code → diagram** (visualize existing infra). CloudBlocks
 git clone https://github.com/yeongseon/cloudblocks.git
 cd cloudblocks
 pnpm install
-cd apps/web && pnpm dev
+pnpm dev
 ```
 
 Open [http://localhost:5173](http://localhost:5173) to start building.
 
-> The frontend works standalone. Start the backend (`apps/api`) for GitHub integration.
+---
 
-## Documentation
+## Monorepo Layout
 
-Full documentation is available in the [`docs/`](docs/) directory:
+| Path | Package | Role |
+|------|---------|------|
+| `apps/web` | `@cloudblocks/web` | Frontend SPA — editor, validation, code generation |
+| `apps/api` | — | FastAPI backend — GitHub OAuth, AI proxy, workspace sync |
+| `packages/schema` | `@cloudblocks/schema` | Architecture model types, enums, JSON Schema |
+| `packages/cloudblocks-domain` | `@cloudblocks/domain` | Domain helpers — hierarchy rules, labels, validation |
 
-- [Getting Started](docs/guides/TUTORIALS.md)
-- [Architecture](docs/concept/ARCHITECTURE.md)
-- [Domain Model](docs/model/DOMAIN_MODEL.md)
-- [Roadmap](docs/concept/ROADMAP.md)
-
-## Development
-
-```bash
-# Frontend development
-cd apps/web && pnpm dev
-
-# Build
-cd apps/web && pnpm build
-
-# Type check
-cd apps/web && npx tsc -b
-
-# Backend
-cd apps/api && pip install -e ".[dev]" && uvicorn app.main:app --reload
-```
-
-## Examples
-
-- [Three-Tier Web App](examples/three-tier-web-app/) — Classic three-tier architecture
-- [Serverless API](examples/serverless-api/) — Serverless function architecture
-- [Event-Driven Pipeline](examples/event-driven-pipeline/) — Event processing pattern
+---
 
 ## Roadmap
 
 | Version | Milestone | Status |
 |---------|-----------|--------|
-| v0.0.0 | Concept Validation | ✅ |
-| v0.4.0 | Milestones 1–4 (MVP → Workspace Management) | ✅ |
-| v0.5.0 | GitHub Integration & Backend API | ✅ |
-| v0.6.0 | Multi-Generator + Template Marketplace | ✅ |
-| v0.7.0 | Collaboration + UX Polish + Auth Migration | ✅ |
-| v0.8.0 | Multi-Cloud Platform | ✅ |
-| v0.9.0 | UX Core Hardening | ✅ |
-| v0.10.0 | External Actors & DevOps UX | ✅ |
-| v0.11.0 | Brick Design System | ✅ |
-| v0.12.0 | Core Model & Provider System | ✅ |
-| v0.13.0 | Terraform Pipeline | ✅ |
-| v0.14.0 | AI-Assisted Architecture | ✅ |
-| v0.15.0 | v2.0 Specification Implementation | ✅ |
-| v0.16.0 | Documentation Architecture | ✅ |
-| v0.17.0 | Product Structure | ✅ |
-| v0.18.0 | DevOps UX | ✅ |
 | v0.19.0 | Resource Category Realignment + Cleanup | ✅ |
 | v0.20.0 | Resource Category UI + Pipeline Migration | |
 | v0.21.0 | Azure v1 Resource Catalog | |
 | v0.22.0 | Generator UX Abstraction | |
 | v0.23.0 | Onboarding + Demo Flow ← **Community Launch** | |
-| v0.24.0 | Runtime Configuration + GitHub Hardening | |
-| v0.25.0 | Observability Baseline | |
-| v0.26.0 | Release Gates | |
-| v0.27.0 | i18n Scaffolding | |
 
 See [CHANGELOG.md](CHANGELOG.md) for release details and [full roadmap](docs/concept/ROADMAP.md) for milestone breakdown.
 
+---
+
+## Documentation
+
+- [Design & Architecture](./DESIGN.md)
+- [Getting Started](docs/guides/TUTORIALS.md)
+- [Domain Model](docs/model/DOMAIN_MODEL.md)
+- [Roadmap](docs/concept/ROADMAP.md)
+- [Contributing Guide](./CONTRIBUTING.md)
+
+---
+
+## Vision
+
+> Make cloud architecture as intuitive as building with Lego
+
+---
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, coding standards, and the PR process.
+Contributions are welcome.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting PRs.
 
-## Community
-
-- [GitHub Issues](https://github.com/yeongseon/cloudblocks/issues) — Bug reports and feature requests
-- [GitHub Discussions](https://github.com/yeongseon/cloudblocks/discussions) — Questions and ideas
+---
 
 ## License
 


### PR DESCRIPTION
## Summary
- Rewrite README.md with unified ResourceNode model, agentic development section, and simplified structure
- Create DESIGN.md documenting philosophy, Plate/Block→Node evolution, key design decisions, and architecture overview
- Update AGENTS.md: add "always work on latest code" working rule, update vocabulary from plates/blocks to nodes (ContainerNode, LeafNode)

## Changes
### README.md
- New tagline: "Learn Cloud Architecture by Building It"
- Simplified structure: Overview → Core Idea → Agentic Development → Current Status → Quick Start → Layout → Roadmap → Docs
- Removed redundant sections (Why CloudBlocks comparison table, detailed feature list)
- Updated to reflect v0.19.0 unified node model

### DESIGN.md (new file)
- §1 Philosophy: "Everything is a resource node"
- §2 Evolution: Before (Plate/Block) → After (ContainerNode/LeafNode)
- §3 Key Design Decisions: Lego composition, architecture-first, validation-before-generation, multi-generator, three-store
- §4 Agentic Development workflow description
- §5 Current Architecture layout
- §6 Future Direction (M20+)
- §7 Design Principles

### AGENTS.md
- Added "Always work on latest code" as first working rule
- Updated vocabulary: "plates, blocks" → "nodes (ContainerNode, LeafNode)" with legacy term note
- Updated Zustand store boundaries description to match current model

## Verification
- `pnpm build` — clean
- `pnpm lint` — clean
- Docs-only changes, no code impact