### PR TITLE
fix(web): neutral IaC labels, Advanced toggle, compare chain guards, PR prefill

### DIFF
--- a/apps/web/src/entities/store/uiStore.test.ts
+++ b/apps/web/src/entities/store/uiStore.test.ts
@@ -15,6 +15,7 @@ describe('useUIStore', () => {
       showResourceGuide: true,
       showValidation: false,
       showCodePreview: false,
+      showAdvancedGeneration: false,
       showWorkspaceManager: false,
       showTemplateGallery: false,
       showGitHubLogin: false,
@@ -46,6 +47,7 @@ describe('useUIStore', () => {
       expect(state.showResourceGuide).toBe(true);
       expect(state.showValidation).toBe(false);
       expect(state.showCodePreview).toBe(false);
+      expect(state.showAdvancedGeneration).toBe(false);
       expect(state.showWorkspaceManager).toBe(false);
       expect(state.showTemplateGallery).toBe(false);
       expect(state.showGitHubLogin).toBe(false);
@@ -546,6 +548,20 @@ describe('useUIStore', () => {
       expect(useUIStore.getState().showCodePreview).toBe(true);
       useUIStore.getState().toggleCodePreview();
       expect(useUIStore.getState().showCodePreview).toBe(false);
+    });
+  });
+
+  describe('toggleAdvancedGeneration', () => {
+    it('should toggle showAdvancedGeneration from false to true', () => {
+      expect(useUIStore.getState().showAdvancedGeneration).toBe(false);
+      useUIStore.getState().toggleAdvancedGeneration();
+      expect(useUIStore.getState().showAdvancedGeneration).toBe(true);
+    });
+
+    it('should toggle showAdvancedGeneration back from true to false', () => {
+      useUIStore.getState().toggleAdvancedGeneration();
+      useUIStore.getState().toggleAdvancedGeneration();
+      expect(useUIStore.getState().showAdvancedGeneration).toBe(false);
     });
   });
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -82,6 +82,8 @@ interface UIState {
   toggleValidation: () => void;
   showCodePreview: boolean;
   toggleCodePreview: () => void;
+  showAdvancedGeneration: boolean;
+  toggleAdvancedGeneration: () => void;
   showWorkspaceManager: boolean;
   toggleWorkspaceManager: () => void;
   showTemplateGallery: boolean;
@@ -144,6 +146,9 @@ interface UIState {
   pendingLinkRepo: string | null;
   setPendingLinkRepo: (fullName: string | null) => void;
 
+  // ── Compare review prefill ──
+  compareReviewPrefill: string | null;
+  setCompareReviewPrefill: (prefill: string | null) => void;
   // ── Resource self-animation ──
   upgradingBlockId: string | null;
   triggerUpgradeAnimation: (blockId: string) => void;
@@ -258,6 +263,10 @@ export const useUIStore = create<UIState>((set) => ({
       ...(!s.showCodePreview ? closeOtherRightPanels('showCodePreview') : {}),
     })),
 
+  showAdvancedGeneration: false,
+  toggleAdvancedGeneration: () =>
+    set((s) => ({ showAdvancedGeneration: !s.showAdvancedGeneration })),
+
   showWorkspaceManager: false,
   toggleWorkspaceManager: () =>
     set((s) => ({ showWorkspaceManager: !s.showWorkspaceManager })),
@@ -351,6 +360,9 @@ export const useUIStore = create<UIState>((set) => ({
   },
   pendingLinkRepo: null,
   setPendingLinkRepo: (fullName) => set({ pendingLinkRepo: fullName }),
+
+  compareReviewPrefill: null,
+  setCompareReviewPrefill: (prefill) => set({ compareReviewPrefill: prefill }),
 
   showOnboarding: false,
   setShowOnboarding: (show) => set({ showOnboarding: show }),

--- a/apps/web/src/features/generate/types.ts
+++ b/apps/web/src/features/generate/types.ts
@@ -119,7 +119,10 @@ export function resolveBlockMapping(
   return blockMappings[category];
 }
 
-/** @deprecated Use ProviderDefinition instead. Kept for backward compat with terraform.ts */
+/**
+ * @deprecated Use `ProviderDefinition` instead.
+ * Legacy adapter type retained for backward compatibility with older Terraform-only paths.
+ */
 export interface ProviderAdapter {
   name: ProviderName;
   displayName: string;
@@ -147,6 +150,13 @@ export interface PulumiProviderConfig {
   runtime: 'nodejs';
 }
 
+/**
+ * Canonical provider abstraction used by the generation pipeline.
+ *
+ * A `ProviderDefinition` owns provider metadata, generic block/plate mappings,
+ * generator-specific configuration (`terraform`, `bicep`, `pulumi`), and optional
+ * subtype-aware block mappings. New generation features should target this interface.
+ */
 export interface ProviderDefinition {
   name: ProviderName;
   displayName: string;

--- a/apps/web/src/widgets/code-preview/CodePreview.test.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CodePreview } from './CodePreview';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
@@ -32,9 +32,14 @@ vi.mock('../../features/generate/registry', () => ({
   listGenerators: listGeneratorsMock,
 }));
 
+vi.mock('../../shared/ui/ConfirmDialog', () => ({
+  confirmDialog: vi.fn(),
+}));
+
 import { generateCode } from '../../features/generate/pipeline';
 import { GenerationError } from '../../features/generate/pipeline';
 import { listGenerators } from '../../features/generate/registry';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 
 const mockArch: ArchitectureModel = {
   id: 'arch-1',
@@ -48,9 +53,12 @@ const mockArch: ArchitectureModel = {
 };
 
 describe('CodePreview', () => {
+  const mockConfirmDialog = vi.mocked(confirmDialog);
+
   beforeEach(() => {
     vi.clearAllMocks();
-    useUIStore.setState({ activeProvider: 'azure' });
+    mockConfirmDialog.mockResolvedValue(true);
+    useUIStore.setState({ activeProvider: 'azure', showAdvancedGeneration: false });
     useArchitectureStore.setState({
       workspace: {
         id: 'ws-1', name: 'Test', architecture: mockArch,
@@ -91,8 +99,13 @@ describe('CodePreview', () => {
     expect(screen.getByDisplayValue('us-central1')).toBeInTheDocument();
   });
 
-  it('renders generator selector with three options', () => {
+  it('hides generator selector by default and shows it when Advanced is enabled', async () => {
+    const user = userEvent.setup();
     render(<CodePreview />);
+
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Expert generator selection'));
 
     const select = screen.getByRole('combobox');
     expect(select).toBeInTheDocument();
@@ -136,7 +149,7 @@ describe('CodePreview', () => {
     vi.mocked(generateCode).mockReturnValue(mockOutput);
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(generateCode).toHaveBeenCalledWith(mockArch, {
       provider: 'azure',
       mode: 'draft',
@@ -166,7 +179,7 @@ describe('CodePreview', () => {
     vi.mocked(generateCode).mockReturnValue(mockOutput);
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     // Default shows first file
     expect(screen.getByText('main content')).toBeInTheDocument();
     // Switch to second tab
@@ -181,7 +194,7 @@ describe('CodePreview', () => {
     });
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(screen.getByText('Architecture is empty')).toBeInTheDocument();
   });
 
@@ -192,7 +205,7 @@ describe('CodePreview', () => {
     });
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(screen.getByText('Unexpected error during code generation.')).toBeInTheDocument();
   });
 
@@ -212,7 +225,7 @@ describe('CodePreview', () => {
     vi.mocked(generateCode).mockReturnValue(mockOutput);
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     await user.click(screen.getByText(/Copy/));
     expect(writeTextMock).toHaveBeenCalledWith('resource content');
   });
@@ -242,7 +255,7 @@ describe('CodePreview', () => {
     vi.mocked(generateCode).mockReturnValue(mockOutput);
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     await user.click(screen.getByText(/Download All/));
     expect(clickMock).toHaveBeenCalledTimes(2);
     expect(revokeObjectURLMock).toHaveBeenCalledTimes(2);
@@ -259,7 +272,7 @@ describe('CodePreview', () => {
     vi.mocked(generateCode).mockReturnValue(mockOutput);
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(screen.getByText(/v0\.3\.0/)).toBeInTheDocument();
     expect(screen.getByText(/azure/)).toBeInTheDocument();
   });
@@ -271,7 +284,7 @@ describe('CodePreview', () => {
       throw new GenerationError('First error');
     });
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(screen.getByText('First error')).toBeInTheDocument();
 
     // Second: succeed
@@ -280,30 +293,41 @@ describe('CodePreview', () => {
       metadata: { generator: 'terraform', version: '0.3.0', provider: 'azure' as const, generatedAt: '2026-01-01T00:00:00.000Z' },
     };
     vi.mocked(generateCode).mockReturnValue(mockOutput);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(screen.queryByText('First error')).not.toBeInTheDocument();
     expect(screen.getByText('main.tf')).toBeInTheDocument();
   });
 
-  it('updates generate button label when selecting bicep and pulumi', async () => {
+  it('keeps a neutral generate button label when selecting advanced generators', async () => {
     const user = userEvent.setup();
     render(<CodePreview />);
 
+    await user.click(screen.getByLabelText('Expert generator selection'));
     const select = screen.getByRole('combobox');
     await user.selectOptions(select, 'bicep');
-    expect(screen.getByText(/Generate Bicep \(Azure\)/)).toBeInTheDocument();
+    expect(screen.getByText('🚀 Generate Code')).toBeInTheDocument();
 
     await user.selectOptions(select, 'pulumi');
-    expect(screen.getByText(/Generate Pulumi \(TypeScript\)/)).toBeInTheDocument();
+    expect(screen.getByText('🚀 Generate Code')).toBeInTheDocument();
   });
 
-  it('falls back to generic generate label for unknown generator value', () => {
+  it('resets advanced generator selection back to terraform when advanced mode is disabled', async () => {
+    const user = userEvent.setup();
     render(<CodePreview />);
 
+    await user.click(screen.getByLabelText('Expert generator selection'));
     const select = screen.getByRole('combobox');
-    fireEvent.change(select, { target: { value: 'unknown-generator' } });
+    await user.selectOptions(select, 'bicep');
+    await user.click(screen.getByLabelText('Expert generator selection'));
 
-    expect(screen.getByText('🚀 Generate Code')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText(/Generate Code/));
+
+    expect(generateCode).toHaveBeenCalledWith(
+      mockArch,
+      expect.objectContaining({ generator: 'terraform' }),
+    );
   });
 
   it('swallows clipboard write failure when copying generated file', async () => {
@@ -322,7 +346,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     await expect(user.click(screen.getByText(/Copy/))).resolves.toBeUndefined();
     expect(writeTextMock).toHaveBeenCalledWith('resource content');
   });
@@ -342,7 +366,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     await expect(user.click(screen.getByText(/Copy/))).resolves.toBeUndefined();
   });
 
@@ -356,7 +380,7 @@ describe('CodePreview', () => {
 
     const { container } = render(<CodePreview />);
 
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     const codeElement = container.querySelector('.code-preview-code code');
     expect(codeElement?.textContent).toBe('');
   });
@@ -375,7 +399,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
     await user.click(screen.getByText('🚀 Compare Providers'));
 
     expect(vi.mocked(generateCode)).toHaveBeenCalledTimes(3);
@@ -391,24 +415,33 @@ describe('CodePreview', () => {
     const user = userEvent.setup();
     render(<CodePreview />);
 
+    await user.click(screen.getByLabelText('Expert generator selection'));
     const select = screen.getByRole('combobox');
     await user.selectOptions(select, 'bicep');
-    const compareCheckbox = screen.getByRole('checkbox');
+    const compareCheckbox = screen.getByLabelText('Azure / AWS / GCP');
 
     expect(compareCheckbox).toBeDisabled();
   });
 
-  it('resets generated output when active provider changes', async () => {
+  it('preserves comparison outputs when active provider changes', async () => {
     const user = userEvent.setup();
-    const mockOutput = {
-      files: [{ path: 'main.tf', content: 'resource content', language: 'hcl' as const }],
-      metadata: { generator: 'terraform', version: '0.3.0', provider: 'azure' as const, generatedAt: '2026-01-01T00:00:00.000Z' },
-    };
-    vi.mocked(generateCode).mockReturnValue(mockOutput);
+    vi.mocked(generateCode).mockImplementation((_, options) => ({
+      files: [{ path: 'main.tf', content: `provider=${options.provider}`, language: 'hcl' as const }],
+      metadata: {
+        generator: 'terraform',
+        version: '0.3.0',
+        provider: options.provider,
+        generatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    }));
 
     const { rerender } = render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
-    expect(screen.getByText('main.tf')).toBeInTheDocument();
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
+    await user.click(screen.getByText('🚀 Compare Providers'));
+
+    expect(screen.getByText('provider=azure')).toBeInTheDocument();
+    expect(screen.getByText('provider=aws')).toBeInTheDocument();
+    expect(screen.getByText('provider=gcp')).toBeInTheDocument();
 
     act(() => {
       useUIStore.setState({ activeProvider: 'aws' });
@@ -416,8 +449,9 @@ describe('CodePreview', () => {
     rerender(<CodePreview />);
 
     await waitFor(() => {
-      expect(screen.queryByText('main.tf')).not.toBeInTheDocument();
-      expect(screen.queryByText('resource content')).not.toBeInTheDocument();
+      expect(screen.getByText('provider=azure')).toBeInTheDocument();
+      expect(screen.getByText('provider=aws')).toBeInTheDocument();
+      expect(screen.getByText('provider=gcp')).toBeInTheDocument();
     });
   });
 
@@ -466,7 +500,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
     await user.click(screen.getByText('🚀 Compare Providers'));
 
     expect(screen.getByText('main.tf')).toBeInTheDocument();
@@ -504,7 +538,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
     await user.click(screen.getByText('🚀 Compare Providers'));
     await user.click(screen.getByText(/Copy/));
 
@@ -558,7 +592,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
     await user.click(screen.getByText('🚀 Compare Providers'));
     await user.click(screen.getByText(/Download All/));
 
@@ -590,7 +624,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
     await user.click(screen.getByText('🚀 Compare Providers'));
 
     expect(callCount).toBe(3);
@@ -608,7 +642,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
     await user.click(screen.getByText('🚀 Compare Providers'));
 
     expect(screen.getByText('All provider generations failed.')).toBeInTheDocument();
@@ -635,7 +669,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
     await user.click(screen.getByText('🚀 Compare Providers'));
 
     expect(callCount).toBe(3);
@@ -656,10 +690,13 @@ describe('CodePreview', () => {
     expect(writeTextMock).not.toHaveBeenCalled();
   });
 
-  it('resets region when provider changes', async () => {
+  it('preserves custom region when switching providers', async () => {
+    const user = userEvent.setup();
     const { rerender } = render(<CodePreview />);
 
-    expect(screen.getByDisplayValue('eastus')).toBeInTheDocument();
+    const azureRegionInput = screen.getByDisplayValue('eastus');
+    await user.clear(azureRegionInput);
+    await user.type(azureRegionInput, 'westus2');
 
     act(() => {
       useUIStore.setState({ activeProvider: 'aws' });
@@ -668,6 +705,15 @@ describe('CodePreview', () => {
 
     await waitFor(() => {
       expect(screen.getByDisplayValue('us-east-1')).toBeInTheDocument();
+    });
+
+    act(() => {
+      useUIStore.setState({ activeProvider: 'azure' });
+    });
+    rerender(<CodePreview />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('westus2')).toBeInTheDocument();
     });
   });
 
@@ -685,7 +731,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
 
     // Verify per-provider region inputs are rendered
     expect(screen.getByDisplayValue('eastus')).toBeInTheDocument();
@@ -723,7 +769,7 @@ describe('CodePreview', () => {
 
     render(<CodePreview />);
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
 
     // Edit the Azure region
     const azureInput = screen.getByDisplayValue('eastus');
@@ -750,9 +796,10 @@ describe('CodePreview', () => {
     });
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(screen.getByText('main.tf')).toBeInTheDocument();
 
+    await user.click(screen.getByLabelText('Expert generator selection'));
     const select = screen.getByRole('combobox');
     await user.selectOptions(select, 'bicep');
 
@@ -825,12 +872,101 @@ describe('CodePreview', () => {
     });
 
     render(<CodePreview />);
-    await user.click(screen.getByText(/Generate Terraform \(HCL\)/));
+    await user.click(screen.getByText(/Generate Code/));
     expect(screen.getByText('main.tf')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('checkbox'));
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
 
     expect(screen.queryByText('main.tf')).not.toBeInTheDocument();
+  });
+
+  it('makes controls read-only and shows clear action when compare results are active', async () => {
+    const user = userEvent.setup();
+    vi.mocked(generateCode).mockImplementation((_, options) => ({
+      files: [{ path: 'main.tf', content: `provider=${options.provider}`, language: 'hcl' as const }],
+      metadata: {
+        generator: 'terraform',
+        version: '0.3.0',
+        provider: options.provider,
+        generatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    }));
+
+    render(<CodePreview />);
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
+    await user.click(screen.getByText('🚀 Compare Providers'));
+
+    // Advanced toggle should be disabled during compare
+    const advancedCheckbox = screen.getByLabelText('Expert generator selection');
+    expect(advancedCheckbox).toBeDisabled();
+
+    // Enable Advanced before compare to check combobox would be disabled
+    // (Advanced is disabled during compare, so combobox is hidden)
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue('test')).toBeDisabled();
+    expect(screen.getByDisplayValue('eastus')).toBeDisabled();
+    expect(screen.getByDisplayValue('us-east-1')).toBeDisabled();
+    expect(screen.getByDisplayValue('us-central1')).toBeDisabled();
+    expect(screen.getByLabelText('Azure / AWS / GCP')).toBeDisabled();
+    expect(screen.getByText('🚀 Clear Results')).toBeInTheDocument();
+
+    await user.click(screen.getByText('🚀 Clear Results'));
+    await waitFor(() => {
+      expect(screen.queryByText('provider=azure')).not.toBeInTheDocument();
+    });
+    expect(advancedCheckbox).not.toBeDisabled();
+  });
+
+  it('prompts before enabling compare when single output exists and keeps state on cancel', async () => {
+    const user = userEvent.setup();
+    vi.mocked(generateCode).mockReturnValue({
+      files: [{ path: 'main.tf', content: 'resource content', language: 'hcl' as const }],
+      metadata: {
+        generator: 'terraform',
+        version: '0.3.0',
+        provider: 'azure',
+        generatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+
+    render(<CodePreview />);
+    await user.click(screen.getByText(/Generate Code/));
+
+    mockConfirmDialog.mockResolvedValueOnce(false);
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
+
+    await waitFor(() => {
+      expect(mockConfirmDialog).toHaveBeenCalledWith(
+        'Starting comparison will discard current generated output. Continue?',
+        'Start Comparison?'
+      );
+    });
+    expect(screen.getByLabelText('Azure / AWS / GCP')).not.toBeChecked();
+    expect(screen.getByText('main.tf')).toBeInTheDocument();
+  });
+
+  it('enables compare and clears single output after discard confirmation', async () => {
+    const user = userEvent.setup();
+    vi.mocked(generateCode).mockReturnValue({
+      files: [{ path: 'main.tf', content: 'resource content', language: 'hcl' as const }],
+      metadata: {
+        generator: 'terraform',
+        version: '0.3.0',
+        provider: 'azure',
+        generatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+
+    render(<CodePreview />);
+    await user.click(screen.getByText(/Generate Code/));
+
+    mockConfirmDialog.mockResolvedValueOnce(true);
+    await user.click(screen.getByLabelText('Azure / AWS / GCP'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Azure / AWS / GCP')).toBeChecked();
+      expect(screen.queryByText('main.tf')).not.toBeInTheDocument();
+    });
   });
 
 });

--- a/apps/web/src/widgets/code-preview/CodePreview.tsx
+++ b/apps/web/src/widgets/code-preview/CodePreview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { generateCode, GenerationError } from '../../features/generate/pipeline';
@@ -10,6 +10,7 @@ import {
 } from '../../features/generate/types';
 import { listGenerators } from '../../features/generate/registry';
 import type { ProviderType } from '@cloudblocks/schema';
+import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import './CodePreview.css';
 
 const PROVIDERS: ProviderType[] = ['azure', 'aws', 'gcp'];
@@ -30,6 +31,8 @@ function clearGeneratedState(
 
 export function CodePreview() {
   const toggleCodePreview = useUIStore((s) => s.toggleCodePreview);
+  const showAdvancedGeneration = useUIStore((s) => s.showAdvancedGeneration);
+  const toggleAdvancedGeneration = useUIStore((s) => s.toggleAdvancedGeneration);
   const activeProvider = useUIStore((s) => s.activeProvider);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
 
@@ -54,7 +57,6 @@ export function CodePreview() {
   const [comparisonOutputs, setComparisonOutputs] = useState<Record<ProviderType, GeneratedOutput> | null>(null);
   const [comparisonErrors, setComparisonErrors] = useState<Partial<Record<ProviderType, string>> | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const prevProviderRef = useRef(activeProvider);
   const selectedGenerator = generatorOptions.find((g) => g.id === generator);
   const supportedProviders = selectedGenerator?.supportedProviders ?? [];
   const canCompareProviders = PROVIDERS.every((provider) =>
@@ -62,6 +64,7 @@ export function CodePreview() {
   );
 
   const effectiveCompare = compareProviders && canCompareProviders;
+  const hasCompareResults = comparisonOutputs != null;
 
   const mismatchedProviders = architecture.nodes
     .filter((node) => node.kind === 'resource')
@@ -73,25 +76,30 @@ export function CodePreview() {
     }, new Map<string, number>());
   const hasMismatch = mismatchedProviders.size > 0;
 
-  useEffect(() => {
-    if (prevProviderRef.current !== activeProvider) {
-      prevProviderRef.current = activeProvider;
-      queueMicrotask(() => {
-        clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab);
-        setRegions((prev) => ({
-          ...prev,
-          [activeProvider]: DEFAULT_REGION_BY_PROVIDER[activeProvider],
-        }));
-      });
-    }
-  }, [activeProvider]);
-
   const handleGeneratorChange = (newGenerator: GeneratorId) => {
     setGenerator(newGenerator);
     clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab);
   };
 
-  const handleCompareChange = (checked: boolean) => {
+  const handleAdvancedToggle = (checked: boolean) => {
+    if (!checked && generator !== 'terraform') {
+      setGenerator('terraform');
+      clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab);
+    }
+    toggleAdvancedGeneration();
+  };
+
+  const handleCompareChange = async (checked: boolean) => {
+    if (checked && output != null) {
+      const confirmed = await confirmDialog(
+        'Starting comparison will discard current generated output. Continue?',
+        'Start Comparison?'
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+
     setCompareProviders(checked);
     clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab);
   };
@@ -138,6 +146,9 @@ export function CodePreview() {
         }
 
         setComparisonOutputs(generated as Record<ProviderType, GeneratedOutput>);
+        const totalResults = Object.values(generated).length;
+        const summary = `## Provider Comparison\n\nGenerated code for ${totalResults} providers: ${Object.keys(generated).join(', ').toUpperCase()}\n\nReview the differences below before submitting.`;
+        useUIStore.getState().setCompareReviewPrefill(summary);
         setComparisonErrors(Object.keys(errors).length > 0 ? errors : null);
         if (Object.keys(errors).length > 0) {
           setError('Some providers failed. Showing partial comparison results.');
@@ -236,24 +247,40 @@ export function CodePreview() {
             ⚠️ Canvas has {Array.from(mismatchedProviders.entries()).map(([p, count]) => `${count} ${p.toUpperCase()}`).join(', ')} block(s) but generating for {activeProvider.toUpperCase()}. Use &quot;Compare&quot; to see all providers.
           </div>
         )}
-        <label className="code-preview-field">
-          <span className="code-preview-field-label">Generator</span>
-          <select
-            className="code-preview-input"
-            value={generator}
-            onChange={(e) => handleGeneratorChange(e.target.value as GeneratorId)}
-          >
-            {generatorOptions.map((g) => (
-              <option key={g.id} value={g.id}>{g.label}</option>
-            ))}
-          </select>
+        <label className="code-preview-field code-preview-field-checkbox">
+          <span className="code-preview-field-label">Advanced</span>
+          <label className="code-preview-checkbox-label">
+            <input
+              type="checkbox"
+              checked={showAdvancedGeneration}
+              disabled={hasCompareResults}
+              onChange={(e) => handleAdvancedToggle(e.target.checked)}
+            />
+            Expert generator selection
+          </label>
         </label>
+        {showAdvancedGeneration && (
+          <label className="code-preview-field">
+            <span className="code-preview-field-label">Generator</span>
+            <select
+              className="code-preview-input"
+              value={generator}
+              disabled={hasCompareResults}
+              onChange={(e) => handleGeneratorChange(e.target.value as GeneratorId)}
+            >
+              {generatorOptions.map((g) => (
+                <option key={g.id} value={g.id}>{g.label}</option>
+              ))}
+            </select>
+          </label>
+        )}
         <label className="code-preview-field">
           <span className="code-preview-field-label">Project</span>
           <input
             className="code-preview-input"
             type="text"
             value={projectName}
+            disabled={hasCompareResults}
             onChange={(e) => setProjectName(e.target.value)}
           />
         </label>
@@ -268,6 +295,7 @@ export function CodePreview() {
                     className="code-preview-input"
                     type="text"
                     value={regions[provider]}
+                    disabled={hasCompareResults}
                     onChange={(e) =>
                       setRegions((prev) => ({ ...prev, [provider]: e.target.value }))
                     }
@@ -283,6 +311,7 @@ export function CodePreview() {
               className="code-preview-input"
               type="text"
               value={regions[activeProvider]}
+              disabled={hasCompareResults}
               onChange={(e) =>
                 setRegions((prev) => ({ ...prev, [activeProvider]: e.target.value }))
               }
@@ -295,14 +324,20 @@ export function CodePreview() {
             <input
               type="checkbox"
               checked={effectiveCompare}
-              disabled={!canCompareProviders}
-              onChange={(e) => handleCompareChange(e.target.checked)}
+              disabled={hasCompareResults || !canCompareProviders}
+              onChange={(e) => void handleCompareChange(e.target.checked)}
             />
             Azure / AWS / GCP
           </label>
         </label>
-        <button type="button" className="code-preview-generate-btn" onClick={handleGenerate}>
-          🚀 {effectiveCompare ? 'Compare Providers' : `Generate ${selectedGenerator?.label ?? 'Code'}`}
+        <button
+          type="button"
+          className="code-preview-generate-btn"
+          onClick={hasCompareResults
+            ? () => clearGeneratedState(setError, setOutput, setComparisonOutputs, setComparisonErrors, setActiveTab)
+            : handleGenerate}
+        >
+          🚀 {hasCompareResults ? 'Clear Results' : effectiveCompare ? 'Compare Providers' : 'Generate Code'}
         </button>
       </div>
 

--- a/apps/web/src/widgets/github-pr/GitHubPR.tsx
+++ b/apps/web/src/widgets/github-pr/GitHubPR.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
@@ -32,6 +32,15 @@ export function GitHubPR() {
 
   const [title, setTitle] = useState(DEFAULT_TITLE);
   const [body, setBody] = useState(DEFAULT_BODY);
+  const compareReviewPrefill = useUIStore((s) => s.compareReviewPrefill);
+  const setCompareReviewPrefill = useUIStore((s) => s.setCompareReviewPrefill);
+
+  useEffect(() => {
+    if (compareReviewPrefill) {
+      setBody(compareReviewPrefill);
+      setCompareReviewPrefill(null);
+    }
+  }, [compareReviewPrefill, setCompareReviewPrefill]);
   const [branch, setBranch] = useState(DEFAULT_BRANCH);
   const [commitMessage, setCommitMessage] = useState(DEFAULT_COMMIT_MESSAGE);
   const [loading, setLoading] = useState(false);

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -611,7 +611,7 @@ describe('MenuBar', () => {
     expect(useUIStore.getState().showValidation).toBe(true);
 
     buildDropdown = await openMenu(user, 'Build');
-    await user.click(within(buildDropdown).getByRole('button', { name: /Generate Terraform/ }));
+    await user.click(within(buildDropdown).getByRole('button', { name: /Generate Code/ }));
     expect(useUIStore.getState().showCodePreview).toBe(true);
 
     buildDropdown = await openMenu(user, 'Build');

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -385,7 +385,7 @@ export function MenuBar() {
               )}
             </button>
             <button type="button" className="menu-item" onClick={() => handleAction(toggleCodePreview)}>
-              <span className="menu-item-left">⚡ Generate Terraform</span>
+              <span className="menu-item-left">⚡ Generate Code</span>
             </button>
             <div className="menu-separator" />
             <button type="button" className="menu-item" onClick={() => handleAction(toggleTemplateGallery)}>

--- a/docs/engine/provider.md
+++ b/docs/engine/provider.md
@@ -1,211 +1,114 @@
-# Provider Adapter Specification
+# Provider Definition Specification
 
-CloudBlocks uses provider adapters to convert provider-neutral architecture models into cloud-specific infrastructure definitions.
+CloudBlocks uses `ProviderDefinition` as the canonical provider abstraction for generation.
 
-This allows the core DSL and rule engine to remain generic while infrastructure generation becomes cloud-aware.
+This keeps the architecture model provider-neutral while allowing Terraform, Bicep, and Pulumi output from the same model.
 
 ---
 
 # Purpose
 
-The provider adapter layer exists to:
+The provider layer exists to:
 
-- map generic block categories to provider resources
-- translate architecture graph semantics into cloud-specific constructs
-- keep the core DSL provider-neutral
-- support future multi-cloud generation
-
----
-
-# Core Principle
-
-CloudBlocks DSL must remain generic.
-
-Examples of generic categories:
-
-- compute
-- database
-- storage
-- gateway
-- function
-- queue
-- event
-- analytics
-- identity
-- observability
-
-Examples of provider-specific resources:
-
-- Azure App Service
-- AWS ECS Service
-- GCP Cloud Run
-
-The adapter layer performs this mapping.
+- map generic block and plate concepts to provider resources
+- preserve provider-neutral modeling in the architecture DSL
+- enable consistent multi-generator output from one provider definition
+- surface unsupported mappings explicitly instead of silently dropping resources
 
 ---
 
-# Adapter Responsibilities
+# Canonical Abstraction: `ProviderDefinition`
 
-Each provider adapter must implement:
+`ProviderDefinition` is the single source of truth for provider generation behavior.
 
-- block mapping
-- plate mapping
-- connection interpretation
-- code generation hooks
-- validation extensions
-
----
-
-# Block Mapping
-
-A provider adapter maps generic blocks to provider resources.
-
-Example:
-
-| DSL Block | Azure | AWS | GCP |
-|-----------|-------|-----|-----|
-| compute | azurerm_linux_web_app | aws_ecs_service | google_cloud_run_v2_service |
-| database | azurerm_postgresql_flexible_server | aws_db_instance | google_sql_database_instance |
-| storage | azurerm_storage_account | aws_s3_bucket | google_storage_bucket |
-| gateway | azurerm_application_gateway | aws_lb | google_compute_backend_service |
-| function | azurerm_linux_function_app | - | - |
-| queue | azurerm_storage_queue | - | - |
-| event | azurerm_eventgrid_topic | - | - |
-| analytics | azurerm_log_analytics_workspace | - | - |
-| identity | azurerm_user_assigned_identity | - | - |
-| observability | azurerm_monitor_workspace | - | - |
-
----
-
-# Plate Mapping
-
-A provider adapter maps structural boundaries to provider-specific containers.
-
-Examples:
-
-| DSL Plate | Azure | AWS | GCP |
-|-----------|-------|-----|-----|
-| network | virtual network | VPC | VPC network |
-| subnet | subnet | subnet | subnetwork |
-| resource group boundary | resource group | n/a | project/folder context |
-
-Not all providers support identical boundary concepts.
-
-Adapters may need approximation rules.
-
----
-
-# Connection Interpretation
-
-Connections in the DSL represent abstract communication flow.
-
-Provider adapters interpret these flows into infrastructure relationships such as:
-
-- network permissions
-- routing
-- security groups
-- firewall rules
-- private endpoints
-
-The adapter decides how to express the flow in the target platform.
-
----
-
-# Adapter Interface
-
-A provider adapter should expose a minimal interface like:
-
-- mapArchitecture()
-- mapPlate()
-- mapBlock()
-- mapConnection()
-- generateArtifacts()
-
-Exact implementation details may vary by language and package structure.
-
----
-
-# Output Responsibility
-
-Provider adapters do not own the full pipeline.
-
-Recommended division of responsibility:
-
-- core pipeline builds normalized architecture graph
-- provider adapter maps graph elements to provider model
-- generator backend renders IaC artifacts
-
----
-
-# Adapter Constraints
-
-Provider adapters must follow these constraints:
-
-- must not mutate the canonical DSL model
-- must preserve deterministic generation
-- must report unsupported mappings clearly
-- must avoid leaking provider-specific assumptions into the DSL
-
----
-
-# Unsupported Mappings
-
-If a DSL concept cannot be represented by the provider, the adapter must:
-
-- return an explicit error
-- explain the unsupported mapping
-- avoid silently dropping resources
-
-This is critical for trust and predictability.
-
----
-
-# Packaging Strategy
-
-Recommended long-term package structure:
-
-```
-packages/
-  model/
-  graph/
-  rule-engine/
-  generator-core/
-  provider-azure/
-  provider-aws/
-  provider-gcp/
+```ts
+interface ProviderDefinition {
+  name: ProviderType;
+  displayName: string;
+  blockMappings: BlockResourceMap;
+  plateMappings: PlateResourceMap;
+  generators: {
+    terraform: TerraformProviderConfig;
+    bicep: BicepProviderConfig;
+    pulumi: PulumiProviderConfig;
+  };
+  subtypeBlockMappings?: SubtypeResourceMap;
+}
 ```
 
-This allows providers to evolve independently.
+## `generators` section
+
+Every provider definition includes generator-specific settings:
+
+- `terraform: TerraformProviderConfig`
+  - `requiredProviders(): string`
+  - `providerBlock(region: string): string`
+- `bicep: BicepProviderConfig`
+  - `targetScope: 'resourceGroup' | 'subscription'`
+- `pulumi: PulumiProviderConfig`
+  - `packageName: string`
+  - `runtime: 'nodejs'`
 
 ---
 
-# Future Direction
+# Subtype-Aware Resource Resolution
 
-Planned provider adapter improvements:
+Use `subtypeBlockMappings` when a block category has multiple provider resources depending on subtype.
 
-- plugin discovery
-- provider capability metadata
-- provider-specific validation packs
-- mixed-provider experimental support
+- base mapping: `blockMappings[category]`
+- subtype override: `subtypeBlockMappings[category][subtype]`
 
-# Cross-Provider Challenges
+### `resolveBlockMapping()`
 
-Mapping the same DSL to multiple providers introduces real-world inconsistencies:
+`resolveBlockMapping(blockMappings, subtypeMappings, category, subtype?)` resolves in this order:
 
-| Challenge | Example | Mitigation |
-|-----------|---------|------------|
-| Naming divergence | Azure uses `azurerm_linux_web_app`, GCP uses `google_cloud_run_v2_service` | Adapter mapping table per provider |
-| Feature gaps | AWS has no direct equivalent to Azure Resource Groups | Adapter approximation rules + explicit warnings |
-| Networking models | Azure VNet vs AWS VPC vs GCP VPC Network have different subnet semantics | Plate mapping abstraction layer |
-| Security model | Security Groups (AWS) vs NSG (Azure) vs Firewall Rules (GCP) | Connection interpretation per provider |
-| Default configurations | Each provider has different defaults for compute, storage, etc. | Provider-specific default packs |
+1. Return subtype mapping when `subtype` is provided and exists
+2. Otherwise return `blockMappings[category]`
+3. Return `undefined` when neither mapping exists
 
-When an exact mapping is impossible, adapters must surface a clear error rather than silently approximate.
+This gives deterministic fallback behavior while supporting subtype precision.
+
+---
+
+# Generation Pipeline Flow
+
+Provider resolution is part of the generation pipeline:
+
+1. `validate` - run generator/plugin validation rules
+2. `resolve provider` - load `ProviderDefinition` by target provider
+3. `normalize` - convert architecture into generator-ready normalized model
+4. `generate` - produce files using provider + generator config
+5. `format` - apply optional generator formatter pass
+
+Pipeline stages are pure and deterministic for the same input model and options.
+
+---
+
+# `ProviderAdapter` Deprecation
+
+`ProviderAdapter` is deprecated and kept only for backward compatibility with older Terraform-only paths.
+
+Migration guidance:
+
+- new provider work must implement `ProviderDefinition`
+- new generator capabilities must read from `ProviderDefinition.generators`
+- existing `ProviderAdapter` usages should be incrementally migrated to `ProviderDefinition`
+
+---
+
+# Constraints
+
+Provider definitions and resolution logic must:
+
+- not mutate the canonical architecture model
+- keep generation deterministic
+- report unsupported mappings clearly
+- avoid leaking provider-specific semantics back into the DSL
+
 ---
 
 > **Cross-references:**
 > - Generator pipeline: [generator.md](./generator.md)
 > - Architecture model: [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md)
-> - DSL & pipeline overview: [ARCHITECTURE_MODEL_OVERVIEW.md](../model/ARCHITECTURE_MODEL_OVERVIEW.md)
-> - Architecture model overview: [ARCHITECTURE_MODEL_OVERVIEW.md](../model/ARCHITECTURE_MODEL_OVERVIEW.md)
+> - DSL overview: [ARCHITECTURE_MODEL_OVERVIEW.md](../model/ARCHITECTURE_MODEL_OVERVIEW.md)
 > - Roadmap timeline: [ROADMAP.md](../concept/ROADMAP.md)


### PR DESCRIPTION
## Summary

- Replace Terraform-specific UI labels with neutral "Generate Code" terminology (#1077, #1080)
- Add Advanced toggle to show/hide generator dropdown — hidden by default, expert users can enable (#1078)
- Document ProviderDefinition as canonical abstraction, mark ProviderAdapter as deprecated (#1079)
- Preserve custom regions when switching provider tabs (#872)
- Preserve compare results when switching code tabs (#873)
- Make code preview controls read-only during active compare, show "Clear Results" button (#846)
- Warn before discarding output when starting compare (#847)
- Pre-fill PR body from compare results via uiStore compareReviewPrefill (#876)

## Changes

| File | Change |
|------|--------|
| `CodePreview.tsx` | Remove provider-change useEffect, add Advanced toggle, hasCompareResults guards, confirmDialog, compareReviewPrefill |
| `CodePreview.test.tsx` | Updated 16+ test selectors for neutral labels, added Advanced toggle tests, compare guard tests |
| `uiStore.ts` | Added `showAdvancedGeneration` toggle and `compareReviewPrefill` state |
| `uiStore.test.ts` | Added toggle and default value tests |
| `GitHubPR.tsx` | Added useEffect to read compareReviewPrefill and populate body |
| `MenuBar.tsx` | "⚡ Generate Terraform" → "⚡ Generate Code" |
| `MenuBar.test.tsx` | Updated assertion |
| `types.ts` | Enhanced JSDoc on ProviderDefinition, @deprecated on ProviderAdapter |
| `docs/engine/provider.md` | Complete rewrite documenting ProviderDefinition pipeline |

Fixes #1077, Fixes #1078, Fixes #1079, Fixes #1080, Fixes #872, Fixes #873, Fixes #846, Fixes #847, Fixes #876