### PR TITLE
feat(web): auto-trigger onboarding tour on first visit

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -59,6 +59,9 @@ vi.mock('../widgets/rollback-dialog/RollbackDialog', () => ({
 vi.mock('../widgets/promote-history/PromoteHistory', () => ({
   PromoteHistory: () => <div data-testid="promote-history" />,
 }));
+vi.mock('../widgets/onboarding-tour/OnboardingTour', () => ({
+  OnboardingTour: () => <div data-testid="onboarding-tour" />,
+}));
 vi.mock('../features/templates/builtin', () => ({
   registerBuiltinTemplates: vi.fn(),
 }));
@@ -142,6 +145,7 @@ describe('App', () => {
     expect(await screen.findByTestId('github-repos')).toBeInTheDocument();
     expect(await screen.findByTestId('github-sync')).toBeInTheDocument();
     expect(await screen.findByTestId('github-pr')).toBeInTheDocument();
+    expect(screen.getByTestId('onboarding-tour')).toBeInTheDocument();
     expect(screen.getByTestId('app-toaster')).toBeInTheDocument();
   });
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -17,6 +17,7 @@ import { registerBuiltinTemplates } from '../features/templates/builtin';
 import { FlowDiagram } from '../widgets/flow-diagram/FlowDiagram';
 import { BottomPanel } from '../widgets/bottom-panel';
 import { LearningPanel } from '../widgets/learning-panel/LearningPanel';
+import { OnboardingTour } from '../widgets/onboarding-tour/OnboardingTour';
 import { registerBuiltinScenarios } from '../features/learning/scenarios/builtin';
 import { audioService } from '../shared/utils/audioService';
 import { SOUND_ASSETS } from '../shared/assets/sounds';
@@ -239,6 +240,7 @@ function App() {
           </Suspense>
         </div>
       </div>
+      <OnboardingTour />
       <Toaster
         position="bottom-center"
         toastOptions={{

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -364,7 +364,7 @@ export const useUIStore = create<UIState>((set) => ({
   compareReviewPrefill: null,
   setCompareReviewPrefill: (prefill) => set({ compareReviewPrefill: prefill }),
 
-  showOnboarding: false,
+  showOnboarding: !localStorage.getItem('cloudblocks:onboarding-completed'),
   setShowOnboarding: (show) => set({ showOnboarding: show }),
 
   persona: (localStorage.getItem('cloudblocks:persona') as Persona | null),

--- a/apps/web/src/widgets/onboarding-tour/OnboardingTour.test.tsx
+++ b/apps/web/src/widgets/onboarding-tour/OnboardingTour.test.tsx
@@ -61,6 +61,7 @@ describe('OnboardingTour', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    localStorage.setItem(STORAGE_KEY, 'true');
     // Set persona so existing tour tests bypass PersonaSelection screen
     localStorage.setItem(PERSONA_STORAGE_KEY, 'devops');
     useUIStore.setState({ showOnboarding: false, persona: 'devops' as const, complexityLevel: 'advanced' as const });
@@ -77,6 +78,26 @@ describe('OnboardingTour', () => {
     useUIStore.setState({ showOnboarding: false });
     render(<OnboardingTour />);
     expect(screen.queryByTestId('onboarding-tour')).not.toBeInTheDocument();
+  });
+
+  it('automatically shows onboarding when onboarding-completed key is absent', () => {
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(PERSONA_STORAGE_KEY);
+    useUIStore.setState({ showOnboarding: !localStorage.getItem(STORAGE_KEY), persona: null });
+
+    render(<OnboardingTour />);
+
+    expect(screen.getByTestId('persona-selection')).toBeInTheDocument();
+  });
+
+  it('does not show onboarding when onboarding-completed key exists', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    useUIStore.setState({ showOnboarding: !localStorage.getItem(STORAGE_KEY) });
+
+    render(<OnboardingTour />);
+
+    expect(screen.queryByTestId('onboarding-tour')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('persona-selection')).not.toBeInTheDocument();
   });
 
   it('renders tour when showOnboarding is true', async () => {


### PR DESCRIPTION
## Summary
- Mount `<OnboardingTour />` in App.tsx (before Toaster, non-lazy)
- Change `showOnboarding` initial value in uiStore to auto-detect first visit via `localStorage.getItem('cloudblocks:onboarding-completed')`
- Add auto-trigger tests: shows onboarding when key absent, hides when key exists
- Mock OnboardingTour in App.test.tsx for isolation

## Test Results
- 1927 tests pass
- Branch coverage: 90.38% (threshold: 90%)

Fixes #462