### PR TITLE
fix(web): align RightDrawer to top of viewport

### DIFF
--- a/apps/web/src/widgets/right-drawer/RightDrawer.css
+++ b/apps/web/src/widgets/right-drawer/RightDrawer.css
@@ -1,13 +1,13 @@
 .right-drawer-backdrop {
   position: absolute;
-  inset: 40px 0 0 0;
+  inset: 0 0 0 0;
   background: transparent;
   z-index: 50;
 }
 
 .right-drawer {
   position: absolute;
-  top: 40px;
+  top: 0;
   right: 0;
   bottom: 0;
   width: var(--drawer-width, 360px);


### PR DESCRIPTION
## Summary

- Fixes the property panel (RightDrawer) starting 40px below the top of the viewport
- Changes `top: 40px` → `top: 0` for both `.right-drawer` and `.right-drawer-backdrop`
- Property panel now starts directly below the menu bar as expected

## Changes

- `RightDrawer.css`: Updated `inset` shorthand for backdrop from `40px 0 0 0` → `0 0 0 0`
- `RightDrawer.css`: Updated `top` for drawer from `40px` → `0`