### PR TITLE
docs: update example architectures to canonical 7-category model

### DIFF
--- a/examples/event-driven-pipeline/README.md
+++ b/examples/event-driven-pipeline/README.md
@@ -19,12 +19,12 @@ Internet → Gateway (Event Ingestion)
 
 ## Components
 
-| Layer | Block Type | Subnet | Description |
-|-------|-----------|--------|-------------|
-| Ingestion | Gateway | Public | Event ingestion endpoint |
-| Processing | Compute | Public | Stream processor / event handler |
-| Persistence | Database | Private | Managed database for processed results |
-| Persistence | Storage | Private | Raw event archive / blob storage |
+| Layer | Category | Block Type | Subnet | Description |
+|-------|----------|-----------|--------|-------------|
+| Ingestion | Edge | Gateway | Public | Event ingestion endpoint |
+| Processing | Compute | Compute | Public | Stream processor / event handler |
+| Persistence | Data | Database | Private | Managed database for processed results |
+| Persistence | Data | Storage | Private | Raw event archive / blob storage |
 
 ## How to Build in CloudBlocks
 

--- a/examples/serverless-api/README.md
+++ b/examples/serverless-api/README.md
@@ -19,12 +19,12 @@ Internet → Gateway (API Gateway)
 
 ## Components
 
-| Layer | Block Type | Subnet | Description |
-|-------|-----------|--------|-------------|
-| Entry | Gateway | Public | API Gateway / Function proxy |
-| Logic | Compute | Public | Serverless functions / Container Apps |
-| Data | Database | Private | Managed database for structured data |
-| Data | Storage | Private | Queue storage for async processing |
+| Layer | Category | Block Type | Subnet | Description |
+|-------|----------|-----------|--------|-------------|
+| Entry | Edge | Gateway | Public | API Gateway / Function proxy |
+| Logic | Compute | Compute | Public | Serverless functions / Container Apps |
+| Data | Data | Database | Private | Managed database for structured data |
+| Data | Data | Storage | Private | Queue storage for async processing |
 
 ## How to Build in CloudBlocks
 

--- a/examples/three-tier-web-app/README.md
+++ b/examples/three-tier-web-app/README.md
@@ -19,12 +19,12 @@ Internet → Gateway (Application Gateway)
 
 ## Components
 
-| Layer | Block Type | Subnet | Description |
-|-------|-----------|--------|-------------|
-| Frontend | Gateway | Public | Application Gateway / Load Balancer |
-| Application | Compute | Public | VM or Container App instances |
-| Data | Database | Private | Managed database server |
-| Data | Storage | Private | Blob storage for static assets |
+| Layer | Category | Block Type | Subnet | Description |
+|-------|----------|-----------|--------|-------------|
+| Frontend | Edge | Gateway | Public | Application Gateway / Load Balancer |
+| Application | Compute | Compute | Public | VM or Container App instances |
+| Data | Data | Database | Private | Managed database server |
+| Data | Data | Storage | Private | Blob storage for static assets |
 
 ## How to Build in CloudBlocks
 


### PR DESCRIPTION
## Summary

- Update all 3 example architecture READMEs to include a "Category" column that maps each block type to its canonical category (Edge, Compute, Data)
- No code changes — documentation only

## Changes

| Example | Updates |
|---------|---------|
| three-tier-web-app | Gateway→Edge, Compute→Compute, Database→Data, Storage→Data |
| serverless-api | Gateway→Edge, Compute→Compute, Database→Data, Storage→Data |
| event-driven-pipeline | Gateway→Edge, Compute→Compute, Database→Data, Storage→Data |

Fixes #1144