### PR TITLE
feat(connection): cross-container routing with LCA-based transition segments

### DIFF
--- a/apps/web/src/entities/connection/__tests__/surfaceRouting.test.ts
+++ b/apps/web/src/entities/connection/__tests__/surfaceRouting.test.ts
@@ -8,8 +8,10 @@ import type {
 } from '@cloudblocks/schema';
 import { CATEGORY_PORTS, endpointId, generateEndpointsForBlock } from '@cloudblocks/schema';
 import {
+  findLCA,
   getConnectionSurfaceRoute,
   resolveSurfacePort,
+  routeCrossContainer,
   routeSameSurface,
   SURFACE_EXIT_OFFSET_CU,
 } from '../surfaceRouting';
@@ -276,7 +278,7 @@ describe('getConnectionSurfaceRoute', () => {
     expect(route!.segments.every((segment) => segment.surfaceId === 'container-a')).toBe(true);
   });
 
-  it('falls back to cross-container transition segments on ground surface', () => {
+  it('routes cross-container with exit, transition, and surface segments via ground', () => {
     const plateA = makePlate({ id: 'container-a', position: { x: 0, y: 1, z: 0 } });
     const plateB = makePlate({ id: 'container-b', position: { x: 20, y: 4, z: 20 } });
     const blockA = makeBlock({
@@ -308,11 +310,25 @@ describe('getConnectionSurfaceRoute', () => {
     expect(route).not.toBeNull();
     expect(route!.srcPort.containerId).toBe('container-a');
     expect(route!.tgtPort.containerId).toBe('container-b');
-    expect(route!.segments.length).toBeGreaterThanOrEqual(2);
-    expect(route!.segments.every((segment) => segment.kind === 'transition')).toBe(true);
-    expect(route!.segments.every((segment) => segment.start[1] === 0 && segment.end[1] === 0)).toBe(
-      true,
-    );
+    expect(route!.segments.length).toBeGreaterThanOrEqual(4);
+
+    // First segment: exit from source block on source container surface
+    expect(route!.segments[0].kind).toBe('exit');
+    expect(route!.segments[0].surfaceId).toBe('container-a');
+
+    // Last segment: exit into target block on target container surface
+    const lastSeg = route!.segments[route!.segments.length - 1];
+    expect(lastSeg.kind).toBe('exit');
+    expect(lastSeg.surfaceId).toBe('container-b');
+
+    // Should contain transition segments (vertical drops to/from ground)
+    expect(route!.segments.some((s) => s.kind === 'transition')).toBe(true);
+
+    // Transition segments should go to/from ground (y=0) since both are top-level
+    const transitions = route!.segments.filter((s) => s.kind === 'transition');
+    for (const t of transitions) {
+      expect(t.start[1] === 0 || t.end[1] === 0).toBe(true);
+    }
   });
 
   it('returns null when source endpoint is missing', () => {
@@ -394,5 +410,213 @@ describe('getConnectionSurfaceRoute', () => {
     );
 
     expect(route).toBeNull();
+  });
+});
+
+describe('findLCA', () => {
+  function buildContainerMap(containers: ContainerBlock[]): Map<string, ContainerBlock> {
+    return new Map(containers.map((c) => [c.id, c]));
+  }
+
+  it('returns null for top-level siblings (no shared ancestor)', () => {
+    const a = makePlate({ id: 'a', parentId: null });
+    const b = makePlate({ id: 'b', parentId: null });
+    const map = buildContainerMap([a, b]);
+    expect(findLCA('a', 'b', map)).toBeNull();
+  });
+
+  it('returns the parent when two containers share the same parent', () => {
+    const parent = makePlate({ id: 'parent', parentId: null });
+    const a = makePlate({ id: 'a', parentId: 'parent' });
+    const b = makePlate({ id: 'b', parentId: 'parent' });
+    const map = buildContainerMap([parent, a, b]);
+    expect(findLCA('a', 'b', map)).toBe('parent');
+  });
+
+  it('returns the ancestor container when one is nested inside the other', () => {
+    const outer = makePlate({ id: 'outer', parentId: null });
+    const inner = makePlate({ id: 'inner', parentId: 'outer' });
+    const map = buildContainerMap([outer, inner]);
+    expect(findLCA('outer', 'inner', map)).toBe('outer');
+    expect(findLCA('inner', 'outer', map)).toBe('outer');
+  });
+
+  it('returns the same container when src and tgt are the same', () => {
+    const a = makePlate({ id: 'a', parentId: null });
+    const map = buildContainerMap([a]);
+    expect(findLCA('a', 'a', map)).toBe('a');
+  });
+
+  it('finds LCA for deeply nested containers', () => {
+    const root = makePlate({ id: 'root', parentId: null });
+    const l1 = makePlate({ id: 'l1', parentId: 'root' });
+    const l2a = makePlate({ id: 'l2a', parentId: 'l1' });
+    const l2b = makePlate({ id: 'l2b', parentId: 'l1' });
+    const map = buildContainerMap([root, l1, l2a, l2b]);
+    expect(findLCA('l2a', 'l2b', map)).toBe('l1');
+  });
+});
+
+describe('routeCrossContainer', () => {
+  function buildContainerMap(containers: ContainerBlock[]): Map<string, ContainerBlock> {
+    return new Map(containers.map((c) => [c.id, c]));
+  }
+
+  it('produces exit + transition + surface + transition + exit for top-level siblings', () => {
+    const plateA = makePlate({
+      id: 'a',
+      parentId: null,
+      position: { x: 0, y: 2, z: 0 },
+      frame: { width: 10, depth: 10, height: 1 },
+    });
+    const plateB = makePlate({
+      id: 'b',
+      parentId: null,
+      position: { x: 20, y: 5, z: 20 },
+      frame: { width: 10, depth: 10, height: 1 },
+    });
+    const map = buildContainerMap([plateA, plateB]);
+
+    const srcPort = makeSurfacePort({
+      surfaceBase: [2, 3, 2],
+      surfaceExit: [2, 3, 1.25],
+      containerId: 'a',
+      surfaceY: 3,
+      normal: 'neg-z',
+    });
+    const tgtPort = makeSurfacePort({
+      surfaceBase: [23, 6, 23],
+      surfaceExit: [22.25, 6, 23],
+      containerId: 'b',
+      surfaceY: 6,
+      normal: 'neg-x',
+    });
+
+    const segments = routeCrossContainer(srcPort, tgtPort, map);
+
+    // First: exit on source surface
+    expect(segments[0].kind).toBe('exit');
+    expect(segments[0].surfaceId).toBe('a');
+
+    // Last: exit on target surface
+    const last = segments[segments.length - 1];
+    expect(last.kind).toBe('exit');
+    expect(last.surfaceId).toBe('b');
+
+    // Should have transition segments (vertical drops)
+    const transitions = segments.filter((s) => s.kind === 'transition');
+    expect(transitions.length).toBeGreaterThanOrEqual(2);
+
+    // Transition to ground: at least one endpoint should be y=0
+    for (const t of transitions) {
+      expect(t.start[1] === 0 || t.end[1] === 0).toBe(true);
+    }
+
+    // Should have surface segments on ground (horizontal routing)
+    const surfaces = segments.filter((s) => s.kind === 'surface');
+    expect(surfaces.length).toBeGreaterThanOrEqual(1);
+    for (const s of surfaces) {
+      expect(s.start[1]).toBe(0);
+      expect(s.end[1]).toBe(0);
+    }
+  });
+
+  it('produces segments through LCA surface for nested siblings', () => {
+    const parent = makePlate({
+      id: 'parent',
+      parentId: null,
+      position: { x: 0, y: 0, z: 0 },
+      frame: { width: 40, depth: 40, height: 2 },
+    });
+    const childA = makePlate({
+      id: 'child-a',
+      parentId: 'parent',
+      position: { x: 1, y: 0, z: 1 },
+      frame: { width: 10, depth: 10, height: 1 },
+    });
+    const childB = makePlate({
+      id: 'child-b',
+      parentId: 'parent',
+      position: { x: 20, y: 0, z: 20 },
+      frame: { width: 10, depth: 10, height: 1 },
+    });
+    const map = buildContainerMap([parent, childA, childB]);
+
+    // child-a surfaceY: parent(y=0+h=2) + child(y=0+h=1) → world depends on how nesting works
+    // For now, surfaceY passed via the port directly
+    const srcPort = makeSurfacePort({
+      surfaceBase: [3, 3, 3],
+      surfaceExit: [3, 3, 2.25],
+      containerId: 'child-a',
+      surfaceY: 3,
+      normal: 'neg-z',
+    });
+    const tgtPort = makeSurfacePort({
+      surfaceBase: [22, 3, 22],
+      surfaceExit: [21.25, 3, 22],
+      containerId: 'child-b',
+      surfaceY: 3,
+      normal: 'neg-x',
+    });
+
+    const segments = routeCrossContainer(srcPort, tgtPort, map);
+
+    // Should route through parent surface (y=0+2=2), not ground (y=0)
+    const transitions = segments.filter((s) => s.kind === 'transition');
+    // At least one transition should involve the parent surface Y=2
+    const reachesParentSurface = transitions.some((t) => t.start[1] === 2 || t.end[1] === 2);
+    expect(reachesParentSurface).toBe(true);
+
+    // Surface segments on parent should be at Y=2
+    const surfaces = segments.filter((s) => s.kind === 'surface');
+    if (surfaces.length > 0) {
+      for (const s of surfaces) {
+        expect(s.start[1]).toBe(2);
+        expect(s.end[1]).toBe(2);
+      }
+    }
+  });
+
+  it('skips transition segments when source and target are at the same Y as shared surface', () => {
+    const plateA = makePlate({
+      id: 'a',
+      parentId: null,
+      position: { x: 0, y: 0, z: 0 },
+      frame: { width: 10, depth: 10, height: 0 },
+    });
+    const plateB = makePlate({
+      id: 'b',
+      parentId: null,
+      position: { x: 20, y: 0, z: 20 },
+      frame: { width: 10, depth: 10, height: 0 },
+    });
+    const map = buildContainerMap([plateA, plateB]);
+
+    // Both surfaces at Y=0, ground also Y=0 → no vertical transitions needed
+    const srcPort = makeSurfacePort({
+      surfaceBase: [2, 0, 2],
+      surfaceExit: [2, 0, 1.25],
+      containerId: 'a',
+      surfaceY: 0,
+      normal: 'neg-z',
+    });
+    const tgtPort = makeSurfacePort({
+      surfaceBase: [22, 0, 22],
+      surfaceExit: [21.25, 0, 22],
+      containerId: 'b',
+      surfaceY: 0,
+      normal: 'neg-x',
+    });
+
+    const segments = routeCrossContainer(srcPort, tgtPort, map);
+
+    // No transition segments since everything is at Y=0
+    const transitions = segments.filter((s) => s.kind === 'transition');
+    expect(transitions).toHaveLength(0);
+
+    // Should still have exit + surface + exit
+    expect(segments[0].kind).toBe('exit');
+    expect(segments[segments.length - 1].kind).toBe('exit');
+    expect(segments.some((s) => s.kind === 'surface')).toBe(true);
   });
 });

--- a/apps/web/src/entities/connection/surfaceRouting.ts
+++ b/apps/web/src/entities/connection/surfaceRouting.ts
@@ -172,6 +172,179 @@ export function routeSameSurface(src: SurfacePort, tgt: SurfacePort): WorldRoute
   return [exitSrc, seg1, seg2, exitTgt];
 }
 
+/**
+ * Walk up the container parentId chain and return the ancestor IDs
+ * from the given container to the root (inclusive).
+ */
+function getAncestorChain(
+  containerId: string,
+  containerMap: Map<string, ContainerBlock>,
+): string[] {
+  const chain: string[] = [containerId];
+  let current = containerMap.get(containerId);
+  while (current?.parentId) {
+    chain.push(current.parentId);
+    current = containerMap.get(current.parentId);
+  }
+  return chain;
+}
+
+/**
+ * Find the Lowest Common Ancestor (LCA) of two containers.
+ * Returns the container ID of the LCA, or null if they share no ancestor
+ * (both are top-level siblings — route via ground plane).
+ */
+export function findLCA(
+  srcContainerId: string,
+  tgtContainerId: string,
+  containerMap: Map<string, ContainerBlock>,
+): string | null {
+  const srcChain = getAncestorChain(srcContainerId, containerMap);
+  const tgtSet = new Set(getAncestorChain(tgtContainerId, containerMap));
+  for (const ancestorId of srcChain) {
+    if (tgtSet.has(ancestorId)) return ancestorId;
+  }
+  return null;
+}
+
+/**
+ * Get the surface Y (top face) of a container in world space.
+ * For nested containers, walks up the parentId chain to accumulate Y offsets.
+ */
+function getContainerWorldSurfaceY(
+  container: ContainerBlock,
+  containerMap: Map<string, ContainerBlock>,
+): number {
+  let y = container.position.y + container.frame.height;
+  let current = container;
+  while (current.parentId) {
+    const parent = containerMap.get(current.parentId);
+    if (!parent) break;
+    y += parent.position.y + parent.frame.height;
+    current = parent;
+  }
+  return y;
+}
+
+/**
+ * Route between two surface ports on DIFFERENT containers.
+ *
+ * Strategy:
+ * 1. Find the LCA (or use ground plane if both are top-level)
+ * 2. Produce exit segments on source container surface
+ * 3. Add vertical transition from source surface down to shared surface
+ * 4. Route horizontally on the shared surface (Manhattan L-shape)
+ * 5. Add vertical transition from shared surface up to target surface
+ * 6. Produce exit segments on target container surface
+ */
+export function routeCrossContainer(
+  srcPort: SurfacePort,
+  tgtPort: SurfacePort,
+  containerMap: Map<string, ContainerBlock>,
+): WorldRouteSegment[] {
+  const lca = findLCA(srcPort.containerId, tgtPort.containerId, containerMap);
+
+  // Determine the shared surface Y: LCA top face, or ground (y=0) for top-level siblings
+  let sharedY: number;
+  let sharedSurfaceId: string;
+  if (lca) {
+    const lcaContainer = containerMap.get(lca);
+    if (lcaContainer) {
+      sharedY = getContainerWorldSurfaceY(lcaContainer, containerMap);
+      sharedSurfaceId = lca;
+    } else {
+      sharedY = 0;
+      sharedSurfaceId = 'ground';
+    }
+  } else {
+    sharedY = 0;
+    sharedSurfaceId = 'ground';
+  }
+
+  const segments: WorldRouteSegment[] = [];
+
+  // 1. Exit from source block to source container surface edge
+  segments.push({
+    start: srcPort.surfaceBase,
+    end: srcPort.surfaceExit,
+    kind: 'exit',
+    surfaceId: srcPort.containerId,
+  });
+
+  // 2. Vertical transition from source surface down to shared surface
+  const srcDropStart = srcPort.surfaceExit;
+  const srcDropEnd: WorldPoint3 = [srcDropStart[0], sharedY, srcDropStart[2]];
+  if (Math.abs(srcDropStart[1] - sharedY) > 0.01) {
+    segments.push({
+      start: srcDropStart,
+      end: srcDropEnd,
+      kind: 'transition',
+      surfaceId: sharedSurfaceId,
+    });
+  }
+
+  // 3. Manhattan route on the shared surface (X/Z plane at sharedY)
+  const sharedSrc: WorldPoint3 = srcDropEnd;
+  const tgtRiseStart: WorldPoint3 = [tgtPort.surfaceExit[0], sharedY, tgtPort.surfaceExit[2]];
+
+  // Route on shared surface: same logic as routeSameSurface but on shared plane
+  const [sx, , sz] = sharedSrc;
+  const [tx, , tz] = tgtRiseStart;
+
+  if (Math.abs(sx - tx) < 0.01 && Math.abs(sz - tz) < 0.01) {
+    // Directly aligned — no horizontal segment needed
+  } else if (Math.abs(sx - tx) < 0.01 || Math.abs(sz - tz) < 0.01) {
+    // Straight line on shared surface
+    segments.push({
+      start: sharedSrc,
+      end: tgtRiseStart,
+      kind: 'surface',
+      surfaceId: sharedSurfaceId,
+    });
+  } else {
+    // L-shape with elbow scoring
+    const elbowA: WorldPoint3 = [sx, sharedY, tz];
+    const elbowB: WorldPoint3 = [tx, sharedY, sz];
+    const scoreA = scoreElbow(sharedSrc, elbowA, tgtRiseStart, srcPort.normal, tgtPort.normal);
+    const scoreB = scoreElbow(sharedSrc, elbowB, tgtRiseStart, srcPort.normal, tgtPort.normal);
+    const elbow = scoreA <= scoreB ? elbowA : elbowB;
+
+    segments.push({
+      start: sharedSrc,
+      end: elbow,
+      kind: 'surface',
+      surfaceId: sharedSurfaceId,
+    });
+    segments.push({
+      start: elbow,
+      end: tgtRiseStart,
+      kind: 'surface',
+      surfaceId: sharedSurfaceId,
+    });
+  }
+
+  // 4. Vertical transition from shared surface up to target surface
+  const tgtRiseEnd = tgtPort.surfaceExit;
+  if (Math.abs(sharedY - tgtRiseEnd[1]) > 0.01) {
+    segments.push({
+      start: tgtRiseStart,
+      end: tgtRiseEnd,
+      kind: 'transition',
+      surfaceId: tgtPort.containerId,
+    });
+  }
+
+  // 5. Exit into target block
+  segments.push({
+    start: tgtPort.surfaceExit,
+    end: tgtPort.surfaceBase,
+    kind: 'exit',
+    surfaceId: tgtPort.containerId,
+  });
+
+  return segments;
+}
+
 function resolveEndpointContext(
   endpointId: string,
   side: PortSide,
@@ -251,24 +424,8 @@ export function getConnectionSurfaceRoute(
     return { segments, srcPort, tgtPort };
   }
 
-  // Cross-container: temporary fallback via ground surface (see #1357)
-  const groundY = 0;
-  const groundSrc: SurfacePort = {
-    ...srcPort,
-    surfaceY: groundY,
-    surfaceBase: [srcPort.surfaceBase[0], groundY, srcPort.surfaceBase[2]],
-    surfaceExit: [srcPort.surfaceExit[0], groundY, srcPort.surfaceExit[2]],
-  };
-  const groundTgt: SurfacePort = {
-    ...tgtPort,
-    surfaceY: groundY,
-    surfaceBase: [tgtPort.surfaceBase[0], groundY, tgtPort.surfaceBase[2]],
-    surfaceExit: [tgtPort.surfaceExit[0], groundY, tgtPort.surfaceExit[2]],
-  };
-  const segments = routeSameSurface(groundSrc, groundTgt);
-  const transitionSegments = segments.map((seg) => ({
-    ...seg,
-    kind: 'transition' as RouteSegmentKind,
-  }));
-  return { segments: transitionSegments, srcPort: groundSrc, tgtPort: groundTgt };
+  // Cross-container: route through nearest shared ancestor surface (or ground)
+  const containerMap = new Map(plates.map((p) => [p.id, p]));
+  const segments = routeCrossContainer(srcPort, tgtPort, containerMap);
+  return { segments, srcPort, tgtPort };
 }


### PR DESCRIPTION
## Summary

- Replace `groundY = 0` hack in `surfaceRouting.ts` with proper LCA-based cross-container routing
- Add `findLCA()` to find the Lowest Common Ancestor of two containers via `parentId` chain traversal
- Add `routeCrossContainer()` that produces structured route segments: exit → transition → surface → transition → exit
- Vertical transitions are between container surfaces and the shared ancestor surface (or ground for top-level)
- Transitions are omitted when surfaces are already co-planar (no vertical drop needed)

## Route Architecture

```
Source Block → exit (on src container surface)
            → transition (vertical drop to shared ancestor surface)
            → surface (Manhattan L-shape on shared plane)
            → transition (vertical rise to tgt container surface)
            → exit (into target block on tgt container surface)
```

## Verification

- `tsc -b` — ✅ clean
- `vitest run` — ✅ 2,085 tests passing (125 test files), +8 new tests
- New tests cover: `findLCA` (5 tests), `routeCrossContainer` (3 tests)
- Test scenarios: top-level siblings, nested siblings through parent, co-planar containers, deeply nested chains, ancestor-descendant cases

Closes #1357