### PR TITLE
docs: rewrite user guide for factual accuracy and M22 UX alignment

### DIFF
--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -1,142 +1,138 @@
 # Core Concepts
 
-CloudBlocks uses a Lego-style composition model. You build cloud architectures by snapping together four types of elements: **containers**, **nodes**, **connections**, and **templates**.
+CloudBlocks uses a Lego-style composition model for cloud architecture. You build infrastructure by placing elements on the canvas, connecting them with typed protocols, and validating against real-world rules.
 
 ---
 
 ## Containers
 
-Containers are the large boundary areas that represent network infrastructure. Every node must be placed inside a container.
+Containers represent logical boundaries and network infrastructure. They are the "plates" that hold other resources.
 
-| Container Type | Cloud Equivalent               | Nesting                                   |
-| -------------- | ------------------------------ | ----------------------------------------- |
-| **Network**    | Azure VNet / AWS VPC / GCP VPC | Top-level — placed directly on the canvas |
-| **Subnet**     | Public or private subnet       | Must be inside a Network                  |
+| Container Type | Cloud Equivalent (Azure / AWS / GCP) | Placement Rules                                |
+| -------------- | ------------------------------------ | ---------------------------------------------- |
+| **Network**    | VNet / VPC / VPC                     | Top-level plate placed directly on the canvas. |
+| **Subnet**     | Subnet / Subnet / Subnet             | Must be placed inside a Network plate.         |
 
-Containers define the network topology of your architecture. A typical setup has one Network containing one or more Subnets.
+Nodes are placed inside either a Network or a Subnet to define their network location.
 
-!!! info "Nesting rules"
-Subnets must be placed inside a Network. Nodes must be placed inside a Subnet (or directly inside a Network). CloudBlocks enforces these rules and shows an error if placement is invalid.
+!!! info "Nesting"
+A typical architecture starts with a Network plate, followed by one or more Subnet plates inside it. Resources like virtual machines or databases are then placed within those subnets.
 
 ---
 
 ## Nodes
 
-Nodes are individual cloud resources — the actual services that run your workload. They are placed inside containers.
+Nodes represent individual cloud resources. CloudBlocks organizes all resources into exactly **7 categories**:
 
-CloudBlocks organizes nodes into **10 categories**:
+| Category       | What It Does                          | Example Azure Resources                                                 |
+| -------------- | ------------------------------------- | ----------------------------------------------------------------------- |
+| **Compute**    | Runs application code                 | VM, App Service, Functions, Container Instances, AKS                    |
+| **Data**       | Stores and manages data               | SQL Database, Cosmos DB, Blob Storage, Cache Store                      |
+| **Edge**       | Handles traffic entry and routing     | Application Gateway, Front Door, CDN, DNS Zone, Load Balancer, Firewall |
+| **Security**   | Protects resources and manages access | Key Vault, Bastion, NSG, Secret Store                                   |
+| **Messaging**  | Connects services asynchronously      | Queue (Service Bus), Event Hub                                          |
+| **Network**    | Manages network infrastructure        | NAT Gateway, Public IP, Route Table, Private Endpoint                   |
+| **Operations** | Monitors and observes                 | Monitoring                                                              |
 
-| Category          | Examples                          | Can Initiate Connections? |
-| ----------------- | --------------------------------- | ------------------------- |
-| **Compute**       | VM, App Service, ECS              | Yes                       |
-| **Database**      | SQL Database, Cosmos DB, RDS      | No (receiver only)        |
-| **Storage**       | Blob Storage, S3, Data Lake       | No (receiver only)        |
-| **Gateway**       | API Gateway, Load Balancer        | Yes                       |
-| **Function**      | Azure Function, Lambda            | Yes                       |
-| **Queue**         | Service Bus, SQS                  | Yes                       |
-| **Event**         | Event Grid, EventBridge           | Yes                       |
-| **Analytics**     | Log Analytics, CloudWatch         | No (receiver only)        |
-| **Identity**      | Entra ID, IAM                     | No (receiver only)        |
-| **Observability** | Azure Monitor, CloudWatch Metrics | No (receiver only)        |
-
-!!! tip "Initiator vs. receiver"
-The "Can Initiate Connections?" column matters when you create connections. Only initiator nodes can be the **source** of a connection. Receiver-only nodes (like databases and storage) can only be **targets**. This reflects real-world patterns — a compute service connects to a database, not the other way around.
+!!! tip "Sidebar Palette"
+You can find and drag these resources from the **Sidebar Palette** on the left side of the editor.
 
 ---
 
 ## Connections
 
-Connections are the lines between nodes that represent communication flows. Each connection has a **type** that describes the nature of the communication.
+Connections represent communication flows between nodes. CloudBlocks uses a port-based model where each node has defined endpoints.
 
-| Type         | Meaning                                | Visual Style |
-| ------------ | -------------------------------------- | ------------ |
-| **Dataflow** | Directional traffic flow               | Solid arrow  |
-| **HTTP**     | Request/response interaction           | Dashed arrow |
-| **Internal** | Internal control-plane communication   | Dotted line  |
-| **Data**     | Data synchronization and state-sharing | Double line  |
-| **Async**    | Asynchronous event or callback         | Wavy line    |
+### Endpoint Model
 
-### Creating a Connection
+- **EndpointSemantic**: `http`, `event`, or `data`. This describes the protocol or data type.
+- **EndpointDirection**: `input` or `output`.
 
-1. Click on the source node (must be an initiator)
-2. Click on the target node
-3. Select the connection type
+A connection links an **output port** on a source node to an **input port** on a target node.
 
-### Connection Rules
+### Allowed Connection Flows
 
-- The source must be an initiator category (Compute, Gateway, Function, Queue, or Event)
-- Queue and Event nodes can only connect to Function nodes
-- A node cannot connect to itself
-- CloudBlocks validates connections in real-time and prevents invalid ones
+The following flows are supported based on resource categories:
+
+| Source Category | Target Category | Allowed Semantics |
+| --------------- | --------------- | ----------------- |
+| internet        | Edge            | http, data        |
+| Edge            | Edge            | http, data        |
+| Edge            | Compute         | http, data        |
+| Compute         | Data            | data              |
+| Compute         | Operations      | event, data       |
+| Compute         | Security        | data              |
+| Compute         | Messaging       | event, data       |
+| Messaging       | Compute         | event, data       |
+
+!!! warning "Receiver-only Categories"
+The following categories can only receive connections and cannot initiate them: **Data**, **Security**, **Operations**, and **Network**.
 
 ---
 
 ## Templates
 
-Templates are pre-built architecture patterns that you can load and customize. They give you a working starting point instead of building from scratch.
+Templates provide pre-configured architecture patterns to help you start quickly. There are 6 built-in templates available:
 
-CloudBlocks includes 6 built-in templates:
-
-| Template                       | Description                                                                  |
-| ------------------------------ | ---------------------------------------------------------------------------- |
-| **Three-Tier Web Application** | Gateway → Compute → Database + Storage                                       |
-| **Simple Compute Setup**       | Single compute instance in a public subnet                                   |
-| **Data Storage Backend**       | Compute → Database + Storage in a private subnet                             |
-| **Serverless HTTP API**        | Gateway → Function → Storage + Database                                      |
-| **Event-Driven Pipeline**      | Event → Function → Queue → Function → Storage                                |
-| **Full-Stack Serverless**      | Complete architecture with API, queue workers, events, database, and storage |
-
-Templates are fully editable — load one, then add, remove, or rearrange nodes and connections to match your needs.
-
-For details on using templates, see [Use Templates](templates.md).
+1.  **Three-Tier Web Application** (beginner, web-application)
+2.  **Simple Compute Setup** (beginner, web-application)
+3.  **Data Storage Backend** (intermediate, data-pipeline)
+4.  **Serverless HTTP API** (intermediate, serverless)
+5.  **Event-Driven Pipeline** (advanced, data-pipeline)
+6.  **Full-Stack Serverless with Event Processing** (advanced, serverless)
 
 ---
 
 ## Cloud Providers
 
