### PR TITLE
refactor(web): remove deprecated GRID_CELL re-export and WorldSegment routing code

### DIFF
--- a/apps/web/src/entities/connection/routing.test.ts
+++ b/apps/web/src/entities/connection/routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeWorldRoute, screenSegmentLength, screenSegmentLengthCU, worldSegmentToScreen, worldSegmentLengthCU } from './routing';
+import { computeWorldRoute, screenSegmentLength, screenSegmentLengthCU } from './routing';
 
 describe('computeWorldRoute — screen-space routing', () => {
   const originX = 400;
@@ -111,36 +111,4 @@ describe('screenSegmentLengthCU', () => {
   });
 });
 
-describe('worldSegmentToScreen (legacy)', () => {
-  it('converts world segment endpoints to screen coordinates', () => {
-    const seg = {
-      start: { worldX: 0, worldZ: 0, worldY: 0 },
-      end: { worldX: 2, worldZ: 0, worldY: 0 },
-      axis: 'x' as const,
-    };
-    const result = worldSegmentToScreen(seg, 400, 300);
-    expect(result.start.x).toBe(400);
-    expect(result.start.y).toBe(300);
-    expect(result.end.x).toBeGreaterThan(result.start.x);
-  });
-});
 
-describe('worldSegmentLengthCU (legacy)', () => {
-  it('returns X-axis length for x segments', () => {
-    const seg = {
-      start: { worldX: 1, worldZ: 3, worldY: 0 },
-      end: { worldX: 4, worldZ: 3, worldY: 0 },
-      axis: 'x' as const,
-    };
-    expect(worldSegmentLengthCU(seg)).toBe(3);
-  });
-
-  it('returns Z-axis length for z segments', () => {
-    const seg = {
-      start: { worldX: 3, worldZ: 1, worldY: 0 },
-      end: { worldX: 3, worldZ: 5, worldY: 0 },
-      axis: 'z' as const,
-    };
-    expect(worldSegmentLengthCU(seg)).toBe(4);
-  });
-});

--- a/apps/web/src/entities/connection/routing.ts
+++ b/apps/web/src/entities/connection/routing.ts
@@ -27,13 +27,6 @@ export interface ConnectorRoute {
   tgtScreen: ScreenPoint;
 }
 
-/** @deprecated Use ScreenSegment instead. */
-export interface WorldSegment {
-  start: WorldPoint;
-  end: WorldPoint;
-  axis: 'x' | 'z';
-}
-
 const SAME_PX_TOLERANCE = 2;
 
 function worldToScreen(
@@ -136,22 +129,3 @@ export function screenSegmentLengthCU(seg: ScreenSegment): number {
   return Math.abs(seg.end.x - seg.start.x) / TILE_W;
 }
 
-/** @deprecated Use screen-space segments directly. */
-export function worldSegmentToScreen(
-  seg: WorldSegment,
-  originX: number,
-  originY: number,
-): { start: ScreenPoint; end: ScreenPoint } {
-  return {
-    start: worldToScreen(seg.start, originX, originY),
-    end: worldToScreen(seg.end, originX, originY),
-  };
-}
-
-/** @deprecated Use screenSegmentLengthCU instead. */
-export function worldSegmentLengthCU(seg: WorldSegment): number {
-  if (seg.axis === 'x') {
-    return Math.abs(seg.end.worldX - seg.start.worldX);
-  }
-  return Math.abs(seg.end.worldZ - seg.start.worldZ);
-}

--- a/apps/web/src/shared/utils/position.test.ts
+++ b/apps/web/src/shared/utils/position.test.ts
@@ -5,10 +5,10 @@ import {
   EXTERNAL_ACTOR_ENDPOINT_Y_OFFSET,
   EXTERNAL_ACTOR_LABEL_POSITION,
   EXTERNAL_ACTOR_POSITION,
-  GRID_CELL,
   getBlockWorldPosition,
   getEndpointWorldPosition,
 } from './position';
+import { GRID_CELL } from './isometric';
 
 function createPlate(id: string): ContainerNode {
   return {

--- a/apps/web/src/shared/utils/position.ts
+++ b/apps/web/src/shared/utils/position.ts
@@ -2,9 +2,6 @@ import type { ContainerNode, ExternalActor, LeafNode } from '@cloudblocks/schema
 
 // ─── Constants ────────────────────────────────────────────
 
-/** @deprecated Import GRID_CELL from './isometric' instead. Re-exported for backward compatibility. */
-export { GRID_CELL } from './isometric';
-
 /** Fixed world position for ExternalActor entities (above and behind the scene). */
 export const EXTERNAL_ACTOR_POSITION: [number, number, number] = [-3, 0, 5];
 


### PR DESCRIPTION
## Summary
- Remove deprecated `GRID_CELL` re-export from `position.ts` (import from `isometric.ts` instead)
- Remove deprecated `WorldSegment` interface, `worldSegmentToScreen()`, and `worldSegmentLengthCU()` from `routing.ts`
- Remove 3 legacy test cases for the deprecated functions
- Update `position.test.ts` to import `GRID_CELL` directly from `isometric`

## Verification
- Build ✅ (`pnpm build`)
- Lint ✅ (0 errors)
- Tests ✅ (2141 pass, 8 skipped)
- LSP diagnostics ✅ (clean on all 4 changed files)

Fixes #1282