### PR TITLE
feat(web): add one-click demo scenario loader

### DIFF
--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.css
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.css
@@ -138,13 +138,25 @@
     0 1px 0 0 #248A3D;
 }
 
-.empty-canvas-btn--placeholder {
-  background: #F5F0E0;
-  border-color: #E8DFC0;
-  color: #B0A080;
-  cursor: default;
-  pointer-events: none;
+.empty-canvas-btn--demo {
+  background: #AF52DE;
+  border-color: #8944AB;
+  color: #FFFFFF;
+  box-shadow:
+    inset 0 3px 0 rgba(255, 255, 255, 0.4),
+    0 4px 0 0 #8944AB;
+}
+
+.empty-canvas-btn--demo:hover {
+  background: #C06AE8;
+  transform: translateY(-2px);
   box-shadow:
     inset 0 3px 0 rgba(255, 255, 255, 0.5),
-    0 4px 0 0 rgba(0, 0, 0, 0.05);
+    0 6px 0 0 #8944AB;
+}
+
+.empty-canvas-btn--demo:active {
+  box-shadow:
+    inset 0 2px 0 rgba(0, 0, 0, 0.2),
+    0 1px 0 0 #8944AB;
 }

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
@@ -3,11 +3,15 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { EmptyCanvasOverlay } from './EmptyCanvasOverlay';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { getTemplate } from '../../features/templates/registry';
 
 vi.mock('../../entities/store/architectureStore');
 vi.mock('../../entities/store/uiStore');
+vi.mock('../../features/templates/registry');
 
 const mockAddPlate = vi.fn();
+const mockLoadFromTemplate = vi.fn();
+const mockSaveToStorage = vi.fn();
 const mockToggleTemplateGallery = vi.fn();
 const mockToggleScenarioGallery = vi.fn();
 
@@ -30,6 +34,8 @@ function setupMocks(plateCount: number, showTemplateGallery = false) {
     const state = {
       workspace: { architecture: { nodes } },
       addPlate: mockAddPlate,
+      loadFromTemplate: mockLoadFromTemplate,
+      saveToStorage: mockSaveToStorage,
     };
     return (selector as (s: typeof state) => unknown)(state);
   }) as typeof useArchitectureStore);
@@ -105,5 +111,32 @@ describe('EmptyCanvasOverlay', () => {
     render(<EmptyCanvasOverlay />);
     fireEvent.click(screen.getByText(/Learn How/));
     expect(mockToggleScenarioGallery).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Try Demo button', () => {
+    setupMocks(0);
+    render(<EmptyCanvasOverlay />);
+    expect(screen.getByText(/Try Demo/)).toBeInTheDocument();
+  });
+
+  it('clicking Try Demo loads the three-tier template', () => {
+    const fakeTemplate = { id: 'template-three-tier', name: 'Three-Tier' };
+    vi.mocked(getTemplate).mockReturnValue(fakeTemplate as ReturnType<typeof getTemplate>);
+    setupMocks(0);
+    render(<EmptyCanvasOverlay />);
+    fireEvent.click(screen.getByText(/Try Demo/));
+    expect(getTemplate).toHaveBeenCalledWith('template-three-tier');
+    expect(mockLoadFromTemplate).toHaveBeenCalledWith(fakeTemplate);
+    expect(mockSaveToStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking Try Demo does nothing if template not found', () => {
+    vi.mocked(getTemplate).mockReturnValue(undefined);
+    setupMocks(0);
+    render(<EmptyCanvasOverlay />);
+    fireEvent.click(screen.getByText(/Try Demo/));
+    expect(getTemplate).toHaveBeenCalledWith('template-three-tier');
+    expect(mockLoadFromTemplate).not.toHaveBeenCalled();
+    expect(mockSaveToStorage).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
@@ -1,15 +1,28 @@
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { getTemplate } from '../../features/templates/registry';
 import './EmptyCanvasOverlay.css';
+
+const DEMO_TEMPLATE_ID = 'template-three-tier';
 
 export function EmptyCanvasOverlay() {
   const containerCount = useArchitectureStore((s) => s.workspace.architecture.nodes.filter((node) => node.kind === 'container').length);
   const showTemplateGallery = useUIStore((s) => s.showTemplateGallery);
   const addPlate = useArchitectureStore((s) => s.addPlate);
+  const loadFromTemplate = useArchitectureStore((s) => s.loadFromTemplate);
+  const saveToStorage = useArchitectureStore((s) => s.saveToStorage);
   const toggleTemplateGallery = useUIStore((s) => s.toggleTemplateGallery);
   const toggleScenarioGallery = useUIStore((s) => s.toggleScenarioGallery);
 
   if (containerCount > 0 || showTemplateGallery) return null;
+
+  const handleLoadDemo = () => {
+    const template = getTemplate(DEMO_TEMPLATE_ID);
+    if (template) {
+      loadFromTemplate(template);
+      saveToStorage();
+    }
+  };
 
   return (
     <div className="empty-canvas-overlay">
@@ -41,9 +54,13 @@ export function EmptyCanvasOverlay() {
           >
             📖 Learn How
           </button>
-          <div className="empty-canvas-btn empty-canvas-btn--placeholder" aria-hidden="true">
-            🎮 Coming Soon
-          </div>
+          <button
+            type="button"
+            className="empty-canvas-btn empty-canvas-btn--demo"
+            onClick={handleLoadDemo}
+          >
+            🚀 Try Demo
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replaces the placeholder "Coming Soon" button in the empty canvas overlay with a functional "Try Demo" button
- Clicking "Try Demo" loads the Three-Tier Web Application template, giving first-time users an instant populated canvas
- Uses existing `loadFromTemplate` + `getTemplate` infrastructure — no new dependencies

## Changes
- `EmptyCanvasOverlay.tsx` — Added demo loader using `getTemplate('template-three-tier')` + `loadFromTemplate` + `saveToStorage`
- `EmptyCanvasOverlay.css` — Replaced `.empty-canvas-btn--placeholder` (gray/disabled) with `.empty-canvas-btn--demo` (purple/active)
- `EmptyCanvasOverlay.test.tsx` — Added 3 tests: button visibility, template loading, graceful handling when template not found

## Testing
- 12/12 tests pass (9 existing + 3 new)
- Lint clean, build passes

Fixes #463