-CloudBlocks supports three cloud providers:
+CloudBlocks supports multiple cloud providers, adapting resource names and icons automatically.
 
-- **Azure** (default)
-- **AWS**
-- **GCP**
+- **Azure**: The default provider with full resource coverage.
+- **AWS**: Resource names adapt to AWS terminology (e.g., VPC, EC2, Lambda, S3, RDS).
+- **GCP**: Resource names adapt to GCP terminology (e.g., Compute Engine, Cloud Functions, Cloud Storage).
 
-You can switch the active provider using the provider tabs in the menu bar. The provider determines which cloud-specific resources are available and how generated code is structured.
-
-!!! warning "Mixed-provider architectures"
-CloudBlocks allows mixing resources from different providers in the same architecture, but warns you when this happens. In most cases, you'll want to use a single provider for the entire architecture.
+Use the provider tabs in the menu bar to switch the active provider for your workspace.
 
 ---
 
 ## Validation
 
-CloudBlocks validates your architecture in real-time at three levels:
+The validation engine ensures your design follows cloud best practices and technical constraints.
 
-| Level            | What It Checks                                                              |
-| ---------------- | --------------------------------------------------------------------------- |
-| **Placement**    | Nodes are inside valid containers (e.g., compute inside a subnet)           |
-| **Connection**   | Valid source/target pairs, initiator rules                                  |
-| **Architecture** | Cross-cutting constraints (e.g., database not directly exposed to internet) |
-
-Validation errors appear as you build. You can also run a full validation manually via **Build → Validate Architecture**.
+- **Real-time Validation**: Errors appear instantly as you place resources or create connections.
+- **Manual Check**: Run a full audit via **Build → Validate Architecture**.
+- **Results**: View detailed error messages and warnings in the **Bottom Dock** under the validation tab.
 
 ---
 
 ## Workspaces
 
-A workspace is a saved architecture project. Each workspace has its own:
+Workspaces allow you to manage multiple projects independently.
 
-- Architecture (containers, nodes, connections)
-- Undo/redo history
-- GitHub link (optional)
+- **Storage**: Saved automatically to your browser's local storage.
+- **Management**: Create, rename, or delete projects via the **Workspaces** button in the menu bar.
+- **GitHub Sync**: Connect a workspace to a GitHub repository to sync your designs and generate Pull Requests.
 
-You can create, rename, and switch between multiple workspaces using the **File** menu. Workspaces are saved to your browser's local storage.
+---
+
+## Learning Mode
+
+Learning Mode offers interactive scenarios to help you master cloud architecture patterns.
+
+- **Three-Tier Web Application**: Beginner scenario, approximately 10 minutes.
+- **Serverless HTTP API**: Intermediate scenario, approximately 8 minutes.
+- **Event-Driven Data Pipeline**: Advanced scenario, approximately 12 minutes.
+
+Access these guided tutorials via **Build → Browse Scenarios** or by clicking the **Learn How** button on an empty canvas.
 
 ---
 
 ## What's Next?
 
-| Goal                                        | Guide                                            |
-| ------------------------------------------- | ------------------------------------------------ |
-| Build your first architecture               | [Quick Start](quick-start.md)                    |
-| Design a complete architecture step by step | [Create an Architecture](create-architecture.md) |
-| Generate infrastructure code                | [Generate Code](generate-code.md)                |
+| Goal                          | Guide                                         |
+| ----------------------------- | --------------------------------------------- |
+| Build your first architecture | [Quick Start](quick-start.md)                 |
+| Create a custom design        | [Create Architecture](create-architecture.md) |
+| Generate infrastructure code  | [Generate Code](generate-code.md)             |
+| Explore pre-built patterns    | [Templates](templates.md)                     |
+| Work faster with hotkeys      | [Keyboard Shortcuts](keyboard-shortcuts.md)   |

--- a/docs/user-guide/create-architecture.md
+++ b/docs/user-guide/create-architecture.md
@@ -1,157 +1,142 @@
 # Create an Architecture
 
-This guide walks you through designing a cloud architecture from scratch on the CloudBlocks canvas. By the end, you'll have a working three-tier web application ready for code generation.
+This guide walks you through designing a cloud architecture on the CloudBlocks canvas. Follow these steps to build a valid, deployable architecture from scratch.
 
 ---
 
-## Step 1 — Create a Network
+## Step 1: Create a Network
 
-Every architecture starts with a network container.
+Every architecture starts with a network container to hold your resources.
 
-1. Open CloudBlocks. On the empty canvas, click **Start from Scratch**
-   - This creates a default Network (VNet) container on the canvas
-2. Alternatively, use the menu: **Insert → Network**
+1.  On the empty canvas, click **Start from Scratch**. This creates a Network (VNet) container.
+2.  Alternatively, open the **Sidebar Palette** on the left side of the screen.
+3.  Find the **Foundation** group and click or drag **Network (VNet)** onto the canvas.
 
-The network container represents a Virtual Private Cloud (VPC on AWS/GCP) or Virtual Network (VNet on Azure).
-
----
-
-## Step 2 — Add Subnets
-
-Subnets divide your network into isolated segments.
-
-1. Go to **Insert → Subnet** (or drag a Subnet from the Command Palette at the bottom)
-2. Place the subnet inside your network container
-3. Add a second subnet for separation (e.g., one public, one private)
-
-!!! tip "Public vs. private"
-A common pattern is two subnets: a **public** subnet for internet-facing resources (gateways, load balancers) and a **private** subnet for backend resources (databases, internal services).
+The network container represents your primary logical boundary, such as a Virtual Private Cloud or Virtual Network.
 
 ---
 
-## Step 3 — Place Nodes
+## Step 2: Add Subnets
 
-Nodes are the cloud resources that make up your workload. Add them from the **Command Palette** at the bottom of the screen.
+Subnets allow you to partition your network into smaller, isolated segments.
 
-1. **Gateway** — Drag a Gateway node into your public subnet. This represents your API Gateway or Load Balancer.
-2. **Compute** — Drag a Compute node into your public or private subnet. This represents your application server.
-3. **Database** — Drag a Database node into your private subnet. This represents your data store.
+1.  Once a network exists, the **Subnet** option becomes enabled in the Sidebar Palette.
+2.  In the Sidebar Palette, find **Subnet** under the Foundation group.
+3.  Click it or drag it inside your Network on the canvas.
+4.  Add a second subnet to separate different tiers. A common pattern uses one subnet for internet-facing resources and another for backend services.
 
-!!! info "Drag from the Command Palette"
-The Command Palette at the bottom of the screen shows all available node categories. Drag a category onto the canvas to place it. The palette filters based on your active cloud provider.
-
-### Node Placement Rules
-
-- Nodes must be placed inside a container (network or subnet)
-- CloudBlocks validates placement in real-time
-- If a placement is invalid, you'll see an error notification
+The Sidebar Palette shows disabled resources with a tooltip. If you cannot select a subnet, the tooltip will explain that you must create a network first.
 
 ---
 
