### PR TITLE
fix(web): replace key-based remount with useEffect for CodePreview provider resets

### DIFF
--- a/apps/web/src/widgets/code-preview/CodePreview.test.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CodePreview } from './CodePreview';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
@@ -398,7 +398,7 @@ describe('CodePreview', () => {
     expect(compareCheckbox).toBeDisabled();
   });
 
-  it('resets generated output on remount (simulating panel close and reopen)', async () => {
+  it('resets generated output when active provider changes', async () => {
     const user = userEvent.setup();
     const mockOutput = {
       files: [{ path: 'main.tf', content: 'resource content', language: 'hcl' as const }],
@@ -406,15 +406,19 @@ describe('CodePreview', () => {
     };
     vi.mocked(generateCode).mockReturnValue(mockOutput);
 
-    const { unmount } = render(<CodePreview />);
+    const { rerender } = render(<CodePreview />);
     await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
     expect(screen.getByText('main.tf')).toBeInTheDocument();
 
-    unmount();
-    render(<CodePreview />);
+    act(() => {
+      useUIStore.setState({ activeProvider: 'aws' });
+    });
+    rerender(<CodePreview />);
 
-    expect(screen.queryByText('main.tf')).not.toBeInTheDocument();
-    expect(screen.queryByText('resource content')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('main.tf')).not.toBeInTheDocument();
+      expect(screen.queryByText('resource content')).not.toBeInTheDocument();
+    });
   });
 
   it('derives default project name from architecture name', () => {
@@ -652,15 +656,19 @@ describe('CodePreview', () => {
     expect(writeTextMock).not.toHaveBeenCalled();
   });
 
-  it('resets region when provider changes', () => {
+  it('resets region when provider changes', async () => {
     const { rerender } = render(<CodePreview />);
 
     expect(screen.getByDisplayValue('eastus')).toBeInTheDocument();
 
-    useUIStore.setState({ activeProvider: 'aws' });
+    act(() => {
+      useUIStore.setState({ activeProvider: 'aws' });
+    });
     rerender(<CodePreview />);
 
-    expect(screen.getByDisplayValue('us-east-1')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('us-east-1')).toBeInTheDocument();
+    });
   });
 
   it('passes provider-specific regions in compare mode', async () => {

--- a/apps/web/src/widgets/code-preview/CodePreview.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { generateCode, GenerationError } from '../../features/generate/pipeline';
@@ -14,12 +14,21 @@ import './CodePreview.css';
 
 const PROVIDERS: ProviderType[] = ['azure', 'aws', 'gcp'];
 
-export function CodePreview() {
-  const activeProvider = useUIStore((s) => s.activeProvider);
-  return <CodePreviewContent key={activeProvider} />;
+function clearGeneratedState(
+  setError: (value: string | null) => void,
+  setOutput: (value: GeneratedOutput | null) => void,
+  setComparisonOutputs: (value: Record<ProviderType, GeneratedOutput> | null) => void,
+  setComparisonErrors: (value: Partial<Record<ProviderType, string>> | null) => void,
+  setActiveTab: (value: number) => void,
+) {
+  setError(null);
+  setOutput(null);
+  setComparisonOutputs(null);
+  setComparisonErrors(null);
+  setActiveTab(0);
 }
 
-function CodePreviewContent() {
+export function CodePreview() {
   const toggleCodePreview = useUIStore((s) => s.toggleCodePreview);
   const activeProvider = useUIStore((s) => s.activeProvider);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
@@ -45,6 +54,7 @@ function CodePreviewContent() {
   const [comparisonOutputs, setComparisonOutputs] = useState<Record<ProviderType, GeneratedOutput> | null>(null);
   const [comparisonErrors, setComparisonErrors] = useState<Partial<Record<ProviderType, string>> | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const prevProviderRef = useRef(activeProvider);
   const selectedGenerator = generatorOptions.find((g) => g.id === generator);
   const supportedProviders = selectedGenerator?.supportedProviders ?? [];
   const canCompareProviders = PROVIDERS.every((provider) =>
@@ -63,22 +73,27 @@ function CodePreviewContent() {
     }, new Map<string, number>());
   const hasMismatch = mismatchedProviders.size > 0;
 
-  const clearGeneratedState = () => {
-    setError(null);
-    setOutput(null);
-    setComparisonOutputs(null);
-    setComparisonErrors(null);
-    setActiveTab(0);
-  };
+  useEffect(() => {
+    if (prevProviderRef.current !== activeProvider) {
+      prevProviderRef.current = activeProvider;
+      queueMicrotask(() => {
+        clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab);
+        setRegions((prev) => ({
+          ...prev,
+          [activeProvider]: DEFAULT_REGION_BY_PROVIDER[activeProvider],
+        }));
+      });
+    }
+  }, [activeProvider]);
 
   const handleGeneratorChange = (newGenerator: GeneratorId) => {
     setGenerator(newGenerator);
-    clearGeneratedState();
+    clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab);
   };
 
   const handleCompareChange = (checked: boolean) => {
     setCompareProviders(checked);
-    clearGeneratedState();
+    clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab);
   };
 
   const handleGenerate = () => {


### PR DESCRIPTION
## Summary
- remove the `key={activeProvider}` remount wrapper so provider changes no longer wipe all CodePreview state.
- add a provider-change `useEffect` that clears only generated/error/tab state and resets the newly active provider region to its default.
- update CodePreview tests to verify provider-switch reset behavior without remount assumptions.

## Why
- remounting on provider switch caused silent loss of user-entered state such as project name, selected generator, compare toggle, and non-active provider regions.
- this change keeps user-owned state intact while still resetting stale generation artifacts tied to the previous provider.

## Validation
- `pnpm vitest run src/widgets/code-preview/CodePreview.test.tsx` (from `apps/web`)
- `npx tsc -b` (from `apps/web`)
- `pnpm lint`

Fixes #886