### PR TITLE
refactor(web): update UI terminology — Block→Node, Plate→Container

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -188,7 +188,7 @@ describe('BlockSprite', () => {
     const block = makeBlock('block-select', 'compute');
 
     render(<BlockSprite block={block} parentPlate={parentPlate} screenX={0} screenY={0} zIndex={1} />);
-    await user.click(screen.getByRole('button', { name: 'Block: compute-block' }));
+    await user.click(screen.getByRole('button', { name: 'Node: compute-block' }));
 
     expect(useUIStore.getState().selectedId).toBe('block-select');
   });
@@ -199,7 +199,7 @@ describe('BlockSprite', () => {
     const block = makeBlock('block-delete', 'storage');
 
     render(<BlockSprite block={block} parentPlate={parentPlate} screenX={0} screenY={0} zIndex={1} />);
-    await user.click(screen.getByRole('button', { name: 'Block: storage-block' }));
+    await user.click(screen.getByRole('button', { name: 'Node: storage-block' }));
 
     expect(removeNodeMock).toHaveBeenCalledWith('block-delete');
   });
@@ -218,10 +218,10 @@ describe('BlockSprite', () => {
       </>,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Block: gateway-block' }));
+    await user.click(screen.getByRole('button', { name: 'Node: gateway-block' }));
     expect(useUIStore.getState().connectionSource).toBe('block-source');
 
-    await user.click(screen.getByRole('button', { name: 'Block: database-block' }));
+    await user.click(screen.getByRole('button', { name: 'Node: database-block' }));
     expect(addConnectionMock).toHaveBeenCalledWith('block-source', 'block-target');
     expect(useUIStore.getState().connectionSource).toBeNull();
   });