-## Step 4 — Connect Nodes
+## Step 3: Place Resources
 
-Create connections to define communication flows between your nodes.
+Add resources from the **Sidebar Palette** on the left side of the screen. The palette organizes resources into functional groups.
 
-1. Click on the **Gateway** node (the source)
-2. Click on the **Compute** node (the target)
-3. Select the connection type — choose **HTTP** for request/response traffic
-4. Repeat: connect **Compute** → **Database** with a **Data** connection type
+### Resource Groups
 
-### Connection Type Guide
+| Group      | Resources                                                                       |
+| ---------- | ------------------------------------------------------------------------------- |
+| Foundation | Network (VNet), Subnet                                                          |
+| Compute    | Functions, App Service, Container Instances, Virtual Machine, Kubernetes (AKS)  |
+| Data       | Blob Storage, SQL Database, Cosmos DB                                           |
+| Edge       | DNS Zone, CDN Profile, Front Door, Application Gateway, Load Balancer, Firewall |
+| Security   | Key Vault, Bastion, Network Security Group                                      |
+| Messaging  | Queue, Event Hub                                                                |
+| Network    | NAT Gateway, Public IP, Route Table, Private Endpoint                           |
+| Operations | Monitoring                                                                      |
 
-| When to use...                 | Choose this type |
-| ------------------------------ | ---------------- |
-| API calls, web requests        | **HTTP**         |
-| General traffic flow           | **Dataflow**     |
-| Database reads/writes          | **Data**         |
-| Background processing          | **Async**        |
-| Internal service communication | **Internal**     |
+### How to Add Resources
 
-!!! warning "Initiator rules"
-Only certain node categories can be the **source** of a connection. Gateway, Compute, Function, Queue, and Event nodes can initiate connections. Database, Storage, Analytics, Identity, and Observability nodes are receiver-only.
+- **Click**: Select a resource in the Sidebar Palette to place it automatically on the best available container.
+- **Drag**: Move a resource from the Sidebar Palette onto the canvas and drop it in your preferred location.
 
----
-
-## Step 5 — Validate
-
-CloudBlocks validates your architecture in real-time, but you can also run a full check:
-
-1. Go to **Build → Validate Architecture**
-2. Review any errors or warnings
-3. Fix issues by adjusting placement or connections
-
-Validation checks three levels:
-
-- **Placement** — Are nodes inside valid containers?
-- **Connection** — Are source/target pairs valid?
-- **Architecture** — Are there cross-cutting constraint violations?
+Some resources require a network to exist before you can place them. These resources appear disabled in the palette until you add a network.
 
 ---
 
-## Step 6 — Generate Code
+## Step 4: Connect Resources
 
-Once your architecture passes validation:
+CloudBlocks uses a port-based connection model to define how resources communicate.
 
-1. Go to **Build → Generate**
-2. The Code Preview panel shows your architecture as infrastructure code
-3. Choose your output format: Terraform, Bicep, or Pulumi
-4. Click **Copy** to copy the code to your clipboard
+### Port Types
 
-For detailed options, see [Generate Code](generate-code.md).
+Each resource has input and output ports (endpoints). Ports use one of three semantic types:
+
+- **http**: For web requests and API calls.
+- **event**: For asynchronous messaging and triggers.
+- **data**: For database access and storage operations.
+
+### Create a Connection
+
+1.  Click an **output port** on the source resource.
+2.  Click an **input port** on the target resource.
+
+### Connection Rules
+
+Connections follow real-world traffic patterns:
+
+- **Internet to Edge**: http, data
+- **Edge to Compute**: http, data
+- **Compute to Data**: data only
+- **Compute to Messaging**: event, data
+- **Messaging to Compute**: event, data (bidirectional)
+
+Resources in the Data, Security, Operations, and Network categories are receiver-only. They cannot initiate connections to other resources.
 
 ---
 
-## Tips for Better Architectures
+## Step 5: Validate
 
-### Use Templates as a Starting Point
+CloudBlocks validates your design in real-time. You can also run a manual check to ensure your architecture is ready for deployment.
 
-Instead of building from scratch, load a [template](templates.md) and modify it. Templates follow cloud best practices.
+1.  Open the menu and select **Build > Validate Architecture**.
+2.  View the results in the **Validation** tab within the **Bottom Dock**.
+3.  Fix any placement or connection errors shown in the list.
 
-### Follow the Tiered Pattern
+---
 
-Organize resources into tiers:
+## Step 6: Generate Code
 
-```
-Internet → Gateway → Compute → Database/Storage
-```
+When your architecture is complete, export it as infrastructure code.
 
-This is the most common cloud architecture pattern and maps cleanly to subnet boundaries.
+1.  Click the **Code** tab in the **Inspector Panel** on the right side of the screen.
+2.  Alternatively, use the menu: **Build > Generate Code**.
+3.  Choose your preferred format: **Terraform**, **Bicep**, or **Pulumi**.
+4.  Click **Copy** to save the code to your clipboard.
 
-### Use Meaningful Names
+---
 
-Click on any node or container to rename it in the bottom panel. Clear names make your architecture easier to understand and produce more readable generated code.
+## Tips for Success
 
-### Leverage Undo/Redo
-
-Made a mistake? Press **Ctrl+Z** to undo. Press **Ctrl+Shift+Z** to redo. CloudBlocks maintains a full history of your changes.
+- **Use Templates**: Start with a pre-built template to save time and follow best practices.
+- **Tiered Pattern**: Arrange your resources in a logical flow from Internet to Edge, then Compute, and finally Data.
+- **Rename Nodes**: Click any node name in the **Inspector Panel** to give it a meaningful name.
+- **Undo Changes**: Use **Ctrl+Z** (Windows/Linux) or **Cmd+Z** (macOS) to quickly revert mistakes.
 
 ---
 
 ## Example: Three-Tier Web Application
 
-Here's the architecture you just built:
+A standard three-tier architecture separates the presentation, logic, and data layers into different subnets.
 
-```
+```text
 Network (VNet)
