### PR TITLE
chore(ci): add tag-gated trigger to production deployment workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,4 +1,9 @@
-# Promote to Production — manual workflow_dispatch with image tag from staging
+# Promote to Production — tag-gated or manual deployment
+#
+# Triggers:
+#   1. Push a release tag (v*) — resolves image tag from the tag's commit SHA.
+#      Aligned with milestone versioning: Milestone N = v0.N.0 (see AGENTS.md).
+#   2. Manual workflow_dispatch — specify an image tag (git SHA) directly.
 #
 # Deploys the SAME image that was validated in staging to production.
 # No rebuild — image tag promotion only. Uses GitHub Environment "production"
@@ -17,6 +22,9 @@
 name: Promote to Production
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       image_tag:
@@ -41,14 +49,37 @@ env:
   IMAGE_NAME: cloudblocks-api
 
 jobs:
+  resolve-tag:
+    name: Resolve Image Tag
+    runs-on: ubuntu-latest
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.tag }}
+      skip-web: ${{ steps.resolve.outputs.skip_web }}
+    steps:
+      - name: Resolve image tag from trigger
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            TAG="${{ github.sha }}"
+            echo "Tag push detected (${{ github.ref_name }}). Using commit SHA: ${TAG}"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "skip_web=false" >> "$GITHUB_OUTPUT"
+          else
+            TAG="${{ inputs.image_tag }}"
+            echo "Manual dispatch. Using provided tag: ${TAG}"
+            echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+            echo "skip_web=${{ inputs.skip_web }}" >> "$GITHUB_OUTPUT"
+          fi
+
   validate-tag:
     name: Validate Image Tag
     runs-on: ubuntu-latest
+    needs: resolve-tag
     environment: production
     steps:
       - name: Validate image tag format
         run: |
-          TAG="${{ inputs.image_tag }}"
+          TAG="${{ needs.resolve-tag.outputs.image-tag }}"
           if ! echo "$TAG" | grep -qE '^[0-9a-f]{40}$'; then
             echo "❌ Invalid image tag format: '$TAG'"
             echo "   Expected a 40-character lowercase hex git SHA (e.g., a1b2c3d4...)."
@@ -66,7 +97,7 @@ jobs:
 
       - name: Verify image exists in ACR
         run: |
-          TAG="${{ inputs.image_tag }}"
+          TAG="${{ needs.resolve-tag.outputs.image-tag }}"
           echo "Verifying ${{ env.IMAGE_NAME }}:${TAG} exists in ACR..."
           TAGS=$(az acr repository show-tags \
             --name ${{ secrets.ACR_NAME }} \
@@ -82,7 +113,7 @@ jobs:
   deploy-api:
     name: Deploy API to Production
     runs-on: ubuntu-latest
-    needs: validate-tag
+    needs: [resolve-tag, validate-tag]
     environment: production
     steps:
       - name: Login to Azure
@@ -94,7 +125,7 @@ jobs:
 
       - name: Deploy new revision
         run: |
-          TAG="${{ inputs.image_tag }}"
+          TAG="${{ needs.resolve-tag.outputs.image-tag }}"
           echo "🚀 Promoting ${{ env.IMAGE_NAME }}:${TAG} to production..."
           az containerapp update \
             --name ${{ secrets.CONTAINER_APP_NAME }} \
@@ -140,14 +171,14 @@ jobs:
   deploy-web:
     name: Deploy Web to Production SWA
     runs-on: ubuntu-latest
-    needs: [validate-tag, deploy-api] # Atomic: web deploys only after API succeeds
-    if: ${{ !inputs.skip_web }}
+    needs: [resolve-tag, validate-tag, deploy-api]
+    if: ${{ needs.resolve-tag.outputs.skip-web != 'true' }}
     environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.image_tag }}
+          ref: ${{ needs.resolve-tag.outputs.image-tag }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Add `push: tags: ['v*']` trigger to `promote.yml` for tag-gated production deploys
- Add `resolve-tag` job that computes image tag from either tag push (commit SHA) or manual dispatch input
- Update all downstream jobs to use resolved tag instead of direct `inputs.image_tag`
- Backward-compatible: manual `workflow_dispatch` still works as before

Fixes #466