### PR TITLE
fix(web): use floor routing for fallback connections

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -23,7 +23,7 @@ import {
   PORT_OUT_PX,
 } from '../../shared/tokens/designTokens';
 import { DIFF_THEMES, lightenColor } from './connectorTheme';
-import { computeWorldRoute, screenSegmentLengthCU } from './routing';
+import { computeFloorRoute, computeWorldRoute, screenSegmentLengthCU } from './routing';
 import type { PinHoleStyle } from './connectorTheme';
 import type { ScreenSegment } from './routing';
 import { getConnectionSurfaceRoute } from './surfaceRouting';
@@ -481,7 +481,17 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
 
   const fallbackRoute = useMemo(() => {
     if (!fallbackEndpoints) return null;
-    const r = computeWorldRoute(fallbackEndpoints.src, fallbackEndpoints.tgt, originX, originY);
+    const usesFloor = fallbackEndpoints.srcFloorY != null && fallbackEndpoints.tgtFloorY != null;
+    const r = usesFloor
+      ? computeFloorRoute(
+          fallbackEndpoints.src,
+          fallbackEndpoints.tgt,
+          fallbackEndpoints.srcFloorY!,
+          fallbackEndpoints.tgtFloorY!,
+          originX,
+          originY,
+        )
+      : computeWorldRoute(fallbackEndpoints.src, fallbackEndpoints.tgt, originX, originY);
     if (fallbackEndpoints.srcSide === 'outbound') {
       r.srcScreen = { x: r.srcScreen.x + PORT_OUT_PX, y: r.srcScreen.y };
     } else if (fallbackEndpoints.srcSide === 'inbound') {


### PR DESCRIPTION
## Summary

- Fixes connection lines routing through block tops instead of floors when `surfaceRoute` is null
- When `srcFloorY`/`tgtFloorY` are available in `fallbackEndpoints`, uses `computeFloorRoute` instead of `computeWorldRoute`
- Ensures connection lines visually connect at the correct floor level of container blocks

## Details

When a connection's surface route computation returns null, the fallback path previously used `computeWorldRoute` unconditionally. This caused connection lines to route through block top faces rather than along the floor surface.

The fix checks for floor Y coordinates in the endpoint anchors and delegates to `computeFloorRoute` when they exist, matching the expected visual behavior.

## Testing

- Build passes (`pnpm build`)
- All 2076 tests pass (`pnpm test`)
- 0 TypeScript errors
- 0 lint errors

Fixes #1398