### PR TITLE
feat(codegen): implicit PIP/NIC generation for VM and firewall blocks

### DIFF
--- a/apps/web/src/features/generate/bicep.test.ts
+++ b/apps/web/src/features/generate/bicep.test.ts
@@ -252,4 +252,54 @@ describe('bicep generator', () => {
     expect(output.metadata.provider).toBe('azure');
     expect(output.metadata.generatedAt).toEqual(expect.any(String));
   });
+
+  it('generates implicit PIP + NIC for VM blocks', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'vm1', name: 'WebServer', category: 'compute', subtype: 'vm' })],
+    });
+    const normalized = normalizeBicep(model, azureProviderDefinition);
+    const mainBicep = generateMainBicep(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(mainBicep).toContain("resource vmWebserverPip 'Microsoft.Network/publicIPAddresses@2023-05-01' = {");
+    expect(mainBicep).toContain("publicIPAllocationMethod: 'Static'");
+    expect(mainBicep).toContain("resource vmWebserverNic 'Microsoft.Network/networkInterfaces@2023-05-01' = {");
+    expect(mainBicep).toContain('id: vmWebserverPip.id');
+
+    const pipIndex = mainBicep.indexOf('publicIPAddresses');
+    const nicIndex = mainBicep.indexOf('networkInterfaces');
+    expect(pipIndex).toBeLessThan(nicIndex);
+  });
+
+  it('generates implicit PIP for firewall blocks but no NIC', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'fw1', name: 'MainFirewall', category: 'edge', subtype: 'firewall' })],
+    });
+    const normalized = normalizeBicep(model, azureProviderDefinition);
+    const mainBicep = generateMainBicep(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(mainBicep).toContain("resource appgwMainfirewallPip 'Microsoft.Network/publicIPAddresses@2023-05-01' = {");
+    expect(mainBicep).not.toContain('networkInterfaces');
+  });
+
+  it('does not generate implicit resources for internal-lb blocks', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'lb1', name: 'InternalLB', category: 'edge', subtype: 'internal-lb' })],
+    });
+    const normalized = normalizeBicep(model, azureProviderDefinition);
+    const mainBicep = generateMainBicep(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(mainBicep).not.toContain('publicIPAddresses');
+    expect(mainBicep).not.toContain('networkInterfaces');
+  });
+
+  it('does not generate implicit resources for regular compute blocks without subtype', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'web1', name: 'App', category: 'compute' })],
+    });
+    const normalized = normalizeBicep(model, azureProviderDefinition);
+    const mainBicep = generateMainBicep(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(mainBicep).not.toContain('publicIPAddresses');
+    expect(mainBicep).not.toContain('networkInterfaces');
+  });
 });

