### PR TITLE
test(web): add AI API client unit tests

### DIFF
--- a/apps/web/src/features/ai/api.test.ts
+++ b/apps/web/src/features/ai/api.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { generateArchitecture, suggestImprovements, estimateCost } from './api';
+import type { GenerateRequest, SuggestRequest, CostRequest, GenerateResponse, SuggestResponse, CostResponse } from './api';
+
+vi.mock('../../shared/api/client', () => ({
+  apiPost: vi.fn(),
+}));
+
+import { apiPost } from '../../shared/api/client';
+
+const mockedApiPost = vi.mocked(apiPost);
+
+describe('AI API client', () => {
+  it('generateArchitecture calls apiPost with correct path and payload', async () => {
+    const mockResponse: GenerateResponse = {
+      architecture: { id: 'gen-1' },
+      explanation: 'Created a VNet',
+      warnings: [],
+    };
+    mockedApiPost.mockResolvedValueOnce(mockResponse);
+
+    const req: GenerateRequest = { prompt: 'create a VNet', provider: 'azure' };
+    const result = await generateArchitecture(req);
+
+    expect(mockedApiPost).toHaveBeenCalledWith('/api/v1/ai/generate', req);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('suggestImprovements calls apiPost with correct path and payload', async () => {
+    const mockResponse: SuggestResponse = {
+      suggestions: [
+        {
+          category: 'security',
+          severity: 'high',
+          message: 'Add NSG',
+          action_description: 'Add a network security group',
+        },
+      ],
+      score: { security: 0.5 },
+    };
+    mockedApiPost.mockResolvedValueOnce(mockResponse);
+
+    const req: SuggestRequest = {
+      architecture: { nodes: [] },
+      provider: 'azure',
+    };
+    const result = await suggestImprovements(req);
+
+    expect(mockedApiPost).toHaveBeenCalledWith('/api/v1/ai/suggest', req);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('estimateCost calls apiPost with correct path and payload', async () => {
+    const mockResponse: CostResponse = {
+      monthly_cost: 150.0,
+      hourly_cost: 0.21,
+      currency: 'USD',
+      resources: [
+        { name: 'VM', monthly_cost: 100.0, details: {} },
+        { name: 'Storage', monthly_cost: 50.0, details: {} },
+      ],
+    };
+    mockedApiPost.mockResolvedValueOnce(mockResponse);
+
+    const req: CostRequest = {
+      architecture: { nodes: [] },
+      provider: 'azure',
+    };
+    const result = await estimateCost(req);
+
+    expect(mockedApiPost).toHaveBeenCalledWith('/api/v1/ai/cost', req);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('propagates errors from apiPost', async () => {
+    mockedApiPost.mockRejectedValueOnce(new Error('Network request failed'));
+
+    const req: GenerateRequest = { prompt: 'test', provider: 'azure' };
+
+    await expect(generateArchitecture(req)).rejects.toThrow('Network request failed');
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for all 3 AI API client wrapper functions (`generateArchitecture`, `suggestImprovements`, `estimateCost`)
- Test error propagation from `apiPost`
- 4 tests, 82 lines — mocks `apiPost` via `vi.mock`

## Coverage Impact
- `ai/api.ts`: Functions 0% → 100%, Lines 0% → 100%
- Overall branch coverage: 90.43% → 90.45% (stays above 90% threshold)

Fixes #1149