### PR TITLE
feat(web): insert 5 core Plausible trackEvent calls

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -5,6 +5,7 @@ import { registerBuiltinTemplates } from '../features/templates/builtin';
 import { registerBuiltinScenarios } from '../features/learning/scenarios/builtin';
 import { audioService } from '../shared/utils/audioService';
 import { SOUND_ASSETS } from '../shared/assets/sounds';
+import { metricsService } from '../shared/utils/metricsService';
 import { LandingPage } from '../widgets/landing-page/LandingPage';
 import { BuilderView } from './BuilderView';
 import './App.css';
@@ -21,6 +22,7 @@ function App() {
 
   useEffect(() => {
     audioService.preloadAll(SOUND_ASSETS).catch(() => {});
+    metricsService.trackEvent('app_loaded');
   }, []);
 
   useEffect(() => {

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -10,6 +10,7 @@ import {
   RESOURCE_RULES,
 } from '@cloudblocks/schema';
 import { generateId } from '../../../shared/utils/id';
+import { metricsService } from '../../../shared/utils/metricsService';
 import type { AddNodeInput, ArchitectureSlice, ArchitectureState, RemoveNodeOptions } from './types';
 import { canConnect } from '../../validation/connection';
 import type { EndpointType } from '../../validation/connection';
@@ -121,6 +122,7 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
 
   // ── Deprecated wrappers (delegates preserved for backward compat) ────────
   addPlate: (type, name, parentId, profileId?: PlateProfileId) => {
+    const prevCount = get().workspace.architecture.nodes.length;
     set((state) => {
       const arch = state.workspace.architecture;
       const containers = arch.nodes.filter(isContainer);
@@ -195,6 +197,9 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         endpoints: [...arch.endpoints, ...generateEndpointsForNode(plate.id)],
       });
     });
+    if (get().workspace.architecture.nodes.length > prevCount) {
+      metricsService.trackEvent('first_plate_placed', { layer: type });
+    }
   },
 
   removePlate: (id) => {
@@ -266,6 +271,7 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
   },
 
   addBlock: (category, name, placementId, provider, subtype, config) => {
+    const prevCount = get().workspace.architecture.nodes.length;
     set((state) => {
       const arch = state.workspace.architecture;
       const containers = arch.nodes.filter(isContainer);
@@ -301,6 +307,9 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         endpoints: [...arch.endpoints, ...generateEndpointsForNode(block.id)],
       });
     });
+    if (get().workspace.architecture.nodes.length > prevCount) {
+      metricsService.trackEvent('first_block_placed', { category });
+    }
   },
 
   duplicateBlock: (blockId) => {
@@ -850,6 +859,7 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         connections: [...nextArch.connections, connection],
       });
     });
+    metricsService.trackEvent('first_connection_created');
     return true;
   },
 

--- a/apps/web/src/features/generate/pipeline.ts
+++ b/apps/web/src/features/generate/pipeline.ts
@@ -12,6 +12,7 @@ import { terraformPlugin } from './terraformPlugin';
 import { bicepPlugin } from './bicep';
 import { pulumiPlugin } from './pulumi';
 import { validateArchitecture } from '../../entities/validation/engine';
+import { metricsService } from '../../shared/utils/metricsService';
 
 /**
  * Code Generation Pipeline Orchestrator (v1.0)
@@ -135,8 +136,10 @@ export function generateCode(
   // Stage 7: Optional format
   if (plugin.format) {
     const formatted = plugin.format(output.files, {});
+    metricsService.trackEvent('code_generated', { format: generatorId });
     return { ...output, files: formatted };
   }
 
+  metricsService.trackEvent('code_generated', { format: generatorId });
   return output;
 }


### PR DESCRIPTION
## Summary
- Insert 5 core `metricsService.trackEvent()` calls for Plausible funnel analytics
- Events: `app_loaded`, `first_plate_placed`, `first_block_placed`, `first_connection_created`, `code_generated`
- Each event fires only on successful action (node count check for plate/block, return-true gate for connection, no-throw for generation)

## Changes
| Event | File | Metadata |
|---|---|---|
| `app_loaded` | `App.tsx` useEffect | — |
| `first_plate_placed` | `domainSlice.ts` addPlate | `{ layer }` |
| `first_block_placed` | `domainSlice.ts` addBlock | `{ category }` |
| `first_connection_created` | `domainSlice.ts` addConnection | — |
| `code_generated` | `pipeline.ts` generateCode | `{ format: generatorId }` |

## Verification
- ✅ `pnpm build` passes
- ✅ 2160/2160 tests pass
- ✅ 0 lint errors/warnings
- ✅ LSP diagnostics clean (only pre-existing deprecation hints)

Fixes #1267