--- a/apps/web/src/features/generate/bicep.ts
+++ b/apps/web/src/features/generate/bicep.ts
@@ -102,10 +102,69 @@ const BICEP_RESOURCE_TYPES: Record<string, string> = {
   azurerm_log_analytics_workspace: 'Microsoft.OperationalInsights/workspaces@2023-09-01',
   azurerm_user_assigned_identity: 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31',
   azurerm_monitor_workspace: 'Microsoft.Monitor/accounts@2023-04-03',
+  azurerm_public_ip: 'Microsoft.Network/publicIPAddresses@2023-05-01',
+  azurerm_network_interface: 'Microsoft.Network/networkInterfaces@2023-05-01',
 };
 
 function getBicepResourceType(terraformType: string): string {
   return BICEP_RESOURCE_TYPES[terraformType] ?? terraformType;
+}
+
+// ─── Implicit Companion Resources ───────────────────────────
+
+function generateImplicitBicepResources(
+  block: LeafNode,
+  resourceName: string,
+): string[] {
+  const sections: string[] = [];
+
+  const needsPip =
+    (block.category === 'compute' && block.subtype === 'vm') ||
+    (block.category === 'edge' && block.subtype === 'firewall');
+
+  const needsNic = block.category === 'compute' && block.subtype === 'vm';
+
+  if (needsPip) {
+    const pipName = `${resourceName}Pip`;
+    const pipType = getBicepResourceType('azurerm_public_ip');
+    sections.push(`resource ${pipName} '${pipType}' = {`);
+    sections.push(`  name: '\${projectName}-${pipName}'`);
+    sections.push(`  location: location`);
+    sections.push(`  sku: {`);
+    sections.push(`    name: 'Standard'`);
+    sections.push(`  }`);
+    sections.push(`  properties: {`);
+    sections.push(`    publicIPAllocationMethod: 'Static'`);
+    sections.push(`  }`);
+    sections.push(`}`);
+    sections.push('');
+  }
+
+  if (needsNic) {
+    const nicName = `${resourceName}Nic`;
+    const pipName = `${resourceName}Pip`;
+    const nicType = getBicepResourceType('azurerm_network_interface');
+    sections.push(`resource ${nicName} '${nicType}' = {`);
+    sections.push(`  name: '\${projectName}-${nicName}'`);
+    sections.push(`  location: location`);
+    sections.push(`  properties: {`);
+    sections.push(`    ipConfigurations: [`);
+    sections.push(`      {`);
+    sections.push(`        name: 'internal'`);
+    sections.push(`        properties: {`);
+    sections.push(`          privateIPAllocationMethod: 'Dynamic'`);
+    sections.push(`          publicIPAddress: {`);
+    sections.push(`            id: ${pipName}.id`);
+    sections.push(`          }`);
+    sections.push(`        }`);
+    sections.push(`      }`);
+    sections.push(`    ]`);
+    sections.push(`  }`);
+    sections.push(`}`);
+    sections.push('');
+  }
+
+  return sections;
 }
 
 // ─── Generate Stage ─────────────────────────────────────────
@@ -297,6 +356,12 @@ export function generateMainBicep(
       block.category,
       block.subtype,
     )!;
+
+    const implicitSections = generateImplicitBicepResources(block, resName);
+    for (const section of implicitSections) {
+      sections.push(section);
+    }
+
     sections.push(generateBlockResource(block, resName, mapping));
     sections.push('');
   }

--- a/apps/web/src/features/generate/pulumi.test.ts
+++ b/apps/web/src/features/generate/pulumi.test.ts
@@ -246,4 +246,54 @@ describe('pulumi generator', () => {
     expect(output.metadata.provider).toBe('azure');
     expect(output.metadata.generatedAt).toEqual(expect.any(String));
   });
+
+  it('generates implicit PIP + NIC for VM blocks', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'vm1', name: 'WebServer', category: 'compute', subtype: 'vm' })],
+    });
+    const normalized = normalizePulumi(model, azureProviderDefinition);
+    const indexTs = generateIndexTs(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(indexTs).toContain('const vmWebServerPip = new azure.network.PublicIPAddress("vmWebServerPip", {');
+    expect(indexTs).toContain('publicIPAllocationMethod: "Static"');
+    expect(indexTs).toContain('const vmWebServerNic = new azure.network.NetworkInterface("vmWebServerNic", {');
+    expect(indexTs).toContain('id: vmWebServerPip.id,');
+
+    const pipIndex = indexTs.indexOf('PublicIPAddress');
+    const nicIndex = indexTs.indexOf('NetworkInterface');
+    expect(pipIndex).toBeLessThan(nicIndex);
+  });
+
+  it('generates implicit PIP for firewall blocks but no NIC', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'fw1', name: 'MainFirewall', category: 'edge', subtype: 'firewall' })],
+    });
+    const normalized = normalizePulumi(model, azureProviderDefinition);
+    const indexTs = generateIndexTs(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(indexTs).toContain('const appgwMainFirewallPip = new azure.network.PublicIPAddress("appgwMainFirewallPip", {');
+    expect(indexTs).not.toContain('NetworkInterface');
+  });
+
+  it('does not generate implicit resources for internal-lb blocks', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'lb1', name: 'InternalLB', category: 'edge', subtype: 'internal-lb' })],
+    });
+    const normalized = normalizePulumi(model, azureProviderDefinition);
+    const indexTs = generateIndexTs(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(indexTs).not.toContain('PublicIPAddress');
+    expect(indexTs).not.toContain('NetworkInterface');
+  });
+
+  it('does not generate implicit resources for regular compute blocks without subtype', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'web1', name: 'App', category: 'compute' })],
+    });
+    const normalized = normalizePulumi(model, azureProviderDefinition);
+    const indexTs = generateIndexTs(normalized, azureProviderDefinition, defaultOptions);
+
+    expect(indexTs).not.toContain('PublicIPAddress');
+    expect(indexTs).not.toContain('NetworkInterface');
+  });
 });

--- a/apps/web/src/features/generate/pulumi.ts
+++ b/apps/web/src/features/generate/pulumi.ts
@@ -102,10 +102,63 @@ const PULUMI_CONSTRUCTORS: Record<string, string> = {
   azurerm_log_analytics_workspace: 'azure.operationalinsights.Workspace',
   azurerm_user_assigned_identity: 'azure.managedidentity.UserAssignedIdentity',
   azurerm_monitor_workspace: 'azure.monitor.AzureMonitorWorkspace',
+  azurerm_public_ip: 'azure.network.PublicIPAddress',
+  azurerm_network_interface: 'azure.network.NetworkInterface',
 };
 
 function getPulumiConstructor(terraformType: string): string {
   return PULUMI_CONSTRUCTORS[terraformType] ?? 'azure.resources.GenericResource';
+}
+
+// ─── Implicit Companion Resources ───────────────────────────
+
+function generateImplicitPulumiResources(
+  block: LeafNode,
+  resourceName: string,
+): string[] {
+  const sections: string[] = [];
+
+  const needsPip =
+    (block.category === 'compute' && block.subtype === 'vm') ||
+    (block.category === 'edge' && block.subtype === 'firewall');
+
+  const needsNic = block.category === 'compute' && block.subtype === 'vm';
+
+  if (needsPip) {
+    const pipName = `${resourceName}Pip`;
+    const pipConstructor = getPulumiConstructor('azurerm_public_ip');
+    sections.push(`const ${pipName} = new ${pipConstructor}("${pipName}", {`);
+    sections.push(`    resourceGroupName: resourceGroup.name,`);
+    sections.push(`    location: location,`);
+    sections.push(`    publicIpAddressName: \`\${projectName}-${pipName}\`,`);
+    sections.push(`    publicIPAllocationMethod: "Static",`);
+    sections.push(`    sku: {`);
+    sections.push(`        name: "Standard",`);
+    sections.push(`    },`);
+    sections.push(`});`);
+    sections.push('');
+  }
+
+  if (needsNic) {
+    const nicName = `${resourceName}Nic`;
+    const pipName = `${resourceName}Pip`;
+    const nicConstructor = getPulumiConstructor('azurerm_network_interface');
+    sections.push(`const ${nicName} = new ${nicConstructor}("${nicName}", {`);
+    sections.push(`    resourceGroupName: resourceGroup.name,`);
+    sections.push(`    location: location,`);
+    sections.push(`    networkInterfaceName: \`\${projectName}-${nicName}\`,`);
+    sections.push(`    ipConfigurations: [{`);
+    sections.push(`        name: "internal",`);
+    sections.push(`        privateIPAllocationMethod: "Dynamic",`);
+    sections.push(`        publicIPAddress: {`);
+    sections.push(`            id: ${pipName}.id,`);
+    sections.push(`        },`);
+    sections.push(`    }],`);
+    sections.push(`});`);
+    sections.push('');
+  }
+
+  return sections;
 }
 
 // ─── Generate Stage ─────────────────────────────────────────
@@ -304,6 +357,12 @@ export function generateIndexTs(
       block.category,
       block.subtype,
     )!;
+
+    const implicitSections = generateImplicitPulumiResources(block, resName);
+    for (const section of implicitSections) {
+      sections.push(section);
+    }
+
     sections.push(generateBlockResource(block, resName, mapping));
     sections.push('');
   }

--- a/apps/web/src/features/generate/terraform.test.ts
+++ b/apps/web/src/features/generate/terraform.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
-import { azureProvider } from './provider';
+import { azureProvider, azureProviderDefinition } from './provider';
 import {
   generateMainTf,
   generateOutputsTf,
@@ -300,6 +300,64 @@ describe('generateMainTf', () => {
 
     expect(hcl).toContain('resource "azurerm_service_plan" "main"');
     expect(hcl).toContain('resource "azurerm_linux_web_app"');
+  });
+
+  it('generates implicit PIP + NIC for VM blocks', () => {
+    const subtypeMappings = azureProviderDefinition.subtypeBlockMappings;
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'vm1', name: 'WebServer', category: 'compute', subtype: 'vm' })],
+    });
+
+    const normalized = normalize(model, azureProvider, subtypeMappings);
+    const hcl = generateMainTf(normalized, azureProvider, defaultOptions, subtypeMappings);
+
+    expect(hcl).toContain('resource "azurerm_public_ip" "vm_webserver_pip"');
+    expect(hcl).toContain('allocation_method   = "Static"');
+    expect(hcl).toContain('resource "azurerm_network_interface" "vm_webserver_nic"');
+    expect(hcl).toContain('public_ip_address_id          = azurerm_public_ip.vm_webserver_pip.id');
+    expect(hcl).toContain('resource "azurerm_linux_virtual_machine" "vm_webserver"');
+
+    const pipIndex = hcl.indexOf('azurerm_public_ip');
+    const nicIndex = hcl.indexOf('azurerm_network_interface');
+    const vmIndex = hcl.indexOf('azurerm_linux_virtual_machine');
+    expect(pipIndex).toBeLessThan(nicIndex);
+    expect(nicIndex).toBeLessThan(vmIndex);
+  });
+
+  it('generates implicit PIP for firewall blocks but no NIC', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'fw1', name: 'MainFirewall', category: 'edge', subtype: 'firewall' })],
+    });
+
+    const normalized = normalize(model, azureProvider);
+    const hcl = generateMainTf(normalized, azureProvider, defaultOptions);
+
+    expect(hcl).toContain('resource "azurerm_public_ip" "appgw_mainfirewall_pip"');
+    expect(hcl).not.toContain('azurerm_network_interface');
+  });
+
+  it('does not generate implicit resources for internal-lb blocks', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'lb1', name: 'InternalLB', category: 'edge', subtype: 'internal-lb' })],
+    });
+
+    const normalized = normalize(model, azureProvider);
+    const hcl = generateMainTf(normalized, azureProvider, defaultOptions);
+
+    expect(hcl).not.toContain('azurerm_public_ip');
+    expect(hcl).not.toContain('azurerm_network_interface');
+  });
+
+  it('does not generate implicit resources for regular compute blocks without subtype', () => {
+    const model = createTestModel({
+      blocks: [createBlock({ id: 'web1', name: 'App', category: 'compute' })],
+    });
+
+    const normalized = normalize(model, azureProvider);
+    const hcl = generateMainTf(normalized, azureProvider, defaultOptions);
+
+    expect(hcl).not.toContain('azurerm_public_ip');
+    expect(hcl).not.toContain('azurerm_network_interface');
   });
 });
 

--- a/apps/web/src/features/generate/terraform.ts
+++ b/apps/web/src/features/generate/terraform.ts
@@ -88,6 +88,62 @@ export function normalize(
   return { architecture, resourceNames };
 }
 
+// ─── Implicit Companion Resources ───────────────────────────
+
+/**
+ * Generate implicit companion resources (PIP, NIC) for blocks that require them.
+ * These are Azure resources that always accompany certain parent resources
+ * but don't need explicit canvas placement.
+ *
+ * Rules:
+ *   - VM (compute, subtype='vm') → PIP + NIC (PIP before NIC, NIC references PIP)
+ *   - Firewall (edge, subtype='firewall') → PIP only
+ *   - Internal LB (edge, subtype='internal-lb') → no implicit resources (internal)
+ */
+function generateImplicitResources(
+  block: LeafNode,
+  resourceName: string,
+): string[] {
+  const sections: string[] = [];
+
+  const needsPip =
+    (block.category === 'compute' && block.subtype === 'vm') ||
+    (block.category === 'edge' && block.subtype === 'firewall');
+
+  const needsNic = block.category === 'compute' && block.subtype === 'vm';
+
+  if (needsPip) {
+    const pipName = `${resourceName}_pip`;
+    sections.push(`resource "azurerm_public_ip" "${pipName}" {`);
+    sections.push(`  name                = "\${var.project_name}-${pipName}"`);
+    sections.push(`  resource_group_name = azurerm_resource_group.main.name`);
+    sections.push(`  location            = azurerm_resource_group.main.location`);
+    sections.push(`  allocation_method   = "Static"`);
+    sections.push(`  sku                 = "Standard"`);
+    sections.push('}');
+    sections.push('');
+  }
+
+  if (needsNic) {
+    const nicName = `${resourceName}_nic`;
+    const pipName = `${resourceName}_pip`;
+    sections.push(`resource "azurerm_network_interface" "${nicName}" {`);
+    sections.push(`  name                = "\${var.project_name}-${nicName}"`);
+    sections.push(`  resource_group_name = azurerm_resource_group.main.name`);
+    sections.push(`  location            = azurerm_resource_group.main.location`);
+    sections.push('');
+    sections.push(`  ip_configuration {`);
+    sections.push(`    name                          = "internal"`);
+    sections.push(`    private_ip_address_allocation = "Dynamic"`);
+    sections.push(`    public_ip_address_id          = azurerm_public_ip.${pipName}.id`);
+    sections.push(`  }`);
+    sections.push('}');
+    sections.push('');
+  }
+
+  return sections;
+}
+
 // ─── Generate Stage ─────────────────────────────────────────
 
 function generatePlateResource(
@@ -264,6 +320,12 @@ export function generateMainTf(
       block.subtype,
     )!;
     const subnetName = resourceNames.get(block.parentId ?? '') ?? null;
+
+    const implicitSections = generateImplicitResources(block, resName);
+    for (const section of implicitSections) {
+      sections.push(section);
+    }
+
     sections.push(
       generateBlockResource(block, resName, mapping, subnetName)
     );


### PR DESCRIPTION
## Summary
- Adds implicit Public IP and NIC resource generation to all three codegen backends (Terraform, Bicep, Pulumi) for VM and firewall blocks
- VM blocks (`subtype='vm'`) automatically generate a PIP + NIC before the main resource
- Firewall blocks (`subtype='firewall'`) automatically generate only a PIP
- Internal-lb and blocks without subtypes generate no implicit resources
- Adds 12 new tests (4 per backend) covering all subtype scenarios

## Changes
- `terraform.ts`: Added `generateImplicitResources()`, called before each block in `generateMainTf()`
- `bicep.ts`: Added `generateImplicitBicepResources()` + 2 `BICEP_RESOURCE_TYPES` entries
- `pulumi.ts`: Added `generateImplicitPulumiResources()` + 2 `PULUMI_CONSTRUCTORS` entries
- `terraform.test.ts`, `bicep.test.ts`, `pulumi.test.ts`: 4 tests each for implicit resource generation

## Verification
- ✅ `pnpm build` passes
- ✅ `pnpm lint` passes
- ✅ 1900 tests pass (105 test files)
- ✅ Branch coverage: 90.68% (above 90% threshold)

Fixes #1154