### PR TITLE
feat(web): show demo mode info bar when no backend is configured

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -8,6 +8,7 @@ import { SOUND_ASSETS } from '../shared/assets/sounds';
 import { metricsService } from '../shared/utils/metricsService';
 import { LandingPage } from '../widgets/landing-page/LandingPage';
 import { BuilderView } from './BuilderView';
+import { DemoBanner } from './DemoBanner';
 import './App.css';
 
 registerBuiltinTemplates();
@@ -30,6 +31,7 @@ function App() {
 
   return (
     <div className="app">
+      <DemoBanner />
       {effectiveAppView === 'landing' ? <LandingPage /> : <BuilderView />}
       <Toaster
         position="bottom-center"

--- a/apps/web/src/app/DemoBanner.test.tsx
+++ b/apps/web/src/app/DemoBanner.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { DemoBanner } from './DemoBanner';
+
+const DEMO_BANNER_DISMISSED_KEY = 'cloudblocks:demo-banner-dismissed';
+
+describe('DemoBanner', () => {
+  beforeEach(() => {
+    // Clear localStorage before each test
+    localStorage.clear();
+    // Reset env var to simulated unset state
+    delete (import.meta.env as Record<string, unknown>).VITE_API_URL;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('shows banner when VITE_API_URL is empty and not dismissed', () => {
+    // Simulate unset VITE_API_URL by setting it to empty string
+    (import.meta.env as Record<string, unknown>).VITE_API_URL = '';
+
+    render(<DemoBanner />);
+
+    expect(screen.getByText(/Demo Mode/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+  });
+
+  it('does not show banner when VITE_API_URL is set', () => {
+    // Simulate configured API URL
+    (import.meta.env as Record<string, unknown>).VITE_API_URL = 'https://api.example.com';
+
+    render(<DemoBanner />);
+
+    expect(screen.queryByText(/Demo Mode/)).not.toBeInTheDocument();
+  });
+
+  it('does not show banner when already dismissed', () => {
+    localStorage.setItem(DEMO_BANNER_DISMISSED_KEY, 'true');
+    (import.meta.env as Record<string, unknown>).VITE_API_URL = '';
+
+    render(<DemoBanner />);
+
+    expect(screen.queryByText(/Demo Mode/)).not.toBeInTheDocument();
+  });
+
+  it('hides banner and persists dismiss state when dismiss button clicked', async () => {
+    (import.meta.env as Record<string, unknown>).VITE_API_URL = '';
+
+    const { rerender } = render(<DemoBanner />);
+
+    expect(screen.getByText(/Demo Mode/)).toBeInTheDocument();
+
+    // Click dismiss button
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    fireEvent.click(dismissButton);
+
+    // Banner should be hidden immediately
+    await waitFor(() => {
+      expect(screen.queryByText(/Demo Mode/)).not.toBeInTheDocument();
+    });
+
+    // Verify localStorage was updated
+    expect(localStorage.getItem(DEMO_BANNER_DISMISSED_KEY)).toBe('true');
+
+    // Re-render to simulate page reload — banner should still be hidden
+    rerender(<DemoBanner />);
+    expect(screen.queryByText(/Demo Mode/)).not.toBeInTheDocument();
+  });
+
+  it('displays correct demo mode message text', () => {
+    (import.meta.env as Record<string, unknown>).VITE_API_URL = '';
+
+    render(<DemoBanner />);
+
+    const messageElement = screen.getByText(
+      /Visual builder, code generation, and templates work instantly/,
+    );
+    expect(messageElement).toBeInTheDocument();
+    expect(messageElement.textContent).toContain('AI and GitHub features require a backend');
+  });
+
+  it('renders dismiss button with accessible text', () => {
+    (import.meta.env as Record<string, unknown>).VITE_API_URL = '';
+
+    render(<DemoBanner />);
+
+    const dismissButton = screen.getByRole('button', { name: 'Dismiss' });
+    expect(dismissButton).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/DemoBanner.tsx
+++ b/apps/web/src/app/DemoBanner.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+
+const DEMO_BANNER_DISMISSED_KEY = 'cloudblocks:demo-banner-dismissed';
+
+function getDemoBannerVisibility(): boolean {
+  // This should only run client-side
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  const apiUrl = import.meta.env.VITE_API_URL;
+  const isDismissed = localStorage.getItem(DEMO_BANNER_DISMISSED_KEY) === 'true';
+
+  return !apiUrl && !isDismissed;
+}
+
+export function DemoBanner() {
+  const [isVisible, setIsVisible] = useState(() => getDemoBannerVisibility());
+
+  const handleDismiss = () => {
+    localStorage.setItem(DEMO_BANNER_DISMISSED_KEY, 'true');
+    setIsVisible(false);
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 10000,
+        backgroundColor: '#0f0f1e',
+        borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+        padding: '12px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '12px',
+        color: '#e0e0e0',
+        fontSize: '14px',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+      }}
+    >
+      <span>
+        ℹ️ Demo Mode — Visual builder, code generation, and templates work instantly. AI and GitHub
+        features require a backend.
+      </span>
+      <button
+        onClick={handleDismiss}
+        style={{
+          backgroundColor: 'transparent',
+          border: '1px solid rgba(255, 255, 255, 0.3)',
+          color: '#e0e0e0',
+          padding: '4px 10px',
+          borderRadius: '4px',
+          cursor: 'pointer',
+          fontSize: '12px',
+          fontWeight: 500,
+          transition: 'all 0.2s ease',
+        }}
+        onMouseEnter={(e) => {
+          const btn = e.currentTarget;
+          btn.style.backgroundColor = 'rgba(255, 255, 255, 0.1)';
+          btn.style.borderColor = 'rgba(255, 255, 255, 0.6)';
+        }}
+        onMouseLeave={(e) => {
+          const btn = e.currentTarget;
+          btn.style.backgroundColor = 'transparent';
+          btn.style.borderColor = 'rgba(255, 255, 255, 0.3)';
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a dismissable demo mode info bar at the top of the app when `VITE_API_URL` is empty/unset (GitHub Pages deployment)
- Banner text: "ℹ️ Demo Mode — Visual builder, code generation, and templates work instantly. AI and GitHub features require a backend. [Dismiss]"
- Dismiss persists in localStorage (`cloudblocks:demo-banner-dismissed`)

## Changes
- **New**: `apps/web/src/app/DemoBanner.tsx` — Demo banner component with dark theme styling
- **New**: `apps/web/src/app/DemoBanner.test.tsx` — 6 tests covering visibility, dismiss, persistence
- **Modified**: `apps/web/src/app/App.tsx` — Import and render DemoBanner

Fixes #411