### PR TITLE
docs(user-guide): add end-user documentation

### DIFF
--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -1,0 +1,142 @@
+# Core Concepts
+
+CloudBlocks uses a Lego-style composition model. You build cloud architectures by snapping together four types of elements: **containers**, **nodes**, **connections**, and **templates**.
+
+---
+
+## Containers
+
+Containers are the large boundary areas that represent network infrastructure. Every node must be placed inside a container.
+
+| Container Type | Cloud Equivalent | Nesting |
+|---|---|---|
+| **Network** | Azure VNet / AWS VPC / GCP VPC | Top-level — placed directly on the canvas |
+| **Subnet** | Public or private subnet | Must be inside a Network |
+
+Containers define the network topology of your architecture. A typical setup has one Network containing one or more Subnets.
+
+!!! info "Nesting rules"
+    Subnets must be placed inside a Network. Nodes must be placed inside a Subnet (or directly inside a Network). CloudBlocks enforces these rules and shows an error if placement is invalid.
+
+---
+
+## Nodes
+
+Nodes are individual cloud resources — the actual services that run your workload. They are placed inside containers.
+
+CloudBlocks organizes nodes into **10 categories**:
+
+| Category | Examples | Can Initiate Connections? |
+|---|---|---|
+| **Compute** | VM, App Service, ECS | Yes |
+| **Database** | SQL Database, Cosmos DB, RDS | No (receiver only) |
+| **Storage** | Blob Storage, S3, Data Lake | No (receiver only) |
+| **Gateway** | API Gateway, Load Balancer | Yes |
+| **Function** | Azure Function, Lambda | Yes |
+| **Queue** | Service Bus, SQS | Yes |
+| **Event** | Event Grid, EventBridge | Yes |
+| **Analytics** | Log Analytics, CloudWatch | No (receiver only) |
+| **Identity** | Entra ID, IAM | No (receiver only) |
+| **Observability** | Azure Monitor, CloudWatch Metrics | No (receiver only) |
+
+!!! tip "Initiator vs. receiver"
+    The "Can Initiate Connections?" column matters when you create connections. Only initiator nodes can be the **source** of a connection. Receiver-only nodes (like databases and storage) can only be **targets**. This reflects real-world patterns — a compute service connects to a database, not the other way around.
+
+---
+
+## Connections
+
+Connections are the lines between nodes that represent communication flows. Each connection has a **type** that describes the nature of the communication.
+
+| Type | Meaning | Visual Style |
+|---|---|---|
+| **Dataflow** | Directional traffic flow | Solid arrow |
+| **HTTP** | Request/response interaction | Dashed arrow |
+| **Internal** | Internal control-plane communication | Dotted line |
+| **Data** | Data synchronization and state-sharing | Double line |
+| **Async** | Asynchronous event or callback | Wavy line |
+
+### Creating a Connection
+
+1. Click on the source node (must be an initiator)
+2. Click on the target node
+3. Select the connection type
+
+### Connection Rules
+
+- The source must be an initiator category (Compute, Gateway, Function, Queue, or Event)
+- Queue and Event nodes can only connect to Function nodes
+- A node cannot connect to itself
+- CloudBlocks validates connections in real-time and prevents invalid ones
+
+---
+
+## Templates
+
+Templates are pre-built architecture patterns that you can load and customize. They give you a working starting point instead of building from scratch.
+
+CloudBlocks includes 6 built-in templates:
+
+| Template | Description |
+|---|---|
+| **Three-Tier Web Application** | Gateway → Compute → Database + Storage |
+| **Simple Compute Setup** | Single compute instance in a public subnet |
+| **Data Storage Backend** | Compute → Database + Storage in a private subnet |
+| **Serverless HTTP API** | Gateway → Function → Storage + Database |
+| **Event-Driven Pipeline** | Event → Function → Queue → Function → Storage |
+| **Full-Stack Serverless** | Complete architecture with API, queue workers, events, database, and storage |
+
+Templates are fully editable — load one, then add, remove, or rearrange nodes and connections to match your needs.
+
+For details on using templates, see [Use Templates](templates.md).
+
+---
+
+## Cloud Providers
+
+CloudBlocks supports three cloud providers:
+
+- **Azure** (default)
+- **AWS**
+- **GCP**
+
+You can switch the active provider using the provider tabs in the menu bar. The provider determines which cloud-specific resources are available and how generated code is structured.
+
+!!! warning "Mixed-provider architectures"
+    CloudBlocks allows mixing resources from different providers in the same architecture, but warns you when this happens. In most cases, you'll want to use a single provider for the entire architecture.
+
+---
+
+## Validation
+
+CloudBlocks validates your architecture in real-time at three levels:
+
+| Level | What It Checks |
+|---|---|
+| **Placement** | Nodes are inside valid containers (e.g., compute inside a subnet) |
+| **Connection** | Valid source/target pairs, initiator rules |
+| **Architecture** | Cross-cutting constraints (e.g., database not directly exposed to internet) |
+
+Validation errors appear as you build. You can also run a full validation manually via **Build → Validate Architecture**.
+
+---
+
+## Workspaces
+
+A workspace is a saved architecture project. Each workspace has its own:
+
+- Architecture (containers, nodes, connections)
+- Undo/redo history
+- GitHub link (optional)
+
+You can create, rename, and switch between multiple workspaces using the **File** menu. Workspaces are saved to your browser's local storage.
+
+---
+
+## What's Next?
+
+| Goal | Guide |
+|---|---|
+| Build your first architecture | [Quick Start](quick-start.md) |
+| Design a complete architecture step by step | [Create an Architecture](create-architecture.md) |
+| Generate infrastructure code | [Generate Code](generate-code.md) |

