### PR TITLE
feat(web): wire NAT Gateway UI to outbound_access RESOURCE_RULES

### DIFF
--- a/apps/web/src/features/generate/providers/aws/index.ts
+++ b/apps/web/src/features/generate/providers/aws/index.ts
@@ -14,6 +14,7 @@ const awsSubtypeBlockMappings: SubtypeResourceMap = {
   edge: {
     alb: { resourceType: 'aws_lb', namePrefix: 'alb' },
     'api-gateway': { resourceType: 'aws_apigatewayv2_api', namePrefix: 'apigw' },
+    'nat-gateway': { resourceType: 'aws_nat_gateway', namePrefix: 'natgw' },
   },
   messaging: {
     sqs: { resourceType: 'aws_sqs_queue', namePrefix: 'queue' },

--- a/apps/web/src/features/generate/providers/aws/subtypes.ts
+++ b/apps/web/src/features/generate/providers/aws/subtypes.ts
@@ -47,6 +47,10 @@ export const awsSubtypeRegistry: SubtypeRegistry = {
       displayName: 'API Gateway',
       description: 'Managed API endpoint',
     },
+    'nat-gateway': {
+      displayName: 'NAT Gateway',
+      description: 'Managed outbound internet access for private subnets',
+    },
   },
   messaging: {
     sqs: {

--- a/apps/web/src/features/generate/providers/azure/index.ts
+++ b/apps/web/src/features/generate/providers/azure/index.ts
@@ -14,6 +14,7 @@ const azureSubtypeBlockMappings: SubtypeResourceMap = {
   edge: {
     'application-gateway': { resourceType: 'azurerm_application_gateway', namePrefix: 'appgw' },
     'api-management': { resourceType: 'azurerm_api_management', namePrefix: 'apim' },
+    'nat-gateway': { resourceType: 'azurerm_nat_gateway', namePrefix: 'natgw' },
   },
   messaging: {
     'service-bus': { resourceType: 'azurerm_storage_queue', namePrefix: 'queue' },

--- a/apps/web/src/features/generate/providers/azure/subtypes.ts
+++ b/apps/web/src/features/generate/providers/azure/subtypes.ts
@@ -47,6 +47,10 @@ export const azureSubtypeRegistry: SubtypeRegistry = {
       displayName: 'API Management',
       description: 'Managed API gateway',
     },
+    'nat-gateway': {
+      displayName: 'NAT Gateway',
+      description: 'Managed outbound internet access for private subnets',
+    },
   },
   messaging: {
     'service-bus': {

--- a/apps/web/src/features/generate/providers/gcp/index.ts
+++ b/apps/web/src/features/generate/providers/gcp/index.ts
@@ -14,6 +14,7 @@ const gcpSubtypeBlockMappings: SubtypeResourceMap = {
   edge: {
     'cloud-load-balancing': { resourceType: 'google_compute_url_map', namePrefix: 'lb' },
     'api-gateway': { resourceType: 'google_api_gateway_api', namePrefix: 'apigw' },
+    'nat-gateway': { resourceType: 'google_compute_router_nat', namePrefix: 'nat' },
   },
   messaging: {
     pubsub: { resourceType: 'google_pubsub_topic', namePrefix: 'topic' },

--- a/apps/web/src/features/generate/providers/gcp/subtypes.ts
+++ b/apps/web/src/features/generate/providers/gcp/subtypes.ts
@@ -47,6 +47,10 @@ export const gcpSubtypeRegistry: SubtypeRegistry = {
       displayName: 'API Gateway',
       description: 'Managed API gateway',
     },
+    'nat-gateway': {
+      displayName: 'Cloud NAT',
+      description: 'Managed outbound internet access for private subnets',
+    },
   },
   messaging: {
     pubsub: {

--- a/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
@@ -226,6 +226,14 @@ describe('useTechTree constants', () => {
         category: 'vnet-required',
         blockCategory: 'edge',
       },
+      'nat-gateway': {
+        id: 'nat-gateway',
+        label: 'NAT Gateway',
+        shortLabel: 'NAT',
+        icon: '🚪',
+        category: 'vnet-required',
+        blockCategory: 'edge',
+      },
     };
 
     const resourceTypes = [
@@ -250,8 +258,9 @@ describe('useTechTree constants', () => {
       'firewall',
       'nsg',
       'bastion',
+      'nat-gateway',
     ];
-    expect(resourceTypes).toHaveLength(21);
+    expect(resourceTypes).toHaveLength(22);
 
     for (const resourceType of resourceTypes) {
       const actual = RESOURCE_DEFINITIONS[resourceType as ResourceType];

--- a/apps/web/src/widgets/bottom-panel/useTechTree.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.ts
@@ -23,7 +23,8 @@ export type ResourceType =
   | 'internal-lb'
   | 'firewall'
   | 'nsg'
-  | 'bastion';
+  | 'bastion'
+  | 'nat-gateway';
 
 export interface ResourceDefinition {
   id: ResourceType;
@@ -218,6 +219,15 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
     blockCategory: 'edge',
     disabledReason: 'Create a Network first. Bastion provides secure VM access through a virtual network.',
   },
+  'nat-gateway': {
+    id: 'nat-gateway',
+    label: 'NAT Gateway',
+    shortLabel: 'NAT',
+    icon: '🚪',
+    category: 'vnet-required',
+    blockCategory: 'edge',
+    disabledReason: 'Create a Network first. NAT Gateways enable outbound internet access for private subnets.',
+  },
 };
 
 // ─── Provider-Specific Labels ─────────────────────────────
@@ -249,6 +259,7 @@ const PROVIDER_LABELS: Record<ProviderType, Partial<Record<ResourceType, Provide
     firewall:             { label: 'Network Firewall',     shortLabel: 'NFW' },
     nsg:                  { label: 'Security Group',       shortLabel: 'SG' },
     bastion:              { label: 'Session Manager',      shortLabel: 'SSM' },
+    'nat-gateway':        { label: 'NAT Gateway',          shortLabel: 'NAT' },
   },
   gcp: {
     network:              { label: 'VPC Network',          shortLabel: 'VPC' },
@@ -270,6 +281,7 @@ const PROVIDER_LABELS: Record<ProviderType, Partial<Record<ResourceType, Provide
     firewall:             { label: 'Cloud Firewall',       shortLabel: 'FW' },
     nsg:                  { label: 'Firewall Rules',       shortLabel: 'FWRules' },
     bastion:              { label: 'IAP Tunnel',           shortLabel: 'IAP' },
+    'nat-gateway':        { label: 'Cloud NAT',            shortLabel: 'CNAT' },
   },
 };
 


### PR DESCRIPTION
## Summary

- Add `nat-gateway` resource type to `useTechTree.ts` RESOURCE_DEFINITIONS with `blockCategory: 'edge'`
- Register NAT Gateway subtype mappings in all three cloud providers:
  - Azure: `azurerm_nat_gateway` (prefix `natgw`)
  - AWS: `aws_nat_gateway` (prefix `natgw`)
  - GCP: `google_compute_router_nat` (prefix `nat`)
- Add provider-specific labels: AWS stays "NAT Gateway", GCP uses "Cloud NAT"
- Add subtype registry entries with descriptions in all three provider `subtypes.ts` files
- Update `useTechTree.test.ts` to include `nat-gateway` (22 resource types, up from 21)

## Verification

- 1888 tests pass
- Branch coverage: 90.51% (≥ 90%)
- Lint clean
- TypeScript type check clean

Fixes #1153