### PR TITLE
fix(web): add Browser external actor to all templates and import fallback

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -1794,8 +1794,11 @@ describe('architectureStore', () => {
       expect(getArch().name).toBe('Imported Architecture');
       expect(getArch().version).toBe('1');
       expect(getArch().connections ?? []).toEqual([]);
-      expect(getArch().externalActors).toHaveLength(1);
-      expect((getArch().externalActors ?? [])[0]!.type).toBe('internet');
+      expect(getArch().externalActors).toHaveLength(2);
+      expect((getArch().externalActors ?? []).map((actor) => actor.type)).toEqual([
+        'browser',
+        'internet',
+      ]);
     });
 
     it('returns error string on invalid JSON without crashing', () => {

--- a/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
+++ b/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
@@ -642,6 +642,7 @@ describe('persistenceSlice branches', () => {
       });
       expect(queue).toMatchObject({ resourceType: 'messaging', provider: 'azure' });
       expect(architecture.externalActors).toEqual([
+        { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
         { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
       ]);
     });

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -237,6 +237,7 @@ export const validateArchitectureShape = (imported: unknown): { valid: true } =>
 
   const externalActorIds = new Set<string>();
   if (imported.externalActors === undefined) {
+    externalActorIds.add('ext-browser');
     externalActorIds.add('ext-internet');
   } else {
     if (!Array.isArray(imported.externalActors)) {
@@ -557,10 +558,16 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
           }),
         ) ?? [
           {
+            id: 'ext-browser',
+            name: 'Browser',
+            type: 'browser',
+            position: { x: -6, y: 0, z: 5 },
+          },
+          {
             id: 'ext-internet',
             name: 'Internet',
             type: 'internet',
-            position: { ...DEFAULT_EXTERNAL_ACTOR_POSITION },
+            position: { x: -3, y: 0, z: 5 },
           },
         ],
         createdAt: (imported.createdAt as string) || now,

--- a/apps/web/src/features/templates/builtin.test.ts
+++ b/apps/web/src/features/templates/builtin.test.ts
@@ -55,7 +55,7 @@ describe('registerBuiltinTemplates', () => {
     expect(template).toBeDefined();
     expect(containerNodes).toHaveLength(3);
     expect(resourceNodes).toHaveLength(4);
-    expect(template?.architecture.connections).toHaveLength(4);
+    expect(template?.architecture.connections).toHaveLength(5);
   });
 
   it('simple compute template has expected container/block/connection counts', async () => {
@@ -71,7 +71,7 @@ describe('registerBuiltinTemplates', () => {
     expect(template).toBeDefined();
     expect(containerNodes).toHaveLength(2);
     expect(resourceNodes).toHaveLength(2);
-    expect(template?.architecture.connections).toHaveLength(2);
+    expect(template?.architecture.connections).toHaveLength(3);
   });
 
   it('data storage template has expected container/block/connection counts', async () => {
@@ -87,7 +87,7 @@ describe('registerBuiltinTemplates', () => {
     expect(template).toBeDefined();
     expect(containerNodes).toHaveLength(3);
     expect(resourceNodes).toHaveLength(4);
-    expect(template?.architecture.connections).toHaveLength(4);
+    expect(template?.architecture.connections).toHaveLength(5);
   });
 
   it('serverless templates have generator compatibility and expected counts', async () => {
@@ -107,7 +107,7 @@ describe('registerBuiltinTemplates', () => {
     expect(
       httpApiTemplate?.architecture.nodes.filter((node) => node.kind === 'resource'),
     ).toHaveLength(4);
-    expect(httpApiTemplate?.architecture.connections).toHaveLength(4);
+    expect(httpApiTemplate?.architecture.connections).toHaveLength(5);
 
     expect(eventPipelineTemplate).toBeDefined();
     expect(eventPipelineTemplate?.generatorCompat).toEqual(['terraform', 'bicep', 'pulumi']);
@@ -117,7 +117,7 @@ describe('registerBuiltinTemplates', () => {
     expect(
       eventPipelineTemplate?.architecture.nodes.filter((node) => node.kind === 'resource'),
     ).toHaveLength(6);
-    expect(eventPipelineTemplate?.architecture.connections).toHaveLength(6);
+    expect(eventPipelineTemplate?.architecture.connections).toHaveLength(7);
   });
 
   it('full-stack serverless template uses all block categories with expected counts', async () => {
@@ -136,8 +136,8 @@ describe('registerBuiltinTemplates', () => {
     expect(template?.architecture.nodes.filter((node) => node.kind === 'resource')).toHaveLength(
       10,
     );
-    expect(template?.architecture.connections).toHaveLength(11);
-    expect(template?.architecture.externalActors).toHaveLength(1);
+    expect(template?.architecture.connections).toHaveLength(12);
+    expect(template?.architecture.externalActors).toHaveLength(2);
 
     const categories = template?.architecture.nodes
       .filter((node) => node.kind === 'resource')

--- a/apps/web/src/features/templates/builtin.ts
+++ b/apps/web/src/features/templates/builtin.ts
@@ -128,6 +128,12 @@ const threeTierTemplate: ArchitectureTemplate = {
     ],
     connections: [
       {
+        id: 'conn-browser-internet',
+        from: endpointId('ext-browser', 'output', 'http'),
+        to: endpointId('ext-internet', 'input', 'http'),
+        metadata: {},
+      },
+      {
         id: 'conn-tmpl-inet-gw',
         from: endpointId('ext-internet', 'output', 'data'),
         to: endpointId('block-tmpl-gw', 'input', 'data'),
@@ -153,6 +159,7 @@ const threeTierTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
     ],
   },
@@ -227,6 +234,12 @@ const simpleComputeTemplate: ArchitectureTemplate = {
     ],
     connections: [
       {
+        id: 'conn-browser-internet',
+        from: endpointId('ext-browser', 'output', 'http'),
+        to: endpointId('ext-internet', 'input', 'http'),
+        metadata: {},
+      },
+      {
         id: 'conn-tmpl-inet-gw2',
         from: endpointId('ext-internet', 'output', 'data'),
         to: endpointId('block-tmpl-gw2', 'input', 'data'),
@@ -240,6 +253,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
     ],
   },
@@ -353,6 +367,12 @@ const dataStorageTemplate: ArchitectureTemplate = {
     ],
     connections: [
       {
+        id: 'conn-browser-internet',
+        from: endpointId('ext-browser', 'output', 'http'),
+        to: endpointId('ext-internet', 'input', 'http'),
+        metadata: {},
+      },
+      {
         id: 'conn-tmpl-inet-gw3',
         from: endpointId('ext-internet', 'output', 'data'),
         to: endpointId('block-tmpl-gw3', 'input', 'data'),
@@ -378,6 +398,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
     ],
   },
@@ -495,6 +516,12 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
     ],
     connections: [
       {
+        id: 'conn-browser-internet',
+        from: endpointId('ext-browser', 'output', 'http'),
+        to: endpointId('ext-internet', 'input', 'http'),
+        metadata: {},
+      },
+      {
         id: 'conn-tmpl-inet-gw4',
         from: endpointId('ext-internet', 'output', 'data'),
         to: endpointId('block-tmpl-gw4', 'input', 'data'),
@@ -520,6 +547,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
     ],
   },
@@ -647,6 +675,12 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
     ],
     connections: [
       {
+        id: 'conn-browser-internet',
+        from: endpointId('ext-browser', 'output', 'http'),
+        to: endpointId('ext-internet', 'input', 'http'),
+        metadata: {},
+      },
+      {
         id: 'conn-tmpl-event-func5a',
         from: endpointId('block-tmpl-event5', 'output', 'data'),
         to: endpointId('block-tmpl-func5a', 'input', 'data'),
@@ -683,7 +717,10 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
         metadata: {},
       },
     ],
-    externalActors: [],
+    externalActors: [
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+    ],
   },
 };
 
@@ -891,6 +928,12 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
       },
     ],
     connections: [
+      {
+        id: 'conn-browser-internet',
+        from: endpointId('ext-browser', 'output', 'http'),
+        to: endpointId('ext-internet', 'input', 'http'),
+        metadata: {},
+      },
       // Internet → Gateway
       {
         id: 'conn-fs-inet-gw',
@@ -970,6 +1013,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
     ],
   },


### PR DESCRIPTION
## Summary
- Add `ext-browser` to all six built-in templates, and add a `Browser -> Internet` HTTP connection in each template architecture.
- Update Event-Driven Pipeline template to include both Browser and Internet external actors (plus Browser -> Internet connection) instead of an empty actor list.
- Update import validation/default fallback in persistence slice so architectures without `externalActors` include both Browser (`x:-6`) and Internet (`x:-3`).

## Verification
- `pnpm test`
- `pnpm build`

Fixes #1399