-├── Public Subnet
-│   ├── Gateway (API Gateway / Load Balancer)
-│   └── Compute (App Server)
-└── Private Subnet
-    └── Database (SQL Database)
-
-Connections:
-  Gateway  →[HTTP]→     Compute
-  Compute  →[Data]→     Database
+├── Subnet 1
+│   ├── Application Gateway (edge)
+│   └── Virtual Machine (compute)
+└── Subnet 2
+    ├── SQL Database (data)
+    └── Blob Storage (data)
 ```
-
-This pattern is available as a built-in template — select **Three-Tier Web Application** from the Template Gallery.
 
 ---
 
 ## What's Next?
 
 | Goal                             | Guide                                       |
-| -------------------------------- | ------------------------------------------- |
-| Export your architecture as code | [Generate Code](generate-code.md)           |
-| Start from a pre-built pattern   | [Use Templates](templates.md)               |
-| Learn the keyboard shortcuts     | [Keyboard Shortcuts](keyboard-shortcuts.md) |
+| :------------------------------- | :------------------------------------------ |
+| Master the code generator        | [Generate Code](generate-code.md)           |
+| Browse all architecture patterns | [Templates](templates.md)                   |
+| Learn all keyboard shortcuts     | [Keyboard Shortcuts](keyboard-shortcuts.md) |
+| Understand the building blocks   | [Core Concepts](core-concepts.md)           |

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-Answers to common questions about CloudBlocks.
+Find answers to frequently asked questions about CloudBlocks.
 
 ---
 
@@ -8,19 +8,19 @@ Answers to common questions about CloudBlocks.
 
 ### What is CloudBlocks?
 
-CloudBlocks is a visual cloud architecture builder that converts your designs into infrastructure-as-code. You design cloud infrastructure by placing nodes on containers, connect them, validate against real-world rules, and generate Terraform, Bicep, or Pulumi — all from the browser.
+CloudBlocks is a visual architecture compiler that lets you design cloud infrastructure by placing blocks on plates. Your designs are then converted into infrastructure-as-code files like Terraform, Bicep, or Pulumi.
 
 ### Is CloudBlocks free?
 
-Yes. CloudBlocks is open-source under the [Apache 2.0 license](https://github.com/yeongseon/cloudblocks/blob/main/LICENSE). You can use it for free, modify it, and contribute to it.
+Yes. CloudBlocks is an open-source project under the Apache 2.0 license.
 
-### Do I need a cloud account to use CloudBlocks?
+### Do I need a cloud account?
 
-No. CloudBlocks runs entirely in your browser. You don't need an Azure, AWS, or GCP account to design architectures and generate code. You only need a cloud account when you actually deploy the generated code.
+No. You can design architectures and generate code entirely in the browser without any cloud provider account. You only need a cloud account when you decide to deploy the generated code to a real environment.
 
 ### Does CloudBlocks deploy infrastructure?
 
-No. CloudBlocks generates infrastructure-as-code files (Terraform, Bicep, Pulumi). You deploy the generated code using your preferred IaC tool and CI/CD pipeline. CloudBlocks is an architecture compiler, not a deployment tool.
+CloudBlocks generates infrastructure-as-code files. You then use your preferred deployment tool (Terraform, Bicep, or Pulumi CLI) to deploy that code. CloudBlocks handles the design and compilation, while you handle the deployment.
 
 ---
 
@@ -28,19 +28,21 @@ No. CloudBlocks generates infrastructure-as-code files (Terraform, Bicep, Pulumi
 
 ### What cloud providers are supported?
 
-CloudBlocks supports **Azure**, **AWS**, and **GCP**. Azure is the default provider with the most complete resource mappings. AWS and GCP support covers core resource categories.
+CloudBlocks supports Azure, AWS, and GCP. Azure currently offers the most comprehensive resource coverage.
 
-### Can I mix resources from different cloud providers?
+### What are the 7 resource categories?
 
-CloudBlocks allows it, but warns you. Mixed-provider architectures generate valid code for each provider, but real-world deployments typically use a single provider. The warning helps you catch accidental provider mixing.
+The seven resource categories are: Compute, Data, Edge, Security, Messaging, Network, and Operations.
 
-### What are the 10 node categories?
+### Why can't I initiate a connection from a Database?
 
-Compute, Database, Storage, Gateway, Function, Queue, Event, Analytics, Identity, and Observability. See [Core Concepts](core-concepts.md) for details on each category.
+CloudBlocks uses an initiator model to reflect real-world connectivity patterns. Only certain categories can initiate connections: Compute, Edge, and Messaging.
 
-### Why can't I connect from a database to a compute node?
+The following categories are receiver-only: Data, Security, Operations, and Network. For example, an application (Compute) connects to a database (Data), but a database does not initiate a connection back to an application.
 
-CloudBlocks enforces an **initiator model** — only certain categories can be the source of a connection. Database, Storage, Analytics, Identity, and Observability nodes are receiver-only, reflecting real-world patterns where applications connect to databases, not the other way around. See [Core Concepts → Connections](core-concepts.md#connections) for the full rules.
+### Where do I find resource details?
+
+To see and edit the details of a node, click on it and look at the **Inspector Panel** on the right side of the editor. To add new resources, use the **Sidebar Palette** on the left side.
 
 ---
 
@@ -48,17 +50,17 @@ CloudBlocks enforces an **initiator model** — only certain categories can be t
 
 ### What output formats are supported?
 
-- **Terraform** (HCL) — Multi-cloud, industry standard
-- **Bicep** — Azure-native
-- **Pulumi** (TypeScript) — Code-first IaC
+- Terraform (HCL)
+- Bicep (Azure)
+- Pulumi (TypeScript)
 
-### Is the generated code production-ready?
+### Is the code production-ready?
 
-Generated code follows cloud best practices and includes proper resource definitions, networking, and variable extraction (in production mode). However, you should review and customize it for your specific requirements — security policies, naming conventions, and organization-specific configurations.
+The generated code follows standard cloud patterns. However, you should review the output to ensure it matches your organization's specific naming conventions and security policies before deploying to a production environment.
 
-### Will regenerating code produce different output?
+### Is code generation deterministic?
 
-No. Code generation is **deterministic** — the same architecture always produces the same code. Only actual changes to your architecture produce different output.
+Yes. Given the same architecture, the generator will always produce the same code.
 
 ---
 
@@ -66,31 +68,11 @@ No. Code generation is **deterministic** — the same architecture always produc
 
 ### Where is my architecture saved?
 
-Your architecture is saved to your browser's **local storage**. It persists across browser sessions but is specific to your browser and device.
+Your work is saved in your browser's local storage. This means it persists across sessions on the same browser and device.
 
-### Can I export my architecture?
+### Can I export my work?
 
-Yes — you can export as infrastructure code (Terraform, Bicep, Pulumi) via the Code Preview panel. The architecture model itself is stored as JSON and can be pushed to GitHub if you connect the backend API.
-
-### What happens if I clear my browser data?
-
-Your saved workspaces will be lost. If you need to preserve your work across devices, use the GitHub integration (requires backend) or copy the generated code.
-
----
-
-## Templates and Learning
-
-### How many templates are available?
-
-CloudBlocks includes **6 built-in templates**: Three-Tier Web Application, Simple Compute Setup, Data Storage Backend, Serverless HTTP API, Event-Driven Pipeline, and Full-Stack Serverless with Event Processing. See [Use Templates](templates.md) for details.
-
-### Can I create my own templates?
-
-Community template sharing is planned for a future release. Currently, you can save your architectures as workspaces and recreate patterns manually.
-
-### What is Learning Mode?
-
-Learning Mode provides guided, step-by-step tutorials that teach you cloud architecture patterns. Access it via the **Learn** menu or by clicking **Learn How** on the empty canvas.
+You can export your design as infrastructure code via the code preview feature. If the backend API is connected, you can also sync your architecture with a GitHub repository.
 
 ---
 
@@ -98,40 +80,26 @@ Learning Mode provides guided, step-by-step tutorials that teach you cloud archi
 
 ### Do I need a GitHub account?
 
-No — GitHub integration is optional. The visual builder, code generation, and templates work without any account. GitHub features (repo sync, PR creation, architecture diff) require the backend API and GitHub OAuth login.
-
-### How do I set up the backend?
-
-See the [Getting Started guide](../guides/TUTORIALS.md) for backend setup instructions. The backend is a Python FastAPI application that handles GitHub OAuth, repository operations, and AI integration.
+A GitHub account is only required if you want to use advanced features like repo sync, pull request creation, and architecture diffing. The core builder and code generation work without any login.
 
 ---
 
 ## Troubleshooting
 
-### The canvas is empty and nothing loads
+### Why can't I place a node?
 
-Try refreshing the page. If the issue persists, check your browser's developer console for errors. CloudBlocks requires a modern browser with JavaScript enabled.
+Nodes must be placed inside a container, such as a Network or Subnet plate. Make sure you have placed a container on the canvas first.
 
-### I can't place a node on the canvas
+### Why won't my connection work?
 
-Nodes must be placed inside a container (Network or Subnet). Make sure you have at least one container on the canvas first. If starting fresh, click **Start from Scratch** to create a default network.
+Check that your source category can initiate connections (Compute, Edge, or Messaging). If you are trying to connect from a Data, Security, Operations, or Network node, the builder will block it because those categories are receiver-only.
 
-### My connections aren't working
+### Where is Learning Mode?
 
-Check that your source node is an **initiator** category (Compute, Gateway, Function, Queue, or Event). Receiver-only nodes (Database, Storage, Analytics, Identity, Observability) cannot be the source of a connection.
-
-### Validation shows errors
-
-Read the error message — it tells you exactly what's wrong. Common issues:
-
-- Node placed outside a container
-- Invalid connection source/target pair
-- Missing required connections
+You can access Learning Mode via **Build → Browse Scenarios** or by clicking the **Learn How** button on the empty canvas. There are three built-in scenarios: Three-Tier Web Application, Serverless HTTP API, and Event-Driven Data Pipeline.
 
 ---
 
 ## Getting Help
 
-- [GitHub Issues](https://github.com/yeongseon/cloudblocks/issues) — Report bugs or request features
-- [GitHub Discussions](https://github.com/yeongseon/cloudblocks/discussions) — Ask questions and share ideas
-- [Live Demo](https://yeongseon.github.io/cloudblocks/) — Try CloudBlocks without installing anything
+If you run into issues or have questions, you can report bugs on GitHub Issues or join the conversation on GitHub Discussions.

--- a/docs/user-guide/generate-code.md
+++ b/docs/user-guide/generate-code.md
@@ -1,4 +1,4 @@
-# Generate Code
+# Generating Code
 
 CloudBlocks converts your visual architecture into infrastructure-as-code. This guide explains how to generate, preview, and export code in Terraform, Bicep, or Pulumi.
 
@@ -6,39 +6,33 @@ CloudBlocks converts your visual architecture into infrastructure-as-code. This 
 
 ## Generating Code
 
-1. Design your architecture on the canvas (see [Create an Architecture](create-architecture.md))
-2. Go to **Build → Generate** in the menu bar
-3. The **Code Preview** panel opens, showing your architecture as infrastructure code
+Design your architecture on the canvas by placing blocks on plates and connecting them. Once your design is ready, you can view the generated code in two ways:
 
-That's it — CloudBlocks generates code automatically from your visual design.
+- **Inspector Panel**: Click the **Code** tab in the Inspector Panel on the right side of the screen. This displays the generated code immediately as you modify your architecture.
+- **Menu Bar**: Use the **Build → Generate Code** menu option to focus the Code tab.
+
+There is no separate code preview window. All code interaction happens within the Code tab of the Inspector Panel.
 
 ---
 
 ## Output Formats
 
-CloudBlocks supports three infrastructure-as-code formats:
+CloudBlocks supports three industry-standard infrastructure-as-code formats. Use the selector inside the Inspector's Code tab to switch between them:
 
-| Format        | Language                               | Best For                                     |
-| ------------- | -------------------------------------- | -------------------------------------------- |
-| **Terraform** | HCL (HashiCorp Configuration Language) | Multi-cloud deployments, industry standard   |
-| **Bicep**     | Bicep (Azure Resource Manager)         | Azure-native infrastructure                  |
-| **Pulumi**    | TypeScript                             | Developers who prefer code over config files |
-
-Switch between formats using the selector in the Code Preview panel. The default is Terraform.
-
-!!! tip "Same architecture, different outputs"
-You can generate code in all three formats from the same architecture. This is useful for comparing approaches or migrating between tools.
+| Format        | Language                               | Best For                                             |
+| :------------ | :------------------------------------- | :--------------------------------------------------- |
+| **Terraform** | HCL (HashiCorp Configuration Language) | Multi-cloud deployments, industry standard (default) |
+| **Bicep**     | Bicep (Azure Resource Manager)         | Azure-native infrastructure                          |
+| **Pulumi**    | TypeScript                             | Developers who prefer code-first IaC                 |
 
 ---
 
 ## Generation Modes
 
-| Mode           | Purpose                                          | Use When                  |
-| -------------- | ------------------------------------------------ | ------------------------- |
-| **Draft**      | Quick preview with inline values                 | Prototyping and exploring |
-| **Production** | Full module structure with variables and outputs | Ready to deploy           |
+You can toggle between two generation modes depending on your workflow:
 
-Draft mode is fast and simple — great for seeing what your architecture looks like in code. Production mode generates commit-ready code with proper variable extraction, output declarations, and module structure.
+- **Draft mode**: Generates a quick preview with inline values. This is ideal for prototyping and exploring how different configurations look in code.
+- **Production mode**: Generates a full module structure including variables, outputs, and proper resource naming conventions. Use this mode when you are ready to commit code to a repository.
 
 ---
 
@@ -47,7 +41,7 @@ Draft mode is fast and simple — great for seeing what your architecture looks 
 Code generation uses default regions based on your active cloud provider:
 
 | Provider  | Default Region |
-| --------- | -------------- |
+| :-------- | :------------- |
 | **Azure** | `eastus`       |
 | **AWS**   | `us-east-1`    |
 | **GCP**   | `us-central1`  |
@@ -56,17 +50,16 @@ Code generation uses default regions based on your active cloud provider:
 
 ## What Gets Generated
 
-The generated code includes:
+The compiler maps your visual design to specific infrastructure components:
 
-- **Resource definitions** — Each node in your architecture maps to a cloud resource
-- **Network configuration** — Containers map to VPCs, VNets, subnets
-- **Connection wiring** — Connections map to security rules, IAM bindings, and network configurations
-- **Variables** — Configurable parameters extracted from your architecture (production mode)
-- **Outputs** — Key values exported for use by other infrastructure (production mode)
+- **Resource definitions**: Each node on the canvas maps to its corresponding cloud resource.
+- **Network configuration**: Containers and plates map to VPCs, VNets, and subnets.
+- **Connection wiring**: Connections between blocks map to security rules, IAM bindings, and network configurations.
+- **Variables and outputs**: In Production mode, the generator extracts configurable parameters and exports key values.
 
 ### Example: Terraform Output
 
-For a simple compute + database architecture, Terraform generates:
+For a simple compute and database architecture, Terraform generates:
 
 ```hcl
 resource "azurerm_resource_group" "main" {
@@ -96,44 +89,40 @@ resource "azurerm_mssql_database" "database" {
 
 ## Copying and Exporting
 
-- **Copy** — Click the Copy button in the Code Preview panel to copy all generated code to your clipboard
-- **Preview** — Scroll through the generated code in the Code Preview panel to review before copying
-
-!!! info "Deterministic generation"
-CloudBlocks generates the same code every time for the same architecture. This means you can safely regenerate without worrying about unexpected changes — only actual architecture modifications produce different code.
+- **Copy to Clipboard**: Use the Copy button in the Inspector's Code tab to copy the generated code.
+- **Export JSON**: Use **File → Export JSON** to save the architecture model itself as a JSON file.
+- **Import JSON**: Use **File → Import JSON** to restore a previously exported architecture model.
 
 ---
 
 ## Validation Before Generation
 
-CloudBlocks validates your architecture before generating code. If validation finds errors:
+CloudBlocks runs a validation engine before generating code. If there are issues with your architecture:
 
-1. The validation panel shows what needs to be fixed
-2. Fix the issues (invalid placements, broken connections)
-3. Re-run generation
-
-Generation will not proceed with an invalid architecture. This prevents generating broken infrastructure code.
+1. Errors appear in the **Validation** tab within the **Bottom Dock**.
+2. You must fix these issues, such as invalid placements or broken connections, before the code reflects the intended state.
+3. The generator ensures that only valid architectures produce infrastructure code.
 
 ---
 
-## Advanced: GitHub Integration
+## GitHub Integration
 
-If you're running the CloudBlocks backend, you can push generated code directly to a GitHub repository:
+The GitHub integration allows you to sync your architecture directly with a repository.
 
-1. Log in with GitHub OAuth via **File → GitHub → Login**
-2. Link your workspace to a repository
-3. Push your architecture and generated code
-4. Create pull requests with architecture changes
-
-!!! info "Backend required"
-GitHub integration requires the CloudBlocks backend API. The frontend-only demo does not include GitHub features. See the [Getting Started guide](../guides/TUTORIALS.md) for backend setup.
+- **Requirements**: This feature requires the CloudBlocks backend API and is not available in the frontend-only demo.
+- **Sign In**: Use the **Sign In** button located in the **GitHub** section of the menu bar.
+- **Workflow**:
+  - Link your workspace to a specific GitHub repository.
+  - Push your architecture and generated code directly to the repo.
+  - Create pull requests for architecture changes.
+  - Compare your local canvas with the state on GitHub.
 
 ---
 
 ## What's Next?
 
 | Goal                                | Guide                                       |
-| ----------------------------------- | ------------------------------------------- |
+| :---------------------------------- | :------------------------------------------ |
 | Start from a pre-built architecture | [Use Templates](templates.md)               |
 | Learn all keyboard shortcuts        | [Keyboard Shortcuts](keyboard-shortcuts.md) |
 | Understand the building blocks      | [Core Concepts](core-concepts.md)           |

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -1,60 +1,47 @@
 # Keyboard Shortcuts
 
-Speed up your CloudBlocks workflow with these keyboard shortcuts.
+You can use keyboard shortcuts to speed up your workflow in CloudBlocks.
 
 ---
 
-## General
+## General Shortcuts
 
-| Shortcut       | Action                                                                           |
-| -------------- | -------------------------------------------------------------------------------- |
-| `Ctrl+S`       | Save workspace                                                                   |
-| `Ctrl+Z`       | Undo                                                                             |
-| `Ctrl+Shift+Z` | Redo                                                                             |
-| `Ctrl+Y`       | Redo (alternative)                                                               |
-| `Escape`       | Deselect current element / Cancel operation / Exit deploy mode / Skip onboarding |
-| `Delete`       | Remove selected element (node, connection, or container)                         |
+| Shortcut                       | Action                                                       |
+| :----------------------------- | :----------------------------------------------------------- |
+| `Ctrl+S` / `Cmd+S`             | Save workspace                                               |
+| `Ctrl+Z` / `Cmd+Z`             | Undo                                                         |
+| `Ctrl+Shift+Z` / `Cmd+Shift+Z` | Redo                                                         |
+| `Ctrl+Y` / `Cmd+Y`             | Redo (alternative)                                           |
+| `Delete` / `Backspace`         | Remove selected element (node, container, or connection)     |
+| `Escape`                       | Deselect current element / Cancel operation / Exit diff mode |
+
+---
+
+## Panel Shortcuts
+
+| Shortcut     | Action                              |
+| :----------- | :---------------------------------- |
+| `Ctrl+Alt+S` | Toggle Sidebar Palette (left side)  |
+| `Ctrl+Alt+I` | Toggle Inspector Panel (right side) |
+| `Ctrl+Alt+D` | Toggle Bottom Dock                  |
 
 ---
 
 ## Navigation
 
-| Shortcut                   | Action                                  |
-| -------------------------- | --------------------------------------- |
-| `Scroll`                   | Zoom in / out on the canvas             |
-| `Click + Drag` (on canvas) | Pan the canvas                          |
-| `Click` (on element)       | Select a node, container, or connection |
-
----
-
-## Menu Shortcuts
-
-| Shortcut     | Action                |
-| ------------ | --------------------- |
-| `Ctrl+Alt+S` | Save workspace (menu) |
-| `Ctrl+Alt+I` | Insert (menu)         |
-| `Ctrl+Alt+D` | Deploy mode (menu)    |
-
----
-
-## Tips
-
-!!! tip "Undo everything"
-CloudBlocks maintains a full undo/redo history for your session. Use `Ctrl+Z` freely — you can always go back.
-
-!!! tip "Quick delete"
-Select any element and press `Delete` to remove it. This works for nodes, connections, and containers.
-
-!!! tip "Escape to reset"
-If you're in the middle of creating a connection or any other operation, press `Escape` to cancel and return to the default selection mode.
+| Shortcut       | Action                                          |
+| :------------- | :---------------------------------------------- |
+| `Scroll`       | Zoom in and out on the canvas                   |
+| `Click + Drag` | Pan the canvas                                  |
+| `Click`        | Select a node, plate (container), or connection |
 
 ---
 
 ## Platform Notes
 
-| Platform            | Modifier Key |
-| ------------------- | ------------ |
-| **Windows / Linux** | `Ctrl`       |
-| **macOS**           | `Cmd` (⌘)    |
+CloudBlocks supports both macOS and Windows/Linux. On macOS, the modifier key `Cmd` (⌘) replaces `Ctrl`.
 
-On macOS, replace `Ctrl` with `Cmd` for all shortcuts listed above.
+| Platform        | Modifier Key |
+| :-------------- | :----------- |
+| Windows / Linux | `Ctrl`       |
+| macOS           | `Cmd` (⌘)    |

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -1,16 +1,15 @@
 # Quick Start
 
-Build your first cloud architecture in under 5 minutes. No cloud account required — everything runs in your browser.
+Build your first cloud architecture in under 5 minutes. No cloud account required. Everything runs in your browser.
 
 ---
 
-## 1. Launch CloudBlocks
+## Step 1 — Launch CloudBlocks
 
-**Option A — Live Demo (no install)**
+You can use CloudBlocks directly in your browser or run it locally for development.
 
-Open the live demo at [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/) in your browser.
-
-**Option B — Run Locally**
+- **Option A: Live Demo** — Visit [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/) to start immediately.
+- **Option B: Run Locally** — Use these commands to launch a local development server:
 
 ```bash
 git clone https://github.com/yeongseon/cloudblocks.git
@@ -19,77 +18,83 @@ pnpm install
 cd apps/web && pnpm dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173).
+Open [http://localhost:5173](http://localhost:5173) in your browser.
+
+When CloudBlocks opens, you'll see a landing page. Choose a persona (e.g., Developer) to enter the builder.
 
 ---
 
-## 2. Start from a Template
+## Step 2 — Start from a Template
 
-When CloudBlocks opens, you'll see three options on the empty canvas:
+When the builder opens with an empty canvas, you'll see the Empty Canvas CTA with three options:
 
-| Option                 | What It Does                                            |
-| ---------------------- | ------------------------------------------------------- |
-| **Use Template**       | Opens the Template Gallery with pre-built architectures |
-| **Start from Scratch** | Creates a blank network container on the canvas         |
-| **Learn How**          | Opens guided tutorials for learning cloud patterns      |
+| Option                 | What it does                                              |
+| :--------------------- | :-------------------------------------------------------- |
+| **Use Template**       | Opens the Template Gallery with 6 pre-built architectures |
+| **Start from Scratch** | Creates a VNet (Network) container on the canvas          |
+| **Learn How**          | Opens guided learning scenarios                           |
 
-Click **Use Template** and select **Three-Tier Web Application**. This loads a complete architecture with a gateway, compute node, and database — all pre-wired.
-
-!!! tip
-Templates are fully editable. Use them as a starting point, then customize for your needs.
+Click **Use Template** and select **Three-Tier Web Application**. This loads a complete architecture with an Application Gateway, VM, SQL Database, and Blob Storage. All components are pre-wired with connections.
 
 ---
 
-## 3. Explore the Canvas
+## Step 3 — Explore the Interface
 
-Your template is now on the canvas. Here's what you see:
+The builder uses a 4-panel layout designed for professional architecture modeling:
 
-- **Containers** (the large rectangular areas) represent network boundaries like VPCs and subnets
-- **Nodes** (the smaller elements inside containers) represent cloud resources like VMs, databases, and gateways
-- **Connections** (the lines between nodes) represent communication flows
+- **Menu Bar** (top) — Access File, Edit, Build, and View menus. Use the Workspaces button to manage projects, switch between Provider tabs (Azure, AWS, GCP), and access the GitHub section.
+- **Sidebar Palette** (left) — Contains the resource palette grouped by category (foundation, compute, data, edge, security, messaging, operations). Click or drag items to create resources.
+- **Canvas** (center) — The main isometric drawing area where you build and view your architecture.
+- **Inspector Panel** (right) — Manage your selected nodes using three tabs:
+  - **Properties**: View node details and perform actions.
+  - **Code**: See a live preview of the generated IaC.
+  - **Connections**: Review related connections for the selected node.
+- **Bottom Dock** (bottom) — Monitor system state through four tabs:
+  - **Output**: View the activity log.
+  - **Validation**: Check rule results for your architecture.
+  - **Logs**: Read system messages.
+  - **Diff**: Compare architecture versions.
 
-Try these interactions:
+### Common Interactions
 
-- **Drag** a node to reposition it within its container
-- **Click** a node to select it and see its details in the bottom panel
-- **Scroll** to zoom in and out
-- Press **Ctrl+Z** to undo any change
-
----
-
-## 4. Generate Infrastructure Code
-
-Now turn your visual design into real infrastructure code:
-
-1. Open the menu: **Build → Generate**
-2. The Code Preview panel opens showing your architecture as Terraform code
-3. Click the **Copy** button to copy the generated code to your clipboard
-
-!!! info "Three output formats"
-CloudBlocks generates code in three formats:
-
-    - **Terraform** (HCL) — Multi-cloud, the default
-    - **Bicep** — Azure-native
-    - **Pulumi** (TypeScript) — Code-first IaC
-
-    Toggle between formats using the selector in the Code Preview panel.
+- **Drag** a node to reposition it on the canvas.
+- **Click** a node to see its details in the Inspector Panel on the right.
+- **Scroll** with your mouse or trackpad to zoom in and out.
+- Press **Ctrl+Z** (Windows/Linux) or **Cmd+Z** (macOS) to undo your last action.
 
 ---
 
-## 5. Save Your Work
+## Step 4 — Generate Infrastructure Code
 
-CloudBlocks saves your architecture to your browser's local storage automatically. Your work persists across browser sessions.
+Turn your visual design into production-ready infrastructure code:
 
-To create a new workspace or switch between saved workspaces, use the **File** menu.
+1. Click the **Code** tab in the Inspector Panel on the right side.
+2. Alternatively, go to **Build → Generate Code** in the top menu bar.
+3. The Code tab displays your architecture as Terraform code by default.
+4. Use the format selector to switch between **Terraform**, **Bicep**, or **Pulumi**.
+5. Click **Copy** to copy the generated code to your clipboard.
+
+!!! info "Multi-Cloud Output"
+CloudBlocks generates valid IaC for multiple providers and tools. You can design once and export to the format that fits your team's workflow.
+
+---
+
+## Step 5 — Save Your Work
+
+Your progress is automatically saved to your browser's local storage.
+
+- Press **Ctrl+S** or **Cmd+S** to save manually.
+- Use **File → Save Workspace** from the menu bar.
+- To manage multiple architectures, click the **Workspaces** button in the menu bar.
 
 ---
 
 ## What's Next?
 
-| Goal                                | Guide                                            |
-| ----------------------------------- | ------------------------------------------------ |
-| Understand the building blocks      | [Core Concepts](core-concepts.md)                |
-| Build an architecture from scratch  | [Create an Architecture](create-architecture.md) |
-| Learn about code generation options | [Generate Code](generate-code.md)                |
-| Explore all available templates     | [Use Templates](templates.md)                    |
-| Speed up with keyboard shortcuts    | [Keyboard Shortcuts](keyboard-shortcuts.md)      |
+| Goal                             | Guide                                         |
+| :------------------------------- | :-------------------------------------------- |
+| Learn the core building blocks   | [Core Concepts](core-concepts.md)             |
+| Create a custom design           | [Create Architecture](create-architecture.md) |
+| Master the code generator        | [Generate Code](generate-code.md)             |
+| Browse all architecture patterns | [Templates](templates.md)                     |
+| Work faster with keys            | [Keyboard Shortcuts](keyboard-shortcuts.md)   |

--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -1,145 +1,83 @@
 # Use Templates
 
-Templates are pre-built architecture patterns that give you a working starting point. Instead of building from scratch, load a template, then customize it for your specific needs.
+Templates are pre-built architecture patterns that provide a working starting point. Instead of building from scratch, you can load a template and customize it for your specific needs.
 
 ---
 
 ## Loading a Template
 
-1. Open CloudBlocks
-2. On the empty canvas, click **Use Template**
-   - Or use the menu: **File → New Workspace**, then click **Use Template**
-3. Browse the **Template Gallery**
-4. Click a template to preview its description and architecture
-5. Click **Use** to load it onto the canvas
+You can load a template in two ways:
 
-The template creates a new workspace with all containers, nodes, and connections pre-configured.
+1.  On the empty canvas, click **Use Template** from the initial call to action.
+2.  Use the menu: **Build → Browse Templates**.
+
+Once the Template Gallery opens, you can browse the available patterns. Click any template to see a preview of its architecture and description. Click **Use** to load the template into your workspace.
+
+When a template loads, it creates a complete workspace with all containers, nodes, and connections pre-configured.
 
 ---
 
 ## Built-in Templates
 
-CloudBlocks ships with 6 built-in templates, organized by difficulty and use case:
+CloudBlocks includes six built-in templates covering various use cases and difficulty levels:
 
-### Three-Tier Web Application
+### 1. Three-Tier Web Application
 
-**Difficulty:** Beginner · **Category:** Web Application
+**Difficulty:** Beginner | **Category:** Web Application
 
-The classic web architecture pattern with three layers:
+This template implements the classic web architecture pattern. It features an Internet source connecting to an Application Gateway, which routes traffic to a Virtual Machine. The backend includes both a SQL Database and Blob Storage. The resources are organized into two pre-wired subnets.
 
-```
-Internet → Gateway (Load Balancer) → Compute (App Server) → Database + Storage
-```
+### 2. Simple Compute Setup
 
-Best for: Web applications, APIs with a database backend, traditional server-based apps.
+**Difficulty:** Beginner | **Category:** Web Application
 
----
+A minimal architecture designed for simple workloads. It connects the Internet to a Gateway, which then routes to an App Service. Everything is contained within a single subnet, making it an ideal starting point for learning the builder.
 
-### Simple Compute Setup
+### 3. Data Storage Backend
 
-**Difficulty:** Beginner · **Category:** Compute
+**Difficulty:** Intermediate | **Category:** Data Pipeline
 
-The simplest possible architecture — a single compute instance:
+This pattern focuses on a backend-only setup where compute resources connect to multiple data stores. It includes an Internet source, an API Gateway, and an API Server. The architecture is split across two subnets: an App Subnet for compute and a Data Subnet for Database and File Storage resources.
 
-```
-Compute (VM / App Service)
-```
+### 4. Serverless HTTP API
 
-Best for: Learning CloudBlocks, quick prototyping, single-service deployments.
+**Difficulty:** Intermediate | **Category:** Serverless
 
----
+A modern serverless pattern using managed services. It routes Internet traffic through an API Gateway to an HTTP Handler (Function). Data is persisted in Blob Storage and CosmosDB. This template demonstrates how to build scalable APIs without managing traditional servers.
 
-### Data Storage Backend
+### 5. Event-Driven Pipeline
 
-**Difficulty:** Beginner · **Category:** Data
+**Difficulty:** Advanced | **Category:** Data Pipeline
 
-A backend-focused architecture where compute connects to multiple data stores:
+This template represents a pure asynchronous processing pipeline. It features Event Sources and a Queue that trigger Processing Functions, which eventually store results in Data Lake Storage. Note that this architecture has no direct internet traffic and relies on timers and events to drive the flow.
 
-```
-Compute → Database + Storage (in private subnet)
-```
+### 6. Full-Stack Serverless with Event Processing
 
-Best for: Data processing services, backend APIs, batch processing.
+**Difficulty:** Advanced | **Category:** Serverless
 
----
-
-### Serverless HTTP API
-
-**Difficulty:** Intermediate · **Category:** Serverless
-
-A serverless API pattern using functions instead of traditional compute:
-
-```
-Gateway (API Gateway) → Function → Storage + Database
-```
-
-Best for: REST APIs, microservices, event-driven backends, cost-optimized workloads.
-
----
-
-### Event-Driven Pipeline
-
-**Difficulty:** Intermediate · **Category:** Event Processing
-
-An asynchronous processing pipeline driven by events and queues:
-
-```
-Event → Function → Queue → Function → Storage
-```
-
-Best for: Data pipelines, stream processing, decoupled architectures, IoT backends.
-
----
-
-### Full-Stack Serverless with Event Processing
-
-**Difficulty:** Advanced · **Category:** Full Stack
-
-A comprehensive architecture combining multiple patterns:
-
-```
-Gateway → Function (API) → Database + Storage
-Event → Function (Worker) → Queue → Function (Processor)
-```
-
-Best for: Production applications, complex microservices, architectures that need both synchronous APIs and asynchronous processing.
+The most complex built-in template, featuring 13 nodes and 11 connections. It combines a synchronous web frontend (Internet → API Gateway → Web Frontend + API Handler Function) with an asynchronous processing backend (Queue → Worker Function and Event → Batch Processor).
 
 ---
 
 ## Customizing Templates
 
-Templates are fully editable. After loading a template:
+Templates are fully editable. After loading one, you can modify it just like a workspace built from scratch:
 
-- **Add nodes** — Drag new resources from the Command Palette
-- **Remove nodes** — Select a node and press Delete
-- **Add connections** — Click a source node, then click a target node
-- **Remove connections** — Select a connection and press Delete
-- **Rearrange** — Drag nodes to reposition them
-- **Add containers** — Insert new networks or subnets via the Insert menu
-- **Rename** — Click any element and edit its name in the bottom panel
-
-!!! tip "Templates as learning tools"
-Load a template and examine how it's structured before building your own architecture. Notice the container layout, connection types, and node placement — these follow cloud best practices.
+- **Add resources**: Drag new components from the **Sidebar Palette** on the left.
+- **Remove elements**: Select any node, container, or connection and press **Delete**.
+- **Connect components**: Click an output port on a source node, then click an input port on a target node.
+- **Rearrange**: Drag nodes and containers to change their position on the canvas.
+- **Rename**: Click a node to select it, then edit its name in the **Inspector Panel** on the right.
 
 ---
 
 ## Choosing the Right Template
 
-| If you need...                            | Use this template          |
-| ----------------------------------------- | -------------------------- |
-| A standard web app with a database        | Three-Tier Web Application |
-| The simplest possible starting point      | Simple Compute Setup       |
-| A backend with database and storage       | Data Storage Backend       |
-| A serverless API without managing servers | Serverless HTTP API        |
-| Asynchronous event processing             | Event-Driven Pipeline      |
-| A full production architecture            | Full-Stack Serverless      |
-
----
-
-## What's Next?
-
-| Goal                               | Guide                                            |
-| ---------------------------------- | ------------------------------------------------ |
-| Generate code from your template   | [Generate Code](generate-code.md)                |
-| Build an architecture from scratch | [Create an Architecture](create-architecture.md) |
-| Understand the building blocks     | [Core Concepts](core-concepts.md)                |
+| If you need...                                  | Use this template          |
+| :---------------------------------------------- | :------------------------- |
+| A standard web app with a database              | Three-Tier Web Application |
+| The simplest possible starting point            | Simple Compute Setup       |
+| A backend with structured and unstructured data | Data Storage Backend       |
+| A serverless API without server management      | Serverless HTTP API        |
+| Asynchronous, event-driven processing           | Event-Driven Pipeline      |
+| A complete production-ready serverless stack    | Full-Stack Serverless      |


### PR DESCRIPTION
## Summary

Full rewrite of all 7 user guide pages to fix major factual errors and align with M22 UX Overhaul (PR #1331).

### What Changed
- **core-concepts.md** — Corrected from 10 to 7 resource categories; updated connection model from deprecated `ConnectionType` to `EndpointSemantic` (http/event/data); added Learning Mode section
- **quick-start.md** — Fixed UI terminology (Sidebar Palette, Inspector Panel, Bottom Dock); corrected 4-panel layout description; updated code generation instructions
- **create-architecture.md** — Removed non-existent "Insert" menu references; added correct resource group table from source code; updated connection rules
- **generate-code.md** — Fixed "Code Preview panel" to Inspector Panel Code tab; corrected GitHub login location; added export/import instructions
- **templates.md** — Rewrote all 6 template descriptions from `builtin.ts` source; added decision table
- **keyboard-shortcuts.md** — Verified all shortcuts against `BuilderView.tsx`; fixed panel toggle mappings (Ctrl+Alt+S/I/D)
- **faq.md** — Fixed category count (7 not 10); corrected initiator model (Compute/Edge/Messaging, not Compute/Gateway/Function/Queue/Event); updated Learning Mode access path

### Key Fixes
| Old (Wrong) | New (Correct) |
|---|---|
| 10 resource categories | 7 categories |
| "Insert" menu | Sidebar Palette (left) |
| "Command Palette at the bottom" | Sidebar Palette (left) |
| "bottom panel" for node details | Inspector Panel (right) |
| ConnectionType: dataflow, http, internal | EndpointSemantic: http, event, data |
| "File → GitHub → Login" | GitHub section in menu bar |

Fixes #1347