### PR TITLE
refactor(web): replace console.warn/error with structured logger

### DIFF
--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -1,4 +1,5 @@
 import type { Workspace } from '../../../shared/types/index';
+import logger from '../../../shared/utils/logger';
 import type {
   ArchitectureModel,
   ContainerNode,
@@ -568,7 +569,7 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (
       return null;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown import error';
-      console.error('Failed to import architecture:', error);
+      logger.error('Failed to import architecture:', error);
       return message;
     }
   },

--- a/apps/web/src/shared/types/schema.ts
+++ b/apps/web/src/shared/types/schema.ts
@@ -9,6 +9,7 @@ import type {
   ResourceCategory,
   Workspace,
 } from './index';
+import logger from '../utils/logger';
 import { buildPlateSizeFromProfileId, inferLegacyPlateProfileId } from './index';
 import {
   connectionTypeToSemantic,
@@ -88,7 +89,7 @@ const LEGACY_CATEGORY_MAP: Record<LegacyBlockCategory, ResourceCategory> = {
 function remapCategory(raw: string): ResourceCategory {
   const mapped = LEGACY_CATEGORY_MAP[raw as LegacyBlockCategory];
   if (mapped) return mapped;
-  console.warn(`Unknown legacy category "${raw}", falling back to "compute".`);
+  logger.warn(`Unknown legacy category "${raw}", falling back to "compute".`);
   return 'compute';
 }
 
@@ -209,7 +210,7 @@ export function deserialize(json: string): Workspace[] {
   }
 
   if (!SUPPORTED_VERSIONS.includes(data.schemaVersion)) {
-    console.warn(
+    logger.warn(
       `Schema version mismatch: expected ${SCHEMA_VERSION}, got ${data.schemaVersion}. ` +
         'Data may need migration.'
     );

--- a/apps/web/src/shared/types/visualProfile.ts
+++ b/apps/web/src/shared/types/visualProfile.ts
@@ -1,4 +1,5 @@
 import type { ProviderType, ResourceCategory } from './index';
+import logger from '../utils/logger';
 
 // BrickSizeTier removed in v2.0 — use BlockTier instead
 
@@ -114,7 +115,7 @@ export const BLOCK_VISUAL_PROFILES: Record<ResourceCategory, BlockVisualProfile>
 export function getBlockVisualProfile(category: ResourceCategory): BlockVisualProfile {
   const profile = BLOCK_VISUAL_PROFILES[category];
   if (!profile) {
-    console.warn(`Unknown resource category "${category}", falling back to "compute" profile.`);
+    logger.warn(`Unknown resource category "${category}", falling back to "compute" profile.`);
     return BLOCK_VISUAL_PROFILES.compute;
   }
   return profile;

--- a/apps/web/src/shared/utils/audioService.ts
+++ b/apps/web/src/shared/utils/audioService.ts
@@ -1,3 +1,5 @@
+import logger from './logger';
+
 export type SoundName = 'block-snap' | 'delete' | 'validation-success' | 'validation-error';
 
 export class AudioService {
@@ -38,7 +40,7 @@ export class AudioService {
         }
       };
     } catch (err) {
-      console.warn('[AudioService] Failed to create AudioContext:', err);
+      logger.warn('[AudioService] Failed to create AudioContext:', err);
       throw err;
     }
 
@@ -55,7 +57,7 @@ export class AudioService {
         await this.ctx.resume();
       }
     } catch (err) {
-      console.warn('[AudioService] Failed to resume AudioContext:', err);
+      logger.warn('[AudioService] Failed to resume AudioContext:', err);
     }
   }
 
@@ -87,7 +89,7 @@ export class AudioService {
       const audioBuffer = await ctx.decodeAudioData(arrayBuffer);
       this.bufferCache.set(name, audioBuffer);
     } catch (err) {
-      console.warn(`[AudioService] Failed to load sound "${name}":`, err);
+      logger.warn(`[AudioService] Failed to load sound "${name}":`, err);
     }
   }
 
@@ -106,7 +108,7 @@ export class AudioService {
       source.connect(this.gainNode!);
       source.start(0);
     } catch (err) {
-      console.warn(`[AudioService] Failed to play sound "${name}":`, err);
+      logger.warn(`[AudioService] Failed to play sound "${name}":`, err);
     }
   }
 

--- a/apps/web/src/shared/utils/logger.ts
+++ b/apps/web/src/shared/utils/logger.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal structured logger that suppresses warnings in production.
+ *
+ * - `logger.warn()`  → only fires when `import.meta.env.DEV` is true
+ * - `logger.error()` → always fires (errors are never silenced)
+ */
+
+const isDev =
+  typeof import.meta !== 'undefined' && import.meta.env?.DEV === true;
+
+const logger = {
+  warn(msg: string, ...args: unknown[]): void {
+    if (isDev) console.warn(msg, ...args);
+  },
+
+  error(msg: string, ...args: unknown[]): void {
+    console.error(msg, ...args);
+  },
+};
+
+export default logger;

--- a/apps/web/src/shared/utils/storage.ts
+++ b/apps/web/src/shared/utils/storage.ts
@@ -1,5 +1,6 @@
 import type { Workspace } from '../types/index';
 import { serialize, deserialize } from '../types/schema';
+import logger from './logger';
 
 const STORAGE_KEY = 'cloudblocks:workspaces';
 const ACTIVE_WORKSPACE_KEY = 'cloudblocks:activeWorkspaceId';
@@ -14,7 +15,7 @@ export function saveWorkspaces(workspaces: Workspace[]): boolean {
     localStorage.setItem(STORAGE_KEY, json);
     return true;
   } catch (error) {
-    console.error('Failed to save workspaces:', error);
+    logger.error('Failed to save workspaces:', error);
     return false;
   }
 }
@@ -50,7 +51,7 @@ export function loadWorkspaces(): Workspace[] {
     if (!json) return [];
     return deserialize(json);
   } catch (error) {
-    console.error('Failed to load workspaces:', error);
+    logger.error('Failed to load workspaces:', error);
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- Create `shared/utils/logger.ts` — minimal logger that suppresses `warn()` in production while always emitting `error()`
- Replace 10 bare `console.warn`/`console.error` calls across 5 modules:
  - `persistenceSlice.ts` (1 error)
  - `storage.ts` (2 errors)
  - `audioService.ts` (4 warns)
  - `visualProfile.ts` (1 warn)
  - `schema.ts` (2 warns)

## Verification
- Build ✅ (`pnpm build`)
- Lint ✅ (0 errors)
- Tests ✅ (2144 pass, 8 skipped)
- LSP diagnostics ✅ (clean on all 6 changed files)

Fixes #1283