### PR TITLE
feat(web): simplify onboarding tour to 3-step canvas workflow

### DIFF
--- a/apps/web/src/widgets/onboarding-tour/OnboardingTour.test.tsx
+++ b/apps/web/src/widgets/onboarding-tour/OnboardingTour.test.tsx
@@ -120,7 +120,7 @@ describe('OnboardingTour', () => {
       await new Promise((r) => requestAnimationFrame(r));
     });
 
-    expect(screen.getByText('Welcome to CloudBlocks!')).toBeInTheDocument();
+    expect(screen.getByText('Add a Node')).toBeInTheDocument();
   });
 
   it('advances to step 2 on Next click', async () => {
@@ -137,7 +137,7 @@ describe('OnboardingTour', () => {
       await new Promise((r) => requestAnimationFrame(r));
     });
 
-    expect(screen.getByText('Resource Palette')).toBeInTheDocument();
+    expect(screen.getByText('Connect Nodes')).toBeInTheDocument();
   });
 
   it('goes back to previous step on Back click', async () => {
@@ -160,7 +160,7 @@ describe('OnboardingTour', () => {
       await new Promise((r) => requestAnimationFrame(r));
     });
 
-    expect(screen.getByText('Welcome to CloudBlocks!')).toBeInTheDocument();
+    expect(screen.getByText('Add a Node')).toBeInTheDocument();
   });
 
   it('does not show Back button on step 1', async () => {
@@ -182,7 +182,7 @@ describe('OnboardingTour', () => {
       await new Promise((r) => requestAnimationFrame(r));
     });
 
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 2; i++) {
       fireEvent.click(screen.getByText('Next'));
       await act(async () => {
         await new Promise((r) => requestAnimationFrame(r));
@@ -215,7 +215,7 @@ describe('OnboardingTour', () => {
       await new Promise((r) => requestAnimationFrame(r));
     });
 
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 2; i++) {
       fireEvent.click(screen.getByText('Next'));
       await act(async () => {
         await new Promise((r) => requestAnimationFrame(r));
@@ -242,7 +242,7 @@ describe('OnboardingTour', () => {
     expect(useUIStore.getState().showOnboarding).toBe(false);
   });
 
-  it('shows step 3 content: Canvas', async () => {
+  it('shows step 3 content: Generate Code', async () => {
     useUIStore.setState({ showOnboarding: true });
     render(<OnboardingTour />);
 
@@ -257,43 +257,7 @@ describe('OnboardingTour', () => {
       });
     }
 
-    expect(screen.getByText('Canvas')).toBeInTheDocument();
-  });
-
-  it('shows step 5 content: Menu Bar', async () => {
-    useUIStore.setState({ showOnboarding: true });
-    render(<OnboardingTour />);
-
-    await act(async () => {
-      await new Promise((r) => requestAnimationFrame(r));
-    });
-
-    for (let i = 0; i < 4; i++) {
-      fireEvent.click(screen.getByText('Next'));
-      await act(async () => {
-        await new Promise((r) => requestAnimationFrame(r));
-      });
-    }
-
-    expect(screen.getByText('Menu Bar')).toBeInTheDocument();
-  });
-
-  it('shows right drawer step content', async () => {
-    useUIStore.setState({ showOnboarding: true });
-    render(<OnboardingTour />);
-
-    await act(async () => {
-      await new Promise((r) => requestAnimationFrame(r));
-    });
-
-    for (let i = 0; i < 3; i++) {
-      fireEvent.click(screen.getByText('Next'));
-      await act(async () => {
-        await new Promise((r) => requestAnimationFrame(r));
-      });
-    }
-
-    expect(screen.getByText('Right Drawer')).toBeInTheDocument();
+    expect(screen.getByText('Generate Code')).toBeInTheDocument();
   });
 
   it('ensure visible opens sidebar for palette step', async () => {
@@ -304,10 +268,7 @@ describe('OnboardingTour', () => {
       await new Promise((r) => requestAnimationFrame(r));
     });
 
-    fireEvent.click(screen.getByText('Next'));
-    await act(async () => {
-      await new Promise((r) => requestAnimationFrame(r));
-    });
+    // Sidebar should open when Add a Node step is shown
 
     expect(useUIStore.getState().sidebar.isOpen).toBe(true);
   });
@@ -351,7 +312,7 @@ describe('OnboardingTour', () => {
 
     expect(screen.queryByTestId('persona-selection')).not.toBeInTheDocument();
     expect(screen.getByTestId('onboarding-tour')).toBeInTheDocument();
-    expect(screen.getByText('Welcome to CloudBlocks!')).toBeInTheDocument();
+    expect(screen.getByText('Add a Node')).toBeInTheDocument();
   });
 
   it('handles window resize during active tour', async () => {
@@ -370,6 +331,6 @@ describe('OnboardingTour', () => {
     });
 
     expect(screen.getByTestId('onboarding-tour')).toBeInTheDocument();
-    expect(screen.getByText('Welcome to CloudBlocks!')).toBeInTheDocument();
+    expect(screen.getByText('Add a Node')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/widgets/onboarding-tour/OnboardingTour.tsx
+++ b/apps/web/src/widgets/onboarding-tour/OnboardingTour.tsx
@@ -20,41 +20,23 @@ interface TourStep {
 
 const STEPS: TourStep[] = [
   {
-    selector: '.empty-canvas-overlay',
-    fallbackSelector: '.scene-canvas',
-    title: 'Welcome to CloudBlocks!',
-    description:
-      'Start by creating a Network node \u2014 click "Start from Scratch" or pick a template.',
-  },
-  {
     selector: '.sidebar-palette',
     fallbackSelector: '.sidebar-palette',
-    title: 'Resource Palette',
-    description:
-      'Browse and drag resources onto the canvas. Resources are grouped by category \u2014 network, compute, data, security, and more.',
+    title: 'Add a Node',
+    description: 'Browse the palette and drag a resource onto the canvas to start building.',
     ensureVisible: () => useUIStore.getState().setSidebarOpen(true),
   },
   {
     selector: '.scene-canvas',
     fallbackSelector: '.builder-canvas',
-    title: 'Canvas',
-    description:
-      'Your main workspace. Place nodes, connect ports, and build cloud architectures visually.',
-  },
-  {
-    selector: '.right-drawer',
-    fallbackSelector: '.builder-canvas',
-    title: 'Right Drawer',
-    description:
-      'Context panels slide in from the right \u2014 properties, validation, connections, and more. Open via the View menu or by selecting elements.',
-    ensureVisible: () => useUIStore.getState().openDrawer('properties'),
+    title: 'Connect Nodes',
+    description: 'Click a port on any node and drag to another node to create a connection.',
   },
   {
     selector: '.menu-bar-nav',
     fallbackSelector: '.menu-bar-nav',
-    title: 'Menu Bar',
-    description:
-      'Access File, Edit, Build, and View menus. Validate architecture, generate IaC, and manage panels.',
+    title: 'Generate Code',
+    description: 'Open Build → Generate to export Terraform, Bicep, or Pulumi code.',
   },
 ];
 


### PR DESCRIPTION
## Summary
- Simplify onboarding from 5 UI-panel steps to 3 workflow-focused steps: Add Node → Connect Nodes → Generate Code
- All existing features preserved: skip, localStorage, persona selection, Escape key, spotlight
- Tests updated (18 pass)

Fixes #1389