### PR TITLE
feat(web): separate NSG from firewall as distinct security resource

### DIFF
--- a/apps/web/src/features/generate/providers/aws/index.ts
+++ b/apps/web/src/features/generate/providers/aws/index.ts
@@ -21,6 +21,7 @@ const awsSubtypeBlockMappings: SubtypeResourceMap = {
   },
   security: {
     iam: { resourceType: 'aws_iam_role', namePrefix: 'role' },
+    nsg: { resourceType: 'aws_security_group', namePrefix: 'sg' },
   },
   operations: {
     cloudwatch: { resourceType: 'aws_cloudwatch_dashboard', namePrefix: 'dashboard' },

--- a/apps/web/src/features/generate/providers/aws/subtypes.ts
+++ b/apps/web/src/features/generate/providers/aws/subtypes.ts
@@ -63,6 +63,10 @@ export const awsSubtypeRegistry: SubtypeRegistry = {
       displayName: 'IAM Role',
       description: 'Identity and access management role',
     },
+    nsg: {
+      displayName: 'Security Group',
+      description: 'Virtual firewall for EC2 instances and subnets',
+    },
   },
   operations: {
     cloudwatch: {

--- a/apps/web/src/features/generate/providers/azure/index.ts
+++ b/apps/web/src/features/generate/providers/azure/index.ts
@@ -21,6 +21,7 @@ const azureSubtypeBlockMappings: SubtypeResourceMap = {
   },
   security: {
     'managed-identity': { resourceType: 'azurerm_user_assigned_identity', namePrefix: 'identity' },
+    nsg: { resourceType: 'azurerm_network_security_group', namePrefix: 'nsg' },
   },
   operations: {
     'log-analytics': { resourceType: 'azurerm_log_analytics_workspace', namePrefix: 'analytics' },

--- a/apps/web/src/features/generate/providers/azure/subtypes.ts
+++ b/apps/web/src/features/generate/providers/azure/subtypes.ts
@@ -63,6 +63,10 @@ export const azureSubtypeRegistry: SubtypeRegistry = {
       displayName: 'Managed Identity',
       description: 'Managed service identity for authentication',
     },
+    nsg: {
+      displayName: 'Network Security Group',
+      description: 'Subnet-level L4 network traffic filtering',
+    },
   },
   operations: {
     'log-analytics': {

--- a/apps/web/src/features/generate/providers/gcp/index.ts
+++ b/apps/web/src/features/generate/providers/gcp/index.ts
@@ -21,6 +21,7 @@ const gcpSubtypeBlockMappings: SubtypeResourceMap = {
   },
   security: {
     iam: { resourceType: 'google_service_account', namePrefix: 'sa' },
+    nsg: { resourceType: 'google_compute_firewall', namePrefix: 'fw' },
   },
   operations: {
     bigquery: { resourceType: 'google_bigquery_dataset', namePrefix: 'analytics' },

--- a/apps/web/src/features/generate/providers/gcp/subtypes.ts
+++ b/apps/web/src/features/generate/providers/gcp/subtypes.ts
@@ -63,6 +63,10 @@ export const gcpSubtypeRegistry: SubtypeRegistry = {
       displayName: 'Service Account',
       description: 'Identity for workloads and services',
     },
+    nsg: {
+      displayName: 'Firewall Rules',
+      description: 'VPC firewall rules for network traffic filtering',
+    },
   },
   operations: {
     bigquery: {

--- a/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
@@ -216,7 +216,7 @@ describe('useTechTree constants', () => {
         shortLabel: 'NSG',
         icon: '🔒',
         category: 'vnet-required',
-        blockCategory: 'edge',
+        blockCategory: 'security',
       },
       bastion: {
         id: 'bastion',

--- a/apps/web/src/widgets/bottom-panel/useTechTree.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.ts
@@ -206,7 +206,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
     shortLabel: 'NSG',
     icon: '🔒',
     category: 'vnet-required',
-    blockCategory: 'edge',
+    blockCategory: 'security',
     disabledReason: 'Create a Network first. NSGs filter traffic at the network level.',
   },
   bastion: {

--- a/packages/schema/src/rules.ts
+++ b/packages/schema/src/rules.ts
@@ -101,6 +101,12 @@ export const RESOURCE_RULES = {
     category: 'security',
     canvasTier: 'shared',
   },
+  network_security_group: {
+    containerCapable: false,
+    allowedParents: ['subnet'],
+    category: 'security',
+    canvasTier: 'shared',
+  },
   secret_store: {
     containerCapable: false,
     allowedParents: ['subnet'],


### PR DESCRIPTION
## Summary

- Add `network_security_group` entry to `RESOURCE_RULES` in `packages/schema/src/rules.ts` with `category: 'security'` and `allowedParents: ['subnet']`
- Register NSG subtype mappings in all three cloud providers:
  - Azure: `azurerm_network_security_group` (prefix `nsg`)
  - AWS: `aws_security_group` (prefix `sg`)
  - GCP: `google_compute_firewall` (prefix `fw`)
- Add NSG subtype registry entries with descriptions in all three provider `subtypes.ts` files
- Change NSG `blockCategory` from `'edge'` to `'security'` in `useTechTree.ts` so it appears in the correct tech-tree section
- Update `useTechTree.test.ts` to match new `blockCategory: 'security'`

## Verification

- 1880 tests pass
- Branch coverage: 90.43% (≥ 90%)
- Lint clean
- TypeScript type check clean

Fixes #1152