### PR TITLE
fix(web): iterate all allowedParents in placement validation

### DIFF
--- a/apps/web/src/entities/validation/engine.test.ts
+++ b/apps/web/src/entities/validation/engine.test.ts
@@ -147,7 +147,7 @@ describe('validateArchitecture', () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]).toMatchObject({
-      ruleId: 'rule-data-subnet',
+      ruleId: 'rule-data-parent',
       severity: 'error',
       targetId: 'db-1',
     });

--- a/apps/web/src/entities/validation/placement.test.ts
+++ b/apps/web/src/entities/validation/placement.test.ts
@@ -71,7 +71,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'region', subnetAccess: undefined });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-compute-subnet',
+      ruleId: 'rule-compute-parent',
       severity: 'error',
       message: 'Compute resource "Compute B" must be placed on a Subnet',
       suggestion: 'Move the Compute resource to a Subnet',
@@ -93,7 +93,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'region', subnetAccess: undefined });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-data-subnet',
+      ruleId: 'rule-data-parent',
       severity: 'error',
       message: 'Data resource "Database A" must be placed on a Subnet',
       suggestion: 'Move the Data resource to a Subnet',
@@ -153,7 +153,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'region', subnetAccess: undefined });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-data-subnet',
+      ruleId: 'rule-data-parent',
       severity: 'error',
       message: 'Data resource "Storage A" must be placed on a Subnet',
       suggestion: 'Move the Data resource to a Subnet',
@@ -182,7 +182,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'region', subnetAccess: undefined });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-compute-subnet',
+      ruleId: 'rule-compute-parent',
       severity: 'error',
       message: 'Compute resource "Block" must be placed on a Subnet',
       suggestion: 'Move the Compute resource to a Subnet',
@@ -195,7 +195,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'subnet', subnetAccess: 'public' });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-messaging-region',
+      ruleId: 'rule-messaging-parent',
       severity: 'error',
       message: 'Messaging resource "QueueA" must be placed on a Region container',
       suggestion: 'Move the Messaging resource to a Region container',
@@ -215,7 +215,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'subnet', subnetAccess: 'public' });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-messaging-region',
+      ruleId: 'rule-messaging-parent',
       severity: 'error',
       message: 'Messaging resource "EventA" must be placed on a Region container',
       suggestion: 'Move the Messaging resource to a Region container',
@@ -235,7 +235,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'region', subnetAccess: undefined });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-operations-subnet',
+      ruleId: 'rule-operations-parent',
       severity: 'error',
       message: 'Operations resource "AnalyticsA" must be placed on a Subnet',
       suggestion: 'Move the Operations resource to a Subnet',
@@ -248,7 +248,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'region', subnetAccess: undefined });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-security-subnet',
+      ruleId: 'rule-security-parent',
       severity: 'error',
       message: 'Security resource "IdentityA" must be placed on a Subnet',
       suggestion: 'Move the Security resource to a Subnet',
@@ -261,7 +261,7 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'region', subnetAccess: undefined });
 
     expect(validatePlacement(block, plate)).toEqual({
-      ruleId: 'rule-operations-subnet',
+      ruleId: 'rule-operations-parent',
       severity: 'error',
       message: 'Operations resource "ObservabilityA" must be placed on a Subnet',
       suggestion: 'Move the Operations resource to a Subnet',
@@ -288,6 +288,32 @@ describe('validatePlacement', () => {
     const plate = makePlate({ type: 'subnet', subnetAccess: 'public' });
 
     expect(validatePlacement(block, plate)).toBeNull();
+  });
+
+  it('uses Set-based allowed layers: each category checks all valid parent layers', () => {
+    const computeBlock = makeBlock({ id: 'vm-1', name: 'VM', category: 'compute' });
+    const msgBlock = makeBlock({ id: 'mq-1', name: 'Queue', category: 'messaging' });
+
+    const subnet = makePlate({ type: 'subnet', subnetAccess: 'public' });
+    const region = makePlate({ type: 'region', subnetAccess: undefined });
+
+    expect(validatePlacement(computeBlock, subnet)).toBeNull();
+    expect(validatePlacement(computeBlock, region)).toEqual({
+      ruleId: 'rule-compute-parent',
+      severity: 'error',
+      message: 'Compute resource "VM" must be placed on a Subnet',
+      suggestion: 'Move the Compute resource to a Subnet',
+      targetId: 'vm-1',
+    });
+
+    expect(validatePlacement(msgBlock, region)).toBeNull();
+    expect(validatePlacement(msgBlock, subnet)).toEqual({
+      ruleId: 'rule-messaging-parent',
+      severity: 'error',
+      message: 'Messaging resource "Queue" must be placed on a Region container',
+      suggestion: 'Move the Messaging resource to a Region container',
+      targetId: 'mq-1',
+    });
   });
 });
 

