### PR TITLE
fix(web): add sync dirty indicator, safe close during ops, post-pull diff+undo (#854, #858, #864)

### DIFF
--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -1,17 +1,29 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 vi.mock('../../shared/api/client', () => ({
   apiPost: vi.fn(),
   apiGet: vi.fn(),
   apiPut: vi.fn(),
   isAuthError: vi.fn(() => false),
 }));
+
+vi.mock('../../shared/ui/ConfirmDialog', () => ({
+  confirmDialog: vi.fn(),
+}));
+
+vi.mock('../../features/diff/engine', () => ({
+  computeArchitectureDiff: vi.fn(),
+}));
+
 import { GitHubSync } from './GitHubSync';
 import { useUIStore } from '../../entities/store/uiStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { apiGet, apiPost, apiPut, isAuthError } from '../../shared/api/client';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
+import { computeArchitectureDiff } from '../../features/diff/engine';
 import type { ArchitectureModel } from '@cloudblocks/schema';
 
 const emptyArch: ArchitectureModel = {
@@ -30,6 +42,8 @@ describe('GitHubSync', () => {
   const mockApiPost = vi.mocked(apiPost);
   const mockApiPut = vi.mocked(apiPut);
   const mockIsAuthError = vi.mocked(isAuthError);
+  const mockConfirmDialog = vi.mocked(confirmDialog);
+  const mockComputeArchitectureDiff = vi.mocked(computeArchitectureDiff);
   const replaceArchitectureMock = vi.fn();
 
   beforeEach(() => {
@@ -65,6 +79,15 @@ describe('GitHubSync', () => {
       updated_at: '',
     });
     mockIsAuthError.mockReturnValue(false);
+    mockConfirmDialog.mockResolvedValue(true);
+    mockComputeArchitectureDiff.mockReturnValue({
+      plates: { added: [], removed: [], modified: [] },
+      blocks: { added: [], removed: [], modified: [] },
+      connections: { added: [], removed: [], modified: [] },
+      externalActors: { added: [], removed: [], modified: [] },
+      rootChanges: [],
+      summary: { totalChanges: 0, hasBreakingChanges: false },
+    } as ReturnType<typeof computeArchitectureDiff>);
   });
 
   it('renders null when hidden', () => {
@@ -128,6 +151,43 @@ describe('GitHubSync', () => {
         commit_message: 'Sync architecture from CloudBlocks',
       });
     });
+  });
+
+  it('shows in-sync indicator after successful sync', async () => {
+    const user = userEvent.setup();
+    mockApiPost.mockResolvedValue({ message: 'ok', commit_sha: 'abc123' });
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    await user.click(await screen.findByRole('button', { name: 'Sync to GitHub' }));
+
+    expect(await screen.findByText('✅ In sync')).toBeInTheDocument();
+  });
+
+  it('shows local-changes indicator when architecture changes after sync', async () => {
+    const user = userEvent.setup();
+    mockApiPost.mockResolvedValue({ message: 'ok', commit_sha: 'abc123' });
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    await user.click(await screen.findByRole('button', { name: 'Sync to GitHub' }));
+    await screen.findByText('✅ In sync');
+
+    useArchitectureStore.setState((state) => ({
+      workspace: {
+        ...state.workspace,
+        architecture: {
+          ...state.workspace.architecture,
+          name: 'Changed after sync',
+        },
+      },
+    }));
+
+    expect(await screen.findByText('⚠️ Local changes since last sync')).toBeInTheDocument();
   });
 
   it('shows error when link repo with invalid format', async () => {
@@ -420,6 +480,103 @@ describe('GitHubSync', () => {
     render(<GitHubSync />);
     await user.click(screen.getByRole('button', { name: 'Close GitHub sync panel' }));
     expect(useUIStore.getState().showGitHubSync).toBe(false);
+  });
+
+  it('asks for confirmation before closing when operation is in progress', async () => {
+    const user = userEvent.setup();
+    let resolveSync!: (value: unknown) => void;
+    mockApiPost.mockReturnValueOnce(new Promise((resolve) => {
+      resolveSync = resolve;
+    }));
+    mockConfirmDialog.mockResolvedValueOnce(false);
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    await user.click(await screen.findByRole('button', { name: 'Sync to GitHub' }));
+    await user.click(screen.getByRole('button', { name: 'Close GitHub sync panel' }));
+
+    expect(mockConfirmDialog).toHaveBeenCalledWith(
+      'An operation is in progress. Closing may hide the result. Close anyway?',
+      'Close GitHub Sync?'
+    );
+    expect(useUIStore.getState().showGitHubSync).toBe(true);
+    resolveSync({ message: 'ok', commit_sha: 'abc' });
+  });
+
+  it('closes immediately when not busy without confirmation dialog', async () => {
+    const user = userEvent.setup();
+    render(<GitHubSync />);
+
+    await user.click(screen.getByRole('button', { name: 'Close GitHub sync panel' }));
+
+    expect(mockConfirmDialog).not.toHaveBeenCalled();
+    expect(useUIStore.getState().showGitHubSync).toBe(false);
+  });
+
+  it('shows post-pull diff summary', async () => {
+    const user = userEvent.setup();
+    const pulledArchitecture = {
+      nodes: [],
+      connections: [],
+      externalActors: [],
+      name: 'Pulled architecture',
+      version: '1.0.0',
+    };
+    mockApiPost.mockResolvedValueOnce({ architecture: pulledArchitecture });
+    mockComputeArchitectureDiff.mockReturnValueOnce({
+      plates: { added: [{ id: 'plate-1' }], removed: [], modified: [] },
+      blocks: { added: [{ id: 'block-1' }], removed: [], modified: [] },
+      connections: { added: [], removed: [], modified: [] },
+      externalActors: { added: [], removed: [], modified: [] },
+      rootChanges: [],
+      summary: { totalChanges: 2, hasBreakingChanges: false },
+    } as unknown as ReturnType<typeof computeArchitectureDiff>);
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    await user.click(await screen.findByRole('button', { name: 'Pull from GitHub' }));
+
+    expect(await screen.findByText('Pulled: 2 changes (1/0 plates added/removed, 1/0 blocks added/removed)')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Undo Pull' })).toBeInTheDocument();
+  });
+
+  it('undo pull restores pre-pull architecture snapshot', async () => {
+    const user = userEvent.setup();
+    const pulledArchitecture = {
+      nodes: [],
+      connections: [],
+      externalActors: [],
+      name: 'Pulled architecture',
+      version: '1.0.0',
+    };
+    mockApiPost.mockResolvedValueOnce({ architecture: pulledArchitecture });
+    mockComputeArchitectureDiff.mockReturnValueOnce({
+      plates: { added: [], removed: [], modified: [] },
+      blocks: { added: [], removed: [], modified: [] },
+      connections: { added: [], removed: [], modified: [] },
+      externalActors: { added: [], removed: [], modified: [] },
+      rootChanges: [],
+      summary: { totalChanges: 0, hasBreakingChanges: false },
+    } as ReturnType<typeof computeArchitectureDiff>);
+
+    render(<GitHubSync />);
+
+    await user.type(screen.getByPlaceholderText('owner/repo'), 'owner/repo-one');
+    await user.click(screen.getByRole('button', { name: 'Link' }));
+    await user.click(await screen.findByRole('button', { name: 'Pull from GitHub' }));
+    await user.click(await screen.findByRole('button', { name: 'Undo Pull' }));
+
+    expect(replaceArchitectureMock).toHaveBeenNthCalledWith(2, {
+      name: 'Test',
+      version: '1.0.0',
+      nodes: [],
+      connections: [],
+      externalActors: [],
+    });
   });
 
   it('open GitHub repos button toggles repos panel', async () => {

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -2,15 +2,27 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { computeArchitectureDiff } from '../../features/diff/engine';
 import { apiGet, apiPost, apiPut, isAuthError } from '../../shared/api/client';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import { isValidGitHubRepoFullName } from '../../shared/utils/githubValidation';
 import type { GitHubCommit, PullResponse, SyncResponse } from '../../shared/types/api';
+import type { ArchitectureModel } from '@cloudblocks/schema';
 import type { ArchitectureSnapshot } from '../../shared/types/learning';
 import './GitHubSync.css';
 
 interface LinkedRepoState {
   repo: string;
   backendWorkspaceId: string;
+}
+
+function cloneArchitecture<T>(architecture: T): T {
+  return JSON.parse(JSON.stringify(architecture)) as T;
+}
+
+function toArchitectureSnapshot(architecture: ArchitectureModel): ArchitectureSnapshot {
+  const { id: _id, createdAt: _createdAt, updatedAt: _updatedAt, ...snapshot } = architecture;
+  return cloneArchitecture(snapshot);
 }
 
 export function GitHubSync() {
@@ -48,6 +60,8 @@ export function GitHubSync() {
   const [pulling, setPulling] = useState(false);
   const [loadingCommits, setLoadingCommits] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [lastSyncedArchitecture, setLastSyncedArchitecture] = useState<ArchitectureModel | null>(null);
+  const [pullDiffSummary, setPullDiffSummary] = useState<string | null>(null);
   const requestSeqRef = useRef(0);
   const mountedRef = useRef(true);
   const showRef = useRef(show);
@@ -55,9 +69,12 @@ export function GitHubSync() {
   const workspaceIdRef = useRef(workspace.id);
   const linkedRepoRef = useRef(linkedRepo);
   const effectiveWorkspaceIdRef = useRef<string | null>(null);
+  const prePullArchitectureRef = useRef<ArchitectureSnapshot | null>(null);
 
   const trimmedCommitMessage = commitMessage.trim();
   const busy = linking || syncing || pulling;
+  const isDirtySinceLastSync = lastSyncedArchitecture !== null
+    && JSON.stringify(workspace.architecture) !== JSON.stringify(lastSyncedArchitecture);
 
   useEffect(() => {
     if (workspace.githubRepo) {
@@ -154,6 +171,7 @@ export function GitHubSync() {
 
     setLinking(true);
     setError(null);
+    setPullDiffSummary(null);
 
     try {
       await apiPut(`/api/v1/workspaces/${encodeURIComponent(bwsId)}`, {
@@ -184,6 +202,9 @@ export function GitHubSync() {
     setBackendWorkspaceIdInput('');
     setCommits([]);
     setError(null);
+    setLastSyncedArchitecture(null);
+    setPullDiffSummary(null);
+    prePullArchitectureRef.current = null;
     setStoreGithubRepo(workspace.id, undefined);
   };
 
@@ -192,11 +213,13 @@ export function GitHubSync() {
 
     setSyncing(true);
     setError(null);
+    setPullDiffSummary(null);
     try {
       await apiPost<SyncResponse>(`/api/v1/workspaces/${encodeURIComponent(effectiveWorkspaceId)}/sync`, {
         architecture: workspace.architecture,
         commit_message: trimmedCommitMessage,
       });
+      setLastSyncedArchitecture(cloneArchitecture(workspace.architecture));
       await loadCommits();
     } catch (err) {
       if (isAuthError(err)) {
@@ -217,11 +240,22 @@ export function GitHubSync() {
 
     setPulling(true);
     setError(null);
+    setPullDiffSummary(null);
     try {
+      const prePullArchitecture = cloneArchitecture(workspace.architecture);
+      prePullArchitectureRef.current = toArchitectureSnapshot(prePullArchitecture);
       const response = await apiPost<PullResponse>(
         `/api/v1/workspaces/${encodeURIComponent(effectiveWorkspaceId)}/pull`
       );
       replaceArchitecture(response.architecture as ArchitectureSnapshot);
+      const postPullArchitecture = useArchitectureStore.getState().workspace.architecture;
+      const diff = computeArchitectureDiff(prePullArchitecture, postPullArchitecture);
+      setLastSyncedArchitecture(cloneArchitecture(postPullArchitecture));
+      setPullDiffSummary(
+        `Pulled: ${diff.summary.totalChanges} changes `
+          + `(${diff.plates.added.length}/${diff.plates.removed.length} plates added/removed, `
+          + `${diff.blocks.added.length}/${diff.blocks.removed.length} blocks added/removed)`
+      );
       await loadCommits();
     } catch (err) {
       if (isAuthError(err)) {
@@ -237,11 +271,33 @@ export function GitHubSync() {
     }
   };
 
+  const handleUndoPull = () => {
+    const prePullArchitecture = prePullArchitectureRef.current;
+    if (!prePullArchitecture) return;
+    replaceArchitecture(prePullArchitecture);
+    setPullDiffSummary(null);
+  };
+
+  const handleClose = async () => {
+    if (!busy) {
+      toggleGitHubSync();
+      return;
+    }
+
+    const shouldClose = await confirmDialog(
+      'An operation is in progress. Closing may hide the result. Close anyway?',
+      'Close GitHub Sync?'
+    );
+    if (shouldClose) {
+      toggleGitHubSync();
+    }
+  };
+
   return (
     <div className="github-sync">
       <div className="github-sync-header">
         <h3 className="github-sync-title">🔄 GitHub Sync</h3>
-        <button type="button" className="github-sync-close" onClick={toggleGitHubSync} aria-label="Close GitHub sync panel">
+        <button type="button" className="github-sync-close" onClick={() => void handleClose()} aria-label="Close GitHub sync panel">
           ✕
         </button>
       </div>
@@ -296,9 +352,28 @@ export function GitHubSync() {
               <div className="github-sync-meta">
                 Linked repo: <strong>{linkedRepo}</strong>
               </div>
+              <div className="github-sync-reconciliation">
+                {lastSyncedArchitecture !== null && !isDirtySinceLastSync
+                  ? '✅ In sync'
+                  : '⚠️ Local changes since last sync'}
+              </div>
               <button type="button" className="github-sync-secondary-btn" onClick={handleUnlink} disabled={busy}>
                 Unlink
               </button>
+
+              {pullDiffSummary && (
+                <div className="github-sync-arch-summary">
+                  <div>{pullDiffSummary}</div>
+                  <div className="github-sync-actions">
+                    <button type="button" className="github-sync-secondary-btn" onClick={handleUndoPull} disabled={busy}>
+                      Undo Pull
+                    </button>
+                    <button type="button" className="github-sync-secondary-btn" onClick={() => setPullDiffSummary(null)} disabled={busy}>
+                      Dismiss
+                    </button>
+                  </div>
+                </div>
+              )}
 
               <label className="github-sync-label" htmlFor="github-sync-commit-message">
                 Commit message


### PR DESCRIPTION
## Summary
- Track local dirty state against a last-synced architecture snapshot and surface an inline sync status indicator in GitHub Sync.
- Protect panel closure during in-flight link/sync/pull operations by using the shared `confirmDialog` flow.
- Add post-pull diff summary with dismiss + Undo Pull actions, plus regression tests for dirty state, safe close, and pull diff/undo behavior.

## Verification
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm --filter @cloudblocks/web test:coverage` (Branches: 90.26%)

Fixes #854
Fixes #858
Fixes #864