### PR TITLE
fix(web): fix React #185 crash on app load in ExternalActorSprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 
 
+
+## [v0.19.2] — 2026-03-22
+
+**Hotfix — App Load Crash (React #185)**
+
+Fixed a crash on initial app load caused by a Zustand selector in `ExternalActorSprite` creating a new array reference on every `getSnapshot` call via `.filter()` inside the selector. React 19's `useSyncExternalStore` detected the unstable snapshot and threw an infinite loop error (React error #185), rendering the entire app blank.
+
+### Bug Fix
+- Move `.filter()` call outside the Zustand selector in `ExternalActorSprite` to avoid creating new array references on each snapshot (#1128)
+
+
 ## [v0.19.1] — 2026-03-22
 
 **Hotfix — Schema Migration Crash**

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -89,7 +89,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 app = FastAPI(
     title="CloudBlocks API",
     description="Thin orchestration backend for CloudBlocks Platform",
-    version="0.19.1",
+    version="0.19.2",
     lifespan=lifespan,
 )
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloudblocks-api"
-version = "0.19.1"
+version = "0.19.2"
 description = "CloudBlocks API — orchestration backend for auth, GitHub integration, and code generation"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudblocks/web",
   "private": true,
-  "version": "0.19.1",
+  "version": "0.19.2",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/apps/web/src/entities/connection/ExternalActorSprite.tsx
+++ b/apps/web/src/entities/connection/ExternalActorSprite.tsx
@@ -31,9 +31,8 @@ export const ExternalActorSprite = memo(function ExternalActorSprite({
   const completeInteraction = useUIStore((s) => s.completeInteraction);
   const addConnection = useArchitectureStore((s) => s.addConnection);
   const moveActorPosition = useArchitectureStore((s) => s.moveActorPosition);
-  const blocks = useArchitectureStore((s) =>
-    s.workspace.architecture.nodes.filter((node): node is LeafNode => node.kind === 'resource')
-  );
+  const nodes = useArchitectureStore((s) => s.workspace.architecture.nodes);
+  const blocks = nodes.filter((node): node is LeafNode => node.kind === 'resource');
   const externalActors = useArchitectureStore((s) => s.workspace.architecture.externalActors);
   const actorRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "Architecture compiler that converts visual infrastructure designs into Terraform, Bicep, and Pulumi code",
   "type": "module",
   "repository": {

--- a/packages/cloudblocks-domain/package.json
+++ b/packages/cloudblocks-domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/domain",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/schema",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Moves `.filter()` call outside the Zustand selector in `ExternalActorSprite` to prevent creating a new array reference on every `getSnapshot` call
- This was causing React 19's `useSyncExternalStore` to detect an unstable snapshot and throw an infinite re-render loop (React error #185), rendering the entire app blank on load
- Version bumped to v0.19.2

## Verification
- 1814 tests pass, build clean, lint clean
- Demo verification: app loads with zero console errors (confirmed via Playwright)

Fixes #1128