### PR TITLE
fix(web): block same-branch PR, handle branch collisions, confirm dirty close (#842, #843, #857)

### DIFF
--- a/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.test.tsx
@@ -10,11 +10,15 @@ vi.mock('../../shared/api/client', () => ({
     return fallback;
   }),
 }));
+vi.mock('../../shared/ui/ConfirmDialog', () => ({
+  confirmDialog: vi.fn(),
+}));
 import { GitHubPR } from './GitHubPR';
 import { useUIStore } from '../../entities/store/uiStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { apiPost, isAuthError } from '../../shared/api/client';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import type { ArchitectureModel } from '@cloudblocks/schema';
 
 const emptyArch: ArchitectureModel = {
@@ -31,6 +35,7 @@ const emptyArch: ArchitectureModel = {
 describe('GitHubPR', () => {
   const mockApiPost = vi.mocked(apiPost);
   const mockIsAuthError = vi.mocked(isAuthError);
+  const mockConfirmDialog = vi.mocked(confirmDialog);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,6 +57,7 @@ describe('GitHubPR', () => {
       },
     });
     mockIsAuthError.mockReturnValue(false);
+    mockConfirmDialog.mockResolvedValue(true);
   });
 
   it('renders null when hidden', () => {
@@ -199,6 +205,17 @@ describe('GitHubPR', () => {
     expect(screen.getByText('Branch name contains invalid characters or format.')).toBeInTheDocument();
   });
 
+  it('disables submit and shows error when branch matches base branch fallback', async () => {
+    const user = userEvent.setup();
+    render(<GitHubPR />);
+
+    const branchField = screen.getByLabelText('Branch name (optional)');
+    await user.type(branchField, 'main');
+
+    expect(screen.getByRole('button', { name: 'Create Pull Request' })).toBeDisabled();
+    expect(screen.getByText('Head branch must differ from base branch (main/master).')).toBeInTheDocument();
+  });
+
 
   it('trims PR title before submission', async () => {
     const user = userEvent.setup();
@@ -234,10 +251,58 @@ describe('GitHubPR', () => {
     resolvePost({ pull_request_url: 'https://github.com/owner/repo/pull/42', number: 42, branch: 'main' });
   });
 
-  it('close button toggles panel', async () => {
+  it('shows actionable branch collision error when backend reports existing branch', async () => {
+    const user = userEvent.setup();
+    mockApiPost.mockRejectedValue(new Error('branch already exists'));
+
+    render(<GitHubPR />);
+    await user.type(screen.getByLabelText('Branch name (optional)'), 'feature/existing-branch');
+    await user.click(screen.getByRole('button', { name: 'Create Pull Request' }));
+
+    expect(
+      await screen.findByText("Branch 'feature/existing-branch' already exists. Please choose a different branch name.")
+    ).toBeInTheDocument();
+  });
+
+  it('close button toggles panel without confirmation when form is clean', async () => {
     const user = userEvent.setup();
     render(<GitHubPR />);
     await user.click(screen.getByRole('button', { name: 'Close pull request panel' }));
+    expect(mockConfirmDialog).not.toHaveBeenCalled();
+    expect(useUIStore.getState().showGitHubPR).toBe(false);
+  });
+
+  it('prompts before closing when form has unsaved edits and keeps panel open on cancel', async () => {
+    const user = userEvent.setup();
+    mockConfirmDialog.mockResolvedValue(false);
+    render(<GitHubPR />);
+
+    await user.type(screen.getByLabelText('Body (optional)'), 'Draft body');
+    await user.click(screen.getByRole('button', { name: 'Close pull request panel' }));
+
+    await waitFor(() => {
+      expect(mockConfirmDialog).toHaveBeenCalledWith(
+        'You have unsaved edits in the PR form. Discard them?',
+        'Discard Draft?'
+      );
+    });
+    expect(useUIStore.getState().showGitHubPR).toBe(true);
+  });
+
+  it('closes panel when user confirms discard on dirty form', async () => {
+    const user = userEvent.setup();
+    mockConfirmDialog.mockResolvedValue(true);
+    render(<GitHubPR />);
+
+    await user.type(screen.getByLabelText('Branch name (optional)'), 'feature/draft');
+    await user.click(screen.getByRole('button', { name: 'Close pull request panel' }));
+
+    await waitFor(() => {
+      expect(mockConfirmDialog).toHaveBeenCalledWith(
+        'You have unsaved edits in the PR form. Discard them?',
+        'Discard Draft?'
+      );
+    });
     expect(useUIStore.getState().showGitHubPR).toBe(false);
   });
 

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -3,9 +3,23 @@ import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { apiPost, getApiErrorMessage, isAuthError } from '../../shared/api/client';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import { isValidGitBranchName } from '../../shared/utils/githubValidation';
 import type { PullRequestResponse } from '../../shared/types/api';
 import './GitHubPR.css';
+
+const DEFAULT_TITLE = 'Update cloud architecture';
+const DEFAULT_BODY = '';
+const DEFAULT_BRANCH = '';
+const DEFAULT_COMMIT_MESSAGE = 'Update architecture via CloudBlocks';
+const FALLBACK_BASE_BRANCHES = ['main', 'master'];
+
+type WorkspaceBranchInfo = {
+  githubBranch?: string;
+  github_branch?: string;
+  defaultBranch?: string;
+  default_branch?: string;
+};
 
 export function GitHubPR() {
   const show = useUIStore((s) => s.showGitHubPR);
@@ -16,18 +30,41 @@ export function GitHubPR() {
   const workspace = useArchitectureStore((s) => s.workspace);
   const hasBackendWorkspaceLink = Boolean(workspace.backendWorkspaceId);
 
-  const [title, setTitle] = useState('Update cloud architecture');
-  const [body, setBody] = useState('');
-  const [branch, setBranch] = useState('');
-  const [commitMessage, setCommitMessage] = useState('Update architecture via CloudBlocks');
+  const [title, setTitle] = useState(DEFAULT_TITLE);
+  const [body, setBody] = useState(DEFAULT_BODY);
+  const [branch, setBranch] = useState(DEFAULT_BRANCH);
+  const [commitMessage, setCommitMessage] = useState(DEFAULT_COMMIT_MESSAGE);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<PullRequestResponse | null>(null);
   const cleanedTitle = title.trim();
   const cleanedBranch = branch.trim();
   const cleanedCommitMessage = commitMessage.trim();
+  const workspaceBranchInfo = workspace as WorkspaceBranchInfo;
+  const workspaceBaseBranch = workspaceBranchInfo.githubBranch
+    ?? workspaceBranchInfo.github_branch
+    ?? workspaceBranchInfo.defaultBranch
+    ?? workspaceBranchInfo.default_branch
+    ?? null;
+  const candidateBaseBranches = [workspaceBaseBranch, ...FALLBACK_BASE_BRANCHES]
+    .filter((candidate): candidate is string => Boolean(candidate?.trim()))
+    .map((candidate) => candidate.trim().toLowerCase());
+  const branchMatchesBase = cleanedBranch.length > 0
+    && candidateBaseBranches.includes(cleanedBranch.toLowerCase());
+  const branchMatchesBaseError = branchMatchesBase
+    ? `Head branch must differ from base branch (${workspaceBaseBranch ?? 'main/master'}).`
+    : null;
   const branchIsValid = !cleanedBranch || isValidGitBranchName(cleanedBranch);
-  const canSubmit = !loading && cleanedTitle.length > 0 && cleanedCommitMessage.length > 0 && branchIsValid && hasBackendWorkspaceLink;
+  const isDirty = title !== DEFAULT_TITLE
+    || body !== DEFAULT_BODY
+    || branch !== DEFAULT_BRANCH
+    || commitMessage !== DEFAULT_COMMIT_MESSAGE;
+  const canSubmit = !loading
+    && cleanedTitle.length > 0
+    && cleanedCommitMessage.length > 0
+    && branchIsValid
+    && !branchMatchesBase
+    && hasBackendWorkspaceLink;
 
   if (!show) return null;
 
@@ -43,6 +80,10 @@ export function GitHubPR() {
     }
     if (cleanedBranch && !isValidGitBranchName(cleanedBranch)) {
       setError('Branch name contains invalid characters or format.');
+      return;
+    }
+    if (branchMatchesBase) {
+      setError(branchMatchesBaseError);
       return;
     }
     if (!cleanedCommitMessage) {
@@ -73,9 +114,36 @@ export function GitHubPR() {
         useUIStore.getState().toggleGitHubLogin();
         return;
       }
-      setError(getApiErrorMessage(err, 'Failed to create pull request.'));
+      const apiErrorMessage = getApiErrorMessage(err, 'Failed to create pull request.');
+      const lowerApiError = apiErrorMessage.toLowerCase();
+      const branchAlreadyExists = lowerApiError.includes('branch already exists')
+        || (lowerApiError.includes('already exists') && lowerApiError.includes('branch'))
+        || lowerApiError.includes('reference already exists')
+        || lowerApiError.includes('ref already exists');
+
+      if (branchAlreadyExists) {
+        const branchLabel = cleanedBranch ? `Branch '${cleanedBranch}'` : 'A branch with this name';
+        setError(`${branchLabel} already exists. Please choose a different branch name.`);
+      } else {
+        setError(apiErrorMessage);
+      }
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handleClose = async () => {
+    if (!isDirty) {
+      toggleGitHubPR();
+      return;
+    }
+
+    const shouldClose = await confirmDialog(
+      'You have unsaved edits in the PR form. Discard them?',
+      'Discard Draft?'
+    );
+    if (shouldClose) {
+      toggleGitHubPR();
     }
   };
 
@@ -83,7 +151,7 @@ export function GitHubPR() {
     <div className="github-pr">
       <div className="github-pr-header">
         <h3 className="github-pr-title">🔀 Pull Request</h3>
-        <button type="button" className="github-pr-close" onClick={toggleGitHubPR} aria-label="Close pull request panel">
+        <button type="button" className="github-pr-close" onClick={() => void handleClose()} aria-label="Close pull request panel">
           ✕
         </button>
       </div>
@@ -131,6 +199,7 @@ export function GitHubPR() {
             placeholder="cloudblocks/update-architecture"
           />
           {!branchIsValid && <div className="github-pr-error">Branch name contains invalid characters or format.</div>}
+          {branchMatchesBaseError && <div className="github-pr-error">{branchMatchesBaseError}</div>}
 
           <label className="github-pr-label" htmlFor="github-pr-commit-message">
             Commit message


### PR DESCRIPTION
## Summary
- block PR creation when the entered head branch matches the detected base branch (workspace branch metadata if present, otherwise `main`/`master`) and surface an inline validation error.
- parse backend branch-collision failures and show an actionable message that tells users to choose a different branch name.
- prompt for confirmation before closing the PR panel when the form has unsaved edits.

## Testing
- pnpm lint
- pnpm build
- pnpm --filter @cloudblocks/web test:coverage (Branches: 90.07%)

Fixes #842
Fixes #843
Fixes #857