### PR TITLE
feat(web): world-space surface routing model with Manhattan routing

### DIFF
--- a/apps/web/src/entities/connection/__tests__/surfaceRouting.test.ts
+++ b/apps/web/src/entities/connection/__tests__/surfaceRouting.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  Connection,
+  ContainerNode,
+  Endpoint,
+  ExternalActor,
+  LeafNode,
+} from '@cloudblocks/schema';
+import { CATEGORY_PORTS, endpointId, generateEndpointsForNode } from '@cloudblocks/schema';
+import {
+  getConnectionSurfaceRoute,
+  resolveSurfacePort,
+  routeSameSurface,
+  SURFACE_EXIT_OFFSET_CU,
+} from '../surfaceRouting';
+import type { SurfacePort } from '../surfaceRouting';
+
+function makePlate(overrides?: Partial<ContainerNode>): ContainerNode {
+  return {
+    id: 'plate-1',
+    kind: 'container',
+    name: 'Test Plate',
+    category: 'network',
+    position: { x: 10, y: 2, z: 20 },
+    size: { width: 16, depth: 16, height: 1 },
+    children: [],
+    ...overrides,
+  } as ContainerNode;
+}
+
+function makeBlock(overrides?: Partial<LeafNode>): LeafNode {
+  return {
+    id: 'block-1',
+    kind: 'resource',
+    name: 'Test Block',
+    category: 'compute',
+    parentId: 'plate-1',
+    position: { x: 2, y: 0, z: 3 },
+    ...overrides,
+  } as LeafNode;
+}
+
+function makeConnection(overrides?: Partial<Connection>): Connection {
+  return {
+    id: 'conn-1',
+    from: endpointId('block-a', 'output', 'data'),
+    to: endpointId('block-b', 'input', 'data'),
+    ...overrides,
+  } as Connection;
+}
+
+function makeEndpoints(nodeIds: string[]): Endpoint[] {
+  return nodeIds.flatMap((nodeId) => generateEndpointsForNode(nodeId));
+}
+
+function makeSurfacePort(overrides?: Partial<SurfacePort>): SurfacePort {
+  return {
+    surfaceBase: [0, 3, 0],
+    surfaceExit: [0, 3, -0.75],
+    plateId: 'plate-1',
+    surfaceY: 3,
+    normal: 'neg-z',
+    ...overrides,
+  };
+}
+
+describe('SURFACE_EXIT_OFFSET_CU', () => {
+  it('is fixed to 0.75 CU', () => {
+    expect(SURFACE_EXIT_OFFSET_CU).toBe(0.75);
+  });
+});
+
+describe('resolveSurfacePort', () => {
+  it('resolves inbound side using t=0.5 for single-port distribution', () => {
+    const plate = makePlate({
+      position: { x: 10, y: 2, z: 20 },
+      size: { width: 16, depth: 16, height: 1 },
+    });
+    const block = makeBlock({ category: 'data', position: { x: 2, y: 0, z: 4 } });
+
+    const result = resolveSurfacePort(block, plate, 'inbound', 0, 1);
+
+    expect(result.plateId).toBe(plate.id);
+    expect(result.surfaceY).toBe(3);
+    expect(result.normal).toBe('neg-x');
+    expect(result.surfaceBase).toEqual([12, 3, 25.5]);
+    expect(result.surfaceExit).toEqual([11.25, 3, 25.5]);
+  });
+
+  it('resolves outbound side using t=0.25 for three-port distribution', () => {
+    const plate = makePlate({
+      position: { x: 10, y: 2, z: 20 },
+      size: { width: 16, depth: 16, height: 1 },
+    });
+    const block = makeBlock({ category: 'compute', position: { x: 2, y: 0, z: 4 } });
+
+    const result = resolveSurfacePort(block, plate, 'outbound', 0, 3);
+
+    expect(result.plateId).toBe(plate.id);
+    expect(result.surfaceY).toBe(3);
+    expect(result.normal).toBe('neg-z');
+    expect(result.surfaceBase).toEqual([12.5, 3, 24]);
+    expect(result.surfaceExit).toEqual([12.5, 3, 23.25]);
+  });
+
+  it('applies category port counts with semantic modulo mapping for output data endpoints', () => {
+    const plate = makePlate({
+      position: { x: 0, y: 5, z: 0 },
+      size: { width: 10, depth: 10, height: 2 },
+    });
+    const block = makeBlock({ category: 'compute', position: { x: 1, y: 0, z: 1 } });
+    const totalPorts = CATEGORY_PORTS.compute.outbound;
+
+    const result = resolveSurfacePort(block, plate, 'outbound', 0, totalPorts);
+
+    expect(totalPorts).toBe(2);
+    expect(result.surfaceBase).toEqual([1 + (1 / 3) * 2, 7, 1]);
+    expect(result.surfaceExit).toEqual([1 + (1 / 3) * 2, 7, 1 - SURFACE_EXIT_OFFSET_CU]);
+  });
+});
+
+describe('routeSameSurface', () => {
+  it('returns only exit segments when exits are coincident', () => {
+    const src = makeSurfacePort({
+      surfaceBase: [1, 3, 1],
+      surfaceExit: [0, 3, 1],
+      normal: 'neg-x',
+    });
+    const tgt = makeSurfacePort({
+      surfaceBase: [2, 3, 1],
+      surfaceExit: [0, 3, 1],
+      normal: 'neg-z',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ kind: 'exit', start: [1, 3, 1], end: [0, 3, 1] });
+    expect(segments[1]).toMatchObject({ kind: 'exit', start: [0, 3, 1], end: [2, 3, 1] });
+  });
+
+  it('routes with a single surface segment when exits share X', () => {
+    const src = makeSurfacePort({
+      surfaceExit: [1, 3, 2],
+      surfaceBase: [2, 3, 2],
+      normal: 'neg-x',
+    });
+    const tgt = makeSurfacePort({
+      surfaceExit: [1, 3, 8],
+      surfaceBase: [1, 3, 9],
+      normal: 'neg-z',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toEqual({
+      start: [1, 3, 2],
+      end: [1, 3, 8],
+      kind: 'surface',
+      surfaceId: 'plate-1',
+    });
+  });
+
+  it('routes with a single surface segment when exits share Z', () => {
+    const src = makeSurfacePort({
+      surfaceExit: [2, 3, 5],
+      surfaceBase: [3, 3, 5],
+      normal: 'neg-z',
+    });
+    const tgt = makeSurfacePort({
+      surfaceExit: [9, 3, 5],
+      surfaceBase: [9, 3, 6],
+      normal: 'neg-x',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toEqual({
+      start: [2, 3, 5],
+      end: [9, 3, 5],
+      kind: 'surface',
+      surfaceId: 'plate-1',
+    });
+  });
+
+  it('routes as L-shape with two surface segments when exits differ in both axes', () => {
+    const src = makeSurfacePort({
+      surfaceExit: [1, 3, 1],
+      surfaceBase: [2, 3, 1],
+      normal: 'neg-z',
+    });
+    const tgt = makeSurfacePort({
+      surfaceExit: [4, 3, 6],
+      surfaceBase: [4, 3, 7],
+      normal: 'neg-x',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(4);
+    expect(segments[1].kind).toBe('surface');
+    expect(segments[2].kind).toBe('surface');
+    expect(segments[1].end).toEqual(segments[2].start);
+
+    const seg1 = segments[1];
+    const seg2 = segments[2];
+    const seg1AxisAligned = seg1.start[0] === seg1.end[0] || seg1.start[2] === seg1.end[2];
+    const seg2AxisAligned = seg2.start[0] === seg2.end[0] || seg2.start[2] === seg2.end[2];
+    expect(seg1AxisAligned).toBe(true);
+    expect(seg2AxisAligned).toBe(true);
+  });
+
+  it('selects the lower-scored elbow candidate based on normal alignment', () => {
+    const src = makeSurfacePort({
+      surfaceBase: [2, 3, 1],
+      surfaceExit: [1, 3, 1],
+      normal: 'neg-x',
+    });
+    const tgt = makeSurfacePort({
+      surfaceBase: [5, 3, 5],
+      surfaceExit: [5, 3, 4],
+      normal: 'neg-z',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(4);
+    expect(segments[1].end).toEqual([5, 3, 1]);
+    expect(segments[2].start).toEqual([5, 3, 1]);
+  });
+});
+
+describe('getConnectionSurfaceRoute', () => {
+  const externalActors: ExternalActor[] = [];
+
+  it('returns same-plate route with surface segments and resolved ports', () => {
+    const plate = makePlate({
+      id: 'plate-a',
+      position: { x: 0, y: 0, z: 0 },
+      size: { width: 20, depth: 20, height: 1 },
+    });
+    const blockA = makeBlock({
+      id: 'block-a',
+      category: 'compute',
+      parentId: plate.id,
+      position: { x: 1, y: 0, z: 1 },
+    });
+    const blockB = makeBlock({
+      id: 'block-b',
+      category: 'data',
+      parentId: plate.id,
+      position: { x: 6, y: 0, z: 5 },
+    });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).not.toBeNull();
+    expect(route!.srcPort.plateId).toBe('plate-a');
+    expect(route!.tgtPort.plateId).toBe('plate-a');
+    expect(route!.srcPort.normal).toBe('neg-z');
+    expect(route!.tgtPort.normal).toBe('neg-x');
+    expect(route!.segments.some((segment) => segment.kind === 'surface')).toBe(true);
+    expect(route!.segments.every((segment) => segment.surfaceId === 'plate-a')).toBe(true);
+  });
+
+  it('falls back to cross-plate transition segments on ground surface', () => {
+    const plateA = makePlate({ id: 'plate-a', position: { x: 0, y: 1, z: 0 } });
+    const plateB = makePlate({ id: 'plate-b', position: { x: 20, y: 4, z: 20 } });
+    const blockA = makeBlock({
+      id: 'block-a',
+      category: 'compute',
+      parentId: plateA.id,
+      position: { x: 2, y: 0, z: 2 },
+    });
+    const blockB = makeBlock({
+      id: 'block-b',
+      category: 'data',
+      parentId: plateB.id,
+      position: { x: 3, y: 0, z: 3 },
+    });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'output', 'event'),
+      to: endpointId(blockB.id, 'input', 'event'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [plateA, plateB],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).not.toBeNull();
+    expect(route!.srcPort.plateId).toBe('plate-a');
+    expect(route!.tgtPort.plateId).toBe('plate-b');
+    expect(route!.segments.length).toBeGreaterThanOrEqual(2);
+    expect(route!.segments.every((segment) => segment.kind === 'transition')).toBe(true);
+    expect(route!.segments.every((segment) => segment.start[1] === 0 && segment.end[1] === 0)).toBe(
+      true,
+    );
+  });
+
+  it('returns null when source endpoint is missing', () => {
+    const plate = makePlate({ id: 'plate-a' });
+    const blockB = makeBlock({ id: 'block-b', parentId: plate.id });
+    const endpoints = makeEndpoints([blockB.id]);
+    const connection = makeConnection({
+      from: endpointId('missing-block', 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null when endpoint exists but block is missing', () => {
+    const plate = makePlate({ id: 'plate-a' });
+    const blockB = makeBlock({ id: 'block-b', parentId: plate.id });
+    const endpoints = makeEndpoints(['ghost-block', blockB.id]);
+    const connection = makeConnection({
+      from: endpointId('ghost-block', 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null when parent plate for an endpoint block is missing', () => {
+    const blockA = makeBlock({ id: 'block-a', parentId: 'missing-plate' });
+    const blockB = makeBlock({ id: 'block-b', parentId: 'missing-plate' });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null on endpoint direction mismatch', () => {
+    const plate = makePlate({ id: 'plate-a' });
+    const blockA = makeBlock({ id: 'block-a', parentId: plate.id });
+    const blockB = makeBlock({ id: 'block-b', parentId: plate.id });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'input', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+});

--- a/apps/web/src/entities/connection/surfaceRouting.ts
+++ b/apps/web/src/entities/connection/surfaceRouting.ts
@@ -1,0 +1,269 @@
+/**
+ * Surface routing — world-space Manhattan routing on plate surfaces.
+ *
+ * Connections are routed as flat PCB-style traces on the plate top face
+ * (X/Z plane at plate surfaceY). This replaces the screen-space L-route
+ * in routing.ts with a world-space surface-first system.
+ */
+
+import type {
+  Connection,
+  ContainerNode,
+  Endpoint,
+  EndpointSemantic,
+  ExternalActor,
+  LeafNode,
+} from '@cloudblocks/schema';
+import { CATEGORY_PORTS } from '@cloudblocks/schema';
+import { getBlockWorldPosition } from '../../shared/utils/position';
+import { getBlockDimensions } from '../../shared/types/visualProfile';
+import type { StubSide } from '../block/blockGeometry';
+
+export type WorldPoint3 = [number, number, number];
+
+export interface SurfacePort {
+  surfaceBase: WorldPoint3;
+  surfaceExit: WorldPoint3;
+  plateId: string;
+  surfaceY: number;
+  normal: 'neg-x' | 'neg-z';
+}
+
+export type RouteSegmentKind = 'exit' | 'surface' | 'transition';
+
+export interface WorldRouteSegment {
+  start: WorldPoint3;
+  end: WorldPoint3;
+  kind: RouteSegmentKind;
+  surfaceId?: string;
+}
+
+export interface SurfaceRoute {
+  segments: WorldRouteSegment[];
+  srcPort: SurfacePort;
+  tgtPort: SurfacePort;
+}
+
+/** Visual clearance (CU) so routes don't start under the block footprint. */
+export const SURFACE_EXIT_OFFSET_CU = 0.75;
+
+/**
+ * Compute the surface port for a block endpoint.
+ *
+ * Inbound ports: LEFT face (world-X edge), offset in neg-X.
+ * Outbound ports: RIGHT face (world-Z edge), offset in neg-Z.
+ * Ports are distributed along the face edge with t = (i+1)/(n+1).
+ */
+export function resolveSurfacePort(
+  block: LeafNode,
+  plate: ContainerNode,
+  side: StubSide,
+  stubIndex: number,
+  totalPorts: number,
+): SurfacePort {
+  const [bx, , bz] = getBlockWorldPosition(block, plate);
+  const cu = getBlockDimensions(block.category, block.provider, block.subtype);
+  const surfaceY = plate.position.y + plate.size.height;
+  const t = (stubIndex + 1) / (totalPorts + 1);
+
+  if (side === 'inbound') {
+    const portZ = bz + t * cu.depth;
+    const surfaceBase: WorldPoint3 = [bx, surfaceY, portZ];
+    const surfaceExit: WorldPoint3 = [bx - SURFACE_EXIT_OFFSET_CU, surfaceY, portZ];
+    return { surfaceBase, surfaceExit, plateId: plate.id, surfaceY, normal: 'neg-x' };
+  }
+
+  const portX = bx + t * cu.width;
+  const surfaceBase: WorldPoint3 = [portX, surfaceY, bz];
+  const surfaceExit: WorldPoint3 = [portX, surfaceY, bz - SURFACE_EXIT_OFFSET_CU];
+  return { surfaceBase, surfaceExit, plateId: plate.id, surfaceY, normal: 'neg-z' };
+}
+
+function manhattanXZ(a: WorldPoint3, b: WorldPoint3): number {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[2] - b[2]);
+}
+
+/**
+ * Score an L-shape elbow candidate. Penalises routes whose first/last
+ * segment does not align with the source/target port normal direction.
+ */
+function scoreElbow(
+  srcExit: WorldPoint3,
+  elbow: WorldPoint3,
+  tgtExit: WorldPoint3,
+  srcNormal: 'neg-x' | 'neg-z',
+  tgtNormal: 'neg-x' | 'neg-z',
+): number {
+  let score = manhattanXZ(srcExit, elbow) + manhattanXZ(elbow, tgtExit);
+
+  const firstDX = Math.abs(elbow[0] - srcExit[0]);
+  const firstDZ = Math.abs(elbow[2] - srcExit[2]);
+  if (srcNormal === 'neg-x' && firstDX < firstDZ) score += 2;
+  if (srcNormal === 'neg-z' && firstDZ < firstDX) score += 2;
+
+  const lastDX = Math.abs(tgtExit[0] - elbow[0]);
+  const lastDZ = Math.abs(tgtExit[2] - elbow[2]);
+  if (tgtNormal === 'neg-x' && lastDX < lastDZ) score += 2;
+  if (tgtNormal === 'neg-z' && lastDZ < lastDX) score += 2;
+
+  return score;
+}
+
+/**
+ * Route between two surface ports on the SAME plate.
+ *
+ * Produces exit → surface (L-shape via elbow) → exit segments.
+ * Evaluates two elbow candidates and picks the lower-scoring one.
+ */
+export function routeSameSurface(src: SurfacePort, tgt: SurfacePort): WorldRouteSegment[] {
+  const y = src.surfaceY;
+  const surfaceId = src.plateId;
+
+  const exitSrc: WorldRouteSegment = {
+    start: src.surfaceBase,
+    end: src.surfaceExit,
+    kind: 'exit',
+    surfaceId,
+  };
+  const exitTgt: WorldRouteSegment = {
+    start: tgt.surfaceExit,
+    end: tgt.surfaceBase,
+    kind: 'exit',
+    surfaceId,
+  };
+
+  const [sx, , sz] = src.surfaceExit;
+  const [tx, , tz] = tgt.surfaceExit;
+
+  if (Math.abs(sx - tx) < 0.01 && Math.abs(sz - tz) < 0.01) {
+    return [exitSrc, exitTgt];
+  }
+
+  if (Math.abs(sx - tx) < 0.01 || Math.abs(sz - tz) < 0.01) {
+    const seg: WorldRouteSegment = {
+      start: src.surfaceExit,
+      end: tgt.surfaceExit,
+      kind: 'surface',
+      surfaceId,
+    };
+    return [exitSrc, seg, exitTgt];
+  }
+
+  const elbowA: WorldPoint3 = [sx, y, tz];
+  const elbowB: WorldPoint3 = [tx, y, sz];
+
+  const scoreA = scoreElbow(src.surfaceExit, elbowA, tgt.surfaceExit, src.normal, tgt.normal);
+  const scoreB = scoreElbow(src.surfaceExit, elbowB, tgt.surfaceExit, src.normal, tgt.normal);
+  const elbow = scoreA <= scoreB ? elbowA : elbowB;
+
+  const seg1: WorldRouteSegment = {
+    start: src.surfaceExit,
+    end: elbow,
+    kind: 'surface',
+    surfaceId,
+  };
+  const seg2: WorldRouteSegment = {
+    start: elbow,
+    end: tgt.surfaceExit,
+    kind: 'surface',
+    surfaceId,
+  };
+
+  return [exitSrc, seg1, seg2, exitTgt];
+}
+
+function resolveEndpointContext(
+  endpointId: string,
+  side: StubSide,
+  blocks: LeafNode[],
+  plates: ContainerNode[],
+  endpoints: Endpoint[],
+): { block: LeafNode; plate: ContainerNode; stubIndex: number; totalPorts: number } | null {
+  const endpoint = endpoints.find((ep) => ep.id === endpointId);
+  if (!endpoint) return null;
+
+  const resolvedSide = endpoint.direction === 'output' ? 'outbound' : 'inbound';
+  if (resolvedSide !== side) return null;
+
+  const block = blocks.find((b) => b.id === endpoint.nodeId);
+  if (!block) return null;
+
+  const plate = plates.find((p) => p.id === block.parentId);
+  if (!plate) return null;
+
+  const ports = CATEGORY_PORTS[block.category];
+  const total = side === 'inbound' ? ports.inbound : ports.outbound;
+  const stubIndex = semanticToIndex(endpoint.semantic, total);
+  if (stubIndex === null) return null;
+
+  return { block, plate, stubIndex, totalPorts: total };
+}
+
+function semanticToIndex(semantic: EndpointSemantic, total: number): number | null {
+  if (total <= 0) return null;
+  const order: EndpointSemantic[] = ['http', 'event', 'data'];
+  const index = order.indexOf(semantic);
+  if (index < 0) return null;
+  return index % total;
+}
+
+/**
+ * Compute the full surface route for a connection.
+ *
+ * Returns null if either endpoint cannot be resolved (external actors
+ * are not yet supported in surface routing).
+ */
+export function getConnectionSurfaceRoute(
+  connection: Connection,
+  blocks: LeafNode[],
+  plates: ContainerNode[],
+  endpoints: Endpoint[],
+  _externalActors: ExternalActor[] = [],
+): SurfaceRoute | null {
+  const srcCtx = resolveEndpointContext(connection.from, 'outbound', blocks, plates, endpoints);
+  if (!srcCtx) return null;
+
+  const tgtCtx = resolveEndpointContext(connection.to, 'inbound', blocks, plates, endpoints);
+  if (!tgtCtx) return null;
+
+  const srcPort = resolveSurfacePort(
+    srcCtx.block,
+    srcCtx.plate,
+    'outbound',
+    srcCtx.stubIndex,
+    srcCtx.totalPorts,
+  );
+  const tgtPort = resolveSurfacePort(
+    tgtCtx.block,
+    tgtCtx.plate,
+    'inbound',
+    tgtCtx.stubIndex,
+    tgtCtx.totalPorts,
+  );
+
+  if (srcPort.plateId === tgtPort.plateId) {
+    const segments = routeSameSurface(srcPort, tgtPort);
+    return { segments, srcPort, tgtPort };
+  }
+
+  // Cross-plate: temporary fallback via ground surface (see #1357)
+  const groundY = 0;
+  const groundSrc: SurfacePort = {
+    ...srcPort,
+    surfaceY: groundY,
+    surfaceBase: [srcPort.surfaceBase[0], groundY, srcPort.surfaceBase[2]],
+    surfaceExit: [srcPort.surfaceExit[0], groundY, srcPort.surfaceExit[2]],
+  };
+  const groundTgt: SurfacePort = {
+    ...tgtPort,
+    surfaceY: groundY,
+    surfaceBase: [tgtPort.surfaceBase[0], groundY, tgtPort.surfaceBase[2]],
+    surfaceExit: [tgtPort.surfaceExit[0], groundY, tgtPort.surfaceExit[2]],
+  };
+  const segments = routeSameSurface(groundSrc, groundTgt);
+  const transitionSegments = segments.map((seg) => ({
+    ...seg,
+    kind: 'transition' as RouteSegmentKind,
+  }));
+  return { segments: transitionSegments, srcPort, tgtPort };
+}


### PR DESCRIPTION
## Summary

- Implements the core route model for PCB-style connections on plate surfaces (`surfaceRouting.ts`)
- 2-point endpoint model: `surfaceBase` (block base on plate) → `surfaceExit` (offset 0.75 CU outward)
- Manhattan L-shape routing with elbow scoring that penalizes misaligned normals
- Cross-plate fallback via ground surface (proper routing deferred to #1357)
- 15 unit tests covering `resolveSurfacePort()`, `routeSameSurface()`, `getConnectionSurfaceRoute()`, and edge cases

## Part of

Epic #1351 — Surface Routing System

Fixes #1352