### PR TITLE
chore(ci): add Codecov upload and coverage badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,14 @@ jobs:
         run: npx vitest run --coverage
         working-directory: apps/web
 
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: apps/web/coverage/lcov.info
+          flags: web
+          fail_ci_if_error: false
+
   package-tests:
     name: Package Tests
     runs-on: ubuntu-latest
@@ -190,5 +198,13 @@ jobs:
         working-directory: apps/api
 
       - name: Run tests with coverage
-        run: python -m pytest app/tests/ -v --cov=app --cov-report=term-missing --cov-fail-under=90
+        run: python -m pytest app/tests/ -v --cov=app --cov-report=term-missing --cov-report=xml:coverage.xml --cov-fail-under=90
         working-directory: apps/api
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: apps/api/coverage.xml
+          flags: api
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![CI](https://github.com/yeongseon/cloudblocks/actions/workflows/ci.yml/badge.svg)](https://github.com/yeongseon/cloudblocks/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/yeongseon/cloudblocks/graph/badge.svg)](https://codecov.io/gh/yeongseon/cloudblocks)
 [![Version](https://img.shields.io/github/v/release/yeongseon/cloudblocks?label=version)](https://github.com/yeongseon/cloudblocks/releases/latest)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev/)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+
+flags:
+  web:
+    paths:
+      - apps/web/src/
+    carryforward: true
+  api:
+    paths:
+      - apps/api/app/
+    carryforward: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true


### PR DESCRIPTION
## Summary
- Add `codecov.yml` config with 90% project target, 80% patch target, and `web`/`api` flags
- Add `codecov/codecov-action@v5` upload steps to `web-test` and `api-test` CI jobs
- Add XML coverage output for pytest (`--cov-report=xml:coverage.xml`)
- Add Codecov badge to README.md

Note: Codecov works tokenless for public repos — no secret configuration needed.

Closes #1310