### PR TITLE
test(schema): un-skip JSON Schema artifact tests

### DIFF
--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { SCHEMA_VERSION } from '../index.js';
 import { RESOURCE_RULES } from '../rules.js';
@@ -49,8 +52,14 @@ describe('Resource rule coverage', () => {
   });
 });
 
-describe.skip('JSON Schema artifact', () => {
-  const schema: Record<string, unknown> = {};
+describe('JSON Schema artifact', () => {
+  const schemaPath = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    '../../dist/architecture-model.schema.json',
+  );
+  const schema: Record<string, unknown> = JSON.parse(
+    readFileSync(schemaPath, 'utf-8'),
+  );
 
   it('should exist and be valid JSON', () => {
     expect(Object.keys(schema).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Un-skip the 8 `JSON Schema artifact` tests that were stubbed with an empty object
- Load the real schema from `packages/schema/dist/architecture-model.schema.json` using `readFileSync`
- All 8 tests now validate: schema existence, root `$ref`, core entity definitions, required fields, ResourceCategory (7 values), NodeKind, ConnectionType (5 values), ProviderType (3 values)

## Verification
- Build ✅ (`pnpm build`)
- Tests ✅ (**2152 pass, 0 skipped** — first time fully unskipped!)
- LSP diagnostics ✅

Fixes #1286