--- a/apps/web/src/entities/validation/placement.ts
+++ b/apps/web/src/entities/validation/placement.ts
@@ -37,34 +37,38 @@ const PARENT_RESOURCE_TYPE_TO_LAYER: Record<string, LayerType> = {
 };
 
 /**
- * Build a map of category → required parent layer from RESOURCE_RULES.
+ * Build a map of category → allowed parent layers from RESOURCE_RULES.
  * Only non-container resource types are included (containers don't need placement validation).
  *
- * For each category, we pick the first allowedParents entry and map it to a layer.
- * If all resources in a category have the same allowedParents, the result is deterministic.
+ * For each category, we collect ALL allowedParents entries and map them to layers,
+ * so resources allowed in multiple parent types are correctly validated.
  */
-function buildCategoryPlacementMap(): Map<ResourceCategory, LayerType> {
-  const map = new Map<ResourceCategory, LayerType>();
+function buildCategoryPlacementMap(): Map<ResourceCategory, Set<LayerType>> {
+  const map = new Map<ResourceCategory, Set<LayerType>>();
   const rules = RESOURCE_RULES as Record<string, ResourceRuleEntry>;
 
   for (const [, rule] of Object.entries(rules)) {
-    if (rule.containerCapable) continue; // Skip containers
-    if (map.has(rule.category)) continue; // First rule per category wins
+    if (rule.containerCapable) continue;
 
-    const parentType = rule.allowedParents[0];
-    if (parentType === null) continue; // Root-level resources don't need placement validation
+    if (!map.has(rule.category)) {
+      map.set(rule.category, new Set<LayerType>());
+    }
 
-    const layer = PARENT_RESOURCE_TYPE_TO_LAYER[parentType];
-    if (layer) {
-      map.set(rule.category, layer);
+    const layers = map.get(rule.category)!;
+    for (const parentType of rule.allowedParents) {
+      if (parentType === null) continue;
+      const layer = PARENT_RESOURCE_TYPE_TO_LAYER[parentType];
+      if (layer) {
+        layers.add(layer);
+      }
     }
   }
 
   return map;
 }
 
-/** Category → required parent layer, derived from RESOURCE_RULES. */
-const CATEGORY_REQUIRED_PARENT_LAYER = buildCategoryPlacementMap();
+/** Category → allowed parent layers, derived from RESOURCE_RULES. */
+const CATEGORY_ALLOWED_PARENT_LAYERS = buildCategoryPlacementMap();
 
 // ---------------------------------------------------------------------------
 // Placement validation
@@ -99,15 +103,15 @@ export function validatePlacement(
   }
 
   // ── RESOURCE_RULES-driven placement check ──
-  const requiredLayer = CATEGORY_REQUIRED_PARENT_LAYER.get(resource.category);
-  if (requiredLayer && parent.layer !== requiredLayer) {
-    const layerLabel = requiredLayer === 'subnet' ? 'Subnet' : 'Region container';
+  const allowedLayers = CATEGORY_ALLOWED_PARENT_LAYERS.get(resource.category);
+  if (allowedLayers && allowedLayers.size > 0 && !allowedLayers.has(parent.layer as LayerType)) {
+    const layerLabels = [...allowedLayers].map((l) => l === 'subnet' ? 'Subnet' : 'Region container');
     const cat = resource.category.charAt(0).toUpperCase() + resource.category.slice(1);
     return {
-      ruleId: `rule-${resource.category}-${requiredLayer}`,
+      ruleId: `rule-${resource.category}-parent`,
       severity: 'error',
-      message: `${cat} resource "${resource.name}" must be placed on a ${layerLabel}`,
-      suggestion: `Move the ${cat} resource to a ${layerLabel}`,
+      message: `${cat} resource "${resource.name}" must be placed on a ${layerLabels.join(' or ')}`,
+      suggestion: `Move the ${cat} resource to a ${layerLabels.join(' or ')}`,
       targetId: resource.id,
     };
   }


### PR DESCRIPTION
## Summary
- Fix `buildCategoryPlacementMap()` to iterate **all** `allowedParents` entries instead of only `allowedParents[0]`
- Change return type from `Map<ResourceCategory, LayerType>` to `Map<ResourceCategory, Set<LayerType>>` so categories with resources spanning multiple valid parent types are correctly validated
- Update ruleId format from `rule-{category}-{layer}` to `rule-{category}-parent` for consistency
- Add new test case validating Set-based cross-category parent layer checks

Fixes #1145