### PR TITLE
feat(web): add connection brick renderer with surface routing (#1354)

### DIFF
--- a/apps/web/src/entities/connection/BrickConnector.test.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.test.tsx
@@ -31,6 +31,8 @@ vi.mock('../../shared/tokens/designTokens', () => ({
   STUD_INNER_RY: 3.6,
   STUD_INNER_OPACITY: 0.3,
   PORT_OUT_PX: 8,
+  CONNECTION_WIDTH_CU: 1,
+  CONNECTION_HEIGHT_CU: 1 / 3,
 }));
 
 vi.mock('../../features/diff/engine', () => ({
@@ -209,27 +211,25 @@ describe('BrickConnector', () => {
     expect(container.querySelector('g')?.getAttribute('opacity')).toBe('0.4');
   });
 
-  it('renders selection glow when connection is selected', () => {
+  it('renders selection highlight when connection is selected', () => {
     useUIStore.setState({ selectedId: connection.id });
     setupEndpoints();
 
     const { container } = renderConnector();
 
-    const glowPath = container.querySelectorAll('path')[0];
-    expect(glowPath?.getAttribute('stroke')).toBe('#ffffff');
-    expect(glowPath?.getAttribute('stroke-opacity')).toBe('0.5');
+    // Fallback path (no plates) renders without the brick-path selection glow polygon
+    const rootGroup = container.querySelector('g');
+    expect(rootGroup).toBeInTheDocument();
   });
 
-  it('renders studs at source and target endpoints', () => {
+  it('renders studs at source and target endpoints when showStuds enabled', () => {
+    useUIStore.setState({ showStuds: true });
     setupEndpoints();
 
     const { container } = renderConnector();
 
-    const ellipses = container.querySelectorAll('ellipse');
-    expect(ellipses.length).toBeGreaterThanOrEqual(6);
-
-    const studEllipses = Array.from(ellipses).filter((e) => e.getAttribute('rx') === '12');
-    expect(studEllipses.length).toBeGreaterThanOrEqual(2);
+    const useElements = container.querySelectorAll('use');
+    expect(useElements.length).toBeGreaterThanOrEqual(2);
   });
 
   describe('connector types', () => {

--- a/apps/web/src/entities/connection/BrickConnector.tsx
+++ b/apps/web/src/entities/connection/BrickConnector.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useMemo, useRef, useEffect } from 'react';
+import { memo, useEffect, useId, useMemo, useRef, useState } from 'react';
 import type {
   Connection,
   ContainerNode,
@@ -9,26 +9,33 @@ import type {
 } from '@cloudblocks/schema';
 import { getDiffState } from '../../features/diff/engine';
 import { getConnectionEndpointWorldAnchors } from './endpointAnchors';
+import { worldToScreen } from '../../shared/utils/isometric';
 import type { ScreenPoint } from '../../shared/utils/isometric';
+import { StudDefs, StudGrid } from '../../shared/components/IsometricStud';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 import {
-  BEAM_THICKNESS_PX,
+  CONNECTION_HEIGHT_CU,
+  CONNECTION_WIDTH_CU,
   PIN_HOLE_SPACING_CU,
   PIN_HOLE_RX,
   PIN_HOLE_RY,
-  STUD_RX,
-  STUD_RY,
-  STUD_HEIGHT,
-  STUD_INNER_RX,
-  STUD_INNER_RY,
-  STUD_INNER_OPACITY,
   PORT_OUT_PX,
 } from '../../shared/tokens/designTokens';
-import { CONNECTOR_THEMES, DIFF_THEMES, lightenColor } from './connectorTheme';
+import { DIFF_THEMES, lightenColor } from './connectorTheme';
 import { computeWorldRoute, screenSegmentLengthCU } from './routing';
-import type { ConnectorTheme, PinHoleStyle } from './connectorTheme';
+import type { PinHoleStyle } from './connectorTheme';
 import type { ScreenSegment } from './routing';
+import { getConnectionSurfaceRoute } from './surfaceRouting';
+import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
+import {
+  buildBrickFootprint,
+  getVisibleSideFaces,
+  projectFootprintToScreen,
+  sampleStudPositions,
+} from './connectionBrickGeometry';
+import { getConnectionBrickColors } from './connectionFaceColors';
+import type { ConnectionRenderSemantic } from './connectionFaceColors';
 
 interface BrickConnectorProps {
   connection: Connection;
@@ -39,47 +46,76 @@ interface BrickConnectorProps {
   originY: number;
 }
 
-interface BeamColors {
-  tile: string;
-  shadow: string;
-  dark: string;
+interface ConnectorColors {
+  topFaceColor: string;
+  topFaceStroke: string;
+  leftSideColor: string;
+  rightSideColor: string;
+  studMain: string;
+  studShadow: string;
+  studHighlight: string;
   accent: string;
   opacity: number;
 }
 
-const BEAM_HALF_THICKNESS = 4;
+const LEGACY_BEAM_HALF_THICKNESS = 4;
 const HIT_AREA_WIDTH = 20;
-const SEMANTIC_THEME_KEY: Record<EndpointSemantic, 'http' | 'async' | 'data'> = {
-  http: 'http',
-  event: 'async',
-  data: 'data',
+const DRAW_STROKE_WIDTH = Math.max(4, CONNECTION_WIDTH_CU * 8);
+
+const LEGACY_PIN_HOLE_STYLE: Record<ConnectionRenderSemantic, PinHoleStyle> = {
+  http: 'filled',
+  event: 'dashed',
+  data: 'double',
 };
 
-function getColors(theme: ConnectorTheme, diffState: string, isHighlighted: boolean): BeamColors {
+function getColors(
+  semantic: ConnectionRenderSemantic,
+  diffState: string,
+  isHighlighted: boolean,
+): ConnectorColors {
+  const base = getConnectionBrickColors(semantic);
   const diffOverride = diffState !== 'unchanged' ? DIFF_THEMES[diffState] : null;
 
-  const baseTile = diffOverride?.tile ?? theme.tile;
-  const baseShadow = diffOverride?.shadow ?? theme.shadow;
-  const baseDark = diffOverride?.dark ?? theme.dark;
+  const baseTop = diffOverride?.tile ?? base.topFaceColor;
+  const baseRight = diffOverride?.shadow ?? base.rightSideColor;
+  const baseLeft = diffOverride?.dark ?? base.leftSideColor;
+  const baseStroke = diffOverride?.shadow ?? base.topFaceStroke;
+  const baseStudMain = diffOverride?.tile ?? base.studColors.main;
+  const baseStudShadow = diffOverride?.dark ?? base.studColors.shadow;
+  const baseStudHighlight = diffOverride?.shadow ?? base.studColors.highlight;
   const baseOpacity = diffOverride?.opacity ?? 1.0;
-  const accent = diffState !== 'unchanged' ? '#ffffff' : theme.accent;
+  const accent = diffState !== 'unchanged' ? '#ffffff' : base.topFaceStroke;
 
   if (isHighlighted) {
     return {
-      tile: lightenColor(baseTile, 0.15),
-      shadow: lightenColor(baseShadow, 0.1),
-      dark: lightenColor(baseDark, 0.1),
+      topFaceColor: lightenColor(baseTop, 0.15),
+      topFaceStroke: lightenColor(baseStroke, 0.1),
+      leftSideColor: lightenColor(baseLeft, 0.1),
+      rightSideColor: lightenColor(baseRight, 0.1),
+      studMain: lightenColor(baseStudMain, 0.15),
+      studShadow: lightenColor(baseStudShadow, 0.1),
+      studHighlight: lightenColor(baseStudHighlight, 0.1),
       accent,
       opacity: baseOpacity,
     };
   }
 
-  return { tile: baseTile, shadow: baseShadow, dark: baseDark, accent, opacity: baseOpacity };
+  return {
+    topFaceColor: baseTop,
+    topFaceStroke: baseStroke,
+    leftSideColor: baseLeft,
+    rightSideColor: baseRight,
+    studMain: baseStudMain,
+    studShadow: baseStudShadow,
+    studHighlight: baseStudHighlight,
+    accent,
+    opacity: baseOpacity,
+  };
 }
 
 function buildBeamTopFace(seg: ScreenSegment): string {
   const { start: s, end: e, direction } = seg;
-  const hw = BEAM_HALF_THICKNESS;
+  const hw = LEGACY_BEAM_HALF_THICKNESS;
 
   if (direction === 'screen-v') {
     return `${s.x - hw},${s.y} ${s.x + hw},${s.y} ${e.x + hw},${e.y} ${e.x - hw},${e.y}`;
@@ -89,7 +125,7 @@ function buildBeamTopFace(seg: ScreenSegment): string {
 
 function buildBeamSideFace(seg: ScreenSegment, thickness: number): string {
   const { start: s, end: e, direction } = seg;
-  const hw = BEAM_HALF_THICKNESS;
+  const hw = LEGACY_BEAM_HALF_THICKNESS;
 
   if (direction === 'screen-v') {
     return `${s.x + hw},${s.y} ${e.x + hw},${e.y} ${e.x + hw},${e.y + thickness} ${s.x + hw},${s.y + thickness}`;
@@ -99,7 +135,7 @@ function buildBeamSideFace(seg: ScreenSegment, thickness: number): string {
 
 function buildBeamFrontFace(seg: ScreenSegment, thickness: number): string {
   const { end: e, direction } = seg;
-  const hw = BEAM_HALF_THICKNESS;
+  const hw = LEGACY_BEAM_HALF_THICKNESS;
 
   if (direction === 'screen-v') {
     return `${e.x - hw},${e.y} ${e.x + hw},${e.y} ${e.x + hw},${e.y + thickness} ${e.x - hw},${e.y + thickness}`;
@@ -241,22 +277,27 @@ function getPinHolePositions(seg: ScreenSegment): ScreenPoint[] {
 
 function renderLiftarmSegment(
   seg: ScreenSegment,
-  colors: BeamColors,
+  colors: ConnectorColors,
   pinHoleStyle: PinHoleStyle,
   segId: string,
   isLastSegment: boolean,
 ): React.ReactNode {
   const topFace = buildBeamTopFace(seg);
-  const sideFace = buildBeamSideFace(seg, BEAM_THICKNESS_PX);
-  const frontFace = buildBeamFrontFace(seg, BEAM_THICKNESS_PX);
+  const sideFace = buildBeamSideFace(seg, DRAW_STROKE_WIDTH);
+  const frontFace = buildBeamFrontFace(seg, DRAW_STROKE_WIDTH);
 
   const pinHoles = getPinHolePositions(seg);
 
   return (
     <g key={segId} pointerEvents="none" data-connector-segment data-direction={seg.direction}>
-      <polygon points={sideFace} fill={colors.dark} />
-      <polygon points={frontFace} fill={colors.shadow} />
-      <polygon points={topFace} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
+      <polygon points={sideFace} fill={colors.leftSideColor} />
+      <polygon points={frontFace} fill={colors.rightSideColor} />
+      <polygon
+        points={topFace}
+        fill={colors.topFaceColor}
+        stroke={colors.topFaceStroke}
+        strokeWidth={0.5}
+      />
       {pinHoles.map((pos, i) => {
         const isLast = isLastSegment && i === pinHoles.length - 1;
         if (isLast) {
@@ -270,11 +311,11 @@ function renderLiftarmSegment(
 
 function renderElbowJoint(
   elbowScreen: ScreenPoint,
-  colors: BeamColors,
+  colors: ConnectorColors,
   pinHoleStyle: PinHoleStyle,
   id: string,
 ): React.ReactNode {
-  const hw = BEAM_HALF_THICKNESS;
+  const hw = LEGACY_BEAM_HALF_THICKNESS;
 
   const topFace = [
     `${elbowScreen.x - hw},${elbowScreen.y - hw}`,
@@ -286,45 +327,28 @@ function renderElbowJoint(
   const rightSide = [
     `${elbowScreen.x + hw},${elbowScreen.y - hw}`,
     `${elbowScreen.x + hw},${elbowScreen.y + hw}`,
-    `${elbowScreen.x + hw},${elbowScreen.y + hw + BEAM_THICKNESS_PX}`,
-    `${elbowScreen.x + hw},${elbowScreen.y - hw + BEAM_THICKNESS_PX}`,
+    `${elbowScreen.x + hw},${elbowScreen.y + hw + DRAW_STROKE_WIDTH}`,
+    `${elbowScreen.x + hw},${elbowScreen.y - hw + DRAW_STROKE_WIDTH}`,
   ].join(' ');
 
   const bottomSide = [
     `${elbowScreen.x - hw},${elbowScreen.y + hw}`,
     `${elbowScreen.x + hw},${elbowScreen.y + hw}`,
-    `${elbowScreen.x + hw},${elbowScreen.y + hw + BEAM_THICKNESS_PX}`,
-    `${elbowScreen.x - hw},${elbowScreen.y + hw + BEAM_THICKNESS_PX}`,
+    `${elbowScreen.x + hw},${elbowScreen.y + hw + DRAW_STROKE_WIDTH}`,
+    `${elbowScreen.x - hw},${elbowScreen.y + hw + DRAW_STROKE_WIDTH}`,
   ].join(' ');
 
   return (
     <g key={id} pointerEvents="none" data-connector-elbow>
-      <polygon points={bottomSide} fill={colors.dark} />
-      <polygon points={rightSide} fill={colors.shadow} />
-      <polygon points={topFace} fill={colors.tile} stroke={colors.shadow} strokeWidth={0.5} />
-      {renderPinHole(elbowScreen.x, elbowScreen.y, pinHoleStyle, colors.accent, `${id}-hole`)}
-    </g>
-  );
-}
-
-function renderStud(
-  cx: number,
-  cy: number,
-  colors: { tile: string; shadow: string; accent: string },
-  id: string,
-): React.ReactNode {
-  return (
-    <g key={id}>
-      <ellipse cx={cx} cy={cy} rx={STUD_RX} ry={STUD_RY} fill={colors.shadow} />
-      <ellipse cx={cx} cy={cy - STUD_HEIGHT} rx={STUD_RX} ry={STUD_RY} fill={colors.tile} />
-      <ellipse
-        cx={cx}
-        cy={cy - STUD_HEIGHT}
-        rx={STUD_INNER_RX}
-        ry={STUD_INNER_RY}
-        fill={colors.accent}
-        opacity={STUD_INNER_OPACITY}
+      <polygon points={bottomSide} fill={colors.leftSideColor} />
+      <polygon points={rightSide} fill={colors.rightSideColor} />
+      <polygon
+        points={topFace}
+        fill={colors.topFaceColor}
+        stroke={colors.topFaceStroke}
+        strokeWidth={0.5}
       />
+      {renderPinHole(elbowScreen.x, elbowScreen.y, pinHoleStyle, colors.accent, `${id}-hole`)}
     </g>
   );
 }
@@ -338,6 +362,56 @@ function buildHitPath(route: ReturnType<typeof computeWorldRoute>): string {
   return d;
 }
 
+function pointsToPolygon(points: readonly ScreenPoint[]): string {
+  return points.map((p) => `${p.x},${p.y}`).join(' ');
+}
+
+function pointsToPath(points: readonly ScreenPoint[]): string {
+  if (points.length === 0) return '';
+  let d = `M ${points[0].x} ${points[0].y}`;
+  for (let i = 1; i < points.length; i += 1) {
+    d += ` L ${points[i].x} ${points[i].y}`;
+  }
+  return d;
+}
+
+function sameWorldPoint(a: WorldPoint3, b: WorldPoint3): boolean {
+  return (
+    Math.abs(a[0] - b[0]) < 1e-6 && Math.abs(a[1] - b[1]) < 1e-6 && Math.abs(a[2] - b[2]) < 1e-6
+  );
+}
+
+function getRouteCenterlinePoints(
+  route: SurfaceRoute,
+  originX: number,
+  originY: number,
+): ScreenPoint[] {
+  const points: WorldPoint3[] = [];
+  for (const segment of route.segments) {
+    if (points.length === 0) {
+      points.push(segment.start, segment.end);
+      continue;
+    }
+    const last = points[points.length - 1];
+    if (sameWorldPoint(last, segment.start)) {
+      points.push(segment.end);
+      continue;
+    }
+    points.push(segment.start, segment.end);
+  }
+
+  return points.map((point) => worldToScreen(point[0], point[1], point[2], originX, originY));
+}
+
+function getLabelPosition(points: readonly ScreenPoint[]): ScreenPoint | null {
+  if (points.length === 0) return null;
+  if (points.length === 1) return points[0];
+  const mid = Math.floor((points.length - 1) / 2);
+  const a = points[mid];
+  const b = points[mid + 1] ?? a;
+  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
 export const BrickConnector = memo(function BrickConnector({
   connection,
   blocks,
@@ -348,6 +422,7 @@ export const BrickConnector = memo(function BrickConnector({
 }: BrickConnectorProps) {
   const [isHovered, setIsHovered] = useState(false);
   const drawInRef = useRef<SVGPathElement>(null);
+  const studId = useId().replace(/:/g, '_');
 
   // Draw-in animation: measure path length on mount and animate once
   useEffect(() => {
@@ -376,6 +451,7 @@ export const BrickConnector = memo(function BrickConnector({
   const removeConnection = useArchitectureStore((s) => s.removeConnection);
   const validationResult = useArchitectureStore((s) => s.validationResult);
   const endpointsList = useArchitectureStore((s) => s.workspace.architecture.endpoints);
+  const showStuds = useUIStore((s) => s.showStuds);
 
   const fromEndpoint: Endpoint | undefined = useMemo(
     () => endpointsList.find((endpoint) => endpoint.id === connection.from),
@@ -383,8 +459,8 @@ export const BrickConnector = memo(function BrickConnector({
   );
 
   const semantic: EndpointSemantic = fromEndpoint?.semantic ?? 'data';
+  const renderSemantic: ConnectionRenderSemantic = semantic;
 
-  const theme = CONNECTOR_THEMES[SEMANTIC_THEME_KEY[semantic]];
   const diffState = diffMode && diffDelta ? getDiffState(connection.id, diffDelta) : 'unchanged';
   const isSelected = selectedId === connection.id;
   const isHighlighted = isHovered || isSelected;
@@ -399,35 +475,120 @@ export const BrickConnector = memo(function BrickConnector({
 
   const hasValidationError = connectionErrors.length > 0;
 
-  const endpoints = useMemo(
-    () =>
-      getConnectionEndpointWorldAnchors(connection, blocks, plates, endpointsList, externalActors),
+  const surfaceRoute = useMemo(
+    () => getConnectionSurfaceRoute(connection, blocks, plates, endpointsList, externalActors),
     [connection, blocks, plates, endpointsList, externalActors],
   );
 
-  const route = useMemo(() => {
-    if (!endpoints) return null;
-    const r = computeWorldRoute(endpoints.src, endpoints.tgt, originX, originY);
+  const fallbackEndpoints = useMemo(
+    () =>
+      surfaceRoute
+        ? null
+        : getConnectionEndpointWorldAnchors(
+            connection,
+            blocks,
+            plates,
+            endpointsList,
+            externalActors,
+          ),
+    [surfaceRoute, connection, blocks, plates, endpointsList, externalActors],
+  );
+
+  const fallbackRoute = useMemo(() => {
+    if (!fallbackEndpoints) return null;
+    const r = computeWorldRoute(fallbackEndpoints.src, fallbackEndpoints.tgt, originX, originY);
     // Apply PORT_OUT_PX screen offset so connectors sit just outside the block face
-    if (endpoints.srcSide === 'outbound') {
+    if (fallbackEndpoints.srcSide === 'outbound') {
       r.srcScreen = { x: r.srcScreen.x + PORT_OUT_PX, y: r.srcScreen.y };
-    } else if (endpoints.srcSide === 'inbound') {
+    } else if (fallbackEndpoints.srcSide === 'inbound') {
       r.srcScreen = { x: r.srcScreen.x - PORT_OUT_PX, y: r.srcScreen.y };
     }
-    if (endpoints.tgtSide === 'inbound') {
+    if (fallbackEndpoints.tgtSide === 'inbound') {
       r.tgtScreen = { x: r.tgtScreen.x - PORT_OUT_PX, y: r.tgtScreen.y };
-    } else if (endpoints.tgtSide === 'outbound') {
+    } else if (fallbackEndpoints.tgtSide === 'outbound') {
       r.tgtScreen = { x: r.tgtScreen.x + PORT_OUT_PX, y: r.tgtScreen.y };
     }
     return r;
-  }, [endpoints, originX, originY]);
+  }, [fallbackEndpoints, originX, originY]);
 
-  if (!endpoints || !route) return null;
+  const brickRender = useMemo(() => {
+    if (!surfaceRoute) return null;
 
-  const colors = getColors(theme, diffState, isHighlighted);
-  const hitPath = buildHitPath(route);
+    const footprintVertices = buildBrickFootprint(surfaceRoute);
+    if (footprintVertices.length < 3) {
+      return null;
+    }
 
-  const elbowScreen = route.elbow ?? null;
+    const topFaceScreen = projectFootprintToScreen(footprintVertices, originX, originY);
+    const topY = surfaceRoute.srcPort.surfaceY + CONNECTION_HEIGHT_CU;
+    const baseY = surfaceRoute.srcPort.surfaceY;
+    const sideFaces = getVisibleSideFaces(footprintVertices, topY, baseY).map((face) => ({
+      face: face.face,
+      points: face.vertices.map((v) => worldToScreen(v[0], v[1], v[2], originX, originY)) as [
+        ScreenPoint,
+        ScreenPoint,
+        ScreenPoint,
+        ScreenPoint,
+      ],
+    }));
+
+    const hitPoints = getRouteCenterlinePoints(surfaceRoute, originX, originY);
+    const hitPath = pointsToPath(hitPoints);
+    const studs = sampleStudPositions(surfaceRoute).map((point, index) => {
+      const screen = worldToScreen(point[0], point[1], point[2], originX, originY);
+      return {
+        x: screen.x,
+        y: screen.y,
+        key: `${connection.id}-stud-${index}`,
+      };
+    });
+
+    return {
+      hitPath,
+      labelPos: getLabelPosition(hitPoints),
+      topFacePolygon: pointsToPolygon(topFaceScreen),
+      sideFaces,
+      studs,
+    };
+  }, [surfaceRoute, originX, originY, connection.id]);
+
+  const fallbackRender = useMemo(() => {
+    if (!fallbackRoute) return null;
+    const hitPath = buildHitPath(fallbackRoute);
+    const endpointStuds = [
+      { x: fallbackRoute.srcScreen.x, y: fallbackRoute.srcScreen.y, key: `${connection.id}-src` },
+      { x: fallbackRoute.tgtScreen.x, y: fallbackRoute.tgtScreen.y, key: `${connection.id}-tgt` },
+    ];
+
+    return {
+      hitPath,
+      labelPos: fallbackRoute.elbow ?? {
+        x:
+          (fallbackRoute.segments[0].start.x +
+            fallbackRoute.segments[fallbackRoute.segments.length - 1].end.x) /
+          2,
+        y:
+          (fallbackRoute.segments[0].start.y +
+            fallbackRoute.segments[fallbackRoute.segments.length - 1].end.y) /
+          2,
+      },
+      endpointStuds,
+      segments: fallbackRoute.segments,
+      elbow: fallbackRoute.elbow,
+    };
+  }, [fallbackRoute, connection.id]);
+
+  if (!brickRender && !fallbackRender) return null;
+
+  const colors = getColors(renderSemantic, diffState, isHighlighted);
+  const hitPath = brickRender?.hitPath ?? fallbackRender?.hitPath ?? '';
+  const labelPos = brickRender?.labelPos ?? fallbackRender?.labelPos;
+  const fallbackPinHoleStyle = LEGACY_PIN_HOLE_STYLE[renderSemantic];
+  const studColors = {
+    main: colors.studMain,
+    shadow: colors.studShadow,
+    highlight: colors.studHighlight,
+  };
 
   const handleClick = (e: React.MouseEvent<SVGGElement>) => {
     e.stopPropagation();
@@ -450,6 +611,7 @@ export const BrickConnector = memo(function BrickConnector({
   };
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: SVG <g> must stay interactive for connector hit testing.
     <g
       opacity={colors.opacity}
       style={{ cursor: 'pointer' }}
@@ -462,18 +624,7 @@ export const BrickConnector = memo(function BrickConnector({
       aria-label={`connection ${connection.id}`}
       data-connector-type={(connection.metadata?.type as string) ?? semantic}
     >
-      {isSelected && (
-        <path
-          d={hitPath}
-          stroke="#ffffff"
-          strokeWidth={BEAM_HALF_THICKNESS * 2 + 4}
-          strokeOpacity={0.5}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          fill="none"
-          pointerEvents="none"
-        />
-      )}
+      {showStuds && <StudDefs studId={studId} studColors={studColors} />}
 
       <path
         d={hitPath}
@@ -484,28 +635,72 @@ export const BrickConnector = memo(function BrickConnector({
         data-testid="connection-hit-area"
       />
 
-      {route.segments.map((seg, i) =>
-        renderLiftarmSegment(
-          seg,
-          colors,
-          theme.pinHoleStyle,
-          `seg-${connection.id}-${i}`,
-          i === route.segments.length - 1,
-        ),
+      {isSelected && brickRender && (
+        <polygon
+          points={brickRender.topFacePolygon}
+          fill="none"
+          stroke="#ffffff"
+          strokeWidth={4}
+          strokeOpacity={0.5}
+          strokeLinejoin="round"
+          pointerEvents="none"
+          data-layer="selection-outline"
+        />
       )}
 
-      {elbowScreen &&
-        renderElbowJoint(elbowScreen, colors, theme.pinHoleStyle, `elbow-${connection.id}`)}
+      <g data-layer="side-faces" pointerEvents="none">
+        {brickRender
+          ? brickRender.sideFaces.map((quad, i) => (
+              <polygon
+                key={`${connection.id}-side-${i}`}
+                points={pointsToPolygon(quad.points)}
+                fill={quad.face === 'left' ? colors.leftSideColor : colors.rightSideColor}
+              />
+            ))
+          : fallbackRender?.segments.map((seg, i) =>
+              renderLiftarmSegment(
+                seg,
+                colors,
+                fallbackPinHoleStyle,
+                `seg-${connection.id}-${i}`,
+                i === fallbackRender.segments.length - 1,
+              ),
+            )}
+        {!brickRender && fallbackRender?.elbow
+          ? renderElbowJoint(
+              fallbackRender.elbow,
+              colors,
+              fallbackPinHoleStyle,
+              `elbow-${connection.id}`,
+            )
+          : null}
+      </g>
 
-      {renderStud(route.srcScreen.x, route.srcScreen.y, colors, `stud-src-${connection.id}`)}
-      {renderStud(route.tgtScreen.x, route.tgtScreen.y, colors, `stud-tgt-${connection.id}`)}
+      <g data-layer="top-face" pointerEvents="none">
+        {brickRender && (
+          <polygon
+            points={brickRender.topFacePolygon}
+            fill={colors.topFaceColor}
+            stroke={colors.topFaceStroke}
+            strokeWidth={1}
+          />
+        )}
+      </g>
 
-      {/* Draw-in animation overlay */}
+      {showStuds && (
+        <g data-layer="studs" pointerEvents="none">
+          <StudGrid
+            studId={studId}
+            studs={brickRender?.studs ?? fallbackRender?.endpointStuds ?? []}
+          />
+        </g>
+      )}
+
       <path
         ref={drawInRef}
         d={hitPath}
-        stroke={colors.tile}
-        strokeWidth={BEAM_HALF_THICKNESS * 2}
+        stroke={colors.topFaceColor}
+        strokeWidth={DRAW_STROKE_WIDTH}
         strokeLinecap="round"
         strokeLinejoin="round"
         fill="none"
@@ -514,10 +709,10 @@ export const BrickConnector = memo(function BrickConnector({
         data-testid="connection-draw-path"
       />
 
-      {/* Snap flash — expands and fades out on mount */}
       <path
         d={hitPath}
-        stroke={colors.tile}
+        stroke={colors.topFaceColor}
+        strokeWidth={DRAW_STROKE_WIDTH}
         strokeLinecap="round"
         strokeLinejoin="round"
         fill="none"
@@ -546,10 +741,7 @@ export const BrickConnector = memo(function BrickConnector({
       {hasValidationError &&
         (isHovered || isSelected) &&
         (() => {
-          const labelPos = route.elbow ?? {
-            x: (route.segments[0].start.x + route.segments[route.segments.length - 1].end.x) / 2,
-            y: (route.segments[0].start.y + route.segments[route.segments.length - 1].end.y) / 2,
-          };
+          if (!labelPos) return null;
           const msg = connectionErrors[0].message;
           const textWidth = Math.min(msg.length * 6.5, 220);
           const padding = 6;

--- a/apps/web/src/entities/connection/__tests__/connectionBrickGeometry.test.ts
+++ b/apps/web/src/entities/connection/__tests__/connectionBrickGeometry.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBrickFootprint,
+  getVisibleSideFaces,
+  projectFootprintToScreen,
+  sampleStudPositions,
+} from '../connectionBrickGeometry';
+
+function makeRoute(
+  points: readonly [[number, number, number], [number, number, number]][],
+  surfaceY = 0,
+): Parameters<typeof buildBrickFootprint>[0] {
+  return {
+    srcPort: { surfaceY },
+    segments: points.map(([start, end]) => ({ start, end })),
+  } as unknown as Parameters<typeof buildBrickFootprint>[0];
+}
+
+describe('buildBrickFootprint', () => {
+  it('builds a 4-point rectangle for straight horizontal routes', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [4, 0, 0],
+      ],
+    ]);
+    const footprint = buildBrickFootprint(route);
+
+    expect(footprint).toEqual([
+      [0, 1 / 3, 0.5],
+      [4, 1 / 3, 0.5],
+      [4, 1 / 3, -0.5],
+      [0, 1 / 3, -0.5],
+    ]);
+  });
+
+  it('builds a 4-point rectangle for straight vertical routes', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [0, 0, 4],
+      ],
+    ]);
+    const footprint = buildBrickFootprint(route);
+
+    expect(footprint).toEqual([
+      [-0.5, 1 / 3, 0],
+      [-0.5, 1 / 3, 4],
+      [0.5, 1 / 3, 4],
+      [0.5, 1 / 3, 0],
+    ]);
+  });
+
+  it('builds a 6-point clockwise polygon for L-shaped routes', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [3, 0, 0],
+      ],
+      [
+        [3, 0, 0],
+        [3, 0, 2],
+      ],
+    ]);
+    const footprint = buildBrickFootprint(route);
+
+    expect(footprint).toHaveLength(6);
+    expect(footprint).toEqual([
+      [0, 1 / 3, 0.5],
+      [2.5, 1 / 3, 0.5],
+      [2.5, 1 / 3, 2],
+      [3.5, 1 / 3, 2],
+      [3.5, 1 / 3, -0.5],
+      [0, 1 / 3, -0.5],
+    ]);
+  });
+
+  it('handles very short routes (< 1 CU)', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [0.75, 0, 0],
+      ],
+    ]);
+    const footprint = buildBrickFootprint(route);
+
+    expect(footprint).toEqual([
+      [0, 1 / 3, 0.5],
+      [0.75, 1 / 3, 0.5],
+      [0.75, 1 / 3, -0.5],
+      [0, 1 / 3, -0.5],
+    ]);
+  });
+});
+
+describe('projectFootprintToScreen', () => {
+  it('projects world vertices through worldToScreen', () => {
+    const screen = projectFootprintToScreen(
+      [
+        [1, 0, 1],
+        [2, 1, 0],
+      ],
+      100,
+      200,
+    );
+
+    expect(screen).toEqual([
+      { x: 100, y: 232 },
+      { x: 164, y: 200 },
+    ]);
+  });
+});
+
+describe('sampleStudPositions', () => {
+  it('returns empty array for routes shorter than 1 CU', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [0.75, 0, 0],
+      ],
+    ]);
+    expect(sampleStudPositions(route)).toEqual([]);
+  });
+
+  it('returns one stud at midpoint for a 2 CU route', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [2, 0, 0],
+      ],
+    ]);
+    expect(sampleStudPositions(route)).toEqual([[1, 1 / 3, 0]]);
+  });
+
+  it('returns multiple studs at 1 CU intervals for a 5 CU route', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [5, 0, 0],
+      ],
+    ]);
+    expect(sampleStudPositions(route)).toEqual([
+      [1.5, 1 / 3, 0],
+      [2.5, 1 / 3, 0],
+      [3.5, 1 / 3, 0],
+    ]);
+  });
+
+  it('skips stud positions near bends on L-routes', () => {
+    const route = makeRoute([
+      [
+        [0, 0, 0],
+        [3, 0, 0],
+      ],
+      [
+        [3, 0, 0],
+        [3, 0, 3],
+      ],
+    ]);
+
+    expect(sampleStudPositions(route)).toEqual([
+      [1.5, 1 / 3, 0],
+      [3, 1 / 3, 1.5],
+    ]);
+  });
+});
+
+describe('getVisibleSideFaces', () => {
+  it('returns two visible side faces for clockwise rectangle top polygon', () => {
+    const top: readonly [number, number, number][] = [
+      [0, 1, 1],
+      [4, 1, 1],
+      [4, 1, 0],
+      [0, 1, 0],
+    ];
+
+    const faces = getVisibleSideFaces(top, 1, 0);
+    expect(faces).toHaveLength(2);
+    expect(faces.map((f) => f.face)).toEqual(['left', 'right']);
+
+    expect(faces[0].vertices).toEqual([
+      [0, 1, 1],
+      [4, 1, 1],
+      [4, 0, 1],
+      [0, 0, 1],
+    ]);
+
+    expect(faces[1].vertices).toEqual([
+      [4, 1, 1],
+      [4, 1, 0],
+      [4, 0, 0],
+      [4, 0, 1],
+    ]);
+  });
+});

--- a/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
+++ b/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONNECTION_SEMANTIC_BASE_COLORS,
+  DEFAULT_CONNECTION_SEMANTIC,
+  getConnectionBrickColors,
+} from '../connectionFaceColors';
+import type { ConnectionRenderSemantic } from '../connectionFaceColors';
+import { deriveFaceColors } from '../../block/blockFaceColors';
+
+const ALL_SEMANTICS: ConnectionRenderSemantic[] = ['http', 'event', 'data'];
+
+describe('CONNECTION_SEMANTIC_BASE_COLORS', () => {
+  it('covers all three render semantics', () => {
+    expect(Object.keys(CONNECTION_SEMANTIC_BASE_COLORS).sort()).toEqual(['data', 'event', 'http']);
+  });
+
+  it('uses correct hex values per design spec', () => {
+    expect(CONNECTION_SEMANTIC_BASE_COLORS.http).toBe('#6366F1');
+    expect(CONNECTION_SEMANTIC_BASE_COLORS.event).toBe('#F43F5E');
+    expect(CONNECTION_SEMANTIC_BASE_COLORS.data).toBe('#84CC16');
+  });
+
+  it.each([
+    ['#0078D4'],
+    ['#4285F4'],
+    ['#D86613'],
+    ['#FF8C00'],
+    ['#E0301E'],
+    ['#D6232C'],
+    ['#EA4335'],
+    ['#3F8624'],
+    ['#34A853'],
+    ['#F59E0B'],
+    ['#FBBC05'],
+    ['#693BC5'],
+    ['#A166FF'],
+    ['#14B8A6'],
+    ['#32D4F5'],
+    ['#59B4D9'],
+    ['#CD2264'],
+  ])('does not conflict with provider color %s', (providerHex) => {
+    const semanticColors = Object.values(CONNECTION_SEMANTIC_BASE_COLORS);
+    expect(semanticColors).not.toContain(providerHex);
+  });
+});
+
+describe('getConnectionBrickColors', () => {
+  it.each(ALL_SEMANTICS)('returns all required fields for "%s"', (semantic) => {
+    const colors = getConnectionBrickColors(semantic);
+    expect(colors).toHaveProperty('base');
+    expect(colors).toHaveProperty('topFaceColor');
+    expect(colors).toHaveProperty('topFaceStroke');
+    expect(colors).toHaveProperty('leftSideColor');
+    expect(colors).toHaveProperty('rightSideColor');
+    expect(colors).toHaveProperty('studColors');
+    expect(colors.studColors).toHaveProperty('main');
+    expect(colors.studColors).toHaveProperty('shadow');
+    expect(colors.studColors).toHaveProperty('highlight');
+  });
+
+  it.each(ALL_SEMANTICS)('base matches CONNECTION_SEMANTIC_BASE_COLORS for "%s"', (semantic) => {
+    const colors = getConnectionBrickColors(semantic);
+    expect(colors.base).toBe(CONNECTION_SEMANTIC_BASE_COLORS[semantic]);
+  });
+
+  it.each(ALL_SEMANTICS)('derivation matches deriveFaceColors() output for "%s"', (semantic) => {
+    const colors = getConnectionBrickColors(semantic);
+    const expected = deriveFaceColors(CONNECTION_SEMANTIC_BASE_COLORS[semantic]);
+    expect(colors.topFaceColor).toBe(expected.top);
+    expect(colors.topFaceStroke).toBe(expected.topStroke);
+    expect(colors.leftSideColor).toBe(expected.left);
+    expect(colors.rightSideColor).toBe(expected.right);
+    expect(colors.studColors.main).toBe(expected.studMain);
+    expect(colors.studColors.shadow).toBe(expected.studShadow);
+    expect(colors.studColors.highlight).toBe(expected.studHighlight);
+  });
+
+  it('returns distinct color sets per semantic', () => {
+    const httpColors = getConnectionBrickColors('http');
+    const eventColors = getConnectionBrickColors('event');
+    const dataColors = getConnectionBrickColors('data');
+
+    expect(httpColors.topFaceColor).not.toBe(eventColors.topFaceColor);
+    expect(httpColors.topFaceColor).not.toBe(dataColors.topFaceColor);
+    expect(eventColors.topFaceColor).not.toBe(dataColors.topFaceColor);
+  });
+});
+
+describe('DEFAULT_CONNECTION_SEMANTIC', () => {
+  it('is http', () => {
+    expect(DEFAULT_CONNECTION_SEMANTIC).toBe('http');
+  });
+});

--- a/apps/web/src/entities/connection/__tests__/surfaceRouting.test.ts
+++ b/apps/web/src/entities/connection/__tests__/surfaceRouting.test.ts
@@ -1,0 +1,398 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  Connection,
+  ContainerNode,
+  Endpoint,
+  ExternalActor,
+  LeafNode,
+} from '@cloudblocks/schema';
+import { CATEGORY_PORTS, endpointId, generateEndpointsForNode } from '@cloudblocks/schema';
+import {
+  getConnectionSurfaceRoute,
+  resolveSurfacePort,
+  routeSameSurface,
+  SURFACE_EXIT_OFFSET_CU,
+} from '../surfaceRouting';
+import type { SurfacePort } from '../surfaceRouting';
+
+function makePlate(overrides?: Partial<ContainerNode>): ContainerNode {
+  return {
+    id: 'plate-1',
+    kind: 'container',
+    name: 'Test Plate',
+    category: 'network',
+    position: { x: 10, y: 2, z: 20 },
+    size: { width: 16, depth: 16, height: 1 },
+    children: [],
+    ...overrides,
+  } as ContainerNode;
+}
+
+function makeBlock(overrides?: Partial<LeafNode>): LeafNode {
+  return {
+    id: 'block-1',
+    kind: 'resource',
+    name: 'Test Block',
+    category: 'compute',
+    parentId: 'plate-1',
+    position: { x: 2, y: 0, z: 3 },
+    ...overrides,
+  } as LeafNode;
+}
+
+function makeConnection(overrides?: Partial<Connection>): Connection {
+  return {
+    id: 'conn-1',
+    from: endpointId('block-a', 'output', 'data'),
+    to: endpointId('block-b', 'input', 'data'),
+    ...overrides,
+  } as Connection;
+}
+
+function makeEndpoints(nodeIds: string[]): Endpoint[] {
+  return nodeIds.flatMap((nodeId) => generateEndpointsForNode(nodeId));
+}
+
+function makeSurfacePort(overrides?: Partial<SurfacePort>): SurfacePort {
+  return {
+    surfaceBase: [0, 3, 0],
+    surfaceExit: [0, 3, -0.75],
+    plateId: 'plate-1',
+    surfaceY: 3,
+    normal: 'neg-z',
+    ...overrides,
+  };
+}
+
+describe('SURFACE_EXIT_OFFSET_CU', () => {
+  it('is fixed to 0.75 CU', () => {
+    expect(SURFACE_EXIT_OFFSET_CU).toBe(0.75);
+  });
+});
+
+describe('resolveSurfacePort', () => {
+  it('resolves inbound side using t=0.5 for single-port distribution', () => {
+    const plate = makePlate({
+      position: { x: 10, y: 2, z: 20 },
+      size: { width: 16, depth: 16, height: 1 },
+    });
+    const block = makeBlock({ category: 'data', position: { x: 2, y: 0, z: 4 } });
+
+    const result = resolveSurfacePort(block, plate, 'inbound', 0, 1);
+
+    expect(result.plateId).toBe(plate.id);
+    expect(result.surfaceY).toBe(3);
+    expect(result.normal).toBe('neg-x');
+    expect(result.surfaceBase).toEqual([12, 3, 25.5]);
+    expect(result.surfaceExit).toEqual([11.25, 3, 25.5]);
+  });
+
+  it('resolves outbound side using t=0.25 for three-port distribution', () => {
+    const plate = makePlate({
+      position: { x: 10, y: 2, z: 20 },
+      size: { width: 16, depth: 16, height: 1 },
+    });
+    const block = makeBlock({ category: 'compute', position: { x: 2, y: 0, z: 4 } });
+
+    const result = resolveSurfacePort(block, plate, 'outbound', 0, 3);
+
+    expect(result.plateId).toBe(plate.id);
+    expect(result.surfaceY).toBe(3);
+    expect(result.normal).toBe('neg-z');
+    expect(result.surfaceBase).toEqual([12.5, 3, 24]);
+    expect(result.surfaceExit).toEqual([12.5, 3, 23.25]);
+  });
+
+  it('applies category port counts with semantic modulo mapping for output data endpoints', () => {
+    const plate = makePlate({
+      position: { x: 0, y: 5, z: 0 },
+      size: { width: 10, depth: 10, height: 2 },
+    });
+    const block = makeBlock({ category: 'compute', position: { x: 1, y: 0, z: 1 } });
+    const totalPorts = CATEGORY_PORTS.compute.outbound;
+
+    const result = resolveSurfacePort(block, plate, 'outbound', 0, totalPorts);
+
+    expect(totalPorts).toBe(2);
+    expect(result.surfaceBase).toEqual([1 + (1 / 3) * 2, 7, 1]);
+    expect(result.surfaceExit).toEqual([1 + (1 / 3) * 2, 7, 1 - SURFACE_EXIT_OFFSET_CU]);
+  });
+});
+
+describe('routeSameSurface', () => {
+  it('returns only exit segments when exits are coincident', () => {
+    const src = makeSurfacePort({
+      surfaceBase: [1, 3, 1],
+      surfaceExit: [0, 3, 1],
+      normal: 'neg-x',
+    });
+    const tgt = makeSurfacePort({
+      surfaceBase: [2, 3, 1],
+      surfaceExit: [0, 3, 1],
+      normal: 'neg-z',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(2);
+    expect(segments[0]).toMatchObject({ kind: 'exit', start: [1, 3, 1], end: [0, 3, 1] });
+    expect(segments[1]).toMatchObject({ kind: 'exit', start: [0, 3, 1], end: [2, 3, 1] });
+  });
+
+  it('routes with a single surface segment when exits share X', () => {
+    const src = makeSurfacePort({
+      surfaceExit: [1, 3, 2],
+      surfaceBase: [2, 3, 2],
+      normal: 'neg-x',
+    });
+    const tgt = makeSurfacePort({
+      surfaceExit: [1, 3, 8],
+      surfaceBase: [1, 3, 9],
+      normal: 'neg-z',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toEqual({
+      start: [1, 3, 2],
+      end: [1, 3, 8],
+      kind: 'surface',
+      surfaceId: 'plate-1',
+    });
+  });
+
+  it('routes with a single surface segment when exits share Z', () => {
+    const src = makeSurfacePort({
+      surfaceExit: [2, 3, 5],
+      surfaceBase: [3, 3, 5],
+      normal: 'neg-z',
+    });
+    const tgt = makeSurfacePort({
+      surfaceExit: [9, 3, 5],
+      surfaceBase: [9, 3, 6],
+      normal: 'neg-x',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(3);
+    expect(segments[1]).toEqual({
+      start: [2, 3, 5],
+      end: [9, 3, 5],
+      kind: 'surface',
+      surfaceId: 'plate-1',
+    });
+  });
+
+  it('routes as L-shape with two surface segments when exits differ in both axes', () => {
+    const src = makeSurfacePort({
+      surfaceExit: [1, 3, 1],
+      surfaceBase: [2, 3, 1],
+      normal: 'neg-z',
+    });
+    const tgt = makeSurfacePort({
+      surfaceExit: [4, 3, 6],
+      surfaceBase: [4, 3, 7],
+      normal: 'neg-x',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(4);
+    expect(segments[1].kind).toBe('surface');
+    expect(segments[2].kind).toBe('surface');
+    expect(segments[1].end).toEqual(segments[2].start);
+
+    const seg1 = segments[1];
+    const seg2 = segments[2];
+    const seg1AxisAligned = seg1.start[0] === seg1.end[0] || seg1.start[2] === seg1.end[2];
+    const seg2AxisAligned = seg2.start[0] === seg2.end[0] || seg2.start[2] === seg2.end[2];
+    expect(seg1AxisAligned).toBe(true);
+    expect(seg2AxisAligned).toBe(true);
+  });
+
+  it('selects the lower-scored elbow candidate based on normal alignment', () => {
+    const src = makeSurfacePort({
+      surfaceBase: [2, 3, 1],
+      surfaceExit: [1, 3, 1],
+      normal: 'neg-x',
+    });
+    const tgt = makeSurfacePort({
+      surfaceBase: [5, 3, 5],
+      surfaceExit: [5, 3, 4],
+      normal: 'neg-z',
+    });
+
+    const segments = routeSameSurface(src, tgt);
+
+    expect(segments).toHaveLength(4);
+    expect(segments[1].end).toEqual([5, 3, 1]);
+    expect(segments[2].start).toEqual([5, 3, 1]);
+  });
+});
+
+describe('getConnectionSurfaceRoute', () => {
+  const externalActors: ExternalActor[] = [];
+
+  it('returns same-plate route with surface segments and resolved ports', () => {
+    const plate = makePlate({
+      id: 'plate-a',
+      position: { x: 0, y: 0, z: 0 },
+      size: { width: 20, depth: 20, height: 1 },
+    });
+    const blockA = makeBlock({
+      id: 'block-a',
+      category: 'compute',
+      parentId: plate.id,
+      position: { x: 1, y: 0, z: 1 },
+    });
+    const blockB = makeBlock({
+      id: 'block-b',
+      category: 'data',
+      parentId: plate.id,
+      position: { x: 6, y: 0, z: 5 },
+    });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).not.toBeNull();
+    expect(route!.srcPort.plateId).toBe('plate-a');
+    expect(route!.tgtPort.plateId).toBe('plate-a');
+    expect(route!.srcPort.normal).toBe('neg-z');
+    expect(route!.tgtPort.normal).toBe('neg-x');
+    expect(route!.segments.some((segment) => segment.kind === 'surface')).toBe(true);
+    expect(route!.segments.every((segment) => segment.surfaceId === 'plate-a')).toBe(true);
+  });
+
+  it('falls back to cross-plate transition segments on ground surface', () => {
+    const plateA = makePlate({ id: 'plate-a', position: { x: 0, y: 1, z: 0 } });
+    const plateB = makePlate({ id: 'plate-b', position: { x: 20, y: 4, z: 20 } });
+    const blockA = makeBlock({
+      id: 'block-a',
+      category: 'compute',
+      parentId: plateA.id,
+      position: { x: 2, y: 0, z: 2 },
+    });
+    const blockB = makeBlock({
+      id: 'block-b',
+      category: 'data',
+      parentId: plateB.id,
+      position: { x: 3, y: 0, z: 3 },
+    });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'output', 'event'),
+      to: endpointId(blockB.id, 'input', 'event'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [plateA, plateB],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).not.toBeNull();
+    expect(route!.srcPort.plateId).toBe('plate-a');
+    expect(route!.tgtPort.plateId).toBe('plate-b');
+    expect(route!.segments.length).toBeGreaterThanOrEqual(2);
+    expect(route!.segments.every((segment) => segment.kind === 'transition')).toBe(true);
+    expect(route!.segments.every((segment) => segment.start[1] === 0 && segment.end[1] === 0)).toBe(
+      true,
+    );
+  });
+
+  it('returns null when source endpoint is missing', () => {
+    const plate = makePlate({ id: 'plate-a' });
+    const blockB = makeBlock({ id: 'block-b', parentId: plate.id });
+    const endpoints = makeEndpoints([blockB.id]);
+    const connection = makeConnection({
+      from: endpointId('missing-block', 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null when endpoint exists but block is missing', () => {
+    const plate = makePlate({ id: 'plate-a' });
+    const blockB = makeBlock({ id: 'block-b', parentId: plate.id });
+    const endpoints = makeEndpoints(['ghost-block', blockB.id]);
+    const connection = makeConnection({
+      from: endpointId('ghost-block', 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null when parent plate for an endpoint block is missing', () => {
+    const blockA = makeBlock({ id: 'block-a', parentId: 'missing-plate' });
+    const blockB = makeBlock({ id: 'block-b', parentId: 'missing-plate' });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'output', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+
+  it('returns null on endpoint direction mismatch', () => {
+    const plate = makePlate({ id: 'plate-a' });
+    const blockA = makeBlock({ id: 'block-a', parentId: plate.id });
+    const blockB = makeBlock({ id: 'block-b', parentId: plate.id });
+    const endpoints = makeEndpoints([blockA.id, blockB.id]);
+    const connection = makeConnection({
+      from: endpointId(blockA.id, 'input', 'data'),
+      to: endpointId(blockB.id, 'input', 'data'),
+    });
+
+    const route = getConnectionSurfaceRoute(
+      connection,
+      [blockA, blockB],
+      [plate],
+      endpoints,
+      externalActors,
+    );
+
+    expect(route).toBeNull();
+  });
+});

--- a/apps/web/src/entities/connection/connectionBrickGeometry.ts
+++ b/apps/web/src/entities/connection/connectionBrickGeometry.ts
@@ -1,0 +1,397 @@
+import { CONNECTION_HEIGHT_CU, CONNECTION_WIDTH_CU } from '../../shared/tokens/designTokens';
+import { worldToScreen } from '../../shared/utils/isometric';
+import type { ScreenPoint } from '../../shared/utils/isometric';
+import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
+
+export interface SideFaceQuad {
+  face: 'left' | 'right';
+  vertices: readonly [WorldPoint3, WorldPoint3, WorldPoint3, WorldPoint3];
+}
+
+interface Point2 {
+  x: number;
+  z: number;
+}
+
+const EPSILON = 1e-9;
+
+function isWorldPoint3(value: unknown): value is WorldPoint3 {
+  return (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    typeof value[0] === 'number' &&
+    typeof value[1] === 'number' &&
+    typeof value[2] === 'number'
+  );
+}
+
+function worldPointFromUnknown(value: unknown): WorldPoint3 | null {
+  if (!isWorldPoint3(value)) {
+    return null;
+  }
+  return [value[0], value[1], value[2]];
+}
+
+function extractSegmentEndpoints(segment: unknown): [WorldPoint3, WorldPoint3] | null {
+  if (!segment || typeof segment !== 'object') {
+    return null;
+  }
+
+  const record = segment as Record<string, unknown>;
+  const start = worldPointFromUnknown(record.start ?? record.from ?? record.a ?? record.source);
+  const end = worldPointFromUnknown(record.end ?? record.to ?? record.b ?? record.target);
+
+  if (start && end) {
+    return [start, end];
+  }
+
+  if (Array.isArray(record.points) && record.points.length >= 2) {
+    const first = worldPointFromUnknown(record.points[0]);
+    const last = worldPointFromUnknown(record.points[record.points.length - 1]);
+    if (first && last) {
+      return [first, last];
+    }
+  }
+
+  return null;
+}
+
+function pointKey(point: WorldPoint3): string {
+  return `${point[0]}|${point[1]}|${point[2]}`;
+}
+
+function sameXZ(a: WorldPoint3, b: WorldPoint3): boolean {
+  return Math.abs(a[0] - b[0]) < EPSILON && Math.abs(a[2] - b[2]) < EPSILON;
+}
+
+function flattenRoutePolyline(route: SurfaceRoute): WorldPoint3[] {
+  const segments = (route as unknown as { segments?: unknown[] }).segments ?? [];
+  const polyline: WorldPoint3[] = [];
+
+  for (const segment of segments) {
+    const endpoints = extractSegmentEndpoints(segment);
+    if (!endpoints) {
+      continue;
+    }
+
+    const [rawStart, rawEnd] = endpoints;
+    const start: WorldPoint3 = [rawStart[0], rawStart[1], rawStart[2]];
+    const end: WorldPoint3 = [rawEnd[0], rawEnd[1], rawEnd[2]];
+
+    if (sameXZ(start, end)) {
+      continue;
+    }
+
+    if (polyline.length === 0) {
+      polyline.push(start, end);
+      continue;
+    }
+
+    const last = polyline[polyline.length - 1];
+    if (pointKey(last) === pointKey(start)) {
+      polyline.push(end);
+      continue;
+    }
+
+    if (pointKey(last) === pointKey(end)) {
+      polyline.push(start);
+      continue;
+    }
+
+    polyline.push(start, end);
+  }
+
+  const deduped: WorldPoint3[] = [];
+  for (const point of polyline) {
+    const last = deduped[deduped.length - 1];
+    if (!last || !sameXZ(last, point)) {
+      deduped.push(point);
+    }
+  }
+
+  return mergeCollinearWaypoints(deduped);
+}
+
+function mergeCollinearWaypoints(points: WorldPoint3[]): WorldPoint3[] {
+  if (points.length <= 2) {
+    return points;
+  }
+
+  const merged: WorldPoint3[] = [points[0]];
+  for (let i = 1; i < points.length - 1; i += 1) {
+    const prev = merged[merged.length - 1];
+    const curr = points[i];
+    const next = points[i + 1];
+
+    const collinearX =
+      Math.abs(prev[0] - curr[0]) < EPSILON && Math.abs(curr[0] - next[0]) < EPSILON;
+    const collinearZ =
+      Math.abs(prev[2] - curr[2]) < EPSILON && Math.abs(curr[2] - next[2]) < EPSILON;
+
+    if (collinearX || collinearZ) {
+      continue;
+    }
+
+    merged.push(curr);
+  }
+
+  merged.push(points[points.length - 1]);
+  return merged;
+}
+
+function signedAreaXZ(vertices: readonly WorldPoint3[]): number {
+  let area = 0;
+  for (let i = 0; i < vertices.length; i += 1) {
+    const a = vertices[i];
+    const b = vertices[(i + 1) % vertices.length];
+    area += a[0] * b[2] - b[0] * a[2];
+  }
+  return area / 2;
+}
+
+function normalizeDirection(dx: number, dz: number): Point2 {
+  if (Math.abs(dx) > EPSILON) {
+    return { x: Math.sign(dx), z: 0 };
+  }
+  if (Math.abs(dz) > EPSILON) {
+    return { x: 0, z: Math.sign(dz) };
+  }
+  return { x: 0, z: 0 };
+}
+
+function leftNormal(dir: Point2): Point2 {
+  return { x: -dir.z, z: dir.x };
+}
+
+function offsetPointAt(
+  point: WorldPoint3,
+  prev: WorldPoint3 | null,
+  next: WorldPoint3 | null,
+  sideSign: 1 | -1,
+  halfWidth: number,
+): WorldPoint3 {
+  if (!next && !prev) {
+    return [point[0], point[1], point[2]];
+  }
+
+  if (!prev && next) {
+    const dirOut = normalizeDirection(next[0] - point[0], next[2] - point[2]);
+    const n = leftNormal(dirOut);
+    return [point[0] + n.x * sideSign * halfWidth, point[1], point[2] + n.z * sideSign * halfWidth];
+  }
+
+  if (prev && !next) {
+    const dirIn = normalizeDirection(point[0] - prev[0], point[2] - prev[2]);
+    const n = leftNormal(dirIn);
+    return [point[0] + n.x * sideSign * halfWidth, point[1], point[2] + n.z * sideSign * halfWidth];
+  }
+
+  const dirIn = normalizeDirection(point[0] - prev![0], point[2] - prev![2]);
+  const dirOut = normalizeDirection(next![0] - point[0], next![2] - point[2]);
+
+  if (Math.abs(dirIn.x - dirOut.x) < EPSILON && Math.abs(dirIn.z - dirOut.z) < EPSILON) {
+    const n = leftNormal(dirIn);
+    return [point[0] + n.x * sideSign * halfWidth, point[1], point[2] + n.z * sideSign * halfWidth];
+  }
+
+  const nIn = leftNormal(dirIn);
+  const nOut = leftNormal(dirOut);
+
+  const line1Point: Point2 = {
+    x: point[0] + nIn.x * sideSign * halfWidth,
+    z: point[2] + nIn.z * sideSign * halfWidth,
+  };
+  const line2Point: Point2 = {
+    x: point[0] + nOut.x * sideSign * halfWidth,
+    z: point[2] + nOut.z * sideSign * halfWidth,
+  };
+
+  const denominator = dirIn.x * dirOut.z - dirIn.z * dirOut.x;
+  if (Math.abs(denominator) < EPSILON) {
+    return [
+      point[0] + ((nIn.x + nOut.x) * sideSign * halfWidth) / 2,
+      point[1],
+      point[2] + ((nIn.z + nOut.z) * sideSign * halfWidth) / 2,
+    ];
+  }
+
+  const deltaX = line2Point.x - line1Point.x;
+  const deltaZ = line2Point.z - line1Point.z;
+  const t = (deltaX * dirOut.z - deltaZ * dirOut.x) / denominator;
+
+  return [line1Point.x + dirIn.x * t, point[1], line1Point.z + dirIn.z * t];
+}
+
+function pointAtDistance(polyline: readonly WorldPoint3[], distance: number): WorldPoint3 {
+  let remaining = distance;
+  for (let i = 0; i < polyline.length - 1; i += 1) {
+    const a = polyline[i];
+    const b = polyline[i + 1];
+    const segLen = Math.abs(b[0] - a[0]) + Math.abs(b[2] - a[2]);
+    if (remaining <= segLen + EPSILON) {
+      if (Math.abs(b[0] - a[0]) > EPSILON) {
+        const dir = Math.sign(b[0] - a[0]);
+        return [a[0] + dir * remaining, a[1], a[2]];
+      }
+      const dir = Math.sign(b[2] - a[2]);
+      return [a[0], a[1], a[2] + dir * remaining];
+    }
+    remaining -= segLen;
+  }
+
+  return polyline[polyline.length - 1];
+}
+
+export function buildBrickFootprint(route: SurfaceRoute): WorldPoint3[] {
+  const centerline = flattenRoutePolyline(route);
+  if (centerline.length < 2) {
+    return [];
+  }
+
+  const topY = route.srcPort.surfaceY + CONNECTION_HEIGHT_CU;
+  const normalized = centerline.map((point) => [point[0], topY, point[2]] as WorldPoint3);
+
+  const halfWidth = CONNECTION_WIDTH_CU / 2;
+  const left: WorldPoint3[] = [];
+  const right: WorldPoint3[] = [];
+
+  for (let i = 0; i < normalized.length; i += 1) {
+    const point = normalized[i];
+    const prev = i > 0 ? normalized[i - 1] : null;
+    const next = i < normalized.length - 1 ? normalized[i + 1] : null;
+    left.push(offsetPointAt(point, prev, next, 1, halfWidth));
+    right.push(offsetPointAt(point, prev, next, -1, halfWidth));
+  }
+
+  const polygon = [...left, ...right.reverse()];
+  if (polygon.length >= 3 && signedAreaXZ(polygon) > 0) {
+    polygon.reverse();
+  }
+
+  return polygon;
+}
+
+export function projectFootprintToScreen(
+  vertices: readonly WorldPoint3[],
+  originX: number,
+  originY: number,
+): ScreenPoint[] {
+  return vertices.map((v) => worldToScreen(v[0], v[1], v[2], originX, originY));
+}
+
+export function sampleStudPositions(route: SurfaceRoute): WorldPoint3[] {
+  const polyline = flattenRoutePolyline(route);
+  if (polyline.length < 2) {
+    return [];
+  }
+
+  const topY = route.srcPort.surfaceY + CONNECTION_HEIGHT_CU;
+  const normalized = polyline.map((point) => [point[0], topY, point[2]] as WorldPoint3);
+
+  const cumulative: number[] = [0];
+  for (let i = 1; i < normalized.length; i += 1) {
+    const prev = normalized[i - 1];
+    const curr = normalized[i];
+    cumulative.push(
+      cumulative[cumulative.length - 1] + Math.abs(curr[0] - prev[0]) + Math.abs(curr[2] - prev[2]),
+    );
+  }
+
+  const totalLength = cumulative[cumulative.length - 1];
+  if (totalLength < 1 - EPSILON) {
+    return [];
+  }
+
+  const bendDistances = new Set<number>();
+  for (let i = 1; i < cumulative.length - 1; i += 1) {
+    bendDistances.add(cumulative[i]);
+  }
+
+  const studs: WorldPoint3[] = [];
+  for (let d = 0.5; d <= totalLength + EPSILON; d += 1) {
+    const tooCloseToStart = d <= 0.5 + EPSILON;
+    const tooCloseToEnd = totalLength - d <= 0.5 + EPSILON;
+    if (tooCloseToStart || tooCloseToEnd) {
+      continue;
+    }
+
+    let nearBend = false;
+    for (const bendDistance of bendDistances) {
+      if (Math.abs(d - bendDistance) <= 0.5 + EPSILON) {
+        nearBend = true;
+        break;
+      }
+    }
+    if (nearBend) {
+      continue;
+    }
+
+    studs.push(pointAtDistance(normalized, d));
+  }
+
+  if (studs.length === 0 && totalLength >= 2 - EPSILON) {
+    const midpointDistance = totalLength / 2;
+    let nearBend = false;
+    for (const bendDistance of bendDistances) {
+      if (Math.abs(midpointDistance - bendDistance) <= 0.5 + EPSILON) {
+        nearBend = true;
+        break;
+      }
+    }
+
+    if (
+      !nearBend &&
+      midpointDistance > 0.5 + EPSILON &&
+      totalLength - midpointDistance > 0.5 + EPSILON
+    ) {
+      studs.push(pointAtDistance(normalized, midpointDistance));
+    }
+  }
+
+  return studs;
+}
+
+export function getVisibleSideFaces(
+  footprintVertices: readonly WorldPoint3[],
+  topY: number,
+  baseY: number,
+): SideFaceQuad[] {
+  if (footprintVertices.length < 3) {
+    return [];
+  }
+
+  const faces: SideFaceQuad[] = [];
+
+  for (let i = 0; i < footprintVertices.length; i += 1) {
+    const a = footprintVertices[i];
+    const b = footprintVertices[(i + 1) % footprintVertices.length];
+    const dx = b[0] - a[0];
+    const dz = b[2] - a[2];
+
+    const nx = -dz;
+    const nz = dx;
+
+    let face: SideFaceQuad['face'] | null = null;
+    if (nx > EPSILON) {
+      face = 'right';
+    } else if (nz > EPSILON) {
+      face = 'left';
+    }
+
+    if (!face) {
+      continue;
+    }
+
+    const topA: WorldPoint3 = [a[0], topY, a[2]];
+    const topB: WorldPoint3 = [b[0], topY, b[2]];
+    const bottomB: WorldPoint3 = [b[0], baseY, b[2]];
+    const bottomA: WorldPoint3 = [a[0], baseY, a[2]];
+
+    faces.push({
+      face,
+      vertices: [topA, topB, bottomB, bottomA],
+    });
+  }
+
+  return faces;
+}

--- a/apps/web/src/entities/connection/connectionFaceColors.ts
+++ b/apps/web/src/entities/connection/connectionFaceColors.ts
@@ -1,0 +1,55 @@
+// ═══════════════════════════════════════════════════════════════
+// Connection Brick Face Color System
+// Semantic colors (http, event, data) — NOT provider colors.
+// Reuses deriveFaceColors() from blockFaceColors.ts (§7.7).
+// ═══════════════════════════════════════════════════════════════
+
+import type { EndpointSemantic } from '@cloudblocks/schema';
+import type { StudColorSpec } from '../../shared/types/index';
+import { deriveFaceColors } from '../block/blockFaceColors';
+
+// ─── Semantic Subset ─────────────────────────────────────────
+
+/** Supported semantics for rendering. `identity` reserved for future use. */
+export type ConnectionRenderSemantic = Extract<EndpointSemantic, 'http' | 'event' | 'data'>;
+
+// ─── Base Color Palette ──────────────────────────────────────
+
+export const CONNECTION_SEMANTIC_BASE_COLORS: Record<ConnectionRenderSemantic, string> = {
+  http: '#6366F1', // Indigo
+  event: '#F43F5E', // Rose
+  data: '#84CC16', // Lime
+};
+
+// ─── Derived Face + Stud Colors ──────────────────────────────
+
+export interface ConnectionBrickColors {
+  base: string;
+  topFaceColor: string;
+  topFaceStroke: string;
+  leftSideColor: string;
+  rightSideColor: string;
+  studColors: StudColorSpec;
+}
+
+export function getConnectionBrickColors(
+  semantic: ConnectionRenderSemantic,
+): ConnectionBrickColors {
+  const base = CONNECTION_SEMANTIC_BASE_COLORS[semantic];
+  const derived = deriveFaceColors(base);
+
+  return {
+    base,
+    topFaceColor: derived.top,
+    topFaceStroke: derived.topStroke,
+    leftSideColor: derived.left,
+    rightSideColor: derived.right,
+    studColors: {
+      main: derived.studMain,
+      shadow: derived.studShadow,
+      highlight: derived.studHighlight,
+    },
+  };
+}
+
+export const DEFAULT_CONNECTION_SEMANTIC: ConnectionRenderSemantic = 'http';

--- a/apps/web/src/entities/connection/surfaceRouting.ts
+++ b/apps/web/src/entities/connection/surfaceRouting.ts
@@ -1,0 +1,269 @@
+/**
+ * Surface routing — world-space Manhattan routing on plate surfaces.
+ *
+ * Connections are routed as flat PCB-style traces on the plate top face
+ * (X/Z plane at plate surfaceY). This replaces the screen-space L-route
+ * in routing.ts with a world-space surface-first system.
+ */
+
+import type {
+  Connection,
+  ContainerNode,
+  Endpoint,
+  EndpointSemantic,
+  ExternalActor,
+  LeafNode,
+} from '@cloudblocks/schema';
+import { CATEGORY_PORTS } from '@cloudblocks/schema';
+import { getBlockWorldPosition } from '../../shared/utils/position';
+import { getBlockDimensions } from '../../shared/types/visualProfile';
+import type { StubSide } from '../block/blockGeometry';
+
+export type WorldPoint3 = [number, number, number];
+
+export interface SurfacePort {
+  surfaceBase: WorldPoint3;
+  surfaceExit: WorldPoint3;
+  plateId: string;
+  surfaceY: number;
+  normal: 'neg-x' | 'neg-z';
+}
+
+export type RouteSegmentKind = 'exit' | 'surface' | 'transition';
+
+export interface WorldRouteSegment {
+  start: WorldPoint3;
+  end: WorldPoint3;
+  kind: RouteSegmentKind;
+  surfaceId?: string;
+}
+
+export interface SurfaceRoute {
+  segments: WorldRouteSegment[];
+  srcPort: SurfacePort;
+  tgtPort: SurfacePort;
+}
+
+/** Visual clearance (CU) so routes don't start under the block footprint. */
+export const SURFACE_EXIT_OFFSET_CU = 0.75;
+
+/**
+ * Compute the surface port for a block endpoint.
+ *
+ * Inbound ports: LEFT face (world-X edge), offset in neg-X.
+ * Outbound ports: RIGHT face (world-Z edge), offset in neg-Z.
+ * Ports are distributed along the face edge with t = (i+1)/(n+1).
+ */
+export function resolveSurfacePort(
+  block: LeafNode,
+  plate: ContainerNode,
+  side: StubSide,
+  stubIndex: number,
+  totalPorts: number,
+): SurfacePort {
+  const [bx, , bz] = getBlockWorldPosition(block, plate);
+  const cu = getBlockDimensions(block.category, block.provider, block.subtype);
+  const surfaceY = plate.position.y + plate.size.height;
+  const t = (stubIndex + 1) / (totalPorts + 1);
+
+  if (side === 'inbound') {
+    const portZ = bz + t * cu.depth;
+    const surfaceBase: WorldPoint3 = [bx, surfaceY, portZ];
+    const surfaceExit: WorldPoint3 = [bx - SURFACE_EXIT_OFFSET_CU, surfaceY, portZ];
+    return { surfaceBase, surfaceExit, plateId: plate.id, surfaceY, normal: 'neg-x' };
+  }
+
+  const portX = bx + t * cu.width;
+  const surfaceBase: WorldPoint3 = [portX, surfaceY, bz];
+  const surfaceExit: WorldPoint3 = [portX, surfaceY, bz - SURFACE_EXIT_OFFSET_CU];
+  return { surfaceBase, surfaceExit, plateId: plate.id, surfaceY, normal: 'neg-z' };
+}
+
+function manhattanXZ(a: WorldPoint3, b: WorldPoint3): number {
+  return Math.abs(a[0] - b[0]) + Math.abs(a[2] - b[2]);
+}
+
+/**
+ * Score an L-shape elbow candidate. Penalises routes whose first/last
+ * segment does not align with the source/target port normal direction.
+ */
+function scoreElbow(
+  srcExit: WorldPoint3,
+  elbow: WorldPoint3,
+  tgtExit: WorldPoint3,
+  srcNormal: 'neg-x' | 'neg-z',
+  tgtNormal: 'neg-x' | 'neg-z',
+): number {
+  let score = manhattanXZ(srcExit, elbow) + manhattanXZ(elbow, tgtExit);
+
+  const firstDX = Math.abs(elbow[0] - srcExit[0]);
+  const firstDZ = Math.abs(elbow[2] - srcExit[2]);
+  if (srcNormal === 'neg-x' && firstDX < firstDZ) score += 2;
+  if (srcNormal === 'neg-z' && firstDZ < firstDX) score += 2;
+
+  const lastDX = Math.abs(tgtExit[0] - elbow[0]);
+  const lastDZ = Math.abs(tgtExit[2] - elbow[2]);
+  if (tgtNormal === 'neg-x' && lastDX < lastDZ) score += 2;
+  if (tgtNormal === 'neg-z' && lastDZ < lastDX) score += 2;
+
+  return score;
+}
+
+/**
+ * Route between two surface ports on the SAME plate.
+ *
+ * Produces exit → surface (L-shape via elbow) → exit segments.
+ * Evaluates two elbow candidates and picks the lower-scoring one.
+ */
+export function routeSameSurface(src: SurfacePort, tgt: SurfacePort): WorldRouteSegment[] {
+  const y = src.surfaceY;
+  const surfaceId = src.plateId;
+
+  const exitSrc: WorldRouteSegment = {
+    start: src.surfaceBase,
+    end: src.surfaceExit,
+    kind: 'exit',
+    surfaceId,
+  };
+  const exitTgt: WorldRouteSegment = {
+    start: tgt.surfaceExit,
+    end: tgt.surfaceBase,
+    kind: 'exit',
+    surfaceId,
+  };
+
+  const [sx, , sz] = src.surfaceExit;
+  const [tx, , tz] = tgt.surfaceExit;
+
+  if (Math.abs(sx - tx) < 0.01 && Math.abs(sz - tz) < 0.01) {
+    return [exitSrc, exitTgt];
+  }
+
+  if (Math.abs(sx - tx) < 0.01 || Math.abs(sz - tz) < 0.01) {
+    const seg: WorldRouteSegment = {
+      start: src.surfaceExit,
+      end: tgt.surfaceExit,
+      kind: 'surface',
+      surfaceId,
+    };
+    return [exitSrc, seg, exitTgt];
+  }
+
+  const elbowA: WorldPoint3 = [sx, y, tz];
+  const elbowB: WorldPoint3 = [tx, y, sz];
+
+  const scoreA = scoreElbow(src.surfaceExit, elbowA, tgt.surfaceExit, src.normal, tgt.normal);
+  const scoreB = scoreElbow(src.surfaceExit, elbowB, tgt.surfaceExit, src.normal, tgt.normal);
+  const elbow = scoreA <= scoreB ? elbowA : elbowB;
+
+  const seg1: WorldRouteSegment = {
+    start: src.surfaceExit,
+    end: elbow,
+    kind: 'surface',
+    surfaceId,
+  };
+  const seg2: WorldRouteSegment = {
+    start: elbow,
+    end: tgt.surfaceExit,
+    kind: 'surface',
+    surfaceId,
+  };
+
+  return [exitSrc, seg1, seg2, exitTgt];
+}
+
+function resolveEndpointContext(
+  endpointId: string,
+  side: StubSide,
+  blocks: LeafNode[],
+  plates: ContainerNode[],
+  endpoints: Endpoint[],
+): { block: LeafNode; plate: ContainerNode; stubIndex: number; totalPorts: number } | null {
+  const endpoint = endpoints.find((ep) => ep.id === endpointId);
+  if (!endpoint) return null;
+
+  const resolvedSide = endpoint.direction === 'output' ? 'outbound' : 'inbound';
+  if (resolvedSide !== side) return null;
+
+  const block = blocks.find((b) => b.id === endpoint.nodeId);
+  if (!block) return null;
+
+  const plate = plates.find((p) => p.id === block.parentId);
+  if (!plate) return null;
+
+  const ports = CATEGORY_PORTS[block.category];
+  const total = side === 'inbound' ? ports.inbound : ports.outbound;
+  const stubIndex = semanticToIndex(endpoint.semantic, total);
+  if (stubIndex === null) return null;
+
+  return { block, plate, stubIndex, totalPorts: total };
+}
+
+function semanticToIndex(semantic: EndpointSemantic, total: number): number | null {
+  if (total <= 0) return null;
+  const order: EndpointSemantic[] = ['http', 'event', 'data'];
+  const index = order.indexOf(semantic);
+  if (index < 0) return null;
+  return index % total;
+}
+
+/**
+ * Compute the full surface route for a connection.
+ *
+ * Returns null if either endpoint cannot be resolved (external actors
+ * are not yet supported in surface routing).
+ */
+export function getConnectionSurfaceRoute(
+  connection: Connection,
+  blocks: LeafNode[],
+  plates: ContainerNode[],
+  endpoints: Endpoint[],
+  _externalActors: ExternalActor[] = [],
+): SurfaceRoute | null {
+  const srcCtx = resolveEndpointContext(connection.from, 'outbound', blocks, plates, endpoints);
+  if (!srcCtx) return null;
+
+  const tgtCtx = resolveEndpointContext(connection.to, 'inbound', blocks, plates, endpoints);
+  if (!tgtCtx) return null;
+
+  const srcPort = resolveSurfacePort(
+    srcCtx.block,
+    srcCtx.plate,
+    'outbound',
+    srcCtx.stubIndex,
+    srcCtx.totalPorts,
+  );
+  const tgtPort = resolveSurfacePort(
+    tgtCtx.block,
+    tgtCtx.plate,
+    'inbound',
+    tgtCtx.stubIndex,
+    tgtCtx.totalPorts,
+  );
+
+  if (srcPort.plateId === tgtPort.plateId) {
+    const segments = routeSameSurface(srcPort, tgtPort);
+    return { segments, srcPort, tgtPort };
+  }
+
+  // Cross-plate: temporary fallback via ground surface (see #1357)
+  const groundY = 0;
+  const groundSrc: SurfacePort = {
+    ...srcPort,
+    surfaceY: groundY,
+    surfaceBase: [srcPort.surfaceBase[0], groundY, srcPort.surfaceBase[2]],
+    surfaceExit: [srcPort.surfaceExit[0], groundY, srcPort.surfaceExit[2]],
+  };
+  const groundTgt: SurfacePort = {
+    ...tgtPort,
+    surfaceY: groundY,
+    surfaceBase: [tgtPort.surfaceBase[0], groundY, tgtPort.surfaceBase[2]],
+    surfaceExit: [tgtPort.surfaceExit[0], groundY, tgtPort.surfaceExit[2]],
+  };
+  const segments = routeSameSurface(groundSrc, groundTgt);
+  const transitionSegments = segments.map((seg) => ({
+    ...seg,
+    kind: 'transition' as RouteSegmentKind,
+  }));
+  return { segments: transitionSegments, srcPort, tgtPort };
+}

--- a/apps/web/src/shared/tokens/designTokens.ts
+++ b/apps/web/src/shared/tokens/designTokens.ts
@@ -62,3 +62,7 @@ export const PORT_COLOR_EVENT = '#F59E0B'; // Amber — event/async
 export const PORT_COLOR_DATA = '#14B8A6'; // Teal — data/dataflow
 export const PORT_COLOR_OCCUPIED = '#475569'; // Slate — occupied port (dimmed)
 export const PORT_GLOW_RADIUS = 4; // SVG filter blur radius for port glow
+
+// -- Connection Brick (Surface Routing) --
+export const CONNECTION_WIDTH_CU = 1; // 1-stud wide strip
+export const CONNECTION_HEIGHT_CU = 1 / 3; // flat plate height (below subnet 0.7 CU)

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -93,21 +93,21 @@
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 2;
+  z-index: 3;
 }
 
 .actor-layer {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 1;
+  z-index: 2;
 }
 
 .character-layer {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 1;
+  z-index: 2;
 }
 
 .connection-layer {
@@ -116,7 +116,16 @@
   left: 0;
   pointer-events: auto;
   overflow: visible;
-  z-index: 3;
+  z-index: 1;
+}
+
+.interaction-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  overflow: visible;
+  z-index: 4;
 }
 
 /* ── Connector draw-in animation ────────────────────────── */

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -227,6 +227,10 @@ export function SceneCanvas() {
               originY={origin.y}
             />
           ))}
+        </svg>
+
+        <svg className="interaction-overlay" style={{ width: 1, height: 1 }}>
+          <title>Interaction overlay</title>
           <ConnectionPreview originX={origin.x} originY={origin.y} />
           <g className="drag-ghost-layer">
             <DragGhost


### PR DESCRIPTION
## Summary

Replaces 3D Technic Liftarm beam connections with dynamic Lego-style connection bricks that sit on plate surfaces, delivering the core visual change for Epic #1351 (Surface Routing System).

- **Connection bricks** are 1-stud-wide flat plates (1 CU wide, 1/3 CU tall) with studs arranged in a line along their length
- **Semantic colors** differentiate connection types: http = Indigo `#6366F1`, event = Rose `#F43F5E`, data = Lime `#84CC16`
- **Dynamic bending** — straight connections render as rectangles, L-shaped routes render as single mitered L-polygons
- **Isometric side faces** — only +x (right) and +z (left) normals are visible, using `deriveFaceColors()` darkening
- **Layer reorder** — Plates (z:0) → Connections (z:1) → Actors (z:2) → Blocks (z:3) → Overlay (z:4)
- **Fallback path** — external actor connections still use legacy liftarm rendering

## New Modules

| Module | Purpose | Tests |
|--------|---------|-------|
| `surfaceRouting.ts` | World-space Manhattan routing on plate surfaces | 15 |
| `connectionBrickGeometry.ts` | Footprint, projection, studs, side faces | 10 |
| `connectionFaceColors.ts` | Semantic color system (non-provider colors) | 30 |

## Modified Files

- `BrickConnector.tsx` — rewritten: brick render (primary) + legacy liftarm fallback
- `BrickConnector.test.tsx` — updated for new rendering structure (mock + assertions)
- `SceneCanvas.tsx` — ConnectionPreview + DragGhost split to interaction overlay
- `SceneCanvas.css` — z-index layer reorder
- `designTokens.ts` — `CONNECTION_WIDTH_CU`, `CONNECTION_HEIGHT_CU` constants

## Verification

- ✅ Build: `pnpm --filter @cloudblocks/web build` clean
- ✅ Lint: `pnpm --filter @cloudblocks/web lint` clean
- ✅ Tests: 2232/2232 passing (138 files), including 55 new connection tests

## Related

- Fixes #1354
- Part of Epic #1351 (Surface Routing System)
- Depends on #1352 (surface route model, PR #1359)