### PR TITLE
feat(web): add Coming Soon banners to Promote and Rollback dialogs

### DIFF
--- a/apps/web/src/widgets/promote-dialog/PromoteDialog.css
+++ b/apps/web/src/widgets/promote-dialog/PromoteDialog.css
@@ -52,6 +52,16 @@
   overflow-y: auto;
 }
 
+.promote-coming-soon-banner {
+  background: rgba(255, 152, 0, 0.1);
+  border: 1px solid rgba(255, 152, 0, 0.3);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #ffb74d;
+  text-align: center;
+}
+
 /* Source info card */
 .promote-source-card {
   background: rgba(255, 255, 255, 0.04);

--- a/apps/web/src/widgets/promote-dialog/PromoteDialog.tsx
+++ b/apps/web/src/widgets/promote-dialog/PromoteDialog.tsx
@@ -84,6 +84,9 @@ export function PromoteDialog() {
         </div>
 
         <div className="promote-dialog-content">
+          <div className="promote-coming-soon-banner">
+            Coming Soon — Promote to Production is under development and not yet functional.
+          </div>
           {/* Source info card */}
           <div className="promote-source-card">
             <div className="promote-source-label">Staging Environment</div>

--- a/apps/web/src/widgets/rollback-dialog/RollbackDialog.css
+++ b/apps/web/src/widgets/rollback-dialog/RollbackDialog.css
@@ -52,6 +52,16 @@
   overflow-y: auto;
 }
 
+.rollback-coming-soon-banner {
+  background: rgba(255, 152, 0, 0.1);
+  border: 1px solid rgba(255, 152, 0, 0.3);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: #ffb74d;
+  text-align: center;
+}
+
 /* Current version card */
 .rollback-current-card {
   background: rgba(255, 255, 255, 0.04);

--- a/apps/web/src/widgets/rollback-dialog/RollbackDialog.tsx
+++ b/apps/web/src/widgets/rollback-dialog/RollbackDialog.tsx
@@ -104,6 +104,9 @@ export function RollbackDialog() {
         </div>
 
         <div className="rollback-dialog-content">
+          <div className="rollback-coming-soon-banner">
+            Coming Soon — Rollback Production is under development and not yet functional.
+          </div>
           {/* Current production version */}
           <div className="rollback-current-card">
             <div className="rollback-current-label">Current Production Version</div>


### PR DESCRIPTION
## Summary
- Add amber "Coming Soon" warning banner to PromoteDialog (first child of content area)
- Add amber "Coming Soon" warning banner to RollbackDialog (first child of content area)
- CSS uses amber color scheme (rgba(255, 152, 0, ...) / #ffb74d) to indicate WIP status

## Verification
- Build ✅ (`pnpm build`)
- Tests ✅ (2144 pass, 8 skipped)
- LSP diagnostics ✅ (pre-existing a11y warnings only, same as before)

Fixes #1288