--- a/docs/user-guide/create-architecture.md
+++ b/docs/user-guide/create-architecture.md
@@ -1,0 +1,157 @@
+# Create an Architecture
+
+This guide walks you through designing a cloud architecture from scratch on the CloudBlocks canvas. By the end, you'll have a working three-tier web application ready for code generation.
+
+---
+
+## Step 1 — Create a Network
+
+Every architecture starts with a network container.
+
+1. Open CloudBlocks. On the empty canvas, click **Start from Scratch**
+   - This creates a default Network (VNet) container on the canvas
+2. Alternatively, use the menu: **Insert → Network**
+
+The network container represents a Virtual Private Cloud (VPC on AWS/GCP) or Virtual Network (VNet on Azure).
+
+---
+
+## Step 2 — Add Subnets
+
+Subnets divide your network into isolated segments.
+
+1. Go to **Insert → Subnet** (or drag a Subnet from the Command Palette at the bottom)
+2. Place the subnet inside your network container
+3. Add a second subnet for separation (e.g., one public, one private)
+
+!!! tip "Public vs. private"
+    A common pattern is two subnets: a **public** subnet for internet-facing resources (gateways, load balancers) and a **private** subnet for backend resources (databases, internal services).
+
+---
+
+## Step 3 — Place Nodes
+
+Nodes are the cloud resources that make up your workload. Add them from the **Command Palette** at the bottom of the screen.
+
+1. **Gateway** — Drag a Gateway node into your public subnet. This represents your API Gateway or Load Balancer.
+2. **Compute** — Drag a Compute node into your public or private subnet. This represents your application server.
+3. **Database** — Drag a Database node into your private subnet. This represents your data store.
+
+!!! info "Drag from the Command Palette"
+    The Command Palette at the bottom of the screen shows all available node categories. Drag a category onto the canvas to place it. The palette filters based on your active cloud provider.
+
+### Node Placement Rules
+
+- Nodes must be placed inside a container (network or subnet)
+- CloudBlocks validates placement in real-time
+- If a placement is invalid, you'll see an error notification
+
+---
+
+## Step 4 — Connect Nodes
+
+Create connections to define communication flows between your nodes.
+
+1. Click on the **Gateway** node (the source)
+2. Click on the **Compute** node (the target)
+3. Select the connection type — choose **HTTP** for request/response traffic
+4. Repeat: connect **Compute** → **Database** with a **Data** connection type
+
+### Connection Type Guide
+
+| When to use... | Choose this type |
+|---|---|
+| API calls, web requests | **HTTP** |
+| General traffic flow | **Dataflow** |
+| Database reads/writes | **Data** |
+| Background processing | **Async** |
+| Internal service communication | **Internal** |
+
+!!! warning "Initiator rules"
+    Only certain node categories can be the **source** of a connection. Gateway, Compute, Function, Queue, and Event nodes can initiate connections. Database, Storage, Analytics, Identity, and Observability nodes are receiver-only.
+
+---
+
+## Step 5 — Validate
+
+CloudBlocks validates your architecture in real-time, but you can also run a full check:
+
+1. Go to **Build → Validate Architecture**
+2. Review any errors or warnings
+3. Fix issues by adjusting placement or connections
+
+Validation checks three levels:
+
+- **Placement** — Are nodes inside valid containers?
+- **Connection** — Are source/target pairs valid?
+- **Architecture** — Are there cross-cutting constraint violations?
+
+---
+
+## Step 6 — Generate Code
+
+Once your architecture passes validation:
+
+1. Go to **Build → Generate**
+2. The Code Preview panel shows your architecture as infrastructure code
+3. Choose your output format: Terraform, Bicep, or Pulumi
+4. Click **Copy** to copy the code to your clipboard
+
+For detailed options, see [Generate Code](generate-code.md).
+
+---
+
+## Tips for Better Architectures
+
+### Use Templates as a Starting Point
+
+Instead of building from scratch, load a [template](templates.md) and modify it. Templates follow cloud best practices.
+
+### Follow the Tiered Pattern
+
+Organize resources into tiers:
+
+```
+Internet → Gateway → Compute → Database/Storage
+```
+
+This is the most common cloud architecture pattern and maps cleanly to subnet boundaries.
+
+### Use Meaningful Names
+
+Click on any node or container to rename it in the bottom panel. Clear names make your architecture easier to understand and produce more readable generated code.
+
+### Leverage Undo/Redo
+
+Made a mistake? Press **Ctrl+Z** to undo. Press **Ctrl+Shift+Z** to redo. CloudBlocks maintains a full history of your changes.
+
+---
+
+## Example: Three-Tier Web Application
+
+Here's the architecture you just built:
+
+```
+Network (VNet)
+├── Public Subnet
+│   ├── Gateway (API Gateway / Load Balancer)
+│   └── Compute (App Server)
+└── Private Subnet
+    └── Database (SQL Database)
+
+Connections:
+  Gateway  →[HTTP]→     Compute
+  Compute  →[Data]→     Database
+```
+
+This pattern is available as a built-in template — select **Three-Tier Web Application** from the Template Gallery.
+
+---
+
+## What's Next?
+
+| Goal | Guide |
+|---|---|
+| Export your architecture as code | [Generate Code](generate-code.md) |
+| Start from a pre-built pattern | [Use Templates](templates.md) |
+| Learn the keyboard shortcuts | [Keyboard Shortcuts](keyboard-shortcuts.md) |

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,0 +1,136 @@
+# FAQ
+
+Answers to common questions about CloudBlocks.
+
+---
+
+## General
+
+### What is CloudBlocks?
+
+CloudBlocks is a visual cloud architecture builder that converts your designs into infrastructure-as-code. You design cloud infrastructure by placing nodes on containers, connect them, validate against real-world rules, and generate Terraform, Bicep, or Pulumi — all from the browser.
+
+### Is CloudBlocks free?
+
+Yes. CloudBlocks is open-source under the [Apache 2.0 license](https://github.com/yeongseon/cloudblocks/blob/main/LICENSE). You can use it for free, modify it, and contribute to it.
+
+### Do I need a cloud account to use CloudBlocks?
+
+No. CloudBlocks runs entirely in your browser. You don't need an Azure, AWS, or GCP account to design architectures and generate code. You only need a cloud account when you actually deploy the generated code.
+
+### Does CloudBlocks deploy infrastructure?
+
+No. CloudBlocks generates infrastructure-as-code files (Terraform, Bicep, Pulumi). You deploy the generated code using your preferred IaC tool and CI/CD pipeline. CloudBlocks is an architecture compiler, not a deployment tool.
+
+---
+
+## Architecture Design
+
+### What cloud providers are supported?
+
+CloudBlocks supports **Azure**, **AWS**, and **GCP**. Azure is the default provider with the most complete resource mappings. AWS and GCP support covers core resource categories.
+
+### Can I mix resources from different cloud providers?
+
+CloudBlocks allows it, but warns you. Mixed-provider architectures generate valid code for each provider, but real-world deployments typically use a single provider. The warning helps you catch accidental provider mixing.
+
+### What are the 10 node categories?
+
+Compute, Database, Storage, Gateway, Function, Queue, Event, Analytics, Identity, and Observability. See [Core Concepts](core-concepts.md) for details on each category.
+
+### Why can't I connect from a database to a compute node?
+
+CloudBlocks enforces an **initiator model** — only certain categories can be the source of a connection. Database, Storage, Analytics, Identity, and Observability nodes are receiver-only, reflecting real-world patterns where applications connect to databases, not the other way around. See [Core Concepts → Connections](core-concepts.md#connections) for the full rules.
+
+---
+
+## Code Generation
+
+### What output formats are supported?
+
+- **Terraform** (HCL) — Multi-cloud, industry standard
+- **Bicep** — Azure-native
+- **Pulumi** (TypeScript) — Code-first IaC
+
+### Is the generated code production-ready?
+
+Generated code follows cloud best practices and includes proper resource definitions, networking, and variable extraction (in production mode). However, you should review and customize it for your specific requirements — security policies, naming conventions, and organization-specific configurations.
+
+### Will regenerating code produce different output?
+
+No. Code generation is **deterministic** — the same architecture always produces the same code. Only actual changes to your architecture produce different output.
+
+---
+
+## Data and Storage
+
+### Where is my architecture saved?
+
+Your architecture is saved to your browser's **local storage**. It persists across browser sessions but is specific to your browser and device.
+
+### Can I export my architecture?
+
+Yes — you can export as infrastructure code (Terraform, Bicep, Pulumi) via the Code Preview panel. The architecture model itself is stored as JSON and can be pushed to GitHub if you connect the backend API.
+
+### What happens if I clear my browser data?
+
+Your saved workspaces will be lost. If you need to preserve your work across devices, use the GitHub integration (requires backend) or copy the generated code.
+
+---
+
+## Templates and Learning
+
+### How many templates are available?
+
+CloudBlocks includes **6 built-in templates**: Three-Tier Web Application, Simple Compute Setup, Data Storage Backend, Serverless HTTP API, Event-Driven Pipeline, and Full-Stack Serverless with Event Processing. See [Use Templates](templates.md) for details.
+
+### Can I create my own templates?
+
+Community template sharing is planned for a future release. Currently, you can save your architectures as workspaces and recreate patterns manually.
+
+### What is Learning Mode?
+
+Learning Mode provides guided, step-by-step tutorials that teach you cloud architecture patterns. Access it via the **Learn** menu or by clicking **Learn How** on the empty canvas.
+
+---
+
+## GitHub Integration
+
+### Do I need a GitHub account?
+
+No — GitHub integration is optional. The visual builder, code generation, and templates work without any account. GitHub features (repo sync, PR creation, architecture diff) require the backend API and GitHub OAuth login.
+
+### How do I set up the backend?
+
+See the [Getting Started guide](../guides/TUTORIALS.md) for backend setup instructions. The backend is a Python FastAPI application that handles GitHub OAuth, repository operations, and AI integration.
+
+---
+
+## Troubleshooting
+
+### The canvas is empty and nothing loads
+
+Try refreshing the page. If the issue persists, check your browser's developer console for errors. CloudBlocks requires a modern browser with JavaScript enabled.
+
+### I can't place a node on the canvas
+
+Nodes must be placed inside a container (Network or Subnet). Make sure you have at least one container on the canvas first. If starting fresh, click **Start from Scratch** to create a default network.
+
+### My connections aren't working
+
+Check that your source node is an **initiator** category (Compute, Gateway, Function, Queue, or Event). Receiver-only nodes (Database, Storage, Analytics, Identity, Observability) cannot be the source of a connection.
+
+### Validation shows errors
+
+Read the error message — it tells you exactly what's wrong. Common issues:
+- Node placed outside a container
+- Invalid connection source/target pair
+- Missing required connections
+
+---
+
+## Getting Help
+
+- [GitHub Issues](https://github.com/yeongseon/cloudblocks/issues) — Report bugs or request features
+- [GitHub Discussions](https://github.com/yeongseon/cloudblocks/discussions) — Ask questions and share ideas
+- [Live Demo](https://yeongseon.github.io/cloudblocks/) — Try CloudBlocks without installing anything

--- a/docs/user-guide/generate-code.md
+++ b/docs/user-guide/generate-code.md
@@ -1,0 +1,139 @@
+# Generate Code
+
+CloudBlocks converts your visual architecture into infrastructure-as-code. This guide explains how to generate, preview, and export code in Terraform, Bicep, or Pulumi.
+
+---
+
+## Generating Code
+
+1. Design your architecture on the canvas (see [Create an Architecture](create-architecture.md))
+2. Go to **Build → Generate** in the menu bar
+3. The **Code Preview** panel opens, showing your architecture as infrastructure code
+
+That's it — CloudBlocks generates code automatically from your visual design.
+
+---
+
+## Output Formats
+
+CloudBlocks supports three infrastructure-as-code formats:
+
+| Format | Language | Best For |
+|---|---|---|
+| **Terraform** | HCL (HashiCorp Configuration Language) | Multi-cloud deployments, industry standard |
+| **Bicep** | Bicep (Azure Resource Manager) | Azure-native infrastructure |
+| **Pulumi** | TypeScript | Developers who prefer code over config files |
+
+Switch between formats using the selector in the Code Preview panel. The default is Terraform.
+
+!!! tip "Same architecture, different outputs"
+    You can generate code in all three formats from the same architecture. This is useful for comparing approaches or migrating between tools.
+
+---
+
+## Generation Modes
+
+| Mode | Purpose | Use When |
+|---|---|---|
+| **Draft** | Quick preview with inline values | Prototyping and exploring |
+| **Production** | Full module structure with variables and outputs | Ready to deploy |
+
+Draft mode is fast and simple — great for seeing what your architecture looks like in code. Production mode generates commit-ready code with proper variable extraction, output declarations, and module structure.
+
+---
+
+## Cloud Provider Regions
+
+Code generation uses default regions based on your active cloud provider:
+
+| Provider | Default Region |
+|---|---|
+| **Azure** | `eastus` |
+| **AWS** | `us-east-1` |
+| **GCP** | `us-central1` |
+
+---
+
+## What Gets Generated
+
+The generated code includes:
+
+- **Resource definitions** — Each node in your architecture maps to a cloud resource
+- **Network configuration** — Containers map to VPCs, VNets, subnets
+- **Connection wiring** — Connections map to security rules, IAM bindings, and network configurations
+- **Variables** — Configurable parameters extracted from your architecture (production mode)
+- **Outputs** — Key values exported for use by other infrastructure (production mode)
+
+### Example: Terraform Output
+
+For a simple compute + database architecture, Terraform generates:
+
+```hcl
+resource "azurerm_resource_group" "main" {
+  name     = var.resource_group_name
+  location = var.location
+}
+
+resource "azurerm_virtual_network" "network" {
+  name                = "vnet-main"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+}
+
+resource "azurerm_linux_web_app" "compute" {
+  name                = "app-compute"
+  # ...
+}
+
+resource "azurerm_mssql_database" "database" {
+  name      = "db-main"
+  # ...
+}
+```
+
+---
+
+## Copying and Exporting
+
+- **Copy** — Click the Copy button in the Code Preview panel to copy all generated code to your clipboard
+- **Preview** — Scroll through the generated code in the Code Preview panel to review before copying
+
+!!! info "Deterministic generation"
+    CloudBlocks generates the same code every time for the same architecture. This means you can safely regenerate without worrying about unexpected changes — only actual architecture modifications produce different code.
+
+---
+
+## Validation Before Generation
+
+CloudBlocks validates your architecture before generating code. If validation finds errors:
+
+1. The validation panel shows what needs to be fixed
+2. Fix the issues (invalid placements, broken connections)
+3. Re-run generation
+
+Generation will not proceed with an invalid architecture. This prevents generating broken infrastructure code.
+
+---
+
+## Advanced: GitHub Integration
+
+If you're running the CloudBlocks backend, you can push generated code directly to a GitHub repository:
+
+1. Log in with GitHub OAuth via **File → GitHub → Login**
+2. Link your workspace to a repository
+3. Push your architecture and generated code
+4. Create pull requests with architecture changes
+
+!!! info "Backend required"
+    GitHub integration requires the CloudBlocks backend API. The frontend-only demo does not include GitHub features. See the [Getting Started guide](../guides/TUTORIALS.md) for backend setup.
+
+---
+
+## What's Next?
+
+| Goal | Guide |
+|---|---|
+| Start from a pre-built architecture | [Use Templates](templates.md) |
+| Learn all keyboard shortcuts | [Keyboard Shortcuts](keyboard-shortcuts.md) |
+| Understand the building blocks | [Core Concepts](core-concepts.md) |

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,0 +1,80 @@
+# User Guide
+
+Welcome to the CloudBlocks User Guide. Whether you're designing your first cloud architecture or generating production-ready infrastructure code, these guides walk you through everything you need.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Quick Start**
+
+    ---
+
+    Build your first architecture in under 5 minutes — from launch to generated code.
+
+    [:octicons-arrow-right-24: Get started](quick-start.md)
+
+-   :material-lightbulb:{ .lg .middle } **Core Concepts**
+
+    ---
+
+    Understand containers, nodes, connections, and templates — the building blocks of every architecture.
+
+    [:octicons-arrow-right-24: Learn concepts](core-concepts.md)
+
+-   :material-pencil-ruler:{ .lg .middle } **Create an Architecture**
+
+    ---
+
+    Step-by-step guide to designing cloud infrastructure on the visual canvas.
+
+    [:octicons-arrow-right-24: Start building](create-architecture.md)
+
+-   :material-code-braces:{ .lg .middle } **Generate Code**
+
+    ---
+
+    Export your architecture to Terraform, Bicep, or Pulumi with one click.
+
+    [:octicons-arrow-right-24: Generate code](generate-code.md)
+
+-   :material-puzzle:{ .lg .middle } **Use Templates**
+
+    ---
+
+    Start from pre-built architecture patterns and customize them for your needs.
+
+    [:octicons-arrow-right-24: Browse templates](templates.md)
+
+-   :material-keyboard:{ .lg .middle } **Keyboard Shortcuts**
+
+    ---
+
+    Speed up your workflow with keyboard shortcuts for common actions.
+
+    [:octicons-arrow-right-24: View shortcuts](keyboard-shortcuts.md)
+
+-   :material-frequently-asked-questions:{ .lg .middle } **FAQ**
+
+    ---
+
+    Answers to common questions about CloudBlocks, supported providers, and more.
+
+    [:octicons-arrow-right-24: Read FAQ](faq.md)
+
+</div>
+
+---
+
+## How to Use This Guide
+
+| If you want to... | Start here |
+|---|---|
+| Get up and running fast | [Quick Start](quick-start.md) |
+| Understand the terminology | [Core Concepts](core-concepts.md) |
+| Design a full architecture | [Create an Architecture](create-architecture.md) |
+| Export infrastructure code | [Generate Code](generate-code.md) |
+| Use a pre-built pattern | [Use Templates](templates.md) |
+| Work faster with hotkeys | [Keyboard Shortcuts](keyboard-shortcuts.md) |
+| Find answers to common questions | [FAQ](faq.md) |
+
+!!! tip "New to CloudBlocks?"
+    Start with the [Quick Start](quick-start.md) to build your first architecture, then read [Core Concepts](core-concepts.md) to understand the fundamentals.

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -1,0 +1,60 @@
+# Keyboard Shortcuts
+
+Speed up your CloudBlocks workflow with these keyboard shortcuts.
+
+---
+
+## General
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+S` | Save workspace |
+| `Ctrl+Z` | Undo |
+| `Ctrl+Shift+Z` | Redo |
+| `Ctrl+Y` | Redo (alternative) |
+| `Escape` | Deselect current element / Cancel operation / Exit deploy mode / Skip onboarding |
+| `Delete` | Remove selected element (node, connection, or container) |
+
+---
+
+## Navigation
+
+| Shortcut | Action |
+|---|---|
+| `Scroll` | Zoom in / out on the canvas |
+| `Click + Drag` (on canvas) | Pan the canvas |
+| `Click` (on element) | Select a node, container, or connection |
+
+---
+
+## Menu Shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+Alt+S` | Save workspace (menu) |
+| `Ctrl+Alt+I` | Insert (menu) |
+| `Ctrl+Alt+D` | Deploy mode (menu) |
+
+---
+
+## Tips
+
+!!! tip "Undo everything"
+    CloudBlocks maintains a full undo/redo history for your session. Use `Ctrl+Z` freely — you can always go back.
+
+!!! tip "Quick delete"
+    Select any element and press `Delete` to remove it. This works for nodes, connections, and containers.
+
+!!! tip "Escape to reset"
+    If you're in the middle of creating a connection or any other operation, press `Escape` to cancel and return to the default selection mode.
+
+---
+
+## Platform Notes
+
+| Platform | Modifier Key |
+|---|---|
+| **Windows / Linux** | `Ctrl` |
+| **macOS** | `Cmd` (⌘) |
+
+On macOS, replace `Ctrl` with `Cmd` for all shortcuts listed above.

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -1,0 +1,95 @@
+# Quick Start
+
+Build your first cloud architecture in under 5 minutes. No cloud account required — everything runs in your browser.
+
+---
+
+## 1. Launch CloudBlocks
+
+**Option A — Live Demo (no install)**
+
+Open the live demo at [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/) in your browser.
+
+**Option B — Run Locally**
+
+```bash
+git clone https://github.com/yeongseon/cloudblocks.git
+cd cloudblocks
+pnpm install
+cd apps/web && pnpm dev
+```
+
+Open [http://localhost:5173](http://localhost:5173).
+
+---
+
+## 2. Start from a Template
+
+When CloudBlocks opens, you'll see three options on the empty canvas:
+
+| Option | What It Does |
+|---|---|
+| **Use Template** | Opens the Template Gallery with pre-built architectures |
+| **Start from Scratch** | Creates a blank network container on the canvas |
+| **Learn How** | Opens guided tutorials for learning cloud patterns |
+
+Click **Use Template** and select **Three-Tier Web Application**. This loads a complete architecture with a gateway, compute node, and database — all pre-wired.
+
+!!! tip
+    Templates are fully editable. Use them as a starting point, then customize for your needs.
+
+---
+
+## 3. Explore the Canvas
+
+Your template is now on the canvas. Here's what you see:
+
+- **Containers** (the large rectangular areas) represent network boundaries like VPCs and subnets
+- **Nodes** (the smaller elements inside containers) represent cloud resources like VMs, databases, and gateways
+- **Connections** (the lines between nodes) represent communication flows
+
+Try these interactions:
+
+- **Drag** a node to reposition it within its container
+- **Click** a node to select it and see its details in the bottom panel
+- **Scroll** to zoom in and out
+- Press **Ctrl+Z** to undo any change
+
+---
+
+## 4. Generate Infrastructure Code
+
+Now turn your visual design into real infrastructure code:
+
+1. Open the menu: **Build → Generate**
+2. The Code Preview panel opens showing your architecture as Terraform code
+3. Click the **Copy** button to copy the generated code to your clipboard
+
+!!! info "Three output formats"
+    CloudBlocks generates code in three formats:
+
+    - **Terraform** (HCL) — Multi-cloud, the default
+    - **Bicep** — Azure-native
+    - **Pulumi** (TypeScript) — Code-first IaC
+
+    Toggle between formats using the selector in the Code Preview panel.
+
+---
+
+## 5. Save Your Work
+
+CloudBlocks saves your architecture to your browser's local storage automatically. Your work persists across browser sessions.
+
+To create a new workspace or switch between saved workspaces, use the **File** menu.
+
+---
+
+## What's Next?
+
+| Goal | Guide |
+|---|---|
+| Understand the building blocks | [Core Concepts](core-concepts.md) |
+| Build an architecture from scratch | [Create an Architecture](create-architecture.md) |
+| Learn about code generation options | [Generate Code](generate-code.md) |
+| Explore all available templates | [Use Templates](templates.md) |
+| Speed up with keyboard shortcuts | [Keyboard Shortcuts](keyboard-shortcuts.md) |

--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -1,0 +1,145 @@
+# Use Templates
+
+Templates are pre-built architecture patterns that give you a working starting point. Instead of building from scratch, load a template, then customize it for your specific needs.
+
+---
+
+## Loading a Template
+
+1. Open CloudBlocks
+2. On the empty canvas, click **Use Template**
+   - Or use the menu: **File → New Workspace**, then click **Use Template**
+3. Browse the **Template Gallery**
+4. Click a template to preview its description and architecture
+5. Click **Use** to load it onto the canvas
+
+The template creates a new workspace with all containers, nodes, and connections pre-configured.
+
+---
+
+## Built-in Templates
+
+CloudBlocks ships with 6 built-in templates, organized by difficulty and use case:
+
+### Three-Tier Web Application
+
+**Difficulty:** Beginner · **Category:** Web Application
+
+The classic web architecture pattern with three layers:
+
+```
+Internet → Gateway (Load Balancer) → Compute (App Server) → Database + Storage
+```
+
+Best for: Web applications, APIs with a database backend, traditional server-based apps.
+
+---
+
+### Simple Compute Setup
+
+**Difficulty:** Beginner · **Category:** Compute
+
+The simplest possible architecture — a single compute instance:
+
+```
+Compute (VM / App Service)
+```
+
+Best for: Learning CloudBlocks, quick prototyping, single-service deployments.
+
+---
+
+### Data Storage Backend
+
+**Difficulty:** Beginner · **Category:** Data
+
+A backend-focused architecture where compute connects to multiple data stores:
+
+```
+Compute → Database + Storage (in private subnet)
+```
+
+Best for: Data processing services, backend APIs, batch processing.
+
+---
+
+### Serverless HTTP API
+
+**Difficulty:** Intermediate · **Category:** Serverless
+
+A serverless API pattern using functions instead of traditional compute:
+
+```
+Gateway (API Gateway) → Function → Storage + Database
+```
+
+Best for: REST APIs, microservices, event-driven backends, cost-optimized workloads.
+
+---
+
+### Event-Driven Pipeline
+
+**Difficulty:** Intermediate · **Category:** Event Processing
+
+An asynchronous processing pipeline driven by events and queues:
+
+```
+Event → Function → Queue → Function → Storage
+```
+
+Best for: Data pipelines, stream processing, decoupled architectures, IoT backends.
+
+---
+
+### Full-Stack Serverless with Event Processing
+
+**Difficulty:** Advanced · **Category:** Full Stack
+
+A comprehensive architecture combining multiple patterns:
+
+```
+Gateway → Function (API) → Database + Storage
+Event → Function (Worker) → Queue → Function (Processor)
+```
+
+Best for: Production applications, complex microservices, architectures that need both synchronous APIs and asynchronous processing.
+
+---
+
+## Customizing Templates
+
+Templates are fully editable. After loading a template:
+
+- **Add nodes** — Drag new resources from the Command Palette
+- **Remove nodes** — Select a node and press Delete
+- **Add connections** — Click a source node, then click a target node
+- **Remove connections** — Select a connection and press Delete
+- **Rearrange** — Drag nodes to reposition them
+- **Add containers** — Insert new networks or subnets via the Insert menu
+- **Rename** — Click any element and edit its name in the bottom panel
+
+!!! tip "Templates as learning tools"
+    Load a template and examine how it's structured before building your own architecture. Notice the container layout, connection types, and node placement — these follow cloud best practices.
+
+---
+
+## Choosing the Right Template
+
+| If you need... | Use this template |
+|---|---|
+| A standard web app with a database | Three-Tier Web Application |
+| The simplest possible starting point | Simple Compute Setup |
+| A backend with database and storage | Data Storage Backend |
+| A serverless API without managing servers | Serverless HTTP API |
+| Asynchronous event processing | Event-Driven Pipeline |
+| A full production architecture | Full-Stack Serverless |
+
+---
+
+## What's Next?
+
+| Goal | Guide |
+|---|---|
+| Generate code from your template | [Generate Code](generate-code.md) |
+| Build an architecture from scratch | [Create an Architecture](create-architecture.md) |
+| Understand the building blocks | [Core Concepts](core-concepts.md) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,16 @@ markdown_extensions:
 nav:
   - Home: README.md
 
+  - User Guide:
+      - user-guide/index.md
+      - Quick Start: user-guide/quick-start.md
+      - Core Concepts: user-guide/core-concepts.md
+      - Create an Architecture: user-guide/create-architecture.md
+      - Generate Code: user-guide/generate-code.md
+      - Use Templates: user-guide/templates.md
+      - Keyboard Shortcuts: user-guide/keyboard-shortcuts.md
+      - FAQ: user-guide/faq.md
+
   - Getting Started:
       - Tutorials (Start Here): guides/TUTORIALS.md
       - Environment & Workspaces: guides/ENVIRONMENT_STRATEGY.md


### PR DESCRIPTION
## Summary

- Write complete **User Guide** section with 8 documentation pages for end-users
- Add **User Guide** tab to mkdocs.yml navigation between Home and Getting Started
- Build verified with `mkdocs build --strict` (no errors)

## Pages Added

| File | Issue | Content |
|---|---|---|
| `docs/user-guide/index.md` | #1317 | Landing page with grid cards linking to all guides |
| `docs/user-guide/quick-start.md` | #1318 | 5-minute first architecture guide |
| `docs/user-guide/core-concepts.md` | #1319 | Containers, nodes, connections, templates explained |
| `docs/user-guide/create-architecture.md` | #1321 | Step-by-step architecture creation walkthrough |
| `docs/user-guide/generate-code.md` | #1322 | Terraform/Bicep/Pulumi export guide |
| `docs/user-guide/templates.md` | #1323 | All 6 built-in templates explained |
| `docs/user-guide/keyboard-shortcuts.md` | #1324 | Keyboard shortcuts reference table |
| `docs/user-guide/faq.md` | #1320 | Common questions and troubleshooting |

## Notes

- Uses updated terminology: Container (not Plate), Node (not Block)
- Audience: end-users (cloud architects, DevOps engineers, developers)
- Tone: friendly, concise, professional — no marketing fluff
- All internal cross-links between guide pages verified

Closes #1316, closes #1317, closes #1318, closes #1319, closes #1320, closes #1321, closes #1322, closes #1323, closes #1324, closes #1325