### PR TITLE
feat(web): update launch landing copy and CTA flow

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>CloudBlocks</title>
+    <meta name="description" content="Visual cloud architecture builder — design infrastructure, validate constraints, and generate Terraform, Bicep, or Pulumi from the browser." />
+    <meta property="og:title" content="CloudBlocks — Visual Cloud Architecture Builder" />
+    <meta property="og:description" content="Design cloud infrastructure visually. Place resources, connect services, validate constraints, and export Terraform, Bicep, or Pulumi." />
+    <meta property="og:type" content="website" />
+    <title>CloudBlocks — Visual Cloud Architecture Builder</title>
     <link href="https://fonts.googleapis.com/css2?family=Varela+Round&display=swap" rel="stylesheet">
   </head>
   <body>

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
@@ -64,13 +64,13 @@ describe('EmptyCanvasOverlay', () => {
   it('renders overlay when no plates', () => {
     setupMocks(0);
     render(<EmptyCanvasOverlay />);
-    expect(screen.getByText('Build Your Architecture')).toBeInTheDocument();
+    expect(screen.getByText('Design Cloud Architecture Visually')).toBeInTheDocument();
   });
 
   it('shows subtitle text', () => {
     setupMocks(0);
     render(<EmptyCanvasOverlay />);
-    expect(screen.getByText('Start designing your cloud infrastructure')).toBeInTheDocument();
+    expect(screen.getByText(/generate Terraform or Bicep in one click/)).toBeInTheDocument();
   });
 
   it('shows Use Template and Start from Scratch buttons', () => {

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
@@ -15,9 +15,9 @@ export function EmptyCanvasOverlay() {
     <div className="empty-canvas-overlay">
       <div className="empty-canvas-content">
         <div className="empty-canvas-icon">🧱</div>
-        <h2 className="empty-canvas-title">Build Your Architecture</h2>
+        <h2 className="empty-canvas-title">Design Cloud Architecture Visually</h2>
         <p className="empty-canvas-subtitle">
-          Start designing your cloud infrastructure
+          Place resources, connect services, and generate Terraform or Bicep in one click
         </p>
         <div className="empty-canvas-grid">
           <button


### PR DESCRIPTION
## Summary
- Update EmptyCanvasOverlay headline to "Design Cloud Architecture Visually" with value proposition subtitle
- Add SEO meta tags (description, og:title, og:description, og:type) to index.html  
- Update page title to "CloudBlocks — Visual Cloud Architecture Builder"
- Update test assertions for new copy (9 tests pass)

Fixes #464