### PR TITLE
chore: release v0.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 
 
+## [v0.19.3] — 2026-03-22
+
+**Hotfix — Panel Role Redesign + BlockSprite Crash Fix**
+
+Redesigns the bottom panel roles: Command Panel becomes the interactive hub (properties display, connection editing, actions), Resource Guide becomes 100% read-only (workspace dashboard, encyclopedia content). Also fixes a React infinite loop crash in BlockSprite.
+
+### Panel Role Redesign (Epic #1112)
+- Rename `showProperties`/`Inspector` to `showResourceGuide`/`Resource Guide` across store and components (#1118)
+- Add read-only properties display to Command Panel actions (#1117)
+- Add connection editing mode to Command Panel with source/target display and delete (#1115)
+- Replace welcome state with workspace dashboard in Resource Guide (#1113)
+- Add encyclopedia content (overview, use cases, best practices) to Resource Guide detail views (#1114)
+- Update onboarding tour Step 2 to reflect new panel roles (#1116)
+
+### Bug Fix
+- Move `.filter()` outside Zustand selector in `BlockSprite` to fix React #185 infinite re-render crash (#1134)
+
+
 ## [v0.19.2] — 2026-03-22
 
 **Hotfix — App Load Crash (React #185)**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Architecture compiler that converts visual infrastructure designs into Terraform, Bicep, and Pulumi code",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

Release v0.19.3 hotfix — version bump and CHANGELOG update.

### Included in v0.19.3
- Panel Role Redesign (Epic #1112): Command Panel → interactive hub, Resource Guide → read-only (#1113–#1118)
- BlockSprite `.filter()` Zustand selector infinite loop fix (#1134)

### Changes in this PR
- `package.json`: version `0.19.2` → `0.19.3`
- `CHANGELOG.md`: add v0.19.3 section