### PR TITLE
chore(web): clean up stale vitest coverage exclusions

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
         'src/main.tsx',
         'src/test/**',
         'src/**/*.test.{ts,tsx}',
-        'src/vite-env.d.ts',
+        'src/**/*.d.ts',
         'src/features/generate/types.ts',
         'src/shared/types/template.ts',
         // SceneCanvas — complex canvas interactions (zoom, pan, drag) need full DOM; excluded from coverage


### PR DESCRIPTION
## Summary
- Remove stale `src/vite-env.d.ts` exclusion (file no longer exists post-M19)
- Replace with `src/**/*.d.ts` glob to exclude all type declaration files from coverage
- This properly excludes `src/__tests__/schema-legacy-compat.d.ts` which was showing as 0% coverage

## Audit Results
All 11 excluded files/patterns verified:
- ✅ `src/main.tsx` — exists, app entry point
- ✅ `src/test/**` — exists, test setup
- ✅ `src/**/*.test.{ts,tsx}` — test files pattern
- ✅ `src/**/*.d.ts` — NEW: replaces stale `vite-env.d.ts`, catches all declaration files
- ✅ `src/features/generate/types.ts` — exists, type-only module
- ✅ `src/shared/types/template.ts` — exists, type-only module
- ✅ `src/widgets/scene-canvas/SceneCanvas.tsx` — exists, complex canvas
- ✅ `src/widgets/ops-center/OpsCenter.tsx` — exists, ops shell
- ✅ `src/widgets/notification-center/NotificationCenter.tsx` — exists
- ✅ `src/widgets/promote-dialog/PromoteDialog.tsx` — exists
- ✅ `src/widgets/promote-history/PromoteHistory.tsx` — exists
- ✅ `src/widgets/rollback-dialog/RollbackDialog.tsx` — exists
- ✅ `src/widgets/bottom-panel/CommandCard.tsx` — exists

## Coverage Impact
No change — branch coverage stays at 90.45%

Fixes #1150