### PR TITLE
fix(web): preserve GitHub action across OAuth, keep login on failure, route auth errors (#836, #838, #867)

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useArchitectureStore } from '../entities/store/architectureStore';
 import { useUIStore } from '../entities/store/uiStore';
 import { useAuthStore } from '../entities/store/authStore';
@@ -154,6 +154,25 @@ describe('App', () => {
   it('calls checkSession on mount', () => {
     render(<App />);
     expect(checkSessionMock).toHaveBeenCalledOnce();
+  });
+
+  it('restores pending GitHub action after authenticated session check', async () => {
+    useUIStore.setState({
+      showGitHubSync: false,
+      showGitHubPR: false,
+      showGitHubRepos: false,
+      pendingGitHubAction: 'repos',
+    });
+    checkSessionMock.mockImplementation(async () => {
+      useAuthStore.setState({ status: 'authenticated' });
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(useUIStore.getState().showGitHubRepos).toBe(true);
+    });
+    expect(useUIStore.getState().pendingGitHubAction).toBe(null);
   });
 
   it('handles Ctrl+S for save with success toast', () => {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -103,7 +103,29 @@ function App() {
     if (!isApiConfigured()) {
       useUIStore.getState().setBackendStatus('not_configured');
     }
-    void useAuthStore.getState().checkSession();
+
+    void (async () => {
+      await useAuthStore.getState().checkSession();
+
+      if (useAuthStore.getState().status !== 'authenticated') {
+        return;
+      }
+
+      const uiState = useUIStore.getState();
+      const pendingAction = uiState.pendingGitHubAction;
+
+      if (pendingAction === 'sync' && !uiState.showGitHubSync) {
+        uiState.toggleGitHubSync();
+      } else if (pendingAction === 'pr' && !uiState.showGitHubPR) {
+        uiState.toggleGitHubPR();
+      } else if (pendingAction === 'repos' && !uiState.showGitHubRepos) {
+        uiState.toggleGitHubRepos();
+      }
+
+      if (pendingAction !== null) {
+        uiState.setPendingGitHubAction(null);
+      }
+    })();
   }, []);
 
   // Keyboard shortcuts

--- a/apps/web/src/entities/store/uiStore.test.ts
+++ b/apps/web/src/entities/store/uiStore.test.ts
@@ -21,10 +21,12 @@ describe('useUIStore', () => {
       showGitHubRepos: false,
       showGitHubSync: false,
       showGitHubPR: false,
+      pendingGitHubAction: null,
       showSuggestionsPanel: false,
       showCostPanel: false,
       activeProvider: 'azure',
       editorMode: 'build',
+      pendingLinkRepo: null,
       showLearningPanel: false,
       showScenarioGallery: false,
       diffMode: false,
@@ -54,6 +56,7 @@ describe('useUIStore', () => {
       expect(state.showCostPanel).toBe(false);
       expect(state.activeProvider).toBe('azure');
       expect(state.editorMode).toBe('build');
+      expect(state.pendingLinkRepo).toBe(null);
       expect(state.showLearningPanel).toBe(false);
       expect(state.showScenarioGallery).toBe(false);
       expect(state.diffMode).toBe(false);
@@ -655,6 +658,34 @@ describe('useUIStore', () => {
       useUIStore.getState().toggleGitHubPR();
       useUIStore.getState().toggleGitHubPR();
       expect(useUIStore.getState().showGitHubPR).toBe(false);
+    });
+  });
+
+  describe('pendingGitHubAction', () => {
+    it('defaults to null', () => {
+      expect(useUIStore.getState().pendingGitHubAction).toBe(null);
+    });
+
+    it('sets and clears pending action while syncing sessionStorage', () => {
+      useUIStore.getState().setPendingGitHubAction('sync');
+      expect(useUIStore.getState().pendingGitHubAction).toBe('sync');
+      expect(sessionStorage.getItem('cloudblocks_pending_github_action')).toBe('sync');
+
+      useUIStore.getState().setPendingGitHubAction(null);
+      expect(useUIStore.getState().pendingGitHubAction).toBe(null);
+      expect(sessionStorage.getItem('cloudblocks_pending_github_action')).toBeNull();
+    });
+  });
+
+  describe('pendingLinkRepo', () => {
+    it('defaults to null and can be set/cleared', () => {
+      expect(useUIStore.getState().pendingLinkRepo).toBe(null);
+
+      useUIStore.getState().setPendingLinkRepo('owner/repo');
+      expect(useUIStore.getState().pendingLinkRepo).toBe('owner/repo');
+
+      useUIStore.getState().setPendingLinkRepo(null);
+      expect(useUIStore.getState().pendingLinkRepo).toBe(null);
     });
   });
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -7,7 +7,36 @@ import type { ArchitectureModel } from '@cloudblocks/schema';
 export type ToolMode = 'select' | 'connect' | 'delete';
 export type InteractionState = 'idle' | 'selecting' | 'dragging' | 'placing' | 'connecting';
 export type BackendStatus = 'unknown' | 'not_configured' | 'available' | 'unavailable';
+export type PendingGitHubAction = 'sync' | 'pr' | 'repos' | null;
 export type { EditorMode } from '../../shared/types/learning';
+
+const PENDING_GITHUB_ACTION_KEY = 'cloudblocks_pending_github_action';
+
+function readPendingGitHubAction(): PendingGitHubAction {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const raw = window.sessionStorage.getItem(PENDING_GITHUB_ACTION_KEY);
+  if (raw === 'sync' || raw === 'pr' || raw === 'repos') {
+    return raw;
+  }
+
+  return null;
+}
+
+function writePendingGitHubAction(action: PendingGitHubAction): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (action === null) {
+    window.sessionStorage.removeItem(PENDING_GITHUB_ACTION_KEY);
+    return;
+  }
+
+  window.sessionStorage.setItem(PENDING_GITHUB_ACTION_KEY, action);
+}
 
 interface UIState {
   // ── Selection ──
@@ -101,6 +130,11 @@ interface UIState {
   // ── Sound preference ──
   isSoundMuted: boolean;
   toggleSound: () => void;
+
+  pendingGitHubAction: PendingGitHubAction;
+  setPendingGitHubAction: (action: PendingGitHubAction) => void;
+  pendingLinkRepo: string | null;
+  setPendingLinkRepo: (fullName: string | null) => void;
 
   // ── Resource self-animation ──
   upgradingBlockId: string | null;
@@ -301,6 +335,14 @@ export const useUIStore = create<UIState>((set) => ({
 
   isSoundMuted: true,
   toggleSound: () => set((s) => ({ isSoundMuted: !s.isSoundMuted })),
+
+  pendingGitHubAction: readPendingGitHubAction(),
+  setPendingGitHubAction: (action) => {
+    writePendingGitHubAction(action);
+    set({ pendingGitHubAction: action });
+  },
+  pendingLinkRepo: null,
+  setPendingLinkRepo: (fullName) => set({ pendingLinkRepo: fullName }),
 
   showOnboarding: false,
   setShowOnboarding: (show) => set({ showOnboarding: show }),

--- a/apps/web/src/shared/api/client.test.ts
+++ b/apps/web/src/shared/api/client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ApiError, apiDelete, apiFetch, apiGet, apiPost, apiPut, getApiErrorMessage, normalizeApiBaseUrl } from './client';
+import { ApiError, apiDelete, apiFetch, apiGet, apiPost, apiPut, getApiErrorMessage, isAuthError, normalizeApiBaseUrl } from './client';
 
 function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), {
@@ -284,5 +284,16 @@ describe('getApiErrorMessage', () => {
 
   it('falls back to supplied message when thrown value is not Error', () => {
     expect(getApiErrorMessage('bad', 'Fallback')).toBe('Fallback');
+  });
+});
+
+describe('isAuthError', () => {
+  it('returns true for ApiError 401', () => {
+    expect(isAuthError(new ApiError('Unauthorized', 401, ''))).toBe(true);
+  });
+
+  it('returns false for non-401 or non-ApiError', () => {
+    expect(isAuthError(new ApiError('Server error', 500, ''))).toBe(false);
+    expect(isAuthError(new Error('Unauthorized'))).toBe(false);
   });
 });

--- a/apps/web/src/shared/api/client.ts
+++ b/apps/web/src/shared/api/client.ts
@@ -32,6 +32,10 @@ export class ApiError extends Error {
   }
 }
 
+export function isAuthError(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 401;
+}
+
 interface FastApiErrorEnvelope {
   detail?: string;
 }

--- a/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.test.tsx
@@ -111,6 +111,21 @@ describe('GitHubLogin', () => {
 
     expect(logoutMock).toHaveBeenCalledOnce();
     expect(useUIStore.getState().showGitHubLogin).toBe(true);
+    expect(screen.getByText('Logout failed. Checking session…')).toBeInTheDocument();
+  });
+
+  it('clears pending GitHub action before OAuth redirect', async () => {
+    const user = userEvent.setup();
+    useUIStore.getState().setPendingGitHubAction('sync');
+    mockApiPost.mockResolvedValueOnce({
+      authorize_url: `${window.location.origin}/#oauth-callback`,
+    });
+
+    render(<GitHubLogin />);
+    await user.click(screen.getByRole('button', { name: 'Sign in with GitHub' }));
+
+    expect(useUIStore.getState().pendingGitHubAction).toBe(null);
+    expect(sessionStorage.getItem('cloudblocks_pending_github_action')).toBeNull();
   });
 
   it('shows error when sign in fails', async () => {

--- a/apps/web/src/widgets/github-login/GitHubLogin.tsx
+++ b/apps/web/src/widgets/github-login/GitHubLogin.tsx
@@ -11,6 +11,7 @@ interface GitHubAuthStartResponse {
 export function GitHubLogin() {
   const show = useUIStore((s) => s.showGitHubLogin);
   const toggleGitHubLogin = useUIStore((s) => s.toggleGitHubLogin);
+  const setPendingGitHubAction = useUIStore((s) => s.setPendingGitHubAction);
 
   const user = useAuthStore((s) => s.user);
   const status = useAuthStore((s) => s.status);
@@ -30,6 +31,7 @@ export function GitHubLogin() {
 
     try {
       const response = await apiPost<GitHubAuthStartResponse>('/api/v1/auth/github');
+      setPendingGitHubAction(null);
       window.location.href = response.authorize_url;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to start GitHub login.';

--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 vi.mock('../../shared/api/client', () => ({
   apiPost: vi.fn(),
   apiGet: vi.fn(),
+  isAuthError: vi.fn(() => false),
   getApiErrorMessage: vi.fn((err: unknown, fallback: string) => {
     if (err instanceof Error) return err.message;
     return fallback;
@@ -13,7 +14,7 @@ import { GitHubPR } from './GitHubPR';
 import { useUIStore } from '../../entities/store/uiStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
-import { apiPost } from '../../shared/api/client';
+import { apiPost, isAuthError } from '../../shared/api/client';
 import type { ArchitectureModel } from '@cloudblocks/schema';
 
 const emptyArch: ArchitectureModel = {
@@ -29,6 +30,7 @@ const emptyArch: ArchitectureModel = {
 
 describe('GitHubPR', () => {
   const mockApiPost = vi.mocked(apiPost);
+  const mockIsAuthError = vi.mocked(isAuthError);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -49,6 +51,7 @@ describe('GitHubPR', () => {
         backendWorkspaceId: 'backend-ws-1',
       },
     });
+    mockIsAuthError.mockReturnValue(false);
   });
 
   it('renders null when hidden', () => {
@@ -120,6 +123,22 @@ describe('GitHubPR', () => {
     await user.click(screen.getByRole('button', { name: 'Create Pull Request' }));
 
     expect(await screen.findByText('Failed to create pull request.')).toBeInTheDocument();
+  });
+
+  it('routes auth error to login panel from PR submit', async () => {
+    const user = userEvent.setup();
+    const unauthorizedError = new Error('Unauthorized');
+    mockApiPost.mockRejectedValueOnce(unauthorizedError);
+    mockIsAuthError.mockReturnValueOnce(true);
+
+    render(<GitHubPR />);
+    await user.click(screen.getByRole('button', { name: 'Create Pull Request' }));
+
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().status).toBe('anonymous');
+    });
+    expect(useAuthStore.getState().error).toBe('Session expired. Please sign in again.');
+    expect(useUIStore.getState().showGitHubLogin).toBe(true);
   });
 
   it('sends custom branch name when provided', async () => {

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import { apiPost, getApiErrorMessage } from '../../shared/api/client';
+import { apiPost, getApiErrorMessage, isAuthError } from '../../shared/api/client';
 import { isValidGitBranchName } from '../../shared/utils/githubValidation';
 import type { PullRequestResponse } from '../../shared/types/api';
 import './GitHubPR.css';
@@ -66,6 +66,13 @@ export function GitHubPR() {
       );
       setResult(response);
     } catch (err) {
+      if (isAuthError(err)) {
+        const authStore = useAuthStore.getState();
+        authStore.setAnonymous();
+        authStore.setError('Session expired. Please sign in again.');
+        useUIStore.getState().toggleGitHubLogin();
+        return;
+      }
       setError(getApiErrorMessage(err, 'Failed to create pull request.'));
     } finally {
       setLoading(false);
@@ -76,7 +83,7 @@ export function GitHubPR() {
     <div className="github-pr">
       <div className="github-pr-header">
         <h3 className="github-pr-title">🔀 Pull Request</h3>
-        <button className="github-pr-close" onClick={toggleGitHubPR} aria-label="Close pull request panel">
+        <button type="button" className="github-pr-close" onClick={toggleGitHubPR} aria-label="Close pull request panel">
           ✕
         </button>
       </div>
@@ -135,7 +142,7 @@ export function GitHubPR() {
             onChange={(e) => setCommitMessage(e.target.value)}
           />
 
-          <button className="github-pr-submit" onClick={handleSubmit} disabled={!canSubmit}>
+          <button type="button" className="github-pr-submit" onClick={handleSubmit} disabled={!canSubmit}>
             Create Pull Request
           </button>
 

--- a/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.test.tsx
@@ -4,25 +4,28 @@ import userEvent from '@testing-library/user-event';
 vi.mock('../../shared/api/client', () => ({
   apiPost: vi.fn(),
   apiGet: vi.fn(),
+  isAuthError: vi.fn(() => false),
 }));
 import { GitHubRepos } from './GitHubRepos';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import { apiGet, apiPost } from '../../shared/api/client';
+import { apiGet, apiPost, isAuthError } from '../../shared/api/client';
 
 describe('GitHubRepos', () => {
   const mockApiGet = vi.mocked(apiGet);
   const mockApiPost = vi.mocked(apiPost);
+  const mockIsAuthError = vi.mocked(isAuthError);
 
   beforeEach(() => {
     vi.clearAllMocks();
-    useUIStore.setState({ showGitHubRepos: true });
+    useUIStore.setState({ showGitHubRepos: true, showGitHubSync: false, pendingLinkRepo: null });
     useAuthStore.setState({
       status: 'authenticated',
       user: null,
       hydrated: true,
       error: null,
     });
+    mockIsAuthError.mockReturnValue(false);
   });
 
   it('renders null when show is false', () => {
@@ -98,6 +101,75 @@ describe('GitHubRepos', () => {
     expect(await screen.findByText('new-repo')).toBeInTheDocument();
   });
 
+  it('keeps success message visible when refresh fails after create', async () => {
+    const user = userEvent.setup();
+    mockApiGet.mockResolvedValueOnce({ repos: [] }).mockRejectedValueOnce(new Error('Refresh failed'));
+    mockApiPost.mockResolvedValueOnce({
+      full_name: 'owner/new-repo',
+      name: 'new-repo',
+      private: true,
+      default_branch: 'main',
+      html_url: 'https://github.com/owner/new-repo',
+    });
+
+    render(<GitHubRepos />);
+
+    await user.type(screen.getByPlaceholderText('Repository name'), 'new-repo');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByText('Repository "new-repo" created successfully.')).toBeInTheDocument();
+    expect(await screen.findByText('Refresh failed')).toBeInTheDocument();
+  });
+
+  it('resets private checkbox to true after successful create', async () => {
+    const user = userEvent.setup();
+    mockApiGet.mockResolvedValueOnce({ repos: [] }).mockResolvedValueOnce({ repos: [] });
+    mockApiPost.mockResolvedValueOnce({
+      full_name: 'owner/new-repo',
+      name: 'new-repo',
+      private: false,
+      default_branch: 'main',
+      html_url: 'https://github.com/owner/new-repo',
+    });
+
+    render(<GitHubRepos />);
+
+    const privateCheckbox = screen.getByRole('checkbox', { name: 'Private repository' });
+    expect(privateCheckbox).toBeChecked();
+    await user.click(privateCheckbox);
+    expect(privateCheckbox).not.toBeChecked();
+
+    await user.type(screen.getByPlaceholderText('Repository name'), 'new-repo');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await screen.findByText('Repository "new-repo" created successfully.');
+    expect(privateCheckbox).toBeChecked();
+  });
+
+  it('shows and wires Link this repo action after successful create', async () => {
+    const user = userEvent.setup();
+    mockApiGet.mockResolvedValueOnce({ repos: [] }).mockResolvedValueOnce({ repos: [] });
+    mockApiPost.mockResolvedValueOnce({
+      full_name: 'owner/new-repo',
+      name: 'new-repo',
+      private: true,
+      default_branch: 'main',
+      html_url: 'https://github.com/owner/new-repo',
+    });
+
+    render(<GitHubRepos />);
+
+    await user.type(screen.getByPlaceholderText('Repository name'), 'new-repo');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    const linkButton = await screen.findByRole('button', { name: 'Link this repo' });
+    expect(linkButton).toBeInTheDocument();
+    await user.click(linkButton);
+
+    expect(useUIStore.getState().pendingLinkRepo).toBe('owner/new-repo');
+    expect(useUIStore.getState().showGitHubSync).toBe(true);
+  });
+
   it('shows error when fetch repos fails', async () => {
     mockApiGet.mockRejectedValueOnce(new Error('Network error'));
 
@@ -112,6 +184,20 @@ describe('GitHubRepos', () => {
     render(<GitHubRepos />);
 
     expect(await screen.findByText('Failed to load repositories.')).toBeInTheDocument();
+  });
+
+  it('routes auth error to login panel from repo fetch', async () => {
+    const unauthorizedError = new Error('Unauthorized');
+    mockApiGet.mockRejectedValueOnce(unauthorizedError);
+    mockIsAuthError.mockReturnValueOnce(true);
+
+    render(<GitHubRepos />);
+
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().status).toBe('anonymous');
+    });
+    expect(useAuthStore.getState().error).toBe('Session expired. Please sign in again.');
+    expect(useUIStore.getState().showGitHubLogin).toBe(true);
   });
 
   it('does not create repo when name is empty', async () => {

--- a/apps/web/src/widgets/github-repos/GitHubRepos.tsx
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import { apiGet, apiPost } from '../../shared/api/client';
+import { apiGet, apiPost, isAuthError } from '../../shared/api/client';
 import { isValidGitHubRepoName } from '../../shared/utils/githubValidation';
 import type { GitHubRepo } from '../../shared/types/api';
 import './GitHubRepos.css';
@@ -9,6 +9,8 @@ import './GitHubRepos.css';
 export function GitHubRepos() {
   const show = useUIStore((s) => s.showGitHubRepos);
   const toggleGitHubRepos = useUIStore((s) => s.toggleGitHubRepos);
+  const toggleGitHubSync = useUIStore((s) => s.toggleGitHubSync);
+  const setPendingLinkRepo = useUIStore((s) => s.setPendingLinkRepo);
   const isAuthenticated = useAuthStore((s) => s.status) === 'authenticated';
   const authStatus = useAuthStore((s) => s.status);
 
@@ -16,6 +18,8 @@ export function GitHubRepos() {
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [createdRepoFullName, setCreatedRepoFullName] = useState<string | null>(null);
   const [newRepoName, setNewRepoName] = useState('');
   const [newRepoDescription, setNewRepoDescription] = useState('');
   const [isPrivate, setIsPrivate] = useState(true);
@@ -23,23 +27,36 @@ export function GitHubRepos() {
   const cleanedRepoDescription = newRepoDescription.trim();
   const canCreateRepo = isValidGitHubRepoName(cleanedRepoName);
 
-  const fetchRepos = async () => {
+  const fetchRepos = useCallback(async (options?: { rethrow?: boolean }) => {
     setLoading(true);
     setError(null);
     try {
       const response = await apiGet<{ repos: GitHubRepo[] }>('/api/v1/github/repos');
       setRepos(response.repos);
     } catch (err) {
+      if (isAuthError(err)) {
+        const authStore = useAuthStore.getState();
+        authStore.setAnonymous();
+        authStore.setError('Session expired. Please sign in again.');
+        useUIStore.getState().toggleGitHubLogin();
+        if (options?.rethrow) {
+          throw err;
+        }
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to load repositories.');
+      if (options?.rethrow) {
+        throw err;
+      }
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (!show || !isAuthenticated) return;
     void fetchRepos();
-  }, [show, isAuthenticated]);
+  }, [show, isAuthenticated, fetchRepos]);
 
   if (!show) return null;
 
@@ -51,28 +68,49 @@ export function GitHubRepos() {
 
     setCreating(true);
     setError(null);
+    setSuccessMessage(null);
+    setCreatedRepoFullName(null);
     try {
-      await apiPost<GitHubRepo>('/api/v1/github/repos', {
+      const createdRepo = await apiPost<GitHubRepo>('/api/v1/github/repos', {
         name: cleanedRepoName,
         description: cleanedRepoDescription,
         private: isPrivate,
       });
+      setSuccessMessage(`Repository "${cleanedRepoName}" created successfully.`);
+      setCreatedRepoFullName(createdRepo.full_name);
       setNewRepoName('');
       setNewRepoDescription('');
       setIsPrivate(true);
-      await fetchRepos();
+      try {
+        await fetchRepos({ rethrow: true });
+      } catch (refreshError) {
+        setError(refreshError instanceof Error ? refreshError.message : 'Failed to refresh repositories after create.');
+      }
     } catch (err) {
+      if (isAuthError(err)) {
+        const authStore = useAuthStore.getState();
+        authStore.setAnonymous();
+        authStore.setError('Session expired. Please sign in again.');
+        useUIStore.getState().toggleGitHubLogin();
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to create repository.');
     } finally {
       setCreating(false);
     }
   };
 
+  const handleLinkCreatedRepo = () => {
+    if (!createdRepoFullName) return;
+    setPendingLinkRepo(createdRepoFullName);
+    toggleGitHubSync();
+  };
+
   return (
     <div className="github-repos">
       <div className="github-repos-header">
         <h3 className="github-repos-title">📦 GitHub Repos</h3>
-        <button className="github-repos-close" onClick={toggleGitHubRepos} aria-label="Close GitHub repos panel">
+        <button type="button" className="github-repos-close" onClick={toggleGitHubRepos} aria-label="Close GitHub repos panel">
           ✕
         </button>
       </div>
@@ -84,6 +122,16 @@ export function GitHubRepos() {
       ) : (
         <>
           {(loading || creating) && <div className="github-repos-loading">Loading...</div>}
+          {successMessage && (
+            <div className="github-repos-success">
+              <span>{successMessage}</span>
+              {createdRepoFullName && (
+                <button type="button" className="github-repos-link-created-btn" onClick={handleLinkCreatedRepo}>
+                  Link this repo
+                </button>
+              )}
+            </div>
+          )}
           {error && <div className="github-repos-error">{error}</div>}
 
           <div className="github-repos-create">
@@ -111,7 +159,7 @@ export function GitHubRepos() {
               />
               <span>Private repository</span>
             </label>
-            <button className="github-repos-create-btn" onClick={handleCreateRepo} disabled={creating || !canCreateRepo}>
+            <button type="button" className="github-repos-create-btn" onClick={handleCreateRepo} disabled={creating || !canCreateRepo}>
               Create
             </button>
           </div>

--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -5,12 +5,13 @@ vi.mock('../../shared/api/client', () => ({
   apiPost: vi.fn(),
   apiGet: vi.fn(),
   apiPut: vi.fn(),
+  isAuthError: vi.fn(() => false),
 }));
 import { GitHubSync } from './GitHubSync';
 import { useUIStore } from '../../entities/store/uiStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
-import { apiGet, apiPost, apiPut } from '../../shared/api/client';
+import { apiGet, apiPost, apiPut, isAuthError } from '../../shared/api/client';
 import type { ArchitectureModel } from '@cloudblocks/schema';
 
 const emptyArch: ArchitectureModel = {
@@ -28,6 +29,7 @@ describe('GitHubSync', () => {
   const mockApiGet = vi.mocked(apiGet);
   const mockApiPost = vi.mocked(apiPost);
   const mockApiPut = vi.mocked(apiPut);
+  const mockIsAuthError = vi.mocked(isAuthError);
   const replaceArchitectureMock = vi.fn();
 
   beforeEach(() => {
@@ -62,6 +64,7 @@ describe('GitHubSync', () => {
       created_at: '',
       updated_at: '',
     });
+    mockIsAuthError.mockReturnValue(false);
   });
 
   it('renders null when hidden', () => {
@@ -81,6 +84,15 @@ describe('GitHubSync', () => {
     expect(screen.getByText('No GitHub repo linked.')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('owner/repo')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Link' })).toBeInTheDocument();
+  });
+
+  it('prefills repository input from pendingLinkRepo and clears handoff state', () => {
+    useUIStore.setState({ pendingLinkRepo: 'owner/from-create' });
+
+    render(<GitHubSync />);
+
+    expect(screen.getByPlaceholderText('owner/repo')).toHaveValue('owner/from-create');
+    expect(useUIStore.getState().pendingLinkRepo).toBe(null);
   });
 
   it('shows sync and pull buttons when repo linked', async () => {
@@ -183,6 +195,25 @@ describe('GitHubSync', () => {
     await user.click(await screen.findByRole('button', { name: 'Pull from GitHub' }));
 
     expect(await screen.findByText('Network down')).toBeInTheDocument();
+  });
+
+  it('routes auth error to login panel from sync action', async () => {
+    const user = userEvent.setup();
+    const unauthorizedError = new Error('Unauthorized');
+    mockApiPost.mockRejectedValueOnce(unauthorizedError);
+    mockIsAuthError.mockReturnValueOnce(true);
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    await user.click(await screen.findByRole('button', { name: 'Sync to GitHub' }));
+
+    await vi.waitFor(() => {
+      expect(useAuthStore.getState().status).toBe('anonymous');
+    });
+    expect(useAuthStore.getState().error).toBe('Session expired. Please sign in again.');
+    expect(useUIStore.getState().showGitHubLogin).toBe(true);
   });
 
   it('shows error when loadCommits fails', async () => {

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
-import { apiGet, apiPost, apiPut } from '../../shared/api/client';
+import { apiGet, apiPost, apiPut, isAuthError } from '../../shared/api/client';
 import { isValidGitHubRepoFullName } from '../../shared/utils/githubValidation';
 import type { GitHubCommit, PullResponse, SyncResponse } from '../../shared/types/api';
 import type { ArchitectureSnapshot } from '../../shared/types/learning';
@@ -17,6 +17,8 @@ export function GitHubSync() {
   const show = useUIStore((s) => s.showGitHubSync);
   const toggleGitHubSync = useUIStore((s) => s.toggleGitHubSync);
   const toggleGitHubRepos = useUIStore((s) => s.toggleGitHubRepos);
+  const pendingLinkRepo = useUIStore((s) => s.pendingLinkRepo);
+  const setPendingLinkRepo = useUIStore((s) => s.setPendingLinkRepo);
 
   const workspace = useArchitectureStore((s) => s.workspace);
   const replaceArchitecture = useArchitectureStore((s) => s.replaceArchitecture);
@@ -69,6 +71,12 @@ export function GitHubSync() {
     setLinkedRepoState(null);
   }, [workspace.githubRepo, workspace.backendWorkspaceId, workspace.id]);
 
+  useEffect(() => {
+    if (!pendingLinkRepo) return;
+    setRepoInput(pendingLinkRepo);
+    setPendingLinkRepo(null);
+  }, [pendingLinkRepo, setPendingLinkRepo]);
+
   useEffect(() => () => {
     mountedRef.current = false;
     requestSeqRef.current += 1;
@@ -110,6 +118,13 @@ export function GitHubSync() {
       setCommits(response.commits);
     } catch (err) {
       if (!canApply()) return;
+      if (isAuthError(err)) {
+        const authStore = useAuthStore.getState();
+        authStore.setAnonymous();
+        authStore.setError('Session expired. Please sign in again.');
+        useUIStore.getState().toggleGitHubLogin();
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to load commits.');
     } finally {
       if (canApply()) {
@@ -149,6 +164,13 @@ export function GitHubSync() {
       setStoreGithubRepo(workspace.id, cleanedRepo);
       setStoreBackendWorkspaceId(workspace.id, bwsId);
     } catch (err) {
+      if (isAuthError(err)) {
+        const authStore = useAuthStore.getState();
+        authStore.setAnonymous();
+        authStore.setError('Session expired. Please sign in again.');
+        useUIStore.getState().toggleGitHubLogin();
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to link repository.');
     } finally {
       setLinking(false);
@@ -177,6 +199,13 @@ export function GitHubSync() {
       });
       await loadCommits();
     } catch (err) {
+      if (isAuthError(err)) {
+        const authStore = useAuthStore.getState();
+        authStore.setAnonymous();
+        authStore.setError('Session expired. Please sign in again.');
+        useUIStore.getState().toggleGitHubLogin();
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to sync workspace.');
     } finally {
       setSyncing(false);
@@ -195,6 +224,13 @@ export function GitHubSync() {
       replaceArchitecture(response.architecture as ArchitectureSnapshot);
       await loadCommits();
     } catch (err) {
+      if (isAuthError(err)) {
+        const authStore = useAuthStore.getState();
+        authStore.setAnonymous();
+        authStore.setError('Session expired. Please sign in again.');
+        useUIStore.getState().toggleGitHubLogin();
+        return;
+      }
       setError(err instanceof Error ? err.message : 'Failed to pull from GitHub.');
     } finally {
       setPulling(false);


### PR DESCRIPTION
## Summary
- preserve pending GitHub action intent across OAuth redirects via `pendingGitHubAction` persisted in `sessionStorage`, and restore/open the intended panel after successful `checkSession()` on app mount
- keep GitHub login UX stable by explicitly testing sign-out failure behavior (panel stays open and error remains visible)
- add `isAuthError` (401 `ApiError`) and route auth failures in GitHub Sync/PR/Repos back into re-auth flow (`setAnonymous()`, open login panel, and show a session-expired message)

## Validation
- `cd apps/web && pnpm vitest run`
- `cd apps/web && npx tsc -b`
- `pnpm lint`

Fixes #836
Fixes #838
Fixes #867