### PR TITLE
refactor(web): unify ResourceNode model — eliminate Plate/Block separation

### DIFF
--- a/apps/web/src/__tests__/legacyModelTestUtils.ts
+++ b/apps/web/src/__tests__/legacyModelTestUtils.ts
@@ -1,4 +1,4 @@
-import type { ArchitectureModel, Block, ContainerCapableResourceType, Plate, ResourceCategory } from '@cloudblocks/schema';
+import type { ArchitectureModel, ContainerCapableResourceType, ContainerNode, LeafNode, ResourceCategory } from '@cloudblocks/schema';
 
 type LegacyCategory =
   | 'database'
@@ -11,22 +11,22 @@ type LegacyCategory =
   | 'identity'
   | 'observability';
 
-export type LegacyPlateOverrides = Partial<Omit<Plate, 'kind' | 'layer' | 'resourceType' | 'category' | 'provider'>> & {
-  type?: Plate['layer'];
+export type LegacyPlateOverrides = Partial<Omit<ContainerNode, 'kind' | 'layer' | 'resourceType' | 'category' | 'provider'>> & {
+  type?: ContainerNode['layer'];
   children?: string[];
 };
 
-export type LegacyBlockOverrides = Partial<Omit<Block, 'kind' | 'layer' | 'resourceType' | 'category' | 'provider' | 'parentId'>> & {
+export type LegacyBlockOverrides = Partial<Omit<LeafNode, 'kind' | 'layer' | 'resourceType' | 'category' | 'provider' | 'parentId'>> & {
   resourceType?: string;
   category?: ResourceCategory | LegacyCategory;
   placementId?: string;
   parentId?: string | null;
-  provider?: Block['provider'];
+  provider?: LeafNode['provider'];
 };
 
 export type LegacyArchitectureOverrides = Partial<Omit<ArchitectureModel, 'nodes'>> & {
-  plates?: Plate[];
-  blocks?: Block[];
+  plates?: ContainerNode[];
+  blocks?: LeafNode[];
   nodes?: ArchitectureModel['nodes'];
 };
 
@@ -52,7 +52,7 @@ const mapCategory = (category: ResourceCategory | LegacyCategory | undefined): R
   return category ?? 'compute';
 };
 
-export function makeTestPlate(overrides: LegacyPlateOverrides = {}): Plate {
+export function makeTestPlate(overrides: LegacyPlateOverrides = {}): ContainerNode {
   return {
     id: 'plate-1',
     name: 'Plate',
@@ -73,7 +73,7 @@ export function makeTestPlate(overrides: LegacyPlateOverrides = {}): Plate {
   };
 }
 
-export function makeTestBlock(overrides: LegacyBlockOverrides = {}): Block {
+export function makeTestBlock(overrides: LegacyBlockOverrides = {}): LeafNode {
   const { category: overrideCategory, placementId, parentId: overrideParentId, provider, ...rest } = overrides;
   const category = mapCategory(overrideCategory);
   const parentId = placementId ?? overrideParentId ?? 'plate-1';
@@ -107,8 +107,8 @@ export function makeTestArchitecture(overrides: LegacyArchitectureOverrides = {}
   };
 }
 
-export const getPlates = (architecture: ArchitectureModel): Plate[] =>
-  architecture.nodes.filter((node): node is Plate => node.kind === 'container');
+export const getPlates = (architecture: ArchitectureModel): ContainerNode[] =>
+  architecture.nodes.filter((node): node is ContainerNode => node.kind === 'container');
 
-export const getBlocks = (architecture: ArchitectureModel): Block[] =>
-  architecture.nodes.filter((node): node is Block => node.kind === 'resource');
+export const getBlocks = (architecture: ArchitectureModel): LeafNode[] =>
+  architecture.nodes.filter((node): node is LeafNode => node.kind === 'resource');

--- a/apps/web/src/__tests__/schema-legacy-compat.d.ts
+++ b/apps/web/src/__tests__/schema-legacy-compat.d.ts
@@ -1,9 +1,7 @@
-import type { Block, Plate } from '@cloudblocks/schema';
-
 declare module '@cloudblocks/schema' {
   interface ArchitectureModel {
-    plates?: Plate[];
-    blocks?: Block[];
+    plates?: ContainerNode[];
+    blocks?: LeafNode[];
   }
 
   interface ContainerNode {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -47,8 +47,7 @@ function App() {
   const saveToStorage = useArchitectureStore((s) => s.saveToStorage);
   const undo = useArchitectureStore((s) => s.undo);
   const redo = useArchitectureStore((s) => s.redo);
-  const removeBlock = useArchitectureStore((s) => s.removeBlock);
-  const removePlate = useArchitectureStore((s) => s.removePlate);
+  const removeNode = useArchitectureStore((s) => s.removeNode);
   const removeConnection = useArchitectureStore((s) => s.removeConnection);
   const selectedId = useUIStore((s) => s.selectedId);
   const setSelectedId = useUIStore((s) => s.setSelectedId);
@@ -183,9 +182,9 @@ function App() {
         const resources = arch.nodes.filter((node): node is LeafNode => node.kind === 'resource');
         const containers = arch.nodes.filter((node): node is ContainerNode => node.kind === 'container');
         if (resources.find((resource) => resource.id === selectedId)) {
-          removeBlock(selectedId);
+          removeNode(selectedId);
         } else if (containers.find((container) => container.id === selectedId)) {
-          removePlate(selectedId);
+          removeNode(selectedId);
         } else if (arch.connections.find((c) => c.id === selectedId)) {
           removeConnection(selectedId);
         }
@@ -211,7 +210,7 @@ function App() {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [undo, redo, saveToStorage, selectedId, removeBlock, removePlate, removeConnection, setSelectedId, interactionState, cancelInteraction]);
+  }, [undo, redo, saveToStorage, selectedId, removeNode, removeConnection, setSelectedId, interactionState, cancelInteraction]);
 
   return (
     <div className="app">

--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -131,8 +131,8 @@ const internetActor: ExternalActor = {
 
 describe('BlockSprite', () => {
   const addConnectionMock = vi.fn();
-  const removeBlockMock = vi.fn();
-  const moveBlockPositionMock = vi.fn();
+  const removeNodeMock = vi.fn();
+  const moveNodePositionMock = vi.fn();
   const initialUIState = useUIStore.getState();
   const initialArchitectureState = useArchitectureStore.getState();
 
@@ -146,8 +146,8 @@ describe('BlockSprite', () => {
     useUIStore.setState({ selectedId: null, toolMode: 'select', connectionSource: null });
     useArchitectureStore.setState({
       addConnection: addConnectionMock,
-      removeBlock: removeBlockMock,
-      moveBlockPosition: moveBlockPositionMock,
+      removeNode: removeNodeMock,
+      moveNodePosition: moveNodePositionMock,
     });
   });
 
@@ -201,7 +201,7 @@ describe('BlockSprite', () => {
     render(<BlockSprite block={block} parentPlate={parentPlate} screenX={0} screenY={0} zIndex={1} />);
     await user.click(screen.getByRole('button', { name: 'Block: storage-block' }));
 
-    expect(removeBlockMock).toHaveBeenCalledWith('block-delete');
+    expect(removeNodeMock).toHaveBeenCalledWith('block-delete');
   });
 
   it('click in connect mode sets source then creates connection on second click', async () => {
@@ -323,7 +323,7 @@ describe('BlockSprite', () => {
     draggableConfig.listeners.start({ target });
     draggableConfig.listeners.move({ dx: 20, dy: 10, target });
 
-    expect(moveBlockPositionMock).toHaveBeenCalledWith('block-drag-move', 0.3125, 0);
+    expect(moveNodePositionMock).toHaveBeenCalledWith('block-drag-move', 0.3125, 0);
   });
 
   it('caches zoom value at drag start and reuses it during move', () => {
@@ -349,7 +349,7 @@ describe('BlockSprite', () => {
 
     draggableConfig.listeners.move({ dx: 20, dy: 10, target });
 
-    expect(moveBlockPositionMock).toHaveBeenCalledWith('block-zoom-cache', 0.3125, 0);
+    expect(moveNodePositionMock).toHaveBeenCalledWith('block-zoom-cache', 0.3125, 0);
   });
 
   it('ignores click while dragging', async () => {
@@ -508,7 +508,7 @@ describe('BlockSprite', () => {
     const snapSpy = vi.spyOn(isometric, 'snapToGrid').mockReturnValue({ x: 2, z: 1 });
     useUIStore.setState({ isSoundMuted: false });
     useArchitectureStore.setState({
-      moveBlockPosition: moveBlockPositionMock,
+      moveNodePosition: moveNodePositionMock,
       workspace: {
         ...useArchitectureStore.getState().workspace,
         architecture: {
@@ -531,7 +531,7 @@ describe('BlockSprite', () => {
     draggableConfig.listeners.move({ dx: 2, dy: 2, target });
     draggableConfig.listeners.end();
 
-    expect(moveBlockPositionMock).toHaveBeenCalledWith('block-snap', 0.8, 0.6);
+    expect(moveNodePositionMock).toHaveBeenCalledWith('block-snap', 0.8, 0.6);
     expect(playSoundSpy).toHaveBeenCalledWith('block-snap');
     snapSpy.mockRestore();
     playSoundSpy.mockRestore();
@@ -543,7 +543,7 @@ describe('BlockSprite', () => {
     const snapSpy = vi.spyOn(isometric, 'snapToGrid').mockReturnValue({ x: 1, z: 1 });
     useUIStore.setState({ isSoundMuted: true });
     useArchitectureStore.setState({
-      moveBlockPosition: moveBlockPositionMock,
+      moveNodePosition: moveNodePositionMock,
       workspace: {
         ...useArchitectureStore.getState().workspace,
         architecture: {
@@ -566,7 +566,7 @@ describe('BlockSprite', () => {
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
     draggableConfig.listeners.end();
 
-    expect(moveBlockPositionMock).toHaveBeenCalledWith('block-snap-muted', 0.8, 0.7);
+    expect(moveNodePositionMock).toHaveBeenCalledWith('block-snap-muted', 0.8, 0.7);
     expect(playSoundSpy).not.toHaveBeenCalled();
     snapSpy.mockRestore();
     playSoundSpy.mockRestore();

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -58,8 +58,8 @@ export const BlockSprite = memo(function BlockSprite({
   const startConnecting = useUIStore((s) => s.startConnecting);
   const completeInteraction = useUIStore((s) => s.completeInteraction);
   const addConnection = useArchitectureStore((s) => s.addConnection);
-  const removeBlock = useArchitectureStore((s) => s.removeBlock);
-  const moveBlockPosition = useArchitectureStore((s) => s.moveBlockPosition);
+  const removeNode = useArchitectureStore((s) => s.removeNode);
+  const moveNodePosition = useArchitectureStore((s) => s.moveNodePosition);
   const nodes = useArchitectureStore((s) => s.workspace.architecture.nodes);
   const blocks = nodes.filter((node): node is LeafNode => node.kind === 'resource');
   const externalActors = useArchitectureStore((s) => s.workspace.architecture.externalActors);
@@ -133,7 +133,7 @@ export const BlockSprite = memo(function BlockSprite({
           const dyScreen = event.dy / dragZoomRef.current;
           const { dWorldX, dWorldZ } = screenDeltaToWorld(dxScreen, dyScreen);
 
-          moveBlockPosition(block.id, dWorldX, dWorldZ);
+          moveNodePosition(block.id, dWorldX, dWorldZ);
         },
         end() {
           const imgEl = blockRef.current?.querySelector('.block-img') as HTMLElement | null;
@@ -166,7 +166,7 @@ export const BlockSprite = memo(function BlockSprite({
               const deltaZ = snappedPosition.z - currentBlock.position.z;
 
               if (deltaX !== 0 || deltaZ !== 0) {
-                moveBlockPosition(block.id, deltaX, deltaZ);
+                moveNodePosition(block.id, deltaX, deltaZ);
 
                 const { isSoundMuted } = useUIStore.getState();
                 if (!isSoundMuted) {
@@ -195,7 +195,7 @@ export const BlockSprite = memo(function BlockSprite({
       el.querySelector('.block-img')?.classList.remove('is-dropping');
       interactable.unset();
     };
-  }, [block.id, moveBlockPosition, toolMode]);
+  }, [block.id, moveNodePosition, toolMode]);
 
   const handleClick = (e: React.MouseEvent) => {
     if (diffMode && diffState === 'removed') return;
@@ -205,7 +205,7 @@ export const BlockSprite = memo(function BlockSprite({
     e.stopPropagation();
 
     if (toolMode === 'delete') {
-      removeBlock(block.id);
+      removeNode(block.id);
       return;
     }
 

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -1,5 +1,5 @@
 import { memo, useId, useMemo } from 'react';
-import type { BlockCategory, BlockRole, ProviderType } from '@cloudblocks/schema';
+import type { BlockRole, ProviderType, ResourceCategory } from '@cloudblocks/schema';
 import { BLOCK_SHORT_NAMES, ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
 import { getBlockIconUrl } from '../../shared/utils/iconResolver';
 import { getBlockDimensions, getBlockVisualProfile } from '../../shared/types/visualProfile';
@@ -17,7 +17,7 @@ import { getBlockFaceColors, getBlockStudColors } from './blockFaceColors';
 import { cuToSilhouetteDimensions, getSilhouetteFromCU } from './silhouettes';
 
 interface BlockSvgProps {
-  category: BlockCategory;
+  category: ResourceCategory;
   provider?: ProviderType;
   subtype?: string;
   name?: string;              // user-given resource name (overrides shortName on left wall)

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import { BlockSvg } from '../BlockSvg';
 import { getBlockFaceColors } from '../blockFaceColors';
 import { getBlockDimensions, CATEGORY_TIER_MAP, TIER_DIMENSIONS } from '../../../shared/types/visualProfile';
-import type { BlockCategory, BlockRole, ProviderType } from '@cloudblocks/schema';
+import type { BlockRole, ProviderType, ResourceCategory } from '@cloudblocks/schema';
 import { BLOCK_PADDING, TILE_H, TILE_W, TILE_Z } from '../../../shared/tokens/designTokens';
 
 import { BLOCK_SHORT_NAMES } from '../../../shared/types/index';
@@ -114,7 +114,7 @@ describe('BlockSvg subtype colors', () => {
 // ─── CU-based Dimension Tests ─────────────────────────────────
 
 describe('BlockSvg CU-based dimensions', () => {
-  const ALL_CATEGORIES: BlockCategory[] = ['compute', 'data', 'edge', 'messaging', 'operations', 'security'];
+  const ALL_CATEGORIES: ResourceCategory[] = ['compute', 'data', 'edge', 'messaging', 'operations', 'security'];
 
   it.each(ALL_CATEGORIES)(
     'renders %s with correct viewBox from CU dimensions',
@@ -240,7 +240,7 @@ describe('BlockSvg stud grid', () => {
   });
 
   it('stud count matches CU width×depth for all categories', () => {
-    const categories: BlockCategory[] = ['compute', 'data', 'edge', 'messaging', 'operations', 'security'];
+    const categories: ResourceCategory[] = ['compute', 'data', 'edge', 'messaging', 'operations', 'security'];
 
     categories.forEach((category) => {
       const cu = getBlockDimensions(category);
@@ -325,7 +325,7 @@ describe('BlockSvg SVG structure', () => {
 
 describe('BlockSvg category-tier mapping consistency', () => {
   it('all categories produce valid CU dimensions (positive integers)', () => {
-    const categories: BlockCategory[] = ['compute', 'data', 'edge', 'messaging', 'operations', 'security'];
+    const categories: ResourceCategory[] = ['compute', 'data', 'edge', 'messaging', 'operations', 'security'];
 
     categories.forEach((category) => {
       const cu = getBlockDimensions(category);

--- a/apps/web/src/entities/block/__tests__/silhouettes.test.ts
+++ b/apps/web/src/entities/block/__tests__/silhouettes.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../silhouettes';
 import { BLOCK_VISUAL_PROFILES } from '../../../shared/types/index';
 import type { BrickSilhouette, BlockTier } from '../../../shared/types/index';
-import type { BlockCategory } from '@cloudblocks/schema';
+import type { ResourceCategory } from '@cloudblocks/schema';
 import type { BlockDimensionsCU } from '../../../shared/types/visualProfile';
 import {
   CATEGORY_TIER_MAP,
@@ -21,7 +21,7 @@ import {
   TILE_Z,
 } from '../../../shared/tokens/designTokens';
 
-const blockCategories: BlockCategory[] = [
+const blockCategories: ResourceCategory[] = [
   'compute',
   'data',
   'edge',

--- a/apps/web/src/entities/connection/BrickConnector.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useMemo } from 'react';
-import type { Connection, Block, Plate, ExternalActor } from '@cloudblocks/schema';
+import type { Connection, ContainerNode, ExternalActor, LeafNode } from '@cloudblocks/schema';
 import { getDiffState } from '../../features/diff/engine';
 import { getEndpointWorldPosition } from '../../shared/utils/position';
 import type { ScreenPoint } from '../../shared/utils/isometric';
@@ -17,8 +17,8 @@ import type { ScreenSegment } from './routing';
 
 interface BrickConnectorProps {
   connection: Connection;
-  blocks: Block[];
-  plates: Plate[];
+  blocks: LeafNode[];
+  plates: ContainerNode[];
   externalActors: ExternalActor[];
   originX: number;
   originY: number;

--- a/apps/web/src/entities/connection/ConnectionPath.tsx
+++ b/apps/web/src/entities/connection/ConnectionPath.tsx
@@ -1,5 +1,5 @@
 import { memo, useState } from 'react';
-import type { Connection, Block, Plate, ExternalActor } from '@cloudblocks/schema';
+import type { Connection, ContainerNode, ExternalActor, LeafNode } from '@cloudblocks/schema';
 import { getDiffState } from '../../features/diff/engine';
 import { getEndpointWorldPosition } from '../../shared/utils/position';
 import { worldToScreen } from '../../shared/utils/isometric';
@@ -9,8 +9,8 @@ import { CONNECTION_VISUAL_STYLES } from '../validation/connection';
 
 interface ConnectionPathProps {
   connection: Connection;
-  blocks: Block[];
-  plates: Plate[];
+  blocks: LeafNode[];
+  plates: ContainerNode[];
   externalActors: ExternalActor[];
   originX: number;
   originY: number;

--- a/apps/web/src/entities/plate/PlateSprite.test.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.test.tsx
@@ -80,14 +80,14 @@ const makeSubnetPlate = (access: 'public' | 'private'): ContainerNode => ({
 });
 
 describe('PlateSprite', () => {
-  const movePlatePositionMock = vi.fn();
+  const moveNodePositionMock = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     interactMocks.draggableFn.mockReturnValue({ unset: interactMocks.unsetFn });
     interactMocks.interactFn.mockReturnValue({ draggable: interactMocks.draggableFn });
     useUIStore.setState({ selectedId: null, toolMode: 'select', connectionSource: null });
-    useArchitectureStore.setState({ movePlatePosition: movePlatePositionMock });
+    useArchitectureStore.setState({ moveNodePosition: moveNodePositionMock });
   });
 
   it('renders with correct position styles', () => {
@@ -186,7 +186,7 @@ describe('PlateSprite', () => {
     draggableConfig.listeners.move({ dx: 20, dy: 12, target });
 
     expect(vi.mocked(screenDeltaToWorld)).toHaveBeenCalledWith(5, 3);
-    expect(movePlatePositionMock).toHaveBeenCalledWith(plate.id, 0, 0);
+    expect(moveNodePositionMock).toHaveBeenCalledWith(plate.id, 0, 0);
   });
 
   it('caches zoom value at drag start and reuses it during move', () => {
@@ -213,7 +213,7 @@ describe('PlateSprite', () => {
     draggableConfig.listeners.move({ dx: 20, dy: 12, target });
 
     expect(vi.mocked(screenDeltaToWorld)).toHaveBeenCalledWith(10, 6);
-    expect(movePlatePositionMock).toHaveBeenCalledWith(plate.id, 0, 0);
+    expect(moveNodePositionMock).toHaveBeenCalledWith(plate.id, 0, 0);
   });
 
   it('ignores click while dragging', async () => {
@@ -384,7 +384,7 @@ describe('PlateSprite', () => {
 
     useUIStore.setState({ isSoundMuted: false });
     useArchitectureStore.setState({
-      movePlatePosition: movePlatePositionMock,
+      moveNodePosition: moveNodePositionMock,
       workspace: {
         ...useArchitectureStore.getState().workspace,
         architecture: { ...useArchitectureStore.getState().workspace.architecture, nodes: [plate] as ResourceNode[] },
@@ -405,7 +405,7 @@ describe('PlateSprite', () => {
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
     draggableConfig.listeners.end();
 
-    expect(movePlatePositionMock).toHaveBeenCalledWith('plate-snap', 0.8, 1.4);
+    expect(moveNodePositionMock).toHaveBeenCalledWith('plate-snap', 0.8, 1.4);
     expect(playSoundSpy).toHaveBeenCalledWith('block-snap');
     playSoundSpy.mockRestore();
   });
@@ -416,7 +416,7 @@ describe('PlateSprite', () => {
 
     useUIStore.setState({ isSoundMuted: true });
     useArchitectureStore.setState({
-      movePlatePosition: movePlatePositionMock,
+      moveNodePosition: moveNodePositionMock,
       workspace: {
         ...useArchitectureStore.getState().workspace,
         architecture: { ...useArchitectureStore.getState().workspace.architecture, nodes: [plate] as ResourceNode[] },
@@ -437,7 +437,7 @@ describe('PlateSprite', () => {
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
     draggableConfig.listeners.end();
 
-    expect(movePlatePositionMock).toHaveBeenCalledWith('plate-muted', 0.5, 0.5);
+    expect(moveNodePositionMock).toHaveBeenCalledWith('plate-muted', 0.5, 0.5);
     expect(playSoundSpy).not.toHaveBeenCalled();
     playSoundSpy.mockRestore();
   });

--- a/apps/web/src/entities/plate/PlateSprite.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.tsx
@@ -34,7 +34,7 @@ export const PlateSprite = memo(function PlateSprite({
   const draggedBlockCategory = useUIStore((s) => s.draggedBlockCategory);
   const diffMode = useUIStore((s) => s.diffMode);
   const diffDelta: DiffDelta | null = useUIStore((s) => s.diffDelta);
-  const movePlatePosition = useArchitectureStore((s) => s.movePlatePosition);
+  const moveNodePosition = useArchitectureStore((s) => s.moveNodePosition);
   const isSelected = selectedId === plate.id;
   const isDragActive = draggedBlockCategory !== null;
   const isValidDropTarget = isDragActive && canPlaceBlock(draggedBlockCategory, plate);
@@ -79,7 +79,7 @@ export const PlateSprite = memo(function PlateSprite({
           const dyScreen = event.dy / dragZoomRef.current;
           const { dWorldX, dWorldZ } = screenDeltaToWorld(dxScreen, dyScreen);
 
-          movePlatePosition(plate.id, dWorldX, dWorldZ);
+          moveNodePosition(plate.id, dWorldX, dWorldZ);
         },
         end() {
           const imgEl = plateRef.current?.querySelector('.plate-img') as HTMLElement | null;
@@ -112,7 +112,7 @@ export const PlateSprite = memo(function PlateSprite({
               const deltaZ = snappedPosition.z - currentPlate.position.z;
 
               if (deltaX !== 0 || deltaZ !== 0) {
-                movePlatePosition(plate.id, deltaX, deltaZ);
+                moveNodePosition(plate.id, deltaX, deltaZ);
 
                 const { isSoundMuted } = useUIStore.getState();
                 if (!isSoundMuted) {
@@ -141,7 +141,7 @@ export const PlateSprite = memo(function PlateSprite({
       el.querySelector('.plate-img')?.classList.remove('is-dropping');
       interactable.unset();
     };
-  }, [plate.id, movePlatePosition]);
+  }, [plate.id, moveNodePosition]);
 
   const handleClick = (e: React.MouseEvent) => {
     if (isDragging.current) {

--- a/apps/web/src/entities/plate/PlateSvg.test.tsx
+++ b/apps/web/src/entities/plate/PlateSvg.test.tsx
@@ -3,8 +3,10 @@ import { render, screen } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { PlateSvg } from './PlateSvg';
 import type { StudColorSpec } from '../../shared/types/index';
-import type { PlateType } from '@cloudblocks/schema';
+import type { LayerType } from '@cloudblocks/schema';
 import { TILE_W, TILE_H, TILE_Z, BLOCK_PADDING } from '../../shared/tokens/designTokens';
+
+type PlateLayerType = Exclude<LayerType, 'resource'>;
 
 const studColors: StudColorSpec = {
   main: '#66BB6A',
@@ -71,7 +73,7 @@ describe('PlateSvg — label and icon', () => {
 // ─── Plate Type Attribute ───────────────────────────────────
 
 describe('PlateSvg — plate type attribute', () => {
-  const allTypes: PlateType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
+  const allTypes: PlateLayerType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
 
   it.each(allTypes)('sets data-plate-type="%s"', (type) => {
     const { container } = renderPlateSvg({ plateType: type });
@@ -194,7 +196,7 @@ describe('PlateSvg — layer-type visuals', () => {
   });
 
   it('each plate type gets a distinct stroke width', () => {
-    const types: PlateType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
+    const types: PlateLayerType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
     const strokeWidths = types.map((type) => {
       const { container } = renderPlateSvg({ plateType: type });
       return Number(container.querySelector('polygon')?.getAttribute('stroke-width'));
@@ -206,7 +208,7 @@ describe('PlateSvg — layer-type visuals', () => {
   });
 
   it('stroke widths follow hierarchy: global > edge > region > zone > subnet', () => {
-    const types: PlateType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
+    const types: PlateLayerType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
     const strokeWidths = types.map((type) => {
       const { container } = renderPlateSvg({ plateType: type });
       return Number(container.querySelector('polygon')?.getAttribute('stroke-width'));
@@ -260,14 +262,14 @@ describe('PlateSvg — colors are independent of plateType', () => {
 
 describe('PlateSvg — profile-based rendering', () => {
   const profiles = [
-    { name: 'network-sandbox',     studsX: 8,  studsY: 12, worldHeight: 0.7, plateType: 'region' as PlateType },
-    { name: 'network-application', studsX: 12, studsY: 16, worldHeight: 0.7, plateType: 'region' as PlateType },
-    { name: 'network-platform',    studsX: 16, studsY: 20, worldHeight: 0.7, plateType: 'region' as PlateType },
-    { name: 'network-hub',         studsX: 20, studsY: 24, worldHeight: 0.7, plateType: 'region' as PlateType },
-    { name: 'subnet-utility',      studsX: 4,  studsY: 6,  worldHeight: 0.5, plateType: 'subnet' as PlateType },
-    { name: 'subnet-service',      studsX: 6,  studsY: 8,  worldHeight: 0.5, plateType: 'subnet' as PlateType },
-    { name: 'subnet-workload',     studsX: 8,  studsY: 10, worldHeight: 0.5, plateType: 'subnet' as PlateType },
-    { name: 'subnet-scale',        studsX: 10, studsY: 12, worldHeight: 0.5, plateType: 'subnet' as PlateType },
+    { name: 'network-sandbox',     studsX: 8,  studsY: 12, worldHeight: 0.7, plateType: 'region' as PlateLayerType },
+    { name: 'network-application', studsX: 12, studsY: 16, worldHeight: 0.7, plateType: 'region' as PlateLayerType },
+    { name: 'network-platform',    studsX: 16, studsY: 20, worldHeight: 0.7, plateType: 'region' as PlateLayerType },
+    { name: 'network-hub',         studsX: 20, studsY: 24, worldHeight: 0.7, plateType: 'region' as PlateLayerType },
+    { name: 'subnet-utility',      studsX: 4,  studsY: 6,  worldHeight: 0.5, plateType: 'subnet' as PlateLayerType },
+    { name: 'subnet-service',      studsX: 6,  studsY: 8,  worldHeight: 0.5, plateType: 'subnet' as PlateLayerType },
+    { name: 'subnet-workload',     studsX: 8,  studsY: 10, worldHeight: 0.5, plateType: 'subnet' as PlateLayerType },
+    { name: 'subnet-scale',        studsX: 10, studsY: 12, worldHeight: 0.5, plateType: 'subnet' as PlateLayerType },
   ];
 
   it.each(profiles)('renders $name profile with correct stud count', (profile) => {

--- a/apps/web/src/entities/plate/PlateSvg.tsx
+++ b/apps/web/src/entities/plate/PlateSvg.tsx
@@ -1,6 +1,6 @@
 import { memo, useId, useMemo } from 'react';
 import type { StudColorSpec } from '../../shared/types/index';
-import type { PlateType } from '@cloudblocks/schema';
+import type { LayerType } from '@cloudblocks/schema';
 import { StudDefs, StudGrid } from '../../shared/components/IsometricStud';
 import { TILE_W, TILE_H, TILE_Z, BLOCK_MARGIN, BLOCK_PADDING } from '../../shared/tokens/designTokens';
 
@@ -16,7 +16,9 @@ interface LayerVisuals {
   cornerRadius: number;      // 0 = sharp diamond, unused today (future use)
 }
 
-const LAYER_VISUALS: Record<PlateType, LayerVisuals> = {
+type PlateLayerType = Exclude<LayerType, 'resource'>;
+
+const LAYER_VISUALS: Record<PlateLayerType, LayerVisuals> = {
   global: {
     strokeWidth: 3,
     strokeOpacity: 0.9,
@@ -57,7 +59,7 @@ const LAYER_VISUALS: Record<PlateType, LayerVisuals> = {
 // ─── Props ─────────────────────────────────────────────────
 
 export interface PlateSvgProps {
-  plateType: PlateType;
+  plateType: PlateLayerType;
   studsX: number;            // CU width (1 stud = 1 CU)
   studsY: number;            // CU depth (1 stud = 1 CU)
   worldHeight: number;       // CH height (fractional OK for plates)

--- a/apps/web/src/entities/plate/plateFaceColors.ts
+++ b/apps/web/src/entities/plate/plateFaceColors.ts
@@ -1,4 +1,6 @@
-import type { PlateType, SubnetAccess } from '@cloudblocks/schema';
+import type { LayerType, SubnetAccess } from '@cloudblocks/schema';
+
+type PlateLayerType = Exclude<LayerType, 'resource'>;
 
 export interface PlateFaceColors {
   topFaceColor: string;
@@ -8,7 +10,7 @@ export interface PlateFaceColors {
 }
 
 export function getPlateFaceColors(plate: {
-  type: PlateType;
+  type: PlateLayerType;
   subnetAccess?: SubnetAccess;
 }): PlateFaceColors {
   if (plate.type === 'global') {

--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import type { ArchitectureModel, Block, ContainerNode, LeafNode, Plate, ResourceCategory } from '@cloudblocks/schema';
+import type { ArchitectureModel, ContainerNode, LeafNode, ResourceCategory } from '@cloudblocks/schema';
 import type { ArchitectureSnapshot } from '../../shared/types/learning';
 import type { ArchitectureTemplate } from '../../shared/types/template';
 
@@ -71,12 +71,12 @@ function makeResourceNode(
   };
 }
 
-type LegacyPlate = Plate & {
-  type: Plate['layer'];
+type LegacyPlate = ContainerNode & {
+  type: ContainerNode['layer'];
   children: string[];
 };
 
-type LegacyBlock = Block & {
+type LegacyBlock = LeafNode & {
   placementId: string;
 };
 
@@ -85,8 +85,8 @@ type LegacyArchitectureModel = Omit<ArchitectureModel, 'blocks' | 'plates'> & {
   blocks: LegacyBlock[];
 };
 
-const isPlateNode = (node: ArchitectureModel['nodes'][number]): node is Plate => node.kind === 'container';
-const isBlockNode = (node: ArchitectureModel['nodes'][number]): node is Block => node.kind === 'resource';
+const isPlateNode = (node: ArchitectureModel['nodes'][number]): node is ContainerNode => node.kind === 'container';
+const isBlockNode = (node: ArchitectureModel['nodes'][number]): node is LeafNode => node.kind === 'resource';
 
 function getArch(): LegacyArchitectureModel {
   const architecture = getState().workspace.architecture;

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -1,8 +1,9 @@
 import type { PlateProfileId } from '../../../shared/types/index';
-import type { Connection, ContainerCapableResourceType, ContainerNode, ExternalActor, LeafNode, PlateType } from '@cloudblocks/schema';
+import type { Connection, ContainerCapableResourceType, ContainerNode, ExternalActor, LeafNode, ResourceCategory } from '@cloudblocks/schema';
 import { buildPlateSizeFromProfileId, DEFAULT_BLOCK_SIZE } from '../../../shared/types/index';
+import { RESOURCE_RULES } from '@cloudblocks/schema';
 import { generateId } from '../../../shared/utils/id';
-import type { ArchitectureSlice, ArchitectureState } from './types';
+import type { AddNodeInput, ArchitectureSlice, ArchitectureState, RemoveNodeOptions } from './types';
 import { canConnect } from '../../validation/connection';
 import type { EndpointType } from '../../validation/connection';
 import { validatePlacement } from '../../validation/placement';
@@ -17,6 +18,10 @@ import {
 
 type DomainSlice = Pick<
   ArchitectureState,
+  | 'addNode'
+  | 'removeNode'
+  | 'renameNode'
+  | 'moveNodePosition'
   | 'addPlate'
   | 'removePlate'
   | 'addBlock'
@@ -40,8 +45,10 @@ const isContainer = (node: ContainerNode | LeafNode): node is ContainerNode =>
 const isResource = (node: ContainerNode | LeafNode): node is LeafNode =>
   node.kind === 'resource';
 
+type PlateLayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
 
-const CONTAINER_RESOURCE_TYPE: Record<PlateType, ContainerCapableResourceType> = {
+
+const CONTAINER_RESOURCE_TYPE: Record<PlateLayerType, ContainerCapableResourceType> = {
   global: 'virtual_network',
   edge: 'virtual_network',
   region: 'virtual_network',
@@ -50,6 +57,60 @@ const CONTAINER_RESOURCE_TYPE: Record<PlateType, ContainerCapableResourceType> =
 };
 
 export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => ({
+
+  // ── Unified Node API ─────────────────────────────────────────────────────
+
+  addNode: (input: AddNodeInput) => {
+    if (input.kind === 'container') {
+      // Resolve layer → PlateType for the existing addPlate logic
+      const layer = input.layer as PlateLayerType;
+      get().addPlate(layer, input.name, input.parentId, input.access, input.profileId);
+    } else {
+      // Derive category from RESOURCE_RULES or fall back to 'compute'
+      const rule = (RESOURCE_RULES as Record<string, { category: ResourceCategory }>)[input.resourceType];
+      const category: ResourceCategory = rule?.category ?? 'compute';
+      get().addBlock(category, input.name, input.parentId!, input.provider, input.subtype ?? input.resourceType, input.config);
+    }
+  },
+
+  removeNode: (id: string, options?: RemoveNodeOptions) => {
+    const arch = get().workspace.architecture;
+    const node = arch.nodes.find((n) => n.id === id);
+    if (!node) return;
+
+    const shouldCascade = options?.cascade ?? node.kind === 'container';
+    if (shouldCascade && node.kind === 'container') {
+      get().removePlate(id);
+    } else {
+      get().removeBlock(id);
+    }
+  },
+
+  renameNode: (id: string, newName: string) => {
+    const arch = get().workspace.architecture;
+    const node = arch.nodes.find((n) => n.id === id);
+    if (!node) return;
+
+    if (node.kind === 'container') {
+      get().renamePlate(id, newName);
+    } else {
+      get().renameBlock(id, newName);
+    }
+  },
+
+  moveNodePosition: (id: string, deltaX: number, deltaZ: number) => {
+    const arch = get().workspace.architecture;
+    const node = arch.nodes.find((n) => n.id === id);
+    if (!node) return;
+
+    if (node.kind === 'container') {
+      get().movePlatePosition(id, deltaX, deltaZ);
+    } else {
+      get().moveBlockPosition(id, deltaX, deltaZ);
+    }
+  },
+
+  // ── Deprecated wrappers (delegates preserved for backward compat) ────────
   addPlate: (type, name, parentId, subnetAccess, profileId?: PlateProfileId) => {
     set((state) => {
       const arch = state.workspace.architecture;

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -1,5 +1,5 @@
 import type { Workspace } from '../../../shared/types/index';
-import type { ArchitectureModel, ContainerNode, LeafNode, PlateType, ResourceCategory } from '@cloudblocks/schema';
+import type { ArchitectureModel, ContainerNode, LeafNode, ResourceCategory } from '@cloudblocks/schema';
 import type { ArchitectureSnapshot } from '../../../shared/types/learning';
 import { saveWorkspaces, loadWorkspaces, saveActiveWorkspaceId, loadActiveWorkspaceId } from '../../../shared/utils/storage';
 import { generateId } from '../../../shared/utils/id';
@@ -16,7 +16,9 @@ import {
 
 const MAX_IMPORT_SIZE_BYTES = 5 * 1024 * 1024;
 const DEFAULT_EXTERNAL_ACTOR_POSITION = { x: -3, y: 0, z: 5 };
-const VALID_PLATE_TYPES: PlateType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
+type PlateLayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
+
+const VALID_PLATE_TYPES: PlateLayerType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
 const VALID_BLOCK_CATEGORIES: ResourceCategory[] = [
   'network',
   'security',
@@ -35,9 +37,9 @@ const isFiniteNumber = (value: unknown): value is number =>
 
 const isValidNodeKind = (value: unknown): value is 'container' | 'resource' =>
   value === 'container' || value === 'resource';
-const isValidPlateType = (value: unknown): value is PlateType =>
+const isValidPlateType = (value: unknown): value is PlateLayerType =>
   typeof value === 'string' &&
-  VALID_PLATE_TYPES.includes(value as PlateType);
+  VALID_PLATE_TYPES.includes(value as PlateLayerType);
 
 const isValidBlockCategory = (value: unknown): value is ResourceCategory =>
   typeof value === 'string' &&

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -1,10 +1,40 @@
 import type { StateCreator } from 'zustand';
 import type { LastPrResult, PlateProfileId, Workspace } from '../../../shared/types/index';
-import type { ArchitectureModel, ProviderType, PlateType, ResourceCategory, SubnetAccess } from '@cloudblocks/schema';
+import type { ArchitectureModel, LayerType, ProviderType, ResourceCategory, SubnetAccess } from '@cloudblocks/schema';
 import type { ValidationResult } from '@cloudblocks/domain';
 import type { ArchitectureSnapshot } from '../../../shared/types/learning';
 import type { ArchitectureTemplate } from '../../../shared/types/template';
 
+type PlateLayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
+
+// ---------------------------------------------------------------------------
+// Unified Node API — discriminated-union input types
+// ---------------------------------------------------------------------------
+
+export type AddNodeInput =
+  | {
+      kind: 'container';
+      resourceType: string;
+      name: string;
+      parentId: string | null;
+      layer: LayerType;
+      access?: SubnetAccess;
+      profileId?: PlateProfileId;
+    }
+  | {
+      kind: 'resource';
+      resourceType: string;
+      name: string;
+      parentId: string | null;
+      provider?: ProviderType;
+      subtype?: string;
+      config?: Record<string, unknown>;
+    };
+
+export interface RemoveNodeOptions {
+  /** Whether to cascade-delete children. Defaults to true for containers, false for resources. */
+  cascade?: boolean;
+}
 export interface ArchitectureState {
   workspace: Workspace;
   workspaces: Workspace[];
@@ -16,15 +46,25 @@ export interface ArchitectureState {
   undo: () => void;
   redo: () => void;
 
+  // ── Unified Node API ──────────────────────────────────────────────
+  addNode: (input: AddNodeInput) => void;
+  removeNode: (id: string, options?: RemoveNodeOptions) => void;
+  renameNode: (id: string, newName: string) => void;
+  moveNodePosition: (id: string, deltaX: number, deltaZ: number) => void;
+
+  // ── Deprecated — use unified API above ─────────────────────────
+  /** @deprecated Use addNode({ kind: 'container', ... }) */
   addPlate: (
-    type: PlateType,
+    type: PlateLayerType,
     name: string,
     parentId: string | null,
     subnetAccess?: SubnetAccess,
     profileId?: PlateProfileId
   ) => void;
+  /** @deprecated Use removeNode(id) */
   removePlate: (id: string) => void;
 
+  /** @deprecated Use addNode({ kind: 'resource', ... }) */
   addBlock: (
     category: ResourceCategory,
     name: string,
@@ -33,13 +73,19 @@ export interface ArchitectureState {
     subtype?: string,
     config?: Record<string, unknown>,
   ) => void;
+  /** @deprecated Use addNode + duplicate logic */
   duplicateBlock: (blockId: string) => void;
+  /** @deprecated Use removeNode(id) */
   removeBlock: (id: string) => void;
+  /** @deprecated Use renameNode(id, name) */
   renameBlock: (blockId: string, newName: string) => void;
+  /** @deprecated Use renameNode(id, name) */
   renamePlate: (plateId: string, newName: string) => void;
   moveBlock: (blockId: string, newPlacementId: string) => void;
   setPlateProfile: (plateId: string, profileId: PlateProfileId) => void;
+  /** @deprecated Use moveNodePosition(id, dx, dz) */
   movePlatePosition: (id: string, deltaX: number, deltaZ: number) => void;
+  /** @deprecated Use moveNodePosition(id, dx, dz) */
   moveBlockPosition: (id: string, deltaX: number, deltaZ: number) => void;
   moveActorPosition: (id: string, deltaX: number, deltaZ: number) => void;
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { BlockCategory, ProviderType } from '@cloudblocks/schema';
+import type { ProviderType, ResourceCategory } from '@cloudblocks/schema';
 import type { EditorMode } from '../../shared/types/learning';
 import type { DiffDelta } from '../../shared/types/diff';
 import type { ArchitectureModel } from '@cloudblocks/schema';
@@ -59,7 +59,7 @@ interface UIState {
 
   // ── Interaction state machine ──
   interactionState: InteractionState;
-  startPlacing: (category: BlockCategory, resourceName: string) => void;
+  startPlacing: (category: ResourceCategory, resourceName: string) => void;
   startConnecting: (sourceId: string) => void;
   startDragging: () => void;
   startSelecting: () => void;
@@ -67,8 +67,8 @@ interface UIState {
   completeInteraction: () => void;
 
   // ── Drag state ──
-  draggedBlockCategory: BlockCategory | null;
-  setDraggedBlockCategory: (category: BlockCategory | null) => void;
+  draggedBlockCategory: ResourceCategory | null;
+  setDraggedBlockCategory: (category: ResourceCategory | null) => void;
   draggedResourceName: string | null;
   setDraggedResourceName: (name: string | null) => void;
   cancelDrag: () => void;

--- a/apps/web/src/entities/validation/aggregation.test.ts
+++ b/apps/web/src/entities/validation/aggregation.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import type { Block } from '@cloudblocks/schema';
+import type { LeafNode } from '@cloudblocks/schema';
 import { validateAggregation } from './aggregation';
 import { makeTestBlock, type LegacyBlockOverrides } from '../../__tests__/legacyModelTestUtils';
 
-function makeBlock(overrides: LegacyBlockOverrides = {}): Block {
+function makeBlock(overrides: LegacyBlockOverrides = {}): LeafNode {
   return makeTestBlock({
     id: 'block-1',
     name: 'Block One',

--- a/apps/web/src/entities/validation/role.test.ts
+++ b/apps/web/src/entities/validation/role.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import type { Block, BlockRole } from '@cloudblocks/schema';
+import type { BlockRole, LeafNode } from '@cloudblocks/schema';
 import { BLOCK_ROLES } from '@cloudblocks/domain';
 import { validateRoles } from './role';
 import { makeTestBlock, type LegacyBlockOverrides } from '../../__tests__/legacyModelTestUtils';
 
-function makeBlock(overrides: LegacyBlockOverrides = {}): Block {
+function makeBlock(overrides: LegacyBlockOverrides = {}): LeafNode {
   return makeTestBlock({
     id: 'block-1',
     name: 'Block One',

--- a/apps/web/src/features/diff/engine.test.ts
+++ b/apps/web/src/features/diff/engine.test.ts
@@ -1,19 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
-import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
+import type { ArchitectureModel, ContainerNode, LeafNode } from '@cloudblocks/schema';
 import type { ModifiedEntity, PropertyChange } from '../../shared/types/diff';
 import { computeArchitectureDiff, getDiffState, normalizeArchitecture } from './engine';
 import { makeTestArchitecture, makeTestBlock, makeTestPlate } from '../../__tests__/legacyModelTestUtils';
 
 type LegacyArchitecture = ArchitectureModel & {
-  plates: Plate[];
-  blocks: Block[];
+  plates: ContainerNode[];
+  blocks: LeafNode[];
 };
 
 function toArchitectureModel(model: ArchitectureModel | LegacyArchitecture): ArchitectureModel {
   const legacy = model as Partial<LegacyArchitecture>;
-  const plates = legacy.plates ?? model.nodes.filter((node): node is Plate => node.kind === 'container');
-  const blocks = legacy.blocks ?? model.nodes.filter((node): node is Block => node.kind === 'resource');
+  const plates = legacy.plates ?? model.nodes.filter((node): node is ContainerNode => node.kind === 'container');
+  const blocks = legacy.blocks ?? model.nodes.filter((node): node is LeafNode => node.kind === 'resource');
 
   return {
     id: model.id,
@@ -55,8 +55,8 @@ function createBaseArchitecture(): LegacyArchitecture {
 }
 
 function createEmptyArchitecture(id: string): LegacyArchitecture {
-  const plates: Plate[] = [];
-  const blocks: Block[] = [];
+  const plates: ContainerNode[] = [];
+  const blocks: LeafNode[] = [];
   const arch = makeTestArchitecture({
     id,
     name: 'Empty Architecture',
@@ -660,8 +660,8 @@ describe('normalizeArchitecture', () => {
     };
 
     const normalized = normalizeArchitecture(toArchitectureModel(unsorted));
-    const normalizedPlates = normalized.nodes.filter((node): node is Plate => node.kind === 'container');
-    const normalizedBlocks = normalized.nodes.filter((node): node is Block => node.kind === 'resource');
+    const normalizedPlates = normalized.nodes.filter((node): node is ContainerNode => node.kind === 'container');
+    const normalizedBlocks = normalized.nodes.filter((node): node is LeafNode => node.kind === 'resource');
 
     expect(normalizedPlates.map((plate) => plate.id)).toEqual(['plate-1', 'plate-2']);
     expect(normalizedBlocks.map((block) => block.id)).toEqual(['block-1', 'block-2']);

--- a/apps/web/src/features/generate/__tests__/generatorSubtype.test.ts
+++ b/apps/web/src/features/generate/__tests__/generatorSubtype.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { ArchitectureModel } from '@cloudblocks/schema';
 import { normalizeBicep } from '../bicep';
 import { normalizePulumi } from '../pulumi';
-import { awsProvider, awsProviderDefinition } from '../providers/aws';
+import { awsProviderDefinition } from '../providers/aws';
 import { generateMainTf, generateOutputsTf, normalize } from '../terraform';
 
 function createArchitecture(subtype?: string): ArchitectureModel {
@@ -50,8 +50,7 @@ describe('generator subtype mapping integration', () => {
   it('terraform normalize uses subtype mapping when block has subtype', () => {
     const model = normalize(
       createArchitecture('ec2'),
-      awsProvider,
-      awsProviderDefinition.subtypeBlockMappings,
+      awsProviderDefinition,
     );
 
     expect(model.resourceNames.get('block-1')).toBe('ec2_compute');
@@ -72,13 +71,12 @@ describe('generator subtype mapping integration', () => {
   it('generated terraform output uses subtype-specific resource type', () => {
     const normalized = normalize(
       createArchitecture('ec2'),
-      awsProvider,
-      awsProviderDefinition.subtypeBlockMappings,
+      awsProviderDefinition,
     );
 
     const mainTf = generateMainTf(
       normalized,
-      awsProvider,
+      awsProviderDefinition,
       {
         provider: 'aws',
         mode: 'draft',
@@ -86,13 +84,11 @@ describe('generator subtype mapping integration', () => {
         region: 'us-east-1',
         generator: 'terraform',
       },
-      awsProviderDefinition.subtypeBlockMappings,
     );
 
     const outputsTf = generateOutputsTf(
       normalized,
-      awsProvider,
-      awsProviderDefinition.subtypeBlockMappings,
+      awsProviderDefinition,
     );
 
     expect(mainTf).toContain('resource "aws_instance" "ec2_compute"');
@@ -105,8 +101,7 @@ describe('generator subtype mapping integration', () => {
 
     const terraformModel = normalize(
       architecture,
-      awsProvider,
-      awsProviderDefinition.subtypeBlockMappings,
+      awsProviderDefinition,
     );
     const bicepModel = normalizeBicep(architecture, awsProviderDefinition);
     const pulumiModel = normalizePulumi(architecture, awsProviderDefinition);

--- a/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
+++ b/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
@@ -3,37 +3,42 @@ import { describe, expect, it } from 'vitest';
 import type { ArchitectureModel, ContainerNode, LeafNode } from '@cloudblocks/schema';
 import type { ProviderName } from '../types';
 import { generateCode } from '../pipeline';
-import { getProvider } from '../provider';
+import { getProviderDefinition } from '../provider';
 
 const providerNames: ProviderName[] = ['azure', 'aws', 'gcp'];
 
-interface AdapterShape {
+interface DefinitionShape {
   name?: unknown;
   displayName?: unknown;
-  providerBlock?: unknown;
-  requiredProviders?: unknown;
   blockMappings?: unknown;
   plateMappings?: unknown;
+  generators?: {
+    terraform?: {
+      providerBlock?: unknown;
+      requiredProviders?: unknown;
+    };
+  };
 }
 
-function assertProviderAdapterShape(adapter: AdapterShape): void {
-  expect(adapter.name).toBeTruthy();
-  expect(adapter.displayName).toBeTruthy();
-  expect(typeof adapter.providerBlock).toBe('function');
-  expect(typeof adapter.requiredProviders).toBe('function');
-  expect(adapter.blockMappings).toBeDefined();
-  expect(adapter.plateMappings).toBeDefined();
+function assertProviderDefinitionShape(definition: DefinitionShape): void {
+  expect(definition.name).toBeTruthy();
+  expect(definition.displayName).toBeTruthy();
+  expect(definition.blockMappings).toBeDefined();
+  expect(definition.plateMappings).toBeDefined();
+  expect(definition.generators).toBeDefined();
+  expect(typeof definition.generators?.terraform?.providerBlock).toBe('function');
+  expect(typeof definition.generators?.terraform?.requiredProviders).toBe('function');
 }
 
-function getRequiredAdapter(name: ProviderName) {
-  const adapter = getProvider(name);
-  expect(adapter).toBeDefined();
+function getRequiredDefinition(name: ProviderName) {
+  const definition = getProviderDefinition(name);
+  expect(definition).toBeDefined();
 
-  if (!adapter) {
-    throw new Error(`Missing provider adapter for ${name}`);
+  if (!definition) {
+    throw new Error(`Missing provider definition for ${name}`);
   }
 
-  return adapter;
+  return definition;
 }
 
 function createContainer(overrides: Partial<ContainerNode>): ContainerNode {
@@ -69,38 +74,38 @@ function createResource(overrides: Partial<LeafNode>): LeafNode {
   };
 }
 
-describe('provider adapters', () => {
-  it('registry includes azure, aws, and gcp adapters', () => {
+describe('provider definitions', () => {
+  it('registry includes azure, aws, and gcp definitions', () => {
     const resolved = providerNames
-      .map((name) => getProvider(name)?.name)
+      .map((name) => getProviderDefinition(name)?.name)
       .filter((name): name is ProviderName => Boolean(name));
 
     expect(resolved.sort()).toEqual([...providerNames].sort());
   });
 
-  it('returns a valid adapter for azure', () => {
-    const adapter = getRequiredAdapter('azure');
+  it('returns a valid definition for azure', () => {
+    const definition = getRequiredDefinition('azure');
 
-    assertProviderAdapterShape(adapter);
-    expect(adapter.name).toBe('azure');
+    assertProviderDefinitionShape(definition);
+    expect(definition.name).toBe('azure');
   });
 
-  it('returns a valid adapter for aws', () => {
-    const adapter = getRequiredAdapter('aws');
+  it('returns a valid definition for aws', () => {
+    const definition = getRequiredDefinition('aws');
 
-    assertProviderAdapterShape(adapter);
-    expect(adapter.name).toBe('aws');
+    assertProviderDefinitionShape(definition);
+    expect(definition.name).toBe('aws');
   });
 
-  it('returns a valid adapter for gcp', () => {
-    const adapter = getRequiredAdapter('gcp');
+  it('returns a valid definition for gcp', () => {
+    const definition = getRequiredDefinition('gcp');
 
-    assertProviderAdapterShape(adapter);
-    expect(adapter.name).toBe('gcp');
+    assertProviderDefinitionShape(definition);
+    expect(definition.name).toBe('gcp');
   });
 
   it('returns undefined for unknown providers', () => {
-    expect(getProvider('oracle-cloud' as ProviderName)).toBeUndefined();
+    expect(getProviderDefinition('oracle-cloud' as ProviderName)).toBeUndefined();
   });
 
   it('azure adapter generates non-empty terraform output', () => {

--- a/apps/web/src/features/generate/bicep.test.ts
+++ b/apps/web/src/features/generate/bicep.test.ts
@@ -7,7 +7,7 @@ import {
   bicepPlugin,
 } from './bicep';
 import { azureProviderDefinition } from './provider';
-import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
+import type { ArchitectureModel, ContainerNode, LeafNode } from '@cloudblocks/schema';
 import type { GenerationOptions } from './types';
 import {
   makeTestArchitecture,
@@ -21,7 +21,7 @@ import {
 const basePosition = { x: 0, y: 0, z: 0 };
 const baseSize = { width: 1, height: 1, depth: 1 };
 
-function createPlate(overrides: LegacyPlateOverrides): Plate {
+function createPlate(overrides: LegacyPlateOverrides): ContainerNode {
   return makeTestPlate({
     id: 'plate-default',
     name: 'Default',
@@ -34,7 +34,7 @@ function createPlate(overrides: LegacyPlateOverrides): Plate {
   });
 }
 
-function createBlock(overrides: LegacyBlockOverrides): Block {
+function createBlock(overrides: LegacyBlockOverrides): LeafNode {
   return makeTestBlock({
     id: 'block-default',
     name: 'Default',

--- a/apps/web/src/features/generate/pipeline.test.ts
+++ b/apps/web/src/features/generate/pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ArchitectureModel, ContainerNode, LeafNode } from '@cloudblocks/schema';
 import type { GeneratedOutput, GeneratedFile, GenerationOptions, GeneratorPlugin } from './types';
-import { GenerationError, generateTerraform, terraformPipeline, generateCode } from './pipeline';
+import { GenerationError, generateCode } from './pipeline';
 import { registerGenerator } from './registry';
 
 describe('pipeline', () => {
@@ -74,7 +74,7 @@ describe('pipeline', () => {
     });
   });
 
-  describe('generateTerraform', () => {
+  describe('generateCode (terraform)', () => {
     const validModel: ArchitectureModel = {
       id: 'arch-1',
       name: 'Test',
@@ -122,7 +122,7 @@ describe('pipeline', () => {
     };
 
     it('should return 3 files (main.tf, variables.tf, outputs.tf)', () => {
-      const result = generateTerraform(validModel, validOptions);
+      const result = generateCode(validModel, { ...validOptions, generator: 'terraform' });
       expect(result.files).toHaveLength(3);
       expect(result.files.map((f) => f.path)).toEqual([
         'main.tf',
@@ -132,34 +132,34 @@ describe('pipeline', () => {
     });
 
     it('should have all files with language "hcl"', () => {
-      const result = generateTerraform(validModel, validOptions);
+      const result = generateCode(validModel, { ...validOptions, generator: 'terraform' });
       result.files.forEach((file) => {
         expect(file.language).toBe('hcl');
       });
     });
 
-    it('should set metadata.generator to "cloudblocks"', () => {
-      const result = generateTerraform(validModel, validOptions);
-      expect(result.metadata.generator).toBe('cloudblocks');
+    it('should set metadata.generator to "terraform"', () => {
+      const result = generateCode(validModel, { ...validOptions, generator: 'terraform' });
+      expect(result.metadata.generator).toBe('terraform');
     });
 
     it('should set metadata.version to "1.0.0"', () => {
-      const result = generateTerraform(validModel, validOptions);
+      const result = generateCode(validModel, { ...validOptions, generator: 'terraform' });
       expect(result.metadata.version).toBe('1.0.0');
     });
 
     it('should set metadata.provider from options', () => {
-      const result = generateTerraform(validModel, validOptions);
+      const result = generateCode(validModel, { ...validOptions, generator: 'terraform' });
       expect(result.metadata.provider).toBe('azure');
     });
 
     it('should set metadata.generatedAt to current time in ISO format', () => {
-      const result = generateTerraform(validModel, validOptions);
+      const result = generateCode(validModel, { ...validOptions, generator: 'terraform' });
       expect(result.metadata.generatedAt).toBe('2025-01-01T00:00:00.000Z');
     });
 
     it('should have content in all files', () => {
-      const result = generateTerraform(validModel, validOptions);
+      const result = generateCode(validModel, { ...validOptions, generator: 'terraform' });
       result.files.forEach((file) => {
         expect(file.content).toBeTruthy();
         expect(typeof file.content).toBe('string');
@@ -206,7 +206,7 @@ describe('pipeline', () => {
         updatedAt: '2025-01-01T00:00:00Z',
       };
 
-      expect(() => generateTerraform(invalidModel, validOptions)).toThrow(
+      expect(() => generateCode(invalidModel, { ...validOptions, generator: 'terraform' })).toThrow(
         GenerationError
       );
     });
@@ -216,77 +216,12 @@ describe('pipeline', () => {
         '{"provider":"oracle-cloud","mode":"draft","projectName":"test","region":"eastus"}'
       ) as GenerationOptions;
 
-      expect(() => generateTerraform(validModel, badOptions)).toThrow(
+      expect(() => generateCode(validModel, { ...badOptions, generator: 'terraform' })).toThrow(
         GenerationError
       );
-      expect(() => generateTerraform(validModel, badOptions)).toThrow(
+      expect(() => generateCode(validModel, { ...badOptions, generator: 'terraform' })).toThrow(
         /Unknown provider/
       );
-    });
-  });
-
-  describe('terraformPipeline', () => {
-    it('should export a pipeline object', () => {
-      expect(terraformPipeline).toBeDefined();
-      expect(terraformPipeline).toHaveProperty('generate');
-    });
-
-    it('should have generate method that is a function', () => {
-      expect(typeof terraformPipeline.generate).toBe('function');
-    });
-
-    it('generate method should be the same as generateTerraform', () => {
-      const validModel: ArchitectureModel = {
-        id: 'arch-1',
-        name: 'Test',
-        version: '1',
-        nodes: [
-          createContainer({
-            id: 'net-1',
-            name: 'VNet',
-            layer: 'region',
-            resourceType: 'virtual_network',
-            parentId: null,
-            position: { x: 0, y: 0, z: 0 },
-            size: { width: 12, height: 0.3, depth: 10 },
-          }),
-          createContainer({
-            id: 'sub-1',
-            name: 'Public',
-            layer: 'subnet',
-            resourceType: 'subnet',
-            subnetAccess: 'public',
-            parentId: 'net-1',
-            position: { x: 0, y: 0.3, z: 0 },
-            size: { width: 5, height: 0.2, depth: 8 },
-          }),
-          createResource({
-            id: 'blk-1',
-            name: 'WebApp',
-            category: 'compute',
-            resourceType: 'web_compute',
-            parentId: 'sub-1',
-            position: { x: 0, y: 0.5, z: 0 },
-          }),
-        ],
-        connections: [],
-        externalActors: [{ id: 'ext-1', name: 'Internet', type: 'internet' , position: { x: -3, y: 0, z: 5 } }],
-        createdAt: '2025-01-01T00:00:00Z',
-        updatedAt: '2025-01-01T00:00:00Z',
-      };
-
-      const validOptions: GenerationOptions = {
-        provider: 'azure',
-        mode: 'draft',
-        projectName: 'test',
-        region: 'eastus',
-      };
-
-      const pipelineResult = terraformPipeline.generate(validModel, validOptions);
-      const functionResult = generateTerraform(validModel, validOptions);
-
-      expect(pipelineResult.files).toEqual(functionResult.files);
-      expect(pipelineResult.metadata).toEqual(functionResult.metadata);
     });
   });
 

--- a/apps/web/src/features/generate/pipeline.ts
+++ b/apps/web/src/features/generate/pipeline.ts
@@ -3,21 +3,14 @@ import type {
   GeneratedOutput,
   GenerationOptions,
   GeneratorId,
-  GeneratorPipeline,
   ProviderName,
 } from './types';
-import { GENERATOR_METADATA_VERSION, isValidAzureRegion } from './types';
-import { getProvider, getProviderDefinition } from './provider';
+import { isValidAzureRegion } from './types';
+import { getProviderDefinition } from './provider';
 import { getGenerator, listGeneratorIds, registerGenerator } from './registry';
 import { terraformPlugin } from './terraformPlugin';
 import { bicepPlugin } from './bicep';
 import { pulumiPlugin } from './pulumi';
-import {
-  normalize,
-  generateMainTf,
-  generateVariablesTf,
-  generateOutputsTf,
-} from './terraform';
 import { validateArchitecture } from '../../entities/validation/engine';
 
 /**
@@ -146,72 +139,4 @@ export function generateCode(
   }
 
   return output;
-}
-
-// ─── Legacy Pipeline (backward compat) ──────────────────────
-
-function legacyGenerate(
-  architecture: ArchitectureModel,
-  options: GenerationOptions
-): GeneratedOutput {
-  // Stage 1: Validate
-  const validation = validateArchitecture(architecture);
-  if (!validation.valid) {
-    const errorMessages = validation.errors
-      .map((e) => e.message)
-      .join('; ');
-    throw new GenerationError(
-      `Architecture has validation errors: ${errorMessages}`
-    );
-  }
-
-  // Stage 1.5: Validate generation options
-  validateRegion(options);
-
-  // Stage 2: Resolve provider adapter (legacy)
-  const provider = getProvider(options.provider);
-  if (!provider) {
-    throw new GenerationError(
-      `Unknown provider: "${options.provider}". Available: azure, aws, gcp`
-    );
-  }
-
-  // Stage 3: Normalize
-  const normalized = normalize(architecture, provider);
-
-  // Stage 4: Generate
-  const mainTf = generateMainTf(normalized, provider, options);
-  const variablesTf = generateVariablesTf(options);
-  const outputsTf = generateOutputsTf(normalized, provider);
-
-  // Stage 5: Format
-  const files = [
-    { path: 'main.tf', content: mainTf, language: 'hcl' as const },
-    { path: 'variables.tf', content: variablesTf, language: 'hcl' as const },
-    { path: 'outputs.tf', content: outputsTf, language: 'hcl' as const },
-  ];
-
-  return {
-    files,
-      metadata: {
-        generator: 'cloudblocks',
-        version: GENERATOR_METADATA_VERSION,
-        provider: options.provider,
-        generatedAt: new Date().toISOString(),
-      },
-  };
-}
-
-export const terraformPipeline: GeneratorPipeline = { generate: legacyGenerate };
-
-/**
- * Convenience function for generating Terraform code.
- * Returns the generated output or throws GenerationError.
- * @deprecated Use generateCode() with options.generator = 'terraform' instead.
- */
-export function generateTerraform(
-  architecture: ArchitectureModel,
-  options: GenerationOptions
-): GeneratedOutput {
-  return terraformPipeline.generate(architecture, options);
 }

--- a/apps/web/src/features/generate/provider.test.ts
+++ b/apps/web/src/features/generate/provider.test.ts
@@ -1,66 +1,62 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  awsProvider,
   awsProviderDefinition,
-  gcpProvider,
   gcpProviderDefinition,
-  azureProvider,
   azureProviderDefinition,
-  getProvider,
   getProviderDefinition,
 } from './provider';
 
-describe('azureProvider', () => {
+describe('azureProviderDefinition', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   it('exposes azure provider identity', () => {
-    expect(azureProvider.name).toBe('azure');
-    expect(azureProvider.displayName).toBe('Azure');
+    expect(azureProviderDefinition.name).toBe('azure');
+    expect(azureProviderDefinition.displayName).toBe('Azure');
   });
 
   it('defines all block mappings', () => {
-    expect(azureProvider.blockMappings.compute).toEqual({
+    expect(azureProviderDefinition.blockMappings.compute).toEqual({
       resourceType: 'azurerm_linux_web_app',
       namePrefix: 'webapp',
     });
-    expect(azureProvider.blockMappings.data).toEqual({
+    expect(azureProviderDefinition.blockMappings.data).toEqual({
       resourceType: 'azurerm_postgresql_flexible_server',
       namePrefix: 'pgserver',
     });
-    expect(azureProvider.blockMappings.edge).toEqual({
+    expect(azureProviderDefinition.blockMappings.edge).toEqual({
       resourceType: 'azurerm_application_gateway',
       namePrefix: 'appgw',
     });
-    expect(azureProvider.blockMappings.messaging).toEqual({
+    expect(azureProviderDefinition.blockMappings.messaging).toEqual({
       resourceType: 'azurerm_storage_queue',
       namePrefix: 'queue',
     });
-    expect(azureProvider.blockMappings.security).toEqual({
+    expect(azureProviderDefinition.blockMappings.security).toEqual({
       resourceType: 'azurerm_user_assigned_identity',
       namePrefix: 'identity',
     });
-    expect(azureProvider.blockMappings.operations).toEqual({
+    expect(azureProviderDefinition.blockMappings.operations).toEqual({
       resourceType: 'azurerm_log_analytics_workspace',
       namePrefix: 'analytics',
     });
   });
 
   it('defines all plate mappings', () => {
-    expect(azureProvider.plateMappings.region).toEqual({
+    expect(azureProviderDefinition.plateMappings.region).toEqual({
       resourceType: 'azurerm_virtual_network',
       namePrefix: 'vnet',
     });
-    expect(azureProvider.plateMappings.subnet).toEqual({
+    expect(azureProviderDefinition.plateMappings.subnet).toEqual({
       resourceType: 'azurerm_subnet',
       namePrefix: 'subnet',
     });
   });
 
   it('builds provider block hcl', () => {
-    const block = azureProvider.providerBlock('eastus');
+    const block = azureProviderDefinition.generators.terraform.providerBlock('eastus');
 
     expect(block).toContain('provider "azurerm" {');
     expect(block).toContain('features {}');
@@ -69,31 +65,13 @@ describe('azureProvider', () => {
   });
 
   it('builds required_providers hcl', () => {
-    const requiredProviders = azureProvider.requiredProviders();
+    const requiredProviders = azureProviderDefinition.generators.terraform.requiredProviders();
 
     expect(requiredProviders).toContain('terraform {');
     expect(requiredProviders).toContain('required_providers {');
     expect(requiredProviders).toContain('azurerm = {');
     expect(requiredProviders).toContain('source  = "hashicorp/azurerm"');
     expect(requiredProviders).toContain('version = "~> 3.0"');
-  });
-});
-
-describe('getProvider', () => {
-  it('returns azure provider for azure name', () => {
-    expect(getProvider('azure')).toBe(azureProvider);
-  });
-
-  it('returns aws provider for aws name', () => {
-    expect(getProvider('aws')).toBe(awsProvider);
-  });
-
-  it('returns undefined for unknown name', () => {
-    expect(getProvider('unknown')).toBeUndefined();
-  });
-
-  it('returns gcp provider for gcp name', () => {
-    expect(getProvider('gcp')).toBe(gcpProvider);
   });
 });
 
@@ -115,60 +93,60 @@ describe('getProviderDefinition', () => {
   });
 });
 
-describe('awsProvider', () => {
+describe('awsProviderDefinition', () => {
   it('uses ECS service mapping for compute category and includes new category mappings', () => {
-    expect(awsProvider.blockMappings.compute).toEqual({
+    expect(awsProviderDefinition.blockMappings.compute).toEqual({
       resourceType: 'aws_ecs_service',
       namePrefix: 'ecs',
     });
-    expect(awsProvider.blockMappings.operations).toEqual({
+    expect(awsProviderDefinition.blockMappings.operations).toEqual({
       resourceType: 'aws_athena_workgroup',
       namePrefix: 'analytics',
     });
-    expect(awsProvider.blockMappings.security).toEqual({
+    expect(awsProviderDefinition.blockMappings.security).toEqual({
       resourceType: 'aws_iam_role',
       namePrefix: 'role',
     });
   });
 
   it('keeps expected network and subnet plate mappings', () => {
-    expect(awsProvider.plateMappings.region).toEqual({
+    expect(awsProviderDefinition.plateMappings.region).toEqual({
       resourceType: 'aws_vpc',
       namePrefix: 'vpc',
     });
-    expect(awsProvider.plateMappings.subnet).toEqual({
+    expect(awsProviderDefinition.plateMappings.subnet).toEqual({
       resourceType: 'aws_subnet',
       namePrefix: 'subnet',
     });
   });
 });
 
-describe('gcpProvider', () => {
+describe('gcpProviderDefinition', () => {
   it('uses Cloud Run/backend mappings and includes new category mappings', () => {
-    expect(gcpProvider.blockMappings.compute).toEqual({
+    expect(gcpProviderDefinition.blockMappings.compute).toEqual({
       resourceType: 'google_cloud_run_v2_service',
       namePrefix: 'run',
     });
-    expect(gcpProvider.blockMappings.edge).toEqual({
+    expect(gcpProviderDefinition.blockMappings.edge).toEqual({
       resourceType: 'google_compute_backend_service',
       namePrefix: 'backend',
     });
-    expect(gcpProvider.blockMappings.operations).toEqual({
+    expect(gcpProviderDefinition.blockMappings.operations).toEqual({
       resourceType: 'google_bigquery_dataset',
       namePrefix: 'analytics',
     });
-    expect(gcpProvider.blockMappings.security).toEqual({
+    expect(gcpProviderDefinition.blockMappings.security).toEqual({
       resourceType: 'google_service_account',
       namePrefix: 'sa',
     });
   });
 
   it('keeps expected network and subnet plate mappings', () => {
-    expect(gcpProvider.plateMappings.region).toEqual({
+    expect(gcpProviderDefinition.plateMappings.region).toEqual({
       resourceType: 'google_compute_network',
       namePrefix: 'network',
     });
-    expect(gcpProvider.plateMappings.subnet).toEqual({
+    expect(gcpProviderDefinition.plateMappings.subnet).toEqual({
       resourceType: 'google_compute_subnetwork',
       namePrefix: 'subnet',
     });

--- a/apps/web/src/features/generate/provider.ts
+++ b/apps/web/src/features/generate/provider.ts
@@ -1,22 +1,12 @@
-import type { ProviderAdapter, ProviderDefinition, ProviderName } from './types';
-import { awsProvider, awsProviderDefinition } from './providers/aws/index';
-import { azureProvider, azureProviderDefinition } from './providers/azure/index';
-import { gcpProvider, gcpProviderDefinition } from './providers/gcp/index';
+import type { ProviderDefinition, ProviderName } from './types';
+import { awsProviderDefinition } from './providers/aws/index';
+import { azureProviderDefinition } from './providers/azure/index';
+import { gcpProviderDefinition } from './providers/gcp/index';
 
 export {
-  awsProvider,
   awsProviderDefinition,
-  azureProvider,
   azureProviderDefinition,
-  gcpProvider,
   gcpProviderDefinition,
-};
-
-/** Provider registry — extensible for future providers */
-const providers: Record<string, ProviderAdapter> = {
-  azure: azureProvider,
-  aws: awsProvider,
-  gcp: gcpProvider,
 };
 
 const providerDefinitions: Record<string, ProviderDefinition> = {
@@ -24,10 +14,6 @@ const providerDefinitions: Record<string, ProviderDefinition> = {
   aws: awsProviderDefinition,
   gcp: gcpProviderDefinition,
 };
-
-export function getProvider(name: string): ProviderAdapter | undefined {
-  return providers[name];
-}
 
 export function getProviderDefinition(name: ProviderName): ProviderDefinition | undefined {
   return providerDefinitions[name];

--- a/apps/web/src/features/generate/providers/aws/index.ts
+++ b/apps/web/src/features/generate/providers/aws/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderAdapter, ProviderDefinition, SubtypeResourceMap } from '../../types';
+import type { ProviderDefinition, SubtypeResourceMap } from '../../types';
 
 const awsSubtypeBlockMappings: SubtypeResourceMap = {
   compute: {
@@ -114,13 +114,4 @@ export const awsProviderDefinition: ProviderDefinition = {
     },
   },
   subtypeBlockMappings: awsSubtypeBlockMappings,
-};
-
-export const awsProvider: ProviderAdapter = {
-  name: awsProviderDefinition.name,
-  displayName: awsProviderDefinition.displayName,
-  blockMappings: awsProviderDefinition.blockMappings,
-  plateMappings: awsProviderDefinition.plateMappings,
-  providerBlock: awsProviderDefinition.generators.terraform.providerBlock,
-  requiredProviders: awsProviderDefinition.generators.terraform.requiredProviders,
 };

--- a/apps/web/src/features/generate/providers/azure/index.ts
+++ b/apps/web/src/features/generate/providers/azure/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderAdapter, ProviderDefinition, SubtypeResourceMap } from '../../types';
+import type { ProviderDefinition, SubtypeResourceMap } from '../../types';
 
 const azureSubtypeBlockMappings: SubtypeResourceMap = {
   compute: {
@@ -172,17 +172,4 @@ export const azureProviderDefinition: ProviderDefinition = {
     },
   },
   subtypeBlockMappings: azureSubtypeBlockMappings,
-};
-
-/**
- * Legacy ProviderAdapter — wraps ProviderDefinition for backward compat with terraform.ts.
- * @deprecated Prefer using ProviderDefinition directly via getProviderDefinition().
- */
-export const azureProvider: ProviderAdapter = {
-  name: azureProviderDefinition.name,
-  displayName: azureProviderDefinition.displayName,
-  blockMappings: azureProviderDefinition.blockMappings,
-  plateMappings: azureProviderDefinition.plateMappings,
-  providerBlock: azureProviderDefinition.generators.terraform.providerBlock,
-  requiredProviders: azureProviderDefinition.generators.terraform.requiredProviders,
 };

--- a/apps/web/src/features/generate/providers/gcp/index.ts
+++ b/apps/web/src/features/generate/providers/gcp/index.ts
@@ -1,4 +1,4 @@
-import type { ProviderAdapter, ProviderDefinition, SubtypeResourceMap } from '../../types';
+import type { ProviderDefinition, SubtypeResourceMap } from '../../types';
 
 const gcpSubtypeBlockMappings: SubtypeResourceMap = {
   compute: {
@@ -114,13 +114,4 @@ export const gcpProviderDefinition: ProviderDefinition = {
     },
   },
   subtypeBlockMappings: gcpSubtypeBlockMappings,
-};
-
-export const gcpProvider: ProviderAdapter = {
-  name: gcpProviderDefinition.name,
-  displayName: gcpProviderDefinition.displayName,
-  blockMappings: gcpProviderDefinition.blockMappings,
-  plateMappings: gcpProviderDefinition.plateMappings,
-  providerBlock: gcpProviderDefinition.generators.terraform.providerBlock,
-  requiredProviders: gcpProviderDefinition.generators.terraform.requiredProviders,
 };

--- a/apps/web/src/features/generate/pulumi.test.ts
+++ b/apps/web/src/features/generate/pulumi.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { normalizePulumi, generateIndexTs, generatePulumiYaml, pulumiPlugin } from './pulumi';
 import { azureProviderDefinition } from './provider';
-import type { ArchitectureModel, Block, Plate } from '@cloudblocks/schema';
+import type { ArchitectureModel, ContainerNode, LeafNode } from '@cloudblocks/schema';
 import type { GenerationOptions } from './types';
 import {
   makeTestArchitecture,
@@ -16,7 +16,7 @@ import {
 const basePosition = { x: 0, y: 0, z: 0 };
 const baseSize = { width: 1, height: 1, depth: 1 };
 
-function createPlate(overrides: LegacyPlateOverrides): Plate {
+function createPlate(overrides: LegacyPlateOverrides): ContainerNode {
   return makeTestPlate({
     id: 'plate-default',
     name: 'Default',
@@ -29,7 +29,7 @@ function createPlate(overrides: LegacyPlateOverrides): Plate {
   });
 }
 
-function createBlock(overrides: LegacyBlockOverrides): Block {
+function createBlock(overrides: LegacyBlockOverrides): LeafNode {
   return makeTestBlock({
     id: 'block-default',
     name: 'Default',

--- a/apps/web/src/features/generate/terraform.test.ts
+++ b/apps/web/src/features/generate/terraform.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { ArchitectureModel, Block, Connection, Plate } from '@cloudblocks/schema';
-import { azureProvider, azureProviderDefinition } from './provider';
+import type { ArchitectureModel, Connection, ContainerNode, LeafNode } from '@cloudblocks/schema';
+import { azureProviderDefinition } from './provider';
 import {
   generateMainTf,
   generateOutputsTf,
@@ -20,7 +20,7 @@ import {
 const basePosition = { x: 0, y: 0, z: 0 };
 const baseSize = { width: 1, height: 1, depth: 1 };
 
-function createPlate(overrides: LegacyPlateOverrides): Plate {
+function createPlate(overrides: LegacyPlateOverrides): ContainerNode {
   return makeTestPlate({
     id: 'plate-default',
     name: 'Default Plate',
@@ -33,7 +33,7 @@ function createPlate(overrides: LegacyPlateOverrides): Plate {
   });
 }
 
-function createBlock(overrides: LegacyBlockOverrides): Block {
+function createBlock(overrides: LegacyBlockOverrides): LeafNode {
   return makeTestBlock({
     id: 'block-default',
     name: 'Default Block',
@@ -96,7 +96,7 @@ describe('normalize', () => {
       ],
     });
 
-    const normalized = normalize(model, azureProvider);
+    const normalized = normalize(model, azureProviderDefinition);
 
     expect(normalized.resourceNames.get('net-1')).toBe('vnet_main_net');
     expect(normalized.resourceNames.get('net-2')).toBe('vnet_main_net_2');
@@ -111,7 +111,7 @@ describe('normalize', () => {
       blocks: [createBlock({ id: 'web-1', name: 'My App ! 01', category: 'compute' })],
     });
 
-    const normalized = normalize(model, azureProvider);
+    const normalized = normalize(model, azureProviderDefinition);
 
     expect(normalized.resourceNames.get('net-1')).toBe('vnet_core_network');
     expect(normalized.resourceNames.get('web-1')).toBe('webapp_my_app_01');
@@ -142,8 +142,8 @@ describe('generateMainTf', () => {
       ],
     });
 
-    const normalized = normalize(model, azureProvider);
-    const hcl = generateMainTf(normalized, azureProvider, defaultOptions);
+    const normalized = normalize(model, azureProviderDefinition);
+    const hcl = generateMainTf(normalized, azureProviderDefinition, defaultOptions);
 
     expect(hcl).toContain('terraform {');
     expect(hcl).toContain('required_providers {');
@@ -165,13 +165,13 @@ describe('generateMainTf', () => {
     });
 
     const withComputeHcl = generateMainTf(
-      normalize(withCompute, azureProvider),
-      azureProvider,
+      normalize(withCompute, azureProviderDefinition),
+      azureProviderDefinition,
       defaultOptions
     );
     const withoutComputeHcl = generateMainTf(
-      normalize(withoutCompute, azureProvider),
-      azureProvider,
+      normalize(withoutCompute, azureProviderDefinition),
+      azureProviderDefinition,
       defaultOptions
     );
 
@@ -193,7 +193,7 @@ describe('generateMainTf', () => {
       ],
     });
 
-    const hcl = generateMainTf(normalize(model, azureProvider), azureProvider, defaultOptions);
+    const hcl = generateMainTf(normalize(model, azureProviderDefinition), azureProviderDefinition, defaultOptions);
     const networkIndex = hcl.indexOf('resource "azurerm_virtual_network" "vnet_app_network"');
     const subnetIndex = hcl.indexOf('resource "azurerm_subnet" "subnet_app_subnet"');
 
@@ -216,7 +216,7 @@ describe('generateMainTf', () => {
       ],
     });
 
-    const hcl = generateMainTf(normalize(model, azureProvider), azureProvider, defaultOptions);
+    const hcl = generateMainTf(normalize(model, azureProviderDefinition), azureProviderDefinition, defaultOptions);
 
     expect(hcl).toContain('virtual_network_name = azurerm_virtual_network.vnet_network-a.name');
     expect(hcl).toContain('address_prefixes     = ["10.0.1.0/24"]');
@@ -233,7 +233,7 @@ describe('generateMainTf', () => {
       ],
     });
 
-    const hcl = generateMainTf(normalize(model, azureProvider), azureProvider, defaultOptions);
+    const hcl = generateMainTf(normalize(model, azureProviderDefinition), azureProviderDefinition, defaultOptions);
 
     expect(hcl).toContain('service_plan_id     = azurerm_service_plan.main.id');
     expect(hcl).toContain('administrator_login    = var.db_admin_username');
@@ -254,13 +254,13 @@ describe('generateMainTf', () => {
     });
 
     const hclWithConnections = generateMainTf(
-      normalize(withConnections, azureProvider),
-      azureProvider,
+      normalize(withConnections, azureProviderDefinition),
+      azureProviderDefinition,
       defaultOptions
     );
     const hclWithoutConnections = generateMainTf(
-      normalize(withoutConnections, azureProvider),
-      azureProvider,
+      normalize(withoutConnections, azureProviderDefinition),
+      azureProviderDefinition,
       defaultOptions
     );
 
@@ -282,7 +282,7 @@ describe('generateMainTf', () => {
       ],
     });
 
-    const hcl = generateMainTf(normalize(model, azureProvider), azureProvider, defaultOptions);
+    const hcl = generateMainTf(normalize(model, azureProviderDefinition), azureProviderDefinition, defaultOptions);
 
     expect(hcl).toContain('resource "azurerm_linux_web_app"');
     expect(hcl).toContain('resource "azurerm_storage_queue"');
@@ -296,20 +296,19 @@ describe('generateMainTf', () => {
       blocks: [createBlock({ id: 'fn1', name: 'Handler', category: 'compute', placementId: 'net1' })],
     });
 
-    const hcl = generateMainTf(normalize(model, azureProvider), azureProvider, defaultOptions);
+    const hcl = generateMainTf(normalize(model, azureProviderDefinition), azureProviderDefinition, defaultOptions);
 
     expect(hcl).toContain('resource "azurerm_service_plan" "main"');
     expect(hcl).toContain('resource "azurerm_linux_web_app"');
   });
 
   it('generates implicit PIP + NIC for VM blocks', () => {
-    const subtypeMappings = azureProviderDefinition.subtypeBlockMappings;
     const model = createTestModel({
       blocks: [createBlock({ id: 'vm1', name: 'WebServer', category: 'compute', subtype: 'vm' })],
     });
 
-    const normalized = normalize(model, azureProvider, subtypeMappings);
-    const hcl = generateMainTf(normalized, azureProvider, defaultOptions, subtypeMappings);
+    const normalized = normalize(model, azureProviderDefinition);
+    const hcl = generateMainTf(normalized, azureProviderDefinition, defaultOptions);
 
     expect(hcl).toContain('resource "azurerm_public_ip" "vm_webserver_pip"');
     expect(hcl).toContain('allocation_method   = "Static"');
@@ -329,8 +328,8 @@ describe('generateMainTf', () => {
       blocks: [createBlock({ id: 'fw1', name: 'MainFirewall', category: 'edge', subtype: 'firewall' })],
     });
 
-    const normalized = normalize(model, azureProvider);
-    const hcl = generateMainTf(normalized, azureProvider, defaultOptions);
+    const normalized = normalize(model, azureProviderDefinition);
+    const hcl = generateMainTf(normalized, azureProviderDefinition, defaultOptions);
 
     expect(hcl).toContain('resource "azurerm_public_ip" "appgw_mainfirewall_pip"');
     expect(hcl).not.toContain('azurerm_network_interface');
@@ -341,8 +340,8 @@ describe('generateMainTf', () => {
       blocks: [createBlock({ id: 'lb1', name: 'InternalLB', category: 'edge', subtype: 'internal-lb' })],
     });
 
-    const normalized = normalize(model, azureProvider);
-    const hcl = generateMainTf(normalized, azureProvider, defaultOptions);
+    const normalized = normalize(model, azureProviderDefinition);
+    const hcl = generateMainTf(normalized, azureProviderDefinition, defaultOptions);
 
     expect(hcl).not.toContain('azurerm_public_ip');
     expect(hcl).not.toContain('azurerm_network_interface');
@@ -353,8 +352,8 @@ describe('generateMainTf', () => {
       blocks: [createBlock({ id: 'web1', name: 'App', category: 'compute' })],
     });
 
-    const normalized = normalize(model, azureProvider);
-    const hcl = generateMainTf(normalized, azureProvider, defaultOptions);
+    const normalized = normalize(model, azureProviderDefinition);
+    const hcl = generateMainTf(normalized, azureProviderDefinition, defaultOptions);
 
     expect(hcl).not.toContain('azurerm_public_ip');
     expect(hcl).not.toContain('azurerm_network_interface');
@@ -390,8 +389,8 @@ describe('generateOutputsTf', () => {
       ],
     });
 
-    const normalized = normalize(model, azureProvider);
-    const hcl = generateOutputsTf(normalized, azureProvider);
+    const normalized = normalize(model, azureProviderDefinition);
+    const hcl = generateOutputsTf(normalized, azureProviderDefinition);
 
     expect(hcl).toContain('output "resource_group_name" {');
     expect(hcl).toContain('output "webapp_compute_id" {');

--- a/apps/web/src/features/generate/terraform.ts
+++ b/apps/web/src/features/generate/terraform.ts
@@ -2,9 +2,8 @@ import type { ArchitectureModel, Connection, ContainerNode, LeafNode } from '@cl
 import type {
   GenerationOptions,
   NormalizedModel,
-  ProviderAdapter,
+  ProviderDefinition,
   ResourceMapping,
-  SubtypeResourceMap,
 } from './types';
 import { resolveBlockMapping, sanitizeIaCValue } from './types';
 
@@ -47,8 +46,7 @@ function getPlateType(plate: ContainerNode): 'global' | 'edge' | 'region' | 'zon
 
 export function normalize(
   architecture: ArchitectureModel,
-  provider: ProviderAdapter,
-  subtypeBlockMappings?: SubtypeResourceMap,
+  provider: ProviderDefinition,
 ): NormalizedModel {
   const containers = architecture.nodes.filter((n): n is ContainerNode => n.kind === 'container');
   const resources = architecture.nodes.filter((n): n is LeafNode => n.kind === 'resource');
@@ -77,7 +75,7 @@ export function normalize(
   for (const block of resources) {
     const mapping = resolveBlockMapping(
       provider.blockMappings,
-      subtypeBlockMappings,
+      provider.subtypeBlockMappings,
       block.category,
       block.subtype,
     )!;
@@ -242,9 +240,8 @@ function generateConnectionComment(
 
 export function generateMainTf(
   normalized: NormalizedModel,
-  provider: ProviderAdapter,
+  provider: ProviderDefinition,
   options: GenerationOptions,
-  subtypeBlockMappings?: SubtypeResourceMap,
 ): string {
   const { architecture, resourceNames } = normalized;
   const containers = architecture.nodes.filter((n): n is ContainerNode => n.kind === 'container');
@@ -258,11 +255,11 @@ export function generateMainTf(
   sections.push('');
 
   // Required providers
-  sections.push(provider.requiredProviders());
+  sections.push(provider.generators.terraform.requiredProviders());
   sections.push('');
 
   // Provider block
-  sections.push(provider.providerBlock(options.region));
+  sections.push(provider.generators.terraform.providerBlock(options.region));
   sections.push('');
 
   // Resource group
@@ -315,7 +312,7 @@ export function generateMainTf(
     const resName = resourceNames.get(block.id)!;
     const mapping = resolveBlockMapping(
       provider.blockMappings,
-      subtypeBlockMappings,
+      provider.subtypeBlockMappings,
       block.category,
       block.subtype,
     )!;
@@ -378,8 +375,7 @@ export function generateVariablesTf(options: GenerationOptions): string {
 
 export function generateOutputsTf(
   normalized: NormalizedModel,
-  provider: ProviderAdapter,
-  subtypeBlockMappings?: SubtypeResourceMap,
+  provider: ProviderDefinition,
 ): string {
   const { architecture, resourceNames } = normalized;
   const resources = architecture.nodes.filter((n): n is LeafNode => n.kind === 'resource');
@@ -396,7 +392,7 @@ export function generateOutputsTf(
     const resName = resourceNames.get(block.id)!;
     const mapping = resolveBlockMapping(
       provider.blockMappings,
-      subtypeBlockMappings,
+      provider.subtypeBlockMappings,
       block.category,
       block.subtype,
     )!;

--- a/apps/web/src/features/generate/terraformPlugin.ts
+++ b/apps/web/src/features/generate/terraformPlugin.ts
@@ -19,34 +19,12 @@ export const terraformPlugin: GeneratorPlugin = {
     { path: 'outputs.tf', language: 'hcl' },
   ],
 
-  normalize: (arch, ctx) => {
-    // The legacy ProviderAdapter interface is compatible enough for normalize()
-    const legacyAdapter = {
-      name: ctx.provider.name,
-      displayName: ctx.provider.displayName,
-      blockMappings: ctx.provider.blockMappings,
-      subtypeBlockMappings: ctx.provider.subtypeBlockMappings,
-      plateMappings: ctx.provider.plateMappings,
-      providerBlock: ctx.provider.generators.terraform.providerBlock,
-      requiredProviders: ctx.provider.generators.terraform.requiredProviders,
-    };
-    return normalize(arch, legacyAdapter, ctx.provider.subtypeBlockMappings);
-  },
+  normalize: (arch, ctx) => normalize(arch, ctx.provider),
 
   generate: (model, ctx) => {
-    const legacyAdapter = {
-      name: ctx.provider.name,
-      displayName: ctx.provider.displayName,
-      blockMappings: ctx.provider.blockMappings,
-      subtypeBlockMappings: ctx.provider.subtypeBlockMappings,
-      plateMappings: ctx.provider.plateMappings,
-      providerBlock: ctx.provider.generators.terraform.providerBlock,
-      requiredProviders: ctx.provider.generators.terraform.requiredProviders,
-    };
-
-    const mainTf = generateMainTf(model, legacyAdapter, ctx.options, ctx.provider.subtypeBlockMappings);
+    const mainTf = generateMainTf(model, ctx.provider, ctx.options);
     const variablesTf = generateVariablesTf(ctx.options);
-    const outputsTf = generateOutputsTf(model, legacyAdapter, ctx.provider.subtypeBlockMappings);
+    const outputsTf = generateOutputsTf(model, ctx.provider);
 
     return {
       files: [

--- a/apps/web/src/features/generate/types.ts
+++ b/apps/web/src/features/generate/types.ts
@@ -1,4 +1,6 @@
-import type { ArchitectureModel, BlockCategory, PlateType, ProviderType } from '@cloudblocks/schema';
+import type { ArchitectureModel, ProviderType, ResourceCategory } from '@cloudblocks/schema';
+
+type PlateLayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
 
 /**
  * Code Generation Types (v1.0)
@@ -9,7 +11,7 @@ import type { ArchitectureModel, BlockCategory, PlateType, ProviderType } from '
  *
  * v1.0 additions:
  *   - GeneratorId, FileLanguage, GeneratorPlugin (multi-generator support)
- *   - ProviderDefinition (per-generator config, replaces ProviderAdapter)
+ *   - ProviderDefinition (per-generator config)
  *   - ValidationIssue (generator-level validation)
  */
 
@@ -85,16 +87,16 @@ export interface ResourceMapping {
   namePrefix: string;
 }
 
-export type BlockResourceMap = Record<BlockCategory, ResourceMapping>;
-export type PlateResourceMap = Record<PlateType, ResourceMapping>;
+export type BlockResourceMap = Record<ResourceCategory, ResourceMapping>;
+export type PlateResourceMap = Record<PlateLayerType, ResourceMapping>;
 
 // ─── Subtype-Aware Mapping ───────────────────────────────────
 
 /**
- * Maps BlockCategory → subtype string → ResourceMapping.
+ * Maps ResourceCategory → subtype string → ResourceMapping.
  * Used alongside BlockResourceMap for subtype-specific resource resolution.
  */
-export type SubtypeResourceMap = Partial<Record<BlockCategory, Record<string, ResourceMapping>>>;
+export type SubtypeResourceMap = Partial<Record<ResourceCategory, Record<string, ResourceMapping>>>;
 
 /**
  * Resolve the correct ResourceMapping for a block based on category and optional subtype.
@@ -106,7 +108,7 @@ export type SubtypeResourceMap = Partial<Record<BlockCategory, Record<string, Re
 export function resolveBlockMapping(
   blockMappings: BlockResourceMap,
   subtypeMappings: SubtypeResourceMap | undefined,
-  category: BlockCategory,
+  category: ResourceCategory,
   subtype?: string,
 ): ResourceMapping | undefined {
   if (subtype && subtypeMappings) {
@@ -117,21 +119,6 @@ export function resolveBlockMapping(
   }
 
   return blockMappings[category];
-}
-
-/**
- * @deprecated Use `ProviderDefinition` instead.
- * Legacy adapter type retained for backward compatibility with older Terraform-only paths.
- */
-export interface ProviderAdapter {
-  name: ProviderName;
-  displayName: string;
-  blockMappings: BlockResourceMap;
-  plateMappings: PlateResourceMap;
-  /** Generate provider block HCL */
-  providerBlock: (region: string) => string;
-  /** Generate terraform required_providers block */
-  requiredProviders: () => string;
 }
 
 // ─── Provider Definition (v1.0) ─────────────────────────────

--- a/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
@@ -98,13 +98,11 @@ const computeBlock: LeafNode = {
 };
 
 describe('CommandCard', () => {
-  const addPlateMock = vi.fn();
-  const addBlockMock = vi.fn();
+  const addNodeMock = vi.fn();
   const duplicateBlockMock = vi.fn();
   const renameBlockMock = vi.fn();
   const renamePlateMock = vi.fn();
-  const removeBlockMock = vi.fn();
-  const removePlateMock = vi.fn();
+  const removeNodeMock = vi.fn();
   const toggleResourceGuideMock = vi.fn();
   const setSelectedIdMock = vi.fn<(id: string | null) => void>();
   const setToolModeMock = vi.fn<(mode: ToolMode) => void>();
@@ -123,13 +121,11 @@ describe('CommandCard', () => {
     });
 
     useArchitectureStore.setState({
-      addPlate: addPlateMock,
-      addBlock: addBlockMock,
+      addNode: addNodeMock,
       duplicateBlock: duplicateBlockMock,
       renameBlock: renameBlockMock,
       renamePlate: renamePlateMock,
-      removeBlock: removeBlockMock,
-      removePlate: removePlateMock,
+      removeNode: removeNodeMock,
       workspace: {
         id: 'ws-1',
         name: 'Test Workspace',
@@ -160,7 +156,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByRole('button', { name: /VNet/i }));
 
-    expect(addPlateMock).toHaveBeenCalledWith('region', 'VNet', null);
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'container', resourceType: 'virtual_network', name: 'VNet', parentId: null, layer: 'region' });
   });
 
   it('creates block resource when network and subnet exist', async () => {
@@ -183,7 +179,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByTitle('Create Virtual Machine'));
 
-    expect(addBlockMock).toHaveBeenCalledWith('compute', 'Virtual Machine 1', 'subnet-public-1', 'azure', 'virtual_machine');
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'resource', resourceType: 'virtual_machine', name: 'Virtual Machine 1', parentId: 'subnet-public-1', provider: 'azure', subtype: 'virtual_machine' });
   });
 
   it('smoke: create VM from Compute tab then show block actions when selected', async () => {
@@ -206,7 +202,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByTitle('Create Virtual Machine'));
 
-    expect(addBlockMock).toHaveBeenCalledWith('compute', 'Virtual Machine 1', 'subnet-public-1', 'azure', 'virtual_machine');
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'resource', resourceType: 'virtual_machine', name: 'Virtual Machine 1', parentId: 'subnet-public-1', provider: 'azure', subtype: 'virtual_machine' });
 
     act(() => {
       useArchitectureStore.setState({
@@ -323,7 +319,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByTitle('Create Private Subnet'));
 
-    expect(addPlateMock).toHaveBeenCalledWith('subnet', 'Private Subnet', 'net-1', 'private');
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'container', resourceType: 'subnet', name: 'Private Subnet', parentId: 'net-1', layer: 'subnet', access: 'private' });
   });
 
   // ─── BlockActionMode Tests ───────────────────────────────
@@ -355,7 +351,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByRole('button', { name: /Delete/ }));
 
-    expect(removeBlockMock).toHaveBeenCalledWith('block-1');
+    expect(removeNodeMock).toHaveBeenCalledWith('block-1');
     expect(setSelectedIdMock).toHaveBeenCalledWith(null);
   });
 
@@ -862,7 +858,7 @@ describe('CommandCard', () => {
     // Now in PlateCreationMode — create a public subnet
     await user.click(screen.getByTitle('Create Public Subnet (Q)'));
 
-    expect(addPlateMock).toHaveBeenCalledWith('subnet', 'Public Subnet', 'net-1', 'public');
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'container', resourceType: 'subnet', name: 'Public Subnet', parentId: 'net-1', layer: 'subnet', access: 'public' });
   });
 
   it('returns from PlateCreationMode to PlateActionMode via back button', async () => {
@@ -917,7 +913,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByRole('button', { name: /Delete/ }));
 
-    expect(removePlateMock).toHaveBeenCalledWith('net-1');
+    expect(removeNodeMock).toHaveBeenCalledWith('net-1');
     expect(setSelectedIdMock).toHaveBeenCalledWith(null);
   });
 
@@ -1033,7 +1029,7 @@ describe('CommandCard', () => {
     // Now in PlateCreationMode — create a VM
     await user.click(screen.getByTitle('Create Virtual Machine (S)'));
 
-    expect(addBlockMock).toHaveBeenCalledWith('compute', 'Virtual Machine 1', 'subnet-public-1', 'azure', 'virtual_machine');
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'resource', resourceType: 'virtual_machine', name: 'Virtual Machine 1', parentId: 'subnet-public-1', provider: 'azure', subtype: 'virtual_machine' });
   });
 
   it('transitions to PlateCreationMode for private subnet deploy and creates SQL', async () => {
@@ -1064,7 +1060,7 @@ describe('CommandCard', () => {
     // Now in PlateCreationMode — create SQL
     await user.click(screen.getByTitle('Create SQL Database (W)'));
 
-    expect(addBlockMock).toHaveBeenCalledWith('data', 'SQL Database 1', 'subnet-private-1', 'azure', 'sql_database');
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'resource', resourceType: 'sql_database', name: 'SQL Database 1', parentId: 'subnet-private-1', provider: 'azure', subtype: 'sql_database' });
   });
 
   it('creates private subnet via Deploy on network plate', async () => {
@@ -1092,6 +1088,6 @@ describe('CommandCard', () => {
     // Create Private Subnet
     await user.click(screen.getByTitle('Create Private Subnet (W)'));
 
-    expect(addPlateMock).toHaveBeenCalledWith('subnet', 'Private Subnet', 'net-1', 'private');
+    expect(addNodeMock).toHaveBeenCalledWith({ kind: 'container', resourceType: 'subnet', name: 'Private Subnet', parentId: 'net-1', layer: 'subnet', access: 'private' });
   });
 });

--- a/apps/web/src/widgets/bottom-panel/CommandCard.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.tsx
@@ -77,10 +77,10 @@ function getPlateHeaderText(plate: ContainerNode): string {
   return plateType === 'region' ? 'VNet' : plateType.charAt(0).toUpperCase() + plateType.slice(1);
 }
 
-type CreationGroupId = ResourceCategory | 'plate';
+type CreationGroupId = ResourceCategory | 'foundation';
 
 const CREATION_GROUP_ORDER: CreationGroupId[] = [
-  'plate',
+  'foundation',
   'compute',
   'data',
   'edge',
@@ -90,7 +90,7 @@ const CREATION_GROUP_ORDER: CreationGroupId[] = [
 ];
 
 function getCreationGroupMeta(groupId: CreationGroupId): { icon: string; label: string; color: string } {
-  if (groupId === 'plate') {
+  if (groupId === 'foundation') {
     return {
       icon: '🧭',
       label: 'Network Foundations',
@@ -107,7 +107,7 @@ function getCreationGroupMeta(groupId: CreationGroupId): { icon: string; label: 
 
 function getCreationGroupId(type: ResourceType): CreationGroupId {
   const blockCategory = RESOURCE_DEFINITIONS[type].blockCategory;
-  return blockCategory ?? 'plate';
+  return blockCategory ?? 'foundation';
 }
 
 
@@ -192,8 +192,8 @@ export function CommandCard({ className = '' }: CommandCardProps) {
 
 function PlateActionMode({ selectedPlate, onDeploy }: { selectedPlate: ContainerNode; onDeploy: () => void }) {
   const setSelectedId = useUIStore((s) => s.setSelectedId);
-  const removePlate = useArchitectureStore((s) => s.removePlate);
-  const renamePlate = useArchitectureStore((s) => s.renamePlate);
+  const removeNode = useArchitectureStore((s) => s.removeNode);
+  const renameNode = useArchitectureStore((s) => s.renameNode);
   const isSoundMuted = useUIStore((s) => s.isSoundMuted);
   const playSound = useCallback((name: SoundName) => { if (!isSoundMuted) audioService.playSound(name); }, [isSoundMuted]);
 
@@ -205,19 +205,19 @@ function PlateActionMode({ selectedPlate, onDeploy }: { selectedPlate: Container
       case 'rename': {
         const newName = await promptDialog('Rename plate:', 'Rename', selectedPlate.name);
         if (newName !== null && newName.trim() !== '') {
-          renamePlate(selectedPlate.id, newName.trim());
+          renameNode(selectedPlate.id, newName.trim());
         }
         break;
       }
       case 'delete':
-        removePlate(selectedPlate.id);
+        removeNode(selectedPlate.id);
         setSelectedId(null);
         playSound('delete');
         break;
       default:
         break;
     }
-  }, [onDeploy, removePlate, renamePlate, selectedPlate.id, selectedPlate.name, setSelectedId, playSound]);
+  }, [onDeploy, removeNode, renameNode, selectedPlate.id, selectedPlate.name, setSelectedId, playSound]);
 
   return (
     <>
@@ -260,8 +260,7 @@ function PlateActionMode({ selectedPlate, onDeploy }: { selectedPlate: Container
 
 function CreationMode() {
   const techTree = useTechTree();
-  const addPlate = useArchitectureStore((s) => s.addPlate);
-  const addBlock = useArchitectureStore((s) => s.addBlock);
+  const addNode = useArchitectureStore((s) => s.addNode);
   const activeProvider = useUIStore((s) => s.activeProvider);
   const startPlacing = useUIStore((s) => s.startPlacing);
   const cancelInteraction = useUIStore((s) => s.cancelInteraction);
@@ -341,20 +340,20 @@ function CreationMode() {
     const def = RESOURCE_DEFINITIONS[type];
 
     // Handle plate creation
-    if (def.category === 'plate') {
+    if (def.category === 'foundation') {
       if (type === 'network') {
-        addPlate('region', 'VNet', null);
+        addNode({ kind: 'container', resourceType: 'virtual_network', name: 'VNet', parentId: null, layer: 'region' });
         playSound('block-snap');
       } else if (type === 'public-subnet') {
         const targetId = techTree.getTargetPlateId(type);
         if (targetId) {
-          addPlate('subnet', 'Public Subnet', targetId, 'public');
+          addNode({ kind: 'container', resourceType: 'subnet', name: 'Public Subnet', parentId: targetId, layer: 'subnet', access: 'public' });
           playSound('block-snap');
         }
       } else if (type === 'private-subnet') {
         const targetId = techTree.getTargetPlateId(type);
         if (targetId) {
-          addPlate('subnet', 'Private Subnet', targetId, 'private');
+          addNode({ kind: 'container', resourceType: 'subnet', name: 'Private Subnet', parentId: targetId, layer: 'subnet', access: 'private' });
           playSound('block-snap');
         }
       }
@@ -372,10 +371,10 @@ function CreationMode() {
 
       counterRef.current += 1;
       const name = `${getResourceLabel(type, activeProvider)} ${counterRef.current}`;
-      addBlock(def.blockCategory, name, targetId, activeProvider, def.schemaResourceType);
+      addNode({ kind: 'resource', resourceType: def.schemaResourceType ?? def.blockCategory, name, parentId: targetId, provider: activeProvider, subtype: def.schemaResourceType });
       playSound('block-snap');
     }
-  }, [activeProvider, addPlate, addBlock, techTree, playSound]);
+  }, [activeProvider, addNode, techTree, playSound]);
 
   return (
     <div ref={gridRef} className="command-card-creation-groups">
@@ -421,8 +420,7 @@ function CreationMode() {
 
 function PlateCreationMode({ selectedPlate }: { selectedPlate: ContainerNode }) {
   const techTree = useTechTree();
-  const addPlate = useArchitectureStore((s) => s.addPlate);
-  const addBlock = useArchitectureStore((s) => s.addBlock);
+  const addNode = useArchitectureStore((s) => s.addNode);
   const activeProvider = useUIStore((s) => s.activeProvider);
   const startPlacing = useUIStore((s) => s.startPlacing);
   const cancelInteraction = useUIStore((s) => s.cancelInteraction);
@@ -501,14 +499,14 @@ function PlateCreationMode({ selectedPlate }: { selectedPlate: ContainerNode }) 
 
     const def = RESOURCE_DEFINITIONS[type];
 
-    if (def.category === 'plate') {
+    if (def.category === 'foundation') {
       if (selectedPlate.layer !== 'region') return;
 
       if (type === 'public-subnet') {
-        addPlate('subnet', 'Public Subnet', selectedPlate.id, 'public');
+        addNode({ kind: 'container', resourceType: 'subnet', name: 'Public Subnet', parentId: selectedPlate.id, layer: 'subnet', access: 'public' });
         playSound('block-snap');
       } else if (type === 'private-subnet') {
-        addPlate('subnet', 'Private Subnet', selectedPlate.id, 'private');
+        addNode({ kind: 'container', resourceType: 'subnet', name: 'Private Subnet', parentId: selectedPlate.id, layer: 'subnet', access: 'private' });
         playSound('block-snap');
       }
 
@@ -521,9 +519,9 @@ function PlateCreationMode({ selectedPlate }: { selectedPlate: ContainerNode }) 
 
     counterRef.current += 1;
     const name = `${getResourceLabel(type, activeProvider)} ${counterRef.current}`;
-    addBlock(def.blockCategory, name, selectedPlate.id, activeProvider, def.schemaResourceType);
+    addNode({ kind: 'resource', resourceType: def.schemaResourceType ?? def.blockCategory, name, parentId: selectedPlate.id, provider: activeProvider, subtype: def.schemaResourceType });
     playSound('block-snap');
-  }, [activeProvider, addPlate, addBlock, selectedPlate.id, selectedPlate.layer, playSound]);
+  }, [activeProvider, addNode, selectedPlate.id, selectedPlate.layer, playSound]);
 
   const resourcePages = chunkResources(filteredContextResources, 9).map((page) => {
     const normalizedPage: (ResourceType | null)[] = [...page];
@@ -695,9 +693,8 @@ function BlockActionMode() {
   const setToolMode = useUIStore((s) => s.setToolMode);
   const toggleResourceGuide = useUIStore((s) => s.toggleResourceGuide);
   const duplicateBlock = useArchitectureStore((s) => s.duplicateBlock);
-  const renameBlock = useArchitectureStore((s) => s.renameBlock);
-  const removeBlock = useArchitectureStore((s) => s.removeBlock);
-  const removePlate = useArchitectureStore((s) => s.removePlate);
+  const renameNode = useArchitectureStore((s) => s.renameNode);
+  const removeNode = useArchitectureStore((s) => s.removeNode);
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
   const isSoundMuted = useUIStore((s) => s.isSoundMuted);
   const playSound = useCallback((name: SoundName) => { if (!isSoundMuted) audioService.playSound(name); }, [isSoundMuted]);
@@ -706,7 +703,6 @@ function BlockActionMode() {
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   const blocks = architecture.nodes.filter((node): node is LeafNode => node.kind === 'resource');
-  const plates = architecture.nodes.filter((node): node is ContainerNode => node.kind === 'container');
   const selectedBlock = selectedId ? blocks.find((b) => b.id === selectedId) ?? null : null;
 
   useEffect(() => {
@@ -734,10 +730,10 @@ function BlockActionMode() {
 
     const trimmedName = nameValue.trim();
     if (trimmedName !== '' && trimmedName !== selectedBlock.name) {
-      renameBlock(selectedId, trimmedName);
+      renameNode(selectedId, trimmedName);
     }
     setEditingName(false);
-  }, [nameValue, renameBlock, selectedBlock, selectedId]);
+  }, [nameValue, renameNode, selectedBlock, selectedId]);
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
@@ -752,18 +748,10 @@ function BlockActionMode() {
 
   const handleDelete = useCallback(() => {
     if (!selectedId) return;
-
-    const isBlock = blocks.some((b) => b.id === selectedId);
-    const isPlate = plates.some((p) => p.id === selectedId);
-
-    if (isBlock) {
-      removeBlock(selectedId);
-    } else if (isPlate) {
-      removePlate(selectedId);
-    }
+    removeNode(selectedId);
     setSelectedId(null);
     playSound('delete');
-  }, [blocks, plates, playSound, removeBlock, removePlate, selectedId, setSelectedId]);
+  }, [playSound, removeNode, selectedId, setSelectedId]);
 
   useEffect(() => {
     if (!selectedId || editingName) return;

--- a/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.test.ts
@@ -107,14 +107,14 @@ describe('useTechTree constants', () => {
       string,
       Pick<ResourceDefinition, 'id' | 'schemaResourceType' | 'label' | 'shortLabel' | 'icon' | 'category' | 'blockCategory'>
     > = {
-      network: { id: 'network', schemaResourceType: 'virtual_network', label: 'Network (VNet)', shortLabel: 'VNet', icon: '🌐', category: 'plate', blockCategory: null },
+      network: { id: 'network', schemaResourceType: 'virtual_network', label: 'Network (VNet)', shortLabel: 'VNet', icon: '🌐', category: 'foundation', blockCategory: null },
       'public-subnet': {
         id: 'public-subnet',
         schemaResourceType: 'subnet',
         label: 'Public Subnet',
         shortLabel: 'Public',
         icon: '🌍',
-        category: 'plate',
+        category: 'foundation',
         blockCategory: null,
       },
       'private-subnet': {
@@ -123,7 +123,7 @@ describe('useTechTree constants', () => {
         label: 'Private Subnet',
         shortLabel: 'Private',
         icon: '🔒',
-        category: 'plate',
+        category: 'foundation',
         blockCategory: null,
       },
       storage: { id: 'storage', schemaResourceType: 'blob_storage', label: 'Blob Storage', shortLabel: 'Storage', icon: '📦', category: 'always', blockCategory: 'data' },

--- a/apps/web/src/widgets/bottom-panel/useTechTree.ts
+++ b/apps/web/src/widgets/bottom-panel/useTechTree.ts
@@ -36,7 +36,7 @@ export interface ResourceDefinition {
   label: string;
   shortLabel: string;
   icon: string;
-  category: 'plate' | 'always' | 'vnet-optional' | 'vnet-required';
+  category: 'foundation' | 'always' | 'vnet-optional' | 'vnet-required';
   blockCategory: ResourceCategory | null;
   disabledReason?: string;
 }
@@ -48,7 +48,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
     label: 'Network (VNet)',
     shortLabel: 'VNet',
     icon: '🌐',
-    category: 'plate',
+    category: 'foundation',
     blockCategory: null,
   },
   'public-subnet': {
@@ -57,7 +57,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
     label: 'Public Subnet',
     shortLabel: 'Public',
     icon: '🌍',
-    category: 'plate',
+    category: 'foundation',
     blockCategory: null,
     disabledReason: 'Create a Network first. Subnets live inside a virtual network.',
   },
@@ -67,7 +67,7 @@ export const RESOURCE_DEFINITIONS: Record<ResourceType, ResourceDefinition> = {
     label: 'Private Subnet',
     shortLabel: 'Private',
     icon: '🔒',
-    category: 'plate',
+    category: 'foundation',
     blockCategory: null,
     disabledReason: 'Create a Network first. Subnets live inside a virtual network.',
   },
@@ -461,7 +461,7 @@ export function useTechTree(): TechTreeState {
       const def = RESOURCE_DEFINITIONS[type];
 
       switch (def.category) {
-        case 'plate':
+        case 'foundation':
           // Network is always enabled
           if (type === 'network') return true;
           // Subnets require VNet

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -65,8 +65,7 @@ export function MenuBar() {
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
 
-  const removePlate = useArchitectureStore((s) => s.removePlate);
-  const removeBlock = useArchitectureStore((s) => s.removeBlock);
+  const removeNode = useArchitectureStore((s) => s.removeNode);
   const removeConnection = useArchitectureStore((s) => s.removeConnection);
   
   const validate = useArchitectureStore((s) => s.validate);
@@ -118,10 +117,10 @@ export function MenuBar() {
   const handleDeleteSelection = () => {
     if (!selectedId) return;
     if (plates.some((p) => p.id === selectedId)) {
-      removePlate(selectedId);
+      removeNode(selectedId);
       playSound('delete');
     } else if (blocks.some((b) => b.id === selectedId)) {
-      removeBlock(selectedId);
+      removeNode(selectedId);
       playSound('delete');
     } else if (architecture.connections.some((c) => c.id === selectedId)) {
       removeConnection(selectedId);

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
@@ -9,7 +9,7 @@ vi.mock('../../entities/store/architectureStore');
 vi.mock('../../entities/store/uiStore');
 vi.mock('../../features/templates/registry');
 
-const mockAddPlate = vi.fn();
+const mockAddNode = vi.fn();
 const mockLoadFromTemplate = vi.fn();
 const mockSaveToStorage = vi.fn();
 const mockToggleTemplateGallery = vi.fn();
@@ -33,7 +33,7 @@ function setupMocks(plateCount: number, showTemplateGallery = false) {
   vi.mocked(useArchitectureStore).mockImplementation(((selector: unknown) => {
     const state = {
       workspace: { architecture: { nodes } },
-      addPlate: mockAddPlate,
+      addNode: mockAddNode,
       loadFromTemplate: mockLoadFromTemplate,
       saveToStorage: mockSaveToStorage,
     };
@@ -93,11 +93,11 @@ describe('EmptyCanvasOverlay', () => {
     expect(mockToggleTemplateGallery).toHaveBeenCalledTimes(1);
   });
 
-  it('clicking Start from Scratch calls addPlate with network VNet', () => {
+  it('clicking Start from Scratch calls addNode with container VNet', () => {
     setupMocks(0);
     render(<EmptyCanvasOverlay />);
     fireEvent.click(screen.getByText(/Start from Scratch/));
-    expect(mockAddPlate).toHaveBeenCalledWith('region', 'VNet', null);
+    expect(mockAddNode).toHaveBeenCalledWith({ kind: 'container', resourceType: 'virtual_network', name: 'VNet', parentId: null, layer: 'region' });
   });
 
   it('shows Learn How link when no plates', () => {

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
@@ -8,7 +8,7 @@ const DEMO_TEMPLATE_ID = 'template-three-tier';
 export function EmptyCanvasOverlay() {
   const containerCount = useArchitectureStore((s) => s.workspace.architecture.nodes.filter((node) => node.kind === 'container').length);
   const showTemplateGallery = useUIStore((s) => s.showTemplateGallery);
-  const addPlate = useArchitectureStore((s) => s.addPlate);
+  const addNode = useArchitectureStore((s) => s.addNode);
   const loadFromTemplate = useArchitectureStore((s) => s.loadFromTemplate);
   const saveToStorage = useArchitectureStore((s) => s.saveToStorage);
   const toggleTemplateGallery = useUIStore((s) => s.toggleTemplateGallery);
@@ -43,7 +43,7 @@ export function EmptyCanvasOverlay() {
           <button
             type="button"
             className="empty-canvas-btn empty-canvas-btn--scratch"
-            onClick={() => addPlate('region', 'VNet', null)}
+            onClick={() => addNode({ kind: 'container', resourceType: 'virtual_network', name: 'VNet', parentId: null, layer: 'region' })}
           >
             ✨ Start from Scratch
           </button>

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -21,7 +21,7 @@ export function SceneCanvas() {
   const architecture = useArchitectureStore((s) => s.workspace.architecture);
   const plates = architecture.nodes.filter((node): node is ContainerNode => node.kind === 'container');
   const blocks = architecture.nodes.filter((node): node is LeafNode => node.kind === 'resource');
-  const addBlock = useArchitectureStore((s) => s.addBlock);
+  const addNode = useArchitectureStore((s) => s.addNode);
   const setSelectedId = useUIStore((s) => s.setSelectedId);
   const interactionState = useUIStore((s) => s.interactionState);
   const draggedBlockCategory = useUIStore((s) => s.draggedBlockCategory);
@@ -112,7 +112,7 @@ export function SceneCanvas() {
       if (plateId) {
           const plate = plates.find((p) => p.id === plateId);
           if (plate && canPlaceBlock(draggedBlockCategory, plate)) {
-            addBlock(draggedBlockCategory, draggedResourceName, plateId, activeProvider);
+            addNode({ kind: 'resource', resourceType: draggedBlockCategory, name: draggedResourceName, parentId: plateId, provider: activeProvider });
             playSound('block-snap');
 
           }


### PR DESCRIPTION
## Summary

- **Phase B (Store Unification)**: Added unified `addNode`, `removeNode`, `renameNode`, `moveNodePosition` methods to architecture store. Migrated 7 UI call sites. Old methods marked `@deprecated`.
- **Phase C (Codegen Cleanup)**: Removed `ProviderAdapter` interface. `terraform.ts` now uses `ProviderDefinition` directly. Removed legacy provider exports (`azureProvider`, `awsProvider`, `gcpProvider`), `getProvider()`, `legacyGenerate()`, `terraformPipeline`.
- **Phase D (UI Category Rename)**: Renamed UI category `'plate'` → `'foundation'` in `useTechTree` and `CommandCard` (6 locations each).
- **Phase E (Import Migration)**: Migrated all 22 `apps/web` files from deprecated type aliases — `Block` → `LeafNode`, `Plate` → `ContainerNode`, `BlockCategory` → `ResourceCategory`, `PlateType` → local plate-layer types. Deprecated schema exports preserved for backward compat.

## Validation

- 1920 tests pass (108 test files)
- Lint clean
- TypeScript clean (`tsc --noEmit`)
- 46 files changed, 452 insertions, 604 deletions (net reduction)

## Breaking Changes

None — deprecated aliases remain in `@cloudblocks/schema` exports.

Closes #1194
Part of Epic #1196