### PR TITLE
chore: add .env.example for web and API apps

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,80 @@
+# CloudBlocks API — Environment Variables
+#
+# Copy this file to .env and fill in the values.
+# All variables are prefixed with CLOUDBLOCKS_ (see config.py env_prefix).
+#
+# See docs/guides/ENVIRONMENT_STRATEGY.md for environment-specific guidance.
+
+# ── Application ───────────────────────────────────────────────────
+# Environment name: development | staging | production
+# Non-development environments enforce strong secret validation.
+CLOUDBLOCKS_APP_ENV=development
+CLOUDBLOCKS_APP_PORT=8000
+CLOUDBLOCKS_APP_DEBUG=true
+
+# ── GitHub OAuth ──────────────────────────────────────────────────
+# Required for GitHub integration (login, repo sync, PR creation).
+# Create a GitHub OAuth App: https://github.com/settings/applications/new
+CLOUDBLOCKS_GITHUB_APP_ID=
+CLOUDBLOCKS_GITHUB_CLIENT_ID=
+CLOUDBLOCKS_GITHUB_CLIENT_SECRET=
+# Callback URL registered in the GitHub OAuth App settings.
+# Local:      http://localhost:8000/api/v1/auth/github/callback
+# Staging:    https://<staging-api-url>/api/v1/auth/github/callback
+# Production: https://<production-api-url>/api/v1/auth/github/callback
+CLOUDBLOCKS_GITHUB_REDIRECT_URI=http://localhost:8000/api/v1/auth/github/callback
+
+# ── Security / Secrets ────────────────────────────────────────────
+# REQUIRED in non-development environments (min 32 chars).
+CLOUDBLOCKS_JWT_SECRET=change-me-in-production
+CLOUDBLOCKS_JWT_ALGORITHM=HS256
+CLOUDBLOCKS_JWT_EXPIRATION_SECONDS=3600
+CLOUDBLOCKS_JWT_REFRESH_EXPIRATION_SECONDS=604800
+# REQUIRED in non-development environments (min 16 chars).
+CLOUDBLOCKS_TOKEN_ENCRYPTION_SALT=cloudblocks-default-salt
+
+# ── Database ──────────────────────────────────────────────────────
+# SQLite (default) or PostgreSQL connection string.
+# SQLite:     sqlite+aiosqlite:///cloudblocks.db
+# PostgreSQL: postgresql+asyncpg://user:pass@host:5432/cloudblocks
+CLOUDBLOCKS_DATABASE_URL=sqlite+aiosqlite:///cloudblocks.db
+
+# ── Session Backend ───────────────────────────────────────────────
+# "sqlite" (default) or "redis" for distributed sessions.
+CLOUDBLOCKS_SESSION_BACKEND=sqlite
+CLOUDBLOCKS_REDIS_URL=redis://localhost:6379/0
+CLOUDBLOCKS_REDIS_SESSION_SLIDING_TTL_DAYS=14
+CLOUDBLOCKS_REDIS_SESSION_ABSOLUTE_TTL_DAYS=30
+
+# ── CORS ──────────────────────────────────────────────────────────
+# Comma-separated list of allowed origins.
+# Local:      ["http://localhost:5173"]
+# Staging:    ["https://staging.cloudblocks.dev"]
+# Production: ["https://cloudblocks.dev"]
+CLOUDBLOCKS_CORS_ORIGINS=["http://localhost:5173"]
+
+# ── Session / Cookie ──────────────────────────────────────────────
+CLOUDBLOCKS_SESSION_COOKIE_NAME=cb_session
+# Set to your domain in production (e.g., .cloudblocks.dev).
+CLOUDBLOCKS_SESSION_COOKIE_DOMAIN=
+# Must be true in production (HTTPS only).
+CLOUDBLOCKS_SESSION_COOKIE_SECURE=false
+CLOUDBLOCKS_SESSION_COOKIE_PATH=/api
+CLOUDBLOCKS_SESSION_TTL_HOURS=168
+CLOUDBLOCKS_OAUTH_STATE_TTL_MINUTES=10
+CLOUDBLOCKS_OAUTH_COOKIE_NAME=cb_oauth
+# Frontend URL for OAuth redirect after login.
+# Local:      http://localhost:5173
+# Staging:    https://staging.cloudblocks.dev
+# Production: https://cloudblocks.dev
+CLOUDBLOCKS_FRONTEND_URL=http://localhost:5173
+
+# ── AI / LLM (Optional) ──────────────────────────────────────────
+# Required only if using AI-assisted architecture features.
+CLOUDBLOCKS_LLM_PROVIDER_URL=https://api.openai.com/v1
+CLOUDBLOCKS_LLM_MODEL=gpt-4o
+CLOUDBLOCKS_LLM_MAX_TOKENS=4096
+CLOUDBLOCKS_LLM_REQUEST_TIMEOUT=60
+CLOUDBLOCKS_INFRACOST_API_KEY=
+# Fernet key for encrypting user-provided API keys at rest.
+CLOUDBLOCKS_AI_ENCRYPTION_KEY=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,14 @@
+# CloudBlocks Web — Environment Variables
+#
+# Copy this file to .env and fill in the values.
+# Only VITE_-prefixed variables are exposed to the browser at build time.
+#
+# See docs/guides/ENVIRONMENT_STRATEGY.md for environment-specific guidance.
+
+# ── API Connection ────────────────────────────────────────────────
+# Backend API base URL. Leave empty for frontend-only mode (no
+# GitHub integration, no AI features).
+# Local:      http://localhost:8000
+# Staging:    https://ca-cloudblocks-api-staging.<region>.azurecontainerapps.io
+# Production: https://api.cloudblocks.dev
+VITE_API_URL=


### PR DESCRIPTION
## Summary
- Creates canonical `.env.example` files for both `apps/web` and `apps/api`
- Documents all required and optional environment variables with inline comments
- Marks environment-specific values (local/staging/production) for each variable
- API env vars follow the `CLOUDBLOCKS_` prefix convention from `config.py`

## Files Added
- `apps/web/.env.example` — Single variable: `VITE_API_URL`
- `apps/api/.env.example` — Full variable reference covering app, OAuth, security, database, session, CORS, and AI/LLM configuration

Fixes #468