### PR TITLE
fix(web): resolve unnecessary eslint-disable comments

### DIFF
--- a/apps/web/src/widgets/ops-center/OpsCenter.tsx
+++ b/apps/web/src/widgets/ops-center/OpsCenter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, type ReactNode } from 'react';
 import { useOpsStore } from '../../entities/store/opsStore';
 import type { EnvironmentInfo, PipelineRun, DeploymentRecord, CostEstimate } from '../../entities/store/opsStore';
 import { timeAgo } from '../../shared/utils/timeAgo';
@@ -290,7 +290,7 @@ export function OpsCenter() {
 
   const refreshSeqRef = useRef(0);
 
-  const safeRefreshAll = async () => {
+  const safeRefreshAll = useCallback(async () => {
     refreshSeqRef.current += 1;
     const seq = refreshSeqRef.current;
     await refreshAll();
@@ -298,15 +298,14 @@ export function OpsCenter() {
     // store already holds the newer data; nothing to discard here because
     // the store is the source of truth and the latest write wins.
     void seq; // read to satisfy lint; guard kept for future per-field apply
-  };
+  }, [refreshAll]);
 
   // Load data on first open
   useEffect(() => {
     if (showOpsCenter) {
       void safeRefreshAll();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showOpsCenter]);
+  }, [showOpsCenter, safeRefreshAll]);
 
   useEffect(() => {
     if (!showOpsCenter) return;

--- a/apps/web/src/widgets/rollback-dialog/RollbackDialog.tsx
+++ b/apps/web/src/widgets/rollback-dialog/RollbackDialog.tsx
@@ -44,12 +44,12 @@ export function RollbackDialog() {
     if (!show) return;
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        handleClose();
+        selectRollbackVersion(null);
+        setShowRollbackDialog(false);
       }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [show, setShowRollbackDialog, selectRollbackVersion]);
 
   if (!show) return null;


### PR DESCRIPTION
## Summary
Audit all 5 `eslint-disable` comments in the codebase:
- **Fixed 2** — removed `eslint-disable-next-line react-hooks/exhaustive-deps` by refactoring code
- **Kept 3** — justified suppressions with existing documentation comments

### Changes

**RollbackDialog.tsx** (fixed):
- Inlined close logic (`selectRollbackVersion(null)` + `setShowRollbackDialog(false)`) directly in the Escape keydown handler
- Eliminates stale `handleClose` reference that was missing from effect deps

**OpsCenter.tsx** (fixed):
- Wrapped `safeRefreshAll` in `useCallback` with `[refreshAll]` dependency
- Added `safeRefreshAll` to the effect dependency array
- Removed `eslint-disable-next-line` comment

### Remaining 3 (justified, no changes needed)
1. `ConfirmDialog.tsx:15` — `react-refresh/only-export-components` — internal component for imperative `confirmDialog()` API
2. `PromptDialog.tsx:16` — `react-refresh/only-export-components` — internal component for imperative `promptDialog()` API
3. `githubValidation.ts:2` — `no-control-regex, no-useless-escape` — regex validates git branch names with control chars

Fixes #1151