### PR TITLE
fix(web): fix lint warning and add a11y roles to dialog backdrops

### DIFF
--- a/apps/web/src/widgets/promote-dialog/PromoteDialog.tsx
+++ b/apps/web/src/widgets/promote-dialog/PromoteDialog.tsx
@@ -68,7 +68,7 @@ export function PromoteDialog() {
 
   return (
     <>
-      <div className="promote-dialog-backdrop" onClick={handleClose} />
+      <div className="promote-dialog-backdrop" role="presentation" onClick={handleClose} />
       <div className="promote-dialog" role="dialog" aria-label="Promote to Production">
         <div className="promote-dialog-header">
           <h3 className="promote-dialog-title">Promote to Production</h3>

--- a/apps/web/src/widgets/rollback-dialog/RollbackDialog.tsx
+++ b/apps/web/src/widgets/rollback-dialog/RollbackDialog.tsx
@@ -88,7 +88,7 @@ export function RollbackDialog() {
 
   return (
     <>
-      <div className="rollback-dialog-backdrop" onClick={handleClose} />
+      <div className="rollback-dialog-backdrop" role="presentation" onClick={handleClose} />
       <div className="rollback-dialog" role="dialog" aria-label="Rollback Production">
         <div className="rollback-dialog-header">
           <h3 className="rollback-dialog-title">Rollback Production</h3>

--- a/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
@@ -23,7 +23,7 @@ export function ConnectionPreview({ originX, originY }: ConnectionPreviewProps) 
   const interactionState = useUIStore((s) => s.interactionState);
   const connectionSource = useUIStore((s) => s.connectionSource);
   const nodes = useArchitectureStore((s) => s.workspace.architecture.nodes);
-  const externalActors = useArchitectureStore((s) => s.workspace.architecture.externalActors) ?? [];
+  const externalActors = useArchitectureStore((s) => s.workspace.architecture.externalActors ?? []);
   const blocks = useMemo(() => nodes.filter((node) => node.kind === 'resource'), [nodes]);
   const plates = useMemo(() => nodes.filter((node) => node.kind === 'container'), [nodes]);
 


### PR DESCRIPTION
## Summary
- Fix the **only** lint warning in the codebase: move `?? []` inside the Zustand selector in `ConnectionPreview.tsx` to satisfy `react-hooks/exhaustive-deps`
- Add `role="presentation"` to `PromoteDialog` and `RollbackDialog` backdrop divs, matching existing `ConfirmDialog`/`PromptDialog` patterns

## Verification
- Build ✅ (`pnpm build`)
- Lint ✅ (`pnpm lint` — **0 errors, 0 warnings** — first time fully clean!)
- Tests ✅ (2144 pass, 8 skipped)
- LSP diagnostics ✅

Fixes #1287