### PR TITLE
feat(web): accessibility — skip-to-content link + aria hardening

### DIFF
--- a/apps/web/src/app/App.css
+++ b/apps/web/src/app/App.css
@@ -8,6 +8,25 @@
   background-color: var(--bg-app);
 }
 
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 16px;
+  z-index: 100000;
+  padding: 8px 16px;
+  background: #1a1a2e;
+  color: #e0e0e0;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+  font-size: 14px;
+  text-decoration: none;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 8px;
+}
+
 .main-content {
   display: flex;
   flex-direction: row;

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -32,6 +32,9 @@ function App() {
 
   return (
     <div className="app">
+      <a href="#main-content" className="skip-link">
+        Skip to content
+      </a>
       <DemoBanner />
       <MobileGuard />
       {effectiveAppView === 'landing' ? <LandingPage /> : <BuilderView />}

--- a/apps/web/src/app/BuilderView.tsx
+++ b/apps/web/src/app/BuilderView.tsx
@@ -233,7 +233,12 @@ export function BuilderView() {
           </div>
         </aside>
 
-        <main className="builder-canvas">
+        <main
+          className="builder-canvas"
+          id="main-content"
+          role="application"
+          aria-label="Architecture builder canvas"
+        >
           <div className="builder-slot">
             <SceneCanvas />
           </div>

--- a/apps/web/src/widgets/landing-navbar/LandingNavbar.tsx
+++ b/apps/web/src/widgets/landing-navbar/LandingNavbar.tsx
@@ -7,7 +7,7 @@ export function LandingNavbar() {
   return (
     <header className="landing-navbar">
       <div className="landing-navbar-logo">🧱 CloudBlocks</div>
-      <nav className="landing-navbar-links">
+      <nav className="landing-navbar-links" aria-label="Main navigation">
         <a href="#templates" className="landing-navbar-link">
           Templates
         </a>

--- a/apps/web/src/widgets/landing-page/LandingPage.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.tsx
@@ -24,7 +24,7 @@ export function LandingPage() {
   return (
     <div className="landing-page" data-theme="workshop">
       <LandingNavbar />
-      <main className="landing-main">
+      <main className="landing-main" id="main-content">
         <section className="landing-hero">
           <h1 className="landing-hero-title">
             Start from templates. Edit visually. Validate instantly.
@@ -100,7 +100,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <footer className="landing-footer">
+        <footer className="landing-footer" role="contentinfo">
           <p className="landing-footer-text">
             CloudBlocks — Azure-first visual architecture builder
           </p>


### PR DESCRIPTION
## Summary
- Add visually-hidden skip-to-content link that appears on keyboard focus (Tab), jumping to `#main-content`
- Add `id="main-content"` to both LandingPage and BuilderView main elements
- Add `role="contentinfo"` to landing footer, `aria-label` to main navigation
- Add `role="application"` and `aria-label` to builder canvas

Fixes #1429