@@ -233,7 +233,7 @@ describe('BlockSprite', () => {
 
     render(<BlockSprite block={block} parentPlate={parentPlate} screenX={0} screenY={0} zIndex={1} />);
 
-    const button = screen.getByRole('button', { name: 'Block: gateway-block' });
+    const button = screen.getByRole('button', { name: 'Node: gateway-block' });
     await user.click(button);
     await user.click(button);
 
@@ -256,8 +256,8 @@ describe('BlockSprite', () => {
       </>,
     );
 
-    await user.click(screen.getByRole('button', { name: 'Block: database-block' }));
-    await user.click(screen.getByRole('button', { name: 'Block: compute-block' }));
+    await user.click(screen.getByRole('button', { name: 'Node: database-block' }));
+    await user.click(screen.getByRole('button', { name: 'Node: compute-block' }));
 
     expect(addConnectionMock).toHaveBeenCalledWith('block-source', 'block-target');
     expect(toastMocks.error).toHaveBeenCalledWith('Invalid connection: check allowed connection rules');
@@ -363,10 +363,10 @@ describe('BlockSprite', () => {
       };
     };
 
-    const target = screen.getByRole('button', { name: 'Block: compute-block' }).closest('.block-sprite') as HTMLElement;
+    const target = screen.getByRole('button', { name: 'Node: compute-block' }).closest('.block-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 5, dy: 5, target });
 
-    await user.click(screen.getByRole('button', { name: 'Block: compute-block' }));
+    await user.click(screen.getByRole('button', { name: 'Node: compute-block' }));
     expect(useUIStore.getState().selectedId).toBeNull();
   });
 
@@ -392,7 +392,7 @@ describe('BlockSprite', () => {
       };
     };
 
-    const button = screen.getByRole('button', { name: 'Block: compute-block' });
+    const button = screen.getByRole('button', { name: 'Node: compute-block' });
     const target = button.closest('.block-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 2, dy: 2, target });
     draggableConfig.listeners.end();
@@ -454,7 +454,7 @@ describe('BlockSprite', () => {
       };
     };
 
-    const sprite = screen.getByRole('button', { name: 'Block: compute-block' }).closest('.block-sprite') as HTMLElement;
+    const sprite = screen.getByRole('button', { name: 'Node: compute-block' }).closest('.block-sprite') as HTMLElement;
     const image = sprite.querySelector('.block-img') as HTMLElement;
     draggableConfig.listeners.move({ dx: 1, dy: 1, target: sprite });
     draggableConfig.listeners.end();
@@ -527,7 +527,7 @@ describe('BlockSprite', () => {
       };
     };
 
-    const target = screen.getByRole('button', { name: 'Block: compute-block' }).closest('.block-sprite') as HTMLElement;
+    const target = screen.getByRole('button', { name: 'Node: compute-block' }).closest('.block-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 2, dy: 2, target });
     draggableConfig.listeners.end();
 
@@ -562,7 +562,7 @@ describe('BlockSprite', () => {
       };
     };
 
-    const target = screen.getByRole('button', { name: 'Block: compute-block' }).closest('.block-sprite') as HTMLElement;
+    const target = screen.getByRole('button', { name: 'Node: compute-block' }).closest('.block-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
     draggableConfig.listeners.end();
 

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -271,7 +271,7 @@ export const BlockSprite = memo(function BlockSprite({
           left: `-${blockSize.width / 2}px`,
           top: `-${blockSize.height / 2}px`,
         }}
-        aria-label={`Block: ${block.name}`}
+        aria-label={`Node: ${block.name}`}
       >
         <div className="block-img" draggable={false}>
           <BlockSvg category={block.category} provider={block.provider} subtype={block.subtype} name={block.name} aggregationCount={block.aggregation?.count} roles={block.roles} showStubs={isConnectMode} />

--- a/apps/web/src/entities/plate/PlateSprite.test.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.test.tsx
@@ -128,7 +128,7 @@ describe('PlateSprite', () => {
     const plate = makeNetworkPlate();
     render(<PlateSprite plate={plate} screenX={0} screenY={0} zIndex={1} />);
 
-    await user.click(screen.getByRole('button', { name: `Plate: ${plate.name}` }));
+    await user.click(screen.getByRole('button', { name: `Container: ${plate.name}` }));
     expect(useUIStore.getState().selectedId).toBe(plate.id);
   });
 
@@ -150,7 +150,7 @@ describe('PlateSprite', () => {
       plate.size.depth,
     );
 
-    const button = screen.getByRole('button', { name: `Plate: ${plate.name}` });
+    const button = screen.getByRole('button', { name: `Container: ${plate.name}` });
     expect(button).toHaveStyle({ width: '320px', height: '180px', left: '-160px', top: '-90px' });
   });
 
@@ -222,10 +222,10 @@ describe('PlateSprite', () => {
       };
     };
 
-    const target = screen.getByRole('button', { name: `Plate: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
+    const target = screen.getByRole('button', { name: `Container: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
 
-    await user.click(screen.getByRole('button', { name: `Plate: ${plate.name}` }));
+    await user.click(screen.getByRole('button', { name: `Container: ${plate.name}` }));
     expect(useUIStore.getState().selectedId).toBeNull();
   });
 
@@ -249,7 +249,7 @@ describe('PlateSprite', () => {
       };
     };
 
-    const button = screen.getByRole('button', { name: `Plate: ${plate.name}` });
+    const button = screen.getByRole('button', { name: `Container: ${plate.name}` });
     const target = button.closest('.plate-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 2, dy: 2, target });
     draggableConfig.listeners.end();
@@ -309,7 +309,7 @@ describe('PlateSprite', () => {
       };
     };
 
-    const sprite = screen.getByRole('button', { name: `Plate: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
+    const sprite = screen.getByRole('button', { name: `Container: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
     const image = sprite.querySelector('.plate-img') as HTMLElement;
     draggableConfig.listeners.move({ dx: 1, dy: 1, target: sprite });
     draggableConfig.listeners.end();
@@ -396,7 +396,7 @@ describe('PlateSprite', () => {
       };
     };
 
-    const target = screen.getByRole('button', { name: `Plate: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
+    const target = screen.getByRole('button', { name: `Container: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
     draggableConfig.listeners.end();
 
@@ -428,7 +428,7 @@ describe('PlateSprite', () => {
       };
     };
 
-    const target = screen.getByRole('button', { name: `Plate: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
+    const target = screen.getByRole('button', { name: `Container: ${plate.name}` }).closest('.plate-sprite') as HTMLElement;
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
     draggableConfig.listeners.end();
 

--- a/apps/web/src/entities/plate/PlateSprite.tsx
+++ b/apps/web/src/entities/plate/PlateSprite.tsx
@@ -202,7 +202,7 @@ export const PlateSprite = memo(function PlateSprite({
         type="button"
         onClick={handleClick}
         className="plate-button"
-        aria-label={`Plate: ${plate.name}`}
+        aria-label={`Container: ${plate.name}`}
         style={{
           left: `${-screenWidth / 2}px`,
           top: `${-screenHeight / 2}px`,

--- a/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
+++ b/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
@@ -123,7 +123,7 @@ describe('persistenceSlice branches', () => {
 
       expect(() => validateArchitectureShape(badPlate)).toThrow('type must be one of global, edge, region, zone, or subnet');
       expect(() => validateArchitectureShape(badBlock)).toThrow('placementId must be a string');
-      expect(() => validateArchitectureShape(badPlacement)).toThrow('does not reference an existing plate');
+      expect(() => validateArchitectureShape(badPlacement)).toThrow('does not reference an existing container');
     });
 
     it('validates connection endpoints and external actor branches', () => {

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -219,7 +219,7 @@ export const validateArchitectureShape = (
 
       if (!legacyPlateIds.has(block.placementId)) {
         throw new Error(
-          `${context}: placementId "${block.placementId}" does not reference an existing plate`
+          `${context}: placementId "${block.placementId}" does not reference an existing container`
         );
       }
 

--- a/apps/web/src/entities/validation/aggregation.test.ts
+++ b/apps/web/src/entities/validation/aggregation.test.ts
@@ -46,7 +46,7 @@ describe('validateAggregation', () => {
     expect(validateAggregation(block)).toEqual({
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: 'Block "ZeroCount" has invalid aggregation count: 0 (must be >= 1)',
+      message: 'Node "ZeroCount" has invalid aggregation count: 0 (must be >= 1)',
       suggestion: 'Set the aggregation count to 1 or greater',
       targetId: 'b1',
     });
@@ -62,7 +62,7 @@ describe('validateAggregation', () => {
     expect(validateAggregation(block)).toEqual({
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: 'Block "NegativeCount" has invalid aggregation count: -3 (must be >= 1)',
+      message: 'Node "NegativeCount" has invalid aggregation count: -3 (must be >= 1)',
       suggestion: 'Set the aggregation count to 1 or greater',
       targetId: 'b2',
     });
@@ -78,7 +78,7 @@ describe('validateAggregation', () => {
     expect(validateAggregation(block)).toEqual({
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: 'Block "FractionalCount" has non-integer aggregation count: 2.5',
+      message: 'Node "FractionalCount" has non-integer aggregation count: 2.5',
       suggestion: 'Set the aggregation count to a whole number',
       targetId: 'b3',
     });

--- a/apps/web/src/entities/validation/aggregation.ts
+++ b/apps/web/src/entities/validation/aggregation.ts
@@ -20,7 +20,7 @@ export function validateAggregation(
     return {
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: `Block "${block.name}" has invalid aggregation count: ${aggregation.count} (must be >= 1)`,
+      message: `Node "${block.name}" has invalid aggregation count: ${aggregation.count} (must be >= 1)`,
       suggestion: 'Set the aggregation count to 1 or greater',
       targetId: block.id,
     };
@@ -30,7 +30,7 @@ export function validateAggregation(
     return {
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: `Block "${block.name}" has non-integer aggregation count: ${aggregation.count}`,
+      message: `Node "${block.name}" has non-integer aggregation count: ${aggregation.count}`,
       suggestion: 'Set the aggregation count to a whole number',
       targetId: block.id,
     };

--- a/apps/web/src/entities/validation/connection.test.ts
+++ b/apps/web/src/entities/validation/connection.test.ts
@@ -106,8 +106,8 @@ describe('validateConnection', () => {
     expect(validateConnection(connection, makeEndpoints(blocks), blocks, [])).toEqual({
       ruleId: 'rule-conn-self',
       severity: 'error',
-      message: 'A block cannot connect to itself',
-      suggestion: 'Connect to a different block',
+      message: 'A node cannot connect to itself',
+      suggestion: 'Connect to a different node',
       targetId: 'conn-self',
     });
   });

--- a/apps/web/src/entities/validation/connection.ts
+++ b/apps/web/src/entities/validation/connection.ts
@@ -109,8 +109,8 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-self',
       severity: 'error',
-      message: 'A block cannot connect to itself',
-      suggestion: 'Connect to a different block',
+      message: 'A node cannot connect to itself',
+      suggestion: 'Connect to a different node',
       targetId: connection.id,
     };
   }

--- a/apps/web/src/entities/validation/providerValidation.ts
+++ b/apps/web/src/entities/validation/providerValidation.ts
@@ -73,7 +73,7 @@ function validateBlockProviderRules(
       warnings.push({
         ruleId: 'rule-provider-unknown-subtype',
         severity: 'warning',
-        message: `Block "${block.name}" has unknown subtype "${block.subtype}" for ${block.provider} ${block.category}.`,
+        message: `Node "${block.name}" has unknown subtype "${block.subtype}" for ${block.provider} ${block.category}.`,
         suggestion: `Check available subtypes for ${block.provider} ${block.category} resources.`,
         targetId: block.id,
       });

--- a/apps/web/src/entities/validation/role.ts
+++ b/apps/web/src/entities/validation/role.ts
@@ -24,7 +24,7 @@ export function validateRoles(
     return {
       ruleId: 'rule-role-invalid',
       severity: 'error',
-      message: `Block "${block.name}" has invalid role(s): ${invalidRoles.join(', ')}`,
+      message: `Node "${block.name}" has invalid role(s): ${invalidRoles.join(', ')}`,
       suggestion: `Valid roles: ${BLOCK_ROLES.join(', ')}`,
       targetId: block.id,
     };
@@ -37,7 +37,7 @@ export function validateRoles(
     return {
       ruleId: 'rule-role-duplicate',
       severity: 'warning',
-      message: `Block "${block.name}" has duplicate role(s): ${[...new Set(duplicates)].join(', ')}`,
+      message: `Node "${block.name}" has duplicate role(s): ${[...new Set(duplicates)].join(', ')}`,
       suggestion: 'Remove duplicate roles',
       targetId: block.id,
     };

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -163,33 +163,33 @@ export const BLOCK_ENCYCLOPEDIA: Record<ResourceCategory, {
 }> = {
   network: {
     what: 'Virtual networks define isolated private address spaces. All other resources live inside network boundaries.',
-    placement: 'Must be placed as the outermost plate. Subnets nest inside networks.',
+    placement: 'Must be placed as the outermost container. Subnets nest inside networks.',
     connections: 'Network resources rarely have direct connections. They provide the boundary for subnet-level routing.',
   },
   security: {
     what: 'Security services enforce access control, identity verification, and threat protection across your architecture.',
     placement: 'Place inside a subnet alongside protected resources.',
-    connections: 'Connects to compute and data blocks via internal or data connections for policy enforcement.',
+    connections: 'Connects to compute and data nodes via internal or data connections for policy enforcement.',
   },
   edge: {
     what: 'Load balancers and CDNs distribute incoming traffic across backend compute instances for high availability.',
-    placement: 'Place in a subnet to receive external traffic. Routes to compute blocks in other subnets.',
+    placement: 'Place in a subnet to receive external traffic. Routes to compute nodes in other subnets.',
     connections: 'Receives HTTP connections from external actors. Sends dataflow connections to compute targets.',
   },
   compute: {
     what: 'Compute instances run application code — virtual machines, containers, or serverless functions.',
     placement: 'Place in any subnet. Use separate subnets for web-facing vs backend services.',
-    connections: 'Receives traffic from edge blocks. Connects to data stores via data connections.',
+    connections: 'Receives traffic from edge nodes. Connects to data stores via data connections.',
   },
   data: {
     what: 'Data stores persist structured or unstructured information — databases, blob storage, caches.',
     placement: 'Place in a subnet. Use NSG rules to restrict access rather than relying on subnet type.',
-    connections: 'Receives data connections from compute blocks. May replicate via async connections.',
+    connections: 'Receives data connections from compute nodes. May replicate via async connections.',
   },
   messaging: {
     what: 'Message services enable asynchronous communication between decoupled components — queues, topics, event streams.',
     placement: 'Place in a subnet. Acts as a buffer between producer and consumer services.',
-    connections: 'Receives async connections from producers. Sends async connections to consumer compute blocks.',
+    connections: 'Receives async connections from producers. Sends async connections to consumer compute nodes.',
   },
   operations: {
     what: 'Monitoring and observability services collect metrics, logs, and traces from all running resources.',

--- a/apps/web/src/shared/ui/PromptDialog.test.tsx
+++ b/apps/web/src/shared/ui/PromptDialog.test.tsx
@@ -8,11 +8,11 @@ describe('promptDialog', () => {
     render(<div />);
     const user = userEvent.setup();
 
-    const promise = promptDialog('Rename plate:', 'Rename', 'My VNet');
+    const promise = promptDialog('Rename container:', 'Rename', 'My VNet');
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Rename')).toBeInTheDocument();
-    expect(screen.getByText('Rename plate:')).toBeInTheDocument();
+    expect(screen.getByText('Rename container:')).toBeInTheDocument();
 
     const input = screen.getByRole('textbox', { name: 'Rename' });
     expect(input).toBeInTheDocument();

--- a/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.test.tsx
@@ -917,7 +917,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByRole('button', { name: /Rename/ }));
 
-    expect(promptMock).toHaveBeenCalledWith('Rename plate:', 'Rename', 'VNet');
+    expect(promptMock).toHaveBeenCalledWith('Rename container:', 'Rename', 'VNet');
     expect(renamePlateMock).toHaveBeenCalledWith('net-1', 'Renamed Plate');
     promptMock.mockRestore();
   });
@@ -945,7 +945,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByRole('button', { name: /Rename/ }));
 
-    expect(promptMock).toHaveBeenCalledWith('Rename plate:', 'Rename', 'VNet');
+    expect(promptMock).toHaveBeenCalledWith('Rename container:', 'Rename', 'VNet');
     expect(renamePlateMock).not.toHaveBeenCalled();
     promptMock.mockRestore();
   });
@@ -973,7 +973,7 @@ describe('CommandCard', () => {
 
     await user.click(screen.getByRole('button', { name: /Rename/ }));
 
-    expect(promptMock).toHaveBeenCalledWith('Rename plate:', 'Rename', 'VNet');
+    expect(promptMock).toHaveBeenCalledWith('Rename container:', 'Rename', 'VNet');
     expect(renamePlateMock).not.toHaveBeenCalled();
     promptMock.mockRestore();
   });

--- a/apps/web/src/widgets/bottom-panel/CommandCard.tsx
+++ b/apps/web/src/widgets/bottom-panel/CommandCard.tsx
@@ -209,7 +209,7 @@ function PlateActionMode({ selectedPlate, onDeploy }: { selectedPlate: Container
         onDeploy();
         break;
       case 'rename': {
-        const newName = await promptDialog('Rename plate:', 'Rename', selectedPlate.name);
+        const newName = await promptDialog('Rename container:', 'Rename', selectedPlate.name);
         if (newName !== null && newName.trim() !== '') {
           renameNode(selectedPlate.id, newName.trim());
         }

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.test.tsx
@@ -100,8 +100,8 @@ describe('DetailPanel', () => {
 
     expect(screen.getByText('Test Workspace')).toBeInTheDocument();
     expect(screen.getByText('AZURE')).toBeInTheDocument();
-    expect(screen.getByText('Plates')).toBeInTheDocument();
-    expect(screen.getByText('Blocks')).toBeInTheDocument();
+    expect(screen.getByText('Containers')).toBeInTheDocument();
+    expect(screen.getByText('Nodes')).toBeInTheDocument();
     expect(screen.getByText('Connection')).toBeInTheDocument();
   });
 
@@ -153,7 +153,7 @@ describe('DetailPanel', () => {
     expect(screen.getByText('Subnet 1')).toBeInTheDocument();
     expect(screen.getByText('Subnet')).toBeInTheDocument();
     expect(screen.getByText('Main VNet')).toBeInTheDocument();
-    expect(screen.getByText('2 blocks')).toBeInTheDocument();
+    expect(screen.getByText('2 nodes')).toBeInTheDocument();
     expect(screen.getByText('What is this?')).toBeInTheDocument();
     expect(screen.getByText('Nesting Rules')).toBeInTheDocument();
   });
@@ -264,7 +264,7 @@ describe('DetailPanel', () => {
 
     render(<DetailPanel />);
 
-    expect(screen.getByText(/1 block$/)).toBeInTheDocument();
+    expect(screen.getByText(/1 node$/)).toBeInTheDocument();
   });
 
   it('renders child subnet count on network plate contents', () => {

--- a/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
+++ b/apps/web/src/widgets/bottom-panel/DetailPanel.tsx
@@ -135,11 +135,11 @@ function WorkspaceDashboard({ className }: { className: string }) {
         </div>
         <div className="detail-dashboard-stat">
           <span className="detail-dashboard-value">{containers.length}</span>
-          <span className="detail-dashboard-label">{containers.length === 1 ? 'Plate' : 'Plates'}</span>
+          <span className="detail-dashboard-label">{containers.length === 1 ? 'Container' : 'Containers'}</span>
         </div>
         <div className="detail-dashboard-stat">
           <span className="detail-dashboard-value">{resources.length}</span>
-          <span className="detail-dashboard-label">{resources.length === 1 ? 'Block' : 'Blocks'}</span>
+          <span className="detail-dashboard-label">{resources.length === 1 ? 'Node' : 'Nodes'}</span>
         </div>
         <div className="detail-dashboard-stat">
           <span className="detail-dashboard-value">{connectionCount}</span>
@@ -287,7 +287,7 @@ function PlateDetail({ plate, className }: { plate: ContainerNode; className: st
         <div className="detail-property">
           <span className="detail-property-label">Contents</span>
           <span className="detail-property-value">
-            {childBlocks.length} block{childBlocks.length !== 1 ? 's' : ''}
+            {childBlocks.length} node{childBlocks.length !== 1 ? 's' : ''}
             {childPlates.length > 0 && `, ${childPlates.length} subnet${childPlates.length !== 1 ? 's' : ''}`}
           </span>
         </div>

--- a/apps/web/src/widgets/diff-panel/DiffPanel.test.tsx
+++ b/apps/web/src/widgets/diff-panel/DiffPanel.test.tsx
@@ -301,7 +301,7 @@ describe('DiffPanel', () => {
     const user = userEvent.setup();
     render(<DiffPanel />);
 
-    const platesSectionToggle = screen.getByRole('button', { name: /Plates/ });
+    const platesSectionToggle = screen.getByRole('button', { name: /Containers/ });
     expect(platesSectionToggle).toHaveAttribute('aria-expanded', 'true');
     expect(screen.getByText('+ Subnet 1 (plate-added-1)')).toBeInTheDocument();
 
@@ -404,7 +404,7 @@ describe('DiffPanel', () => {
     const user = userEvent.setup();
     const { rerender } = render(<DiffPanel />);
 
-    const platesSectionToggle = screen.getByRole('button', { name: /Plates/ });
+    const platesSectionToggle = screen.getByRole('button', { name: /Containers/ });
     await user.click(platesSectionToggle);
     expect(platesSectionToggle).toHaveAttribute('aria-expanded', 'false');
 
@@ -415,7 +415,7 @@ describe('DiffPanel', () => {
     useUIStore.getState().setDiffMode(true, makeDiffDelta());
     rerender(<DiffPanel />);
 
-    const resetPlatesToggle = screen.getByRole('button', { name: /Plates/ });
+    const resetPlatesToggle = screen.getByRole('button', { name: /Containers/ });
     const resetModifiedToggle = screen.getByRole('button', { name: /App Service \(block-modified-1\) \(1 changes\)/ });
     expect(resetPlatesToggle).toHaveAttribute('aria-expanded', 'true');
     expect(resetModifiedToggle).toHaveAttribute('aria-expanded', 'false');
@@ -439,7 +439,7 @@ describe('DiffPanel', () => {
     useUIStore.setState({ diffDelta: delta });
 
     render(<DiffPanel />);
-    expect(screen.getByText('No changes in plates.')).toBeInTheDocument();
+    expect(screen.getByText('No changes in containers.')).toBeInTheDocument();
   });
 
   it('shows no-data message when diffDelta is null and omits summary badges', () => {
@@ -516,7 +516,7 @@ describe('DiffPanel', () => {
     };
     useUIStore.setState({ diffBaseArchitecture: remoteArch });
     render(<DiffPanel />);
-    expect(screen.getByText('Remote: 2 plates · 1 blocks · 3 connections · 1 actors')).toBeInTheDocument();
+    expect(screen.getByText('Remote: 2 containers · 1 nodes · 3 connections · 1 actors')).toBeInTheDocument();
   });
 
   it('hides remote summary when diffBaseArchitecture is null (#879)', () => {

--- a/apps/web/src/widgets/diff-panel/DiffPanel.tsx
+++ b/apps/web/src/widgets/diff-panel/DiffPanel.tsx
@@ -20,8 +20,8 @@ function summarizeArchitecture(arch: ArchitectureModel) {
 type SectionKey = 'plates' | 'blocks' | 'connections' | 'externalActors';
 
 const SECTION_CONFIG: Array<{ key: SectionKey; label: string }> = [
-  { key: 'plates', label: 'Plates' },
-  { key: 'blocks', label: 'Blocks' },
+  { key: 'plates', label: 'Containers' },
+  { key: 'blocks', label: 'Nodes' },
   { key: 'connections', label: 'Connections' },
   { key: 'externalActors', label: 'External Actors' },
 ];
@@ -176,7 +176,7 @@ export function DiffPanelContent({
         const s = summarizeArchitecture(diffBaseArchitecture);
         return (
           <div className="diff-panel-remote-summary">
-            Remote: {s.plates} plates · {s.blocks} blocks · {s.connections} connections · {s.externalActors} actors
+            Remote: {s.plates} containers · {s.blocks} nodes · {s.connections} connections · {s.externalActors} actors
           </div>
         );
       })()}

--- a/apps/web/src/widgets/figure-helper/FigureHelper.test.tsx
+++ b/apps/web/src/widgets/figure-helper/FigureHelper.test.tsx
@@ -79,7 +79,7 @@ describe('FigureHelper', () => {
   it('shows empty canvas hint when no nodes exist', () => {
     render(<FigureHelper />);
     expect(screen.getByTestId('figure-helper')).toBeInTheDocument();
-    expect(screen.getByText('Add a block to start building your architecture.')).toBeInTheDocument();
+    expect(screen.getByText('Add a node to start building your architecture.')).toBeInTheDocument();
   });
 
   it('shows first-block hint when nodes exist but no connections', () => {
@@ -87,7 +87,7 @@ describe('FigureHelper', () => {
       workspace: makeWorkspace({ nodes: [SAMPLE_NODE] }),
     });
     render(<FigureHelper />);
-    expect(screen.getByText('Nice! Now connect blocks to define relationships.')).toBeInTheDocument();
+    expect(screen.getByText('Nice! Now connect nodes to define relationships.')).toBeInTheDocument();
   });
 
   it('shows validation error with Go to button', () => {
@@ -198,7 +198,7 @@ describe('FigureHelper', () => {
     });
     render(<FigureHelper />);
     expect(screen.getByText('Validation error')).toBeInTheDocument();
-    expect(screen.queryByText(/connect blocks/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/connect nodes/)).not.toBeInTheDocument();
   });
 
   it('hint messages do not show Go to button', () => {

--- a/apps/web/src/widgets/figure-helper/helperMessages.ts
+++ b/apps/web/src/widgets/figure-helper/helperMessages.ts
@@ -11,13 +11,13 @@ export interface HelperMessage {
 export const HINT_EMPTY_CANVAS: Omit<HelperMessage, 'targetId'> = {
   key: 'hint-empty-canvas',
   type: 'hint',
-  text: 'Add a block to start building your architecture.',
+  text: 'Add a node to start building your architecture.',
 };
 
 export const HINT_FIRST_BLOCK: Omit<HelperMessage, 'targetId'> = {
   key: 'hint-first-block',
   type: 'hint',
-  text: 'Nice! Now connect blocks to define relationships.',
+  text: 'Nice! Now connect nodes to define relationships.',
 };
 
 export const SUCCESS_VALID: Omit<HelperMessage, 'targetId'> = {

--- a/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.test.tsx
@@ -541,7 +541,7 @@ describe('GitHubSync', () => {
     await user.click(screen.getByRole('button', { name: 'Link' }));
     await user.click(await screen.findByRole('button', { name: 'Pull from GitHub' }));
 
-    expect(await screen.findByText('Pulled: 2 changes (1/0 plates added/removed, 1/0 blocks added/removed)')).toBeInTheDocument();
+    expect(await screen.findByText('Pulled: 2 changes (1/0 containers added/removed, 1/0 nodes added/removed)')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Undo Pull' })).toBeInTheDocument();
   });
 

--- a/apps/web/src/widgets/github-sync/GitHubSync.tsx
+++ b/apps/web/src/widgets/github-sync/GitHubSync.tsx
@@ -253,8 +253,8 @@ export function GitHubSync() {
       setLastSyncedArchitecture(cloneArchitecture(postPullArchitecture));
       setPullDiffSummary(
         `Pulled: ${diff.summary.totalChanges} changes `
-          + `(${diff.plates.added.length}/${diff.plates.removed.length} plates added/removed, `
-          + `${diff.blocks.added.length}/${diff.blocks.removed.length} blocks added/removed)`
+          + `(${diff.plates.added.length}/${diff.plates.removed.length} containers added/removed, `
+          + `${diff.blocks.added.length}/${diff.blocks.removed.length} nodes added/removed)`
       );
       await loadCommits();
     } catch (err) {

--- a/apps/web/src/widgets/inspector-panel/InspectorPanel.test.tsx
+++ b/apps/web/src/widgets/inspector-panel/InspectorPanel.test.tsx
@@ -106,7 +106,7 @@ describe('InspectorPanel', () => {
 
     render(<InspectorPanel />);
 
-    expect(screen.getByText('Block Actions')).toBeInTheDocument();
+    expect(screen.getByText('Node Actions')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'App VM' })).toBeInTheDocument();
     expect(screen.getByText('web_compute')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Link/ })).toBeInTheDocument();

--- a/apps/web/src/widgets/inspector-panel/InspectorPanel.tsx
+++ b/apps/web/src/widgets/inspector-panel/InspectorPanel.tsx
@@ -160,7 +160,7 @@ function PropertiesTab({
         <PropertyRow label="Nodes" value={String(nodeCount)} />
         <PropertyRow label="Connections" value={String(connectionCount)} />
       </div>
-      <p className="inspector-empty-hint">Select a block, plate, or connection to inspect details.</p>
+      <p className="inspector-empty-hint">Select a node, container, or connection to inspect details.</p>
     </div>
   );
 }
@@ -325,7 +325,7 @@ function PlateActionMode({ selectedPlate }: { selectedPlate: ContainerNode }) {
         setSelectedId(selectedPlate.id);
         break;
       case 'rename': {
-        const newName = await promptDialog('Rename plate:', 'Rename', selectedPlate.name);
+        const newName = await promptDialog('Rename container:', 'Rename', selectedPlate.name);
         if (newName !== null && newName.trim() !== '') {
           renameNode(selectedPlate.id, newName.trim());
         }
@@ -499,7 +499,7 @@ function BlockActionMode({ block }: { block: LeafNode }) {
 
   return (
     <div className="inspector-section">
-      <h3 className="inspector-title">Block Actions</h3>
+      <h3 className="inspector-title">Node Actions</h3>
 
       <div className="inspector-block-header">
         {editingName ? (

--- a/apps/web/src/widgets/onboarding-tour/OnboardingTour.tsx
+++ b/apps/web/src/widgets/onboarding-tour/OnboardingTour.tsx
@@ -24,7 +24,7 @@ const STEPS: TourStep[] = [
     fallbackSelector: '.scene-canvas',
     title: 'Welcome to CloudBlocks!',
     description:
-      'Start by creating a Network plate \u2014 click "Start from Scratch" or pick a template.',
+      'Start by creating a Network container \u2014 click "Start from Scratch" or pick a template.',
   },
   {
     selector: '.bottom-panel-command',
@@ -53,7 +53,7 @@ const STEPS: TourStep[] = [
     fallbackSelector: '.bottom-panel',
     title: 'Resource Guide',
     description:
-      'Learn about the selected plate or block. Shows educational content, placement rules, and connection guidance.',
+      'Learn about the selected container or node. Shows educational content, placement rules, and connection guidance.',
   },
   {
     selector: '.bottom-panel-tab-content',

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
@@ -105,7 +105,7 @@ describe('WorkspaceManager', () => {
     useUIStore.setState({ showWorkspaceManager: true });
     render(<WorkspaceManager />);
     expect(screen.getByText(/Default Workspace/)).toBeInTheDocument();
-    expect(screen.getByText(/1 plates · 2 blocks/)).toBeInTheDocument();
+    expect(screen.getByText(/1 containers · 2 nodes/)).toBeInTheDocument();
   });
 
   it('renders active indicator (●) for current workspace', () => {

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
@@ -90,7 +90,7 @@ export function WorkspaceManager() {
                   {isActive && '● '}{ws.name}
                 </span>
                 <span className="workspace-manager-item-stats">
-                  {plateCount} plates · {blockCount} blocks
+                  {plateCount} containers · {blockCount} nodes
                 </span>
               </div>
               <div className="workspace-manager-item-actions">


### PR DESCRIPTION
## Summary

- Update all user-facing strings from old domain vocabulary (Block/Plate) to new vocabulary (Node/Container) across 16 production files and 13 test files
- Covers: aria-labels, panel headers, validation error messages, onboarding tour text, helper messages, encyclopedia descriptions, diff panel labels, workspace stats, GitHub sync summaries
- Code identifiers (variable names, function names, type names, CSS classes, file paths) are intentionally unchanged per issue scope

## Deferred

Learning scenario strings (`features/learning/scenarios/builtin.ts`) contain ~20+ user-facing "plate"/"block" references in instruction/hint text. These are deferred to a follow-up to keep this PR focused.

## Verification

- `pnpm build` ✅ (tsc + vite, 0 errors)
- `pnpm lint` ✅ (0 errors)
- `pnpm test` ✅ (2113/2113 passed, 128 test files)

Fixes #1259