### PR TITLE
feat(web): isometric scene visual redesign

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -234,3 +234,28 @@
     transform: none;
   }
 }
+
+/* ── Screen-aligned label chip ─ */
+.block-label-chip {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: -18px;
+  padding: 1px 6px;
+  background: rgba(15, 23, 42, 0.82);
+  color: rgba(255, 255, 255, 0.88);
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1.4;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -345,6 +345,7 @@ export const BlockSprite = memo(function BlockSprite({
           />
         </div>
       </button>
+      {block.name && <span className="block-label-chip">{block.name}</span>}
     </div>
   );
 });

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -6,8 +6,8 @@ import type {
   ResourceCategory,
 } from '@cloudblocks/schema';
 import { CATEGORY_PORTS } from '@cloudblocks/schema';
-import { BLOCK_SHORT_NAMES, ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
-import { getBlockIconUrl, getSubtypeShortLabel } from '../../shared/utils/iconResolver';
+import { ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
+import { getBlockIconUrl } from '../../shared/utils/iconResolver';
 import { getBlockDimensions, getBlockVisualProfile } from '../../shared/types/visualProfile';
 import {
   BLOCK_PADDING,
@@ -100,8 +100,6 @@ export const BlockSvg = memo(function BlockSvg({
   const svgHeight = diamondHeight + sideWallPx + BLOCK_PADDING;
 
   const faceColors = getBlockFaceColors(category, provider ?? 'azure', subtype);
-  const shortName = BLOCK_SHORT_NAMES[category];
-  const subtypeLabel = getSubtypeShortLabel(provider ?? 'azure', subtype);
   const iconUrl = getBlockIconUrl(provider ?? 'azure', category, subtype);
 
   // ─── v2.0: silhouette from CU dimensions ───────────────────
@@ -109,12 +107,10 @@ export const BlockSvg = memo(function BlockSvg({
 
   const connectorId = useId().replace(/:/g, '_');
 
-  const leftLabelX = (leftX + cx) / 2;
   const rightLabelX = (cx + rightX) / 2;
   const wallCenterY = (midY + bottomY + sideWallPx) / 2;
 
   const minDim = Math.min(cu.width, cu.depth);
-  const labelFontSize = minDim <= 1 ? 8 : minDim <= 2 ? 10 : 13;
   const iconSize = minDim <= 1 ? 12 : minDim <= 2 ? 16 : 20;
 
   return (
@@ -180,7 +176,7 @@ export const BlockSvg = memo(function BlockSvg({
                       y1={line.y1}
                       x2={line.x2}
                       y2={line.y2}
-                      stroke="rgba(255,255,255,0.10)"
+                      stroke="rgba(255,255,255,0.06)"
                       strokeWidth={0.5}
                       fill="none"
                     />
@@ -223,20 +219,6 @@ export const BlockSvg = memo(function BlockSvg({
         strokeWidth={EDGE_HIGHLIGHT_STROKE_WIDTH}
         strokeOpacity={EDGE_HIGHLIGHT_OPACITY}
       />
-
-      {/* ─── Resource type label (left wall — flush) ─── */}
-      <text
-        transform={`matrix(0.8975,0.4410,0,1,${leftLabelX},${wallCenterY})`}
-        fontFamily="system-ui, -apple-system, sans-serif"
-        fontSize={labelFontSize}
-        fontWeight="600"
-        fill="#ffffff"
-        fillOpacity="0.9"
-        textAnchor="middle"
-        dominantBaseline="middle"
-      >
-        {subtypeLabel ?? shortName}
-      </text>
 
       {iconUrl && (
         <image

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -10,9 +10,6 @@ import {
 } from '../../../shared/types/visualProfile';
 import type { BlockRole, ProviderType, ResourceCategory } from '@cloudblocks/schema';
 import { BLOCK_PADDING, TILE_H, TILE_W, TILE_Z } from '../../../shared/tokens/designTokens';
-
-import { BLOCK_SHORT_NAMES } from '../../../shared/types/index';
-
 // ─── Test Helpers ─────────────────────────────────────────────
 
 /** Extract all polygon elements from rendered SVG, excluding those inside defs/clipPath. */
@@ -299,11 +296,11 @@ describe('BlockSvg SVG structure', () => {
     expect(gridLines.length).toBeGreaterThanOrEqual(2); // at least 2 grid lines (1x1 block = 2 subdivisions)
   });
 
-  it('renders short name text element and conditionally renders icon', () => {
+  it('does not render text elements on SVG face (labels are HTML chips)', () => {
     const { container } = render(<BlockSvg category="compute" />);
     const texts = container.querySelectorAll('text');
     const images = container.querySelectorAll('image');
-    expect(texts.length).toBe(1);
+    expect(texts.length).toBe(0);
     expect(images.length).toBe(0);
   });
 
@@ -468,16 +465,16 @@ describe('BlockSvg role badges', () => {
 // ─── Name Prop Tests ──────────────────────────────────────────
 
 describe('BlockSvg name prop', () => {
-  it('renders shortName on left wall when no subtype is provided', () => {
+  it('does not render text on SVG face (labels moved to HTML chips)', () => {
     const { container } = render(<BlockSvg category="compute" />);
     const texts = container.querySelectorAll('text');
-    expect(texts[0].textContent).toBe(BLOCK_SHORT_NAMES.compute);
+    expect(texts.length).toBe(0);
   });
 
-  it('renders subtype label on left wall when subtype is provided', () => {
+  it('renders icon on SVG face when subtype has a registered icon', () => {
     const { container } = render(<BlockSvg category="compute" provider="azure" subtype="vm" />);
-    const texts = container.querySelectorAll('text');
-    expect(texts[0].textContent).toBe('VM');
+    const images = container.querySelectorAll('image');
+    expect(images.length).toBe(1);
   });
 
   it('renders icon on right wall when subtype has a registered icon', () => {
@@ -495,7 +492,7 @@ describe('BlockSvg name prop', () => {
 
     const texts = container.querySelectorAll('text');
     const images = container.querySelectorAll('image');
-    expect(texts[0].textContent).toBe('VM');
+    expect(texts.length).toBe(0);
     expect(images.length).toBe(1);
   });
 });

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -6,12 +6,7 @@ import type { DiffDelta } from '../../shared/types/diff';
 import { ConnectionRenderer } from './ConnectionRenderer';
 import { getDiffState } from '../../features/diff/engine';
 import { getConnectionSurfaceRoute } from './surfaceRouting';
-import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
-import {
-  buildConnectionFootprint,
-  getVisibleSideFaces,
-  projectFootprintToScreen,
-} from './connectionGeometry';
+import type { SurfaceRoute } from './surfaceRouting';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 
@@ -19,21 +14,15 @@ vi.mock('./surfaceRouting', () => ({
   getConnectionSurfaceRoute: vi.fn(),
 }));
 
-vi.mock('./connectionGeometry', () => ({
-  buildConnectionFootprint: vi.fn(),
-  getVisibleSideFaces: vi.fn(),
-  projectFootprintToScreen: vi.fn(),
-}));
-
 vi.mock('../../shared/tokens/designTokens', () => ({
   TILE_W: 64,
   TILE_H: 32,
   TILE_Z: 32,
   RENDER_SCALE: 32,
-  BEAM_WIDTH_CU: 0.5,
-  BEAM_THICKNESS_CU: 1 / 3,
-  CONNECTION_WIDTH_CU: 1,
-  CONNECTION_HEIGHT_CU: 1 / 3,
+  TRACE_STROKE_PX: 2,
+  TRACE_CASE_PX: 4,
+  TRACE_HOVER_PX: 2.5,
+  TRACE_FLASH_PX: 2,
 }));
 
 vi.mock('../../features/diff/engine', () => ({
@@ -81,42 +70,6 @@ function createSurfaceRoute(overrides?: Partial<SurfaceRoute>): SurfaceRoute {
   };
 }
 
-function setupSurfaceRouteMocks() {
-  const footprint: WorldPoint3[] = [
-    [1, 3.333, 1],
-    [3, 3.333, 1],
-    [3, 3.333, 2],
-    [1, 3.333, 2],
-  ];
-  vi.mocked(buildConnectionFootprint).mockReturnValue(footprint);
-  vi.mocked(projectFootprintToScreen).mockReturnValue([
-    { x: 100, y: 220 },
-    { x: 140, y: 240 },
-    { x: 130, y: 260 },
-    { x: 90, y: 240 },
-  ]);
-  vi.mocked(getVisibleSideFaces).mockReturnValue([
-    {
-      face: 'left',
-      vertices: [
-        [1, 3.333, 1],
-        [3, 3.333, 1],
-        [3, 3, 1],
-        [1, 3, 1],
-      ],
-    },
-    {
-      face: 'right',
-      vertices: [
-        [3, 3.333, 1],
-        [3, 3.333, 2],
-        [3, 3, 2],
-        [3, 3, 1],
-      ],
-    },
-  ]);
-}
-
 function renderConnector(conn: Connection = connection) {
   return render(
     <svg aria-label="Test SVG">
@@ -140,7 +93,6 @@ describe('ConnectionRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createSurfaceRoute());
-    setupSurfaceRouteMocks();
     useUIStore.setState(initialUIState, true);
     useArchitectureStore.setState(initialArchitectureState, true);
     useUIStore.setState({
@@ -157,11 +109,11 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('g')).toBeNull();
   });
 
-  it('renders svg group with polygons when surface route exists', () => {
+  it('renders svg group with casing and trace paths when surface route exists', () => {
     const { container } = renderConnector();
     expect(container.querySelector('g')).toBeInTheDocument();
-    const polygons = container.querySelectorAll('polygon');
-    expect(polygons.length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelector('[data-testid="connection-casing"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="connection-trace"]')).toBeInTheDocument();
   });
 
   it('renders hit area with data-testid', () => {
@@ -215,10 +167,8 @@ describe('ConnectionRenderer', () => {
     vi.mocked(getDiffState).mockReturnValue('added');
 
     const { container } = renderConnector();
-    const polygons = container.querySelectorAll('polygon');
-    expect(polygons.length).toBeGreaterThanOrEqual(1);
-    const topFaces = Array.from(polygons).filter((p) => p.getAttribute('fill') === '#22c55e');
-    expect(topFaces.length).toBeGreaterThanOrEqual(1);
+    const casingPath = container.querySelector('[data-testid="connection-casing"]');
+    expect(casingPath).toBeInTheDocument();
     expect(container.querySelector('g')?.getAttribute('opacity')).toBe('1');
   });
 
@@ -235,25 +185,27 @@ describe('ConnectionRenderer', () => {
     const { container } = renderConnector();
     const selectionOutline = container.querySelector('[data-layer="selection-outline"]');
     expect(selectionOutline).toBeInTheDocument();
+    expect(selectionOutline?.tagName.toLowerCase()).toBe('path');
     expect(selectionOutline?.getAttribute('stroke')).toBe('#ffffff');
-    expect(selectionOutline?.getAttribute('stroke-opacity')).toBe('0.5');
+    expect(selectionOutline?.getAttribute('stroke-opacity')).toBe('0.35');
   });
 
   describe('surface render path', () => {
-    it('renders top-face polygon from projected connection footprint', () => {
+    it('renders casing and trace path layers from route centerline', () => {
       const { container } = renderConnector();
-      const topFaceLayer = container.querySelector('[data-layer="top-face"]');
-      const topFacePolygon = topFaceLayer?.querySelector('polygon');
-      expect(topFacePolygon).toBeInTheDocument();
-      expect(topFacePolygon?.getAttribute('points')).toBe('100,220 140,240 130,260 90,240');
+      const casingLayer = container.querySelector('[data-layer="casing"]');
+      const traceLayer = container.querySelector('[data-layer="trace"]');
+      expect(casingLayer).toBeInTheDocument();
+      expect(casingLayer?.tagName.toLowerCase()).toBe('path');
+      expect(traceLayer).toBeInTheDocument();
+      expect(traceLayer?.tagName.toLowerCase()).toBe('path');
     });
 
-    it('renders side-face polygons and no legacy liftarm artifacts', () => {
+    it('casing and trace paths share the same d attribute', () => {
       const { container } = renderConnector();
-      const sideFacesLayer = container.querySelector('[data-layer="side-faces"]');
-      expect(sideFacesLayer?.querySelectorAll('polygon')).toHaveLength(2);
-      expect(sideFacesLayer?.querySelectorAll('[data-connector-segment]')).toHaveLength(0);
-      expect(sideFacesLayer?.querySelectorAll('[data-connector-elbow]')).toHaveLength(0);
+      const casing = container.querySelector('[data-layer="casing"]');
+      const trace = container.querySelector('[data-layer="trace"]');
+      expect(casing?.getAttribute('d')).toBe(trace?.getAttribute('d'));
     });
 
     it('shows validation error label on hover for invalid surface route connections', () => {
@@ -279,8 +231,8 @@ describe('ConnectionRenderer', () => {
       expect(container.querySelector('[data-testid="connection-error-label"]')).toBeInTheDocument();
     });
 
-    it('returns null when connection footprint is degenerate', () => {
-      vi.mocked(buildConnectionFootprint).mockReturnValue([]);
+    it('returns null when route has fewer than 2 centerline points', () => {
+      vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createSurfaceRoute({ segments: [] }));
       const { container } = renderConnector();
       expect(container.querySelector('g')).toBeNull();
     });
@@ -328,8 +280,8 @@ describe('ConnectionRenderer', () => {
 
       const { container } = renderConnector();
       expect(
-        container.querySelector('[data-testid="connection-hit-area"]')?.getAttribute('d'),
-      ).toBe('');
+        container.querySelector('[data-testid="connection-hit-area"]'),
+      ).not.toBeInTheDocument();
       expect(
         container.querySelector('[data-testid="connection-error-label"]'),
       ).not.toBeInTheDocument();
@@ -492,10 +444,10 @@ describe('ConnectionRenderer', () => {
       vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createSurfaceRoute());
 
       const { container } = renderConnector(actorConnection);
-      const topFaceLayer = container.querySelector('[data-layer="top-face"]');
-      expect(topFaceLayer?.querySelector('polygon')).toBeInTheDocument();
-      expect(container.querySelectorAll('[data-connector-segment]')).toHaveLength(0);
-      expect(container.querySelectorAll('[data-connector-elbow]')).toHaveLength(0);
+      const casingLayer = container.querySelector('[data-layer="casing"]');
+      expect(casingLayer).toBeInTheDocument();
+      const traceLayer = container.querySelector('[data-layer="trace"]');
+      expect(traceLayer).toBeInTheDocument();
     });
 
     it('returns null when surface route resolution fails for external actor connection', () => {

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -12,15 +12,15 @@ import { worldToScreen } from '../../shared/utils/isometric';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
-import { CONNECTION_HEIGHT_CU, CONNECTION_WIDTH_CU } from '../../shared/tokens/designTokens';
+import {
+  TRACE_STROKE_PX,
+  TRACE_CASE_PX,
+  TRACE_HOVER_PX,
+  TRACE_FLASH_PX,
+} from '../../shared/tokens/designTokens';
 import { DIFF_THEMES, lightenColor } from './connectorTheme';
 import { getConnectionSurfaceRoute } from './surfaceRouting';
 import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
-import {
-  buildConnectionFootprint,
-  getVisibleSideFaces,
-  projectFootprintToScreen,
-} from './connectionGeometry';
 import { getConnectionColors } from './connectionFaceColors';
 import type { ConnectionRenderSemantic } from './connectionFaceColors';
 
@@ -33,56 +33,40 @@ interface ConnectionRendererProps {
   originY: number;
 }
 
-interface ConnectorColors {
-  topFaceColor: string;
-  topFaceStroke: string;
-  leftSideColor: string;
-  rightSideColor: string;
-  accent: string;
+/** Resolved colors for the 2-layer trace rendering. */
+interface TraceColors {
+  stroke: string;
+  casing: string;
   opacity: number;
 }
 
 const HIT_AREA_WIDTH = 20;
-const DRAW_STROKE_WIDTH = Math.max(4, CONNECTION_WIDTH_CU * 8);
 
 function getColors(
   semantic: ConnectionRenderSemantic,
   diffState: string,
   isHighlighted: boolean,
-): ConnectorColors {
+): TraceColors {
   const base = getConnectionColors(semantic);
   const diffOverride = diffState !== 'unchanged' ? DIFF_THEMES[diffState] : null;
 
-  const baseTop = diffOverride?.tile ?? base.topFaceColor;
-  const baseRight = diffOverride?.shadow ?? base.rightSideColor;
-  const baseLeft = diffOverride?.dark ?? base.leftSideColor;
-  const baseStroke = diffOverride?.shadow ?? base.topFaceStroke;
+  const baseStroke = diffOverride?.tile ?? base.stroke;
+  const baseCasing = diffOverride?.shadow ?? base.casing;
   const baseOpacity = diffOverride?.opacity ?? 1.0;
-  const accent = diffState !== 'unchanged' ? '#ffffff' : base.topFaceStroke;
 
   if (isHighlighted) {
     return {
-      topFaceColor: lightenColor(baseTop, 0.15),
-      topFaceStroke: lightenColor(baseStroke, 0.1),
-      leftSideColor: lightenColor(baseLeft, 0.1),
-      rightSideColor: lightenColor(baseRight, 0.1),
-      accent,
+      stroke: lightenColor(baseStroke, 0.15),
+      casing: lightenColor(baseCasing, 0.1),
       opacity: baseOpacity,
     };
   }
 
   return {
-    topFaceColor: baseTop,
-    topFaceStroke: baseStroke,
-    leftSideColor: baseLeft,
-    rightSideColor: baseRight,
-    accent,
+    stroke: baseStroke,
+    casing: baseCasing,
     opacity: baseOpacity,
   };
-}
-
-function pointsToPolygon(points: readonly ScreenPoint[]): string {
-  return points.map((p) => `${p.x},${p.y}`).join(' ');
 }
 
 function pointsToPath(points: readonly ScreenPoint[]): string {
@@ -200,32 +184,14 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const surfaceRender = useMemo(() => {
     if (!surfaceRoute) return null;
 
-    const footprintVertices = buildConnectionFootprint(surfaceRoute);
-    if (footprintVertices.length < 3) {
-      return null;
-    }
-
-    const topFaceScreen = projectFootprintToScreen(footprintVertices, originX, originY);
-    const topY = surfaceRoute.srcPort.surfaceY + CONNECTION_HEIGHT_CU;
-    const baseY = surfaceRoute.srcPort.surfaceY;
-    const sideFaces = getVisibleSideFaces(footprintVertices, topY, baseY).map((face) => ({
-      face: face.face,
-      points: face.vertices.map((v) => worldToScreen(v[0], v[1], v[2], originX, originY)) as [
-        ScreenPoint,
-        ScreenPoint,
-        ScreenPoint,
-        ScreenPoint,
-      ],
-    }));
-
     const hitPoints = getRouteCenterlinePoints(surfaceRoute, originX, originY);
     const hitPath = pointsToPath(hitPoints);
+
+    if (hitPoints.length < 2) return null;
 
     return {
       hitPath,
       labelPos: getLabelPosition(hitPoints),
-      topFacePolygon: pointsToPolygon(topFaceScreen),
-      sideFaces,
     };
   }, [surfaceRoute, originX, originY]);
 
@@ -234,6 +200,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const colors = getColors(renderSemantic, diffState, isHighlighted);
   const hitPath = surfaceRender.hitPath;
   const labelPos = surfaceRender.labelPos;
+  const innerWidth = isHighlighted ? TRACE_HOVER_PX : TRACE_STROKE_PX;
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -268,56 +235,55 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
         />
       </a>
 
+      {/* Layer 1: Outer casing path */}
+      <path
+        d={hitPath}
+        stroke={colors.casing}
+        strokeWidth={TRACE_CASE_PX}
+        strokeOpacity={0.55}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+        pointerEvents="none"
+        data-testid="connection-casing"
+        data-layer="casing"
+      />
+
+      {/* Layer 2: Inner trace path (with draw-in animation) */}
+      <path
+        ref={drawInRef}
+        d={hitPath}
+        stroke={colors.stroke}
+        strokeWidth={innerWidth}
+        strokeOpacity={0.95}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+        pointerEvents="none"
+        data-testid="connection-trace"
+        data-layer="trace"
+      />
+
+      {/* Selection glow: wider stroke behind the trace */}
       {isSelected && (
-        <polygon
-          points={surfaceRender.topFacePolygon}
-          fill="none"
+        <path
+          d={hitPath}
           stroke="#ffffff"
-          strokeWidth={4}
-          strokeOpacity={0.5}
+          strokeWidth={TRACE_CASE_PX + 2}
+          strokeOpacity={0.35}
+          strokeLinecap="round"
           strokeLinejoin="round"
+          fill="none"
           pointerEvents="none"
           data-layer="selection-outline"
         />
       )}
 
-      <g data-layer="side-faces" pointerEvents="none">
-        {surfaceRender.sideFaces.map((quad) => (
-          <polygon
-            key={`${connection.id}-side-${quad.face}-${pointsToPolygon(quad.points)}`}
-            points={pointsToPolygon(quad.points)}
-            fill={quad.face === 'left' ? colors.leftSideColor : colors.rightSideColor}
-          />
-        ))}
-      </g>
-
-      <g data-layer="top-face" pointerEvents="none">
-        {surfaceRender && (
-          <polygon
-            points={surfaceRender.topFacePolygon}
-            fill={colors.topFaceColor}
-            stroke={colors.topFaceStroke}
-            strokeWidth={1}
-          />
-        )}
-      </g>
-      <path
-        ref={drawInRef}
-        d={hitPath}
-        stroke={colors.topFaceColor}
-        strokeWidth={DRAW_STROKE_WIDTH}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-        pointerEvents="none"
-        opacity={0.6}
-        data-testid="connection-draw-path"
-      />
-
+      {/* Snap flash animation overlay */}
       <path
         d={hitPath}
-        stroke={colors.topFaceColor}
-        strokeWidth={DRAW_STROKE_WIDTH}
+        stroke={colors.stroke}
+        strokeWidth={TRACE_FLASH_PX}
         strokeLinecap="round"
         strokeLinejoin="round"
         fill="none"

--- a/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
+++ b/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
@@ -10,9 +10,9 @@ import { PROVIDER_COLORS } from '../../block/blockFaceColors';
 describe('connectionFaceColors', () => {
   describe('CONNECTION_SEMANTIC_BASE_COLORS', () => {
     it('has entries for http, event, and data', () => {
-      expect(CONNECTION_SEMANTIC_BASE_COLORS.http).toBe('#6366F1');
-      expect(CONNECTION_SEMANTIC_BASE_COLORS.event).toBe('#F43F5E');
-      expect(CONNECTION_SEMANTIC_BASE_COLORS.data).toBe('#84CC16');
+      expect(CONNECTION_SEMANTIC_BASE_COLORS.http).toBe('#6F87B6');
+      expect(CONNECTION_SEMANTIC_BASE_COLORS.event).toBe('#C97A63');
+      expect(CONNECTION_SEMANTIC_BASE_COLORS.data).toBe('#5FA59B');
     });
 
     it('contains exactly 3 semantics', () => {
@@ -28,20 +28,19 @@ describe('connectionFaceColors', () => {
         const colors = getConnectionColors(semantic);
 
         expect(colors.base).toBe(CONNECTION_SEMANTIC_BASE_COLORS[semantic]);
-        expect(colors.topFaceColor).toMatch(/^#[0-9A-F]{6}$/i);
-        expect(colors.topFaceStroke).toMatch(/^#[0-9A-F]{6}$/i);
-        expect(colors.leftSideColor).toMatch(/^#[0-9A-F]{6}$/i);
-        expect(colors.rightSideColor).toMatch(/^#[0-9A-F]{6}$/i);
+        expect(colors.stroke).toMatch(/^#[0-9A-Fa-f]{6}$/);
+        expect(colors.casing).toMatch(/^#[0-9A-Fa-f]{6}$/);
       });
 
-      it(`"${semantic}" topFaceColor differs from base (lightened)`, () => {
+      it(`"${semantic}" stroke equals base color`, () => {
         const colors = getConnectionColors(semantic);
-        expect(colors.topFaceColor).not.toBe(colors.base);
+        expect(colors.stroke).toBe(colors.base);
       });
 
-      it(`"${semantic}" leftSideColor differs from rightSideColor`, () => {
+      it(`"${semantic}" casing is darker than base`, () => {
         const colors = getConnectionColors(semantic);
-        expect(colors.leftSideColor).not.toBe(colors.rightSideColor);
+        // Casing should be a different (darker) color
+        expect(colors.casing).not.toBe(colors.base);
       });
     }
   });

--- a/apps/web/src/entities/connection/connectionFaceColors.ts
+++ b/apps/web/src/entities/connection/connectionFaceColors.ts
@@ -5,7 +5,6 @@
 // ═══════════════════════════════════════════════════════════════
 
 import type { EndpointSemantic } from '@cloudblocks/schema';
-import { deriveFaceColors } from '../block/blockFaceColors';
 
 // ─── Semantic Subset ─────────────────────────────────────────
 
@@ -15,31 +14,32 @@ export type ConnectionRenderSemantic = Extract<EndpointSemantic, 'http' | 'event
 // ─── Base Color Palette ──────────────────────────────────────
 
 export const CONNECTION_SEMANTIC_BASE_COLORS: Record<ConnectionRenderSemantic, string> = {
-  http: '#6366F1', // Indigo
-  event: '#F43F5E', // Rose
-  data: '#84CC16', // Lime
+  http: '#6F87B6', // Muted steel blue
+  event: '#C97A63', // Muted terracotta
+  data: '#5FA59B', // Muted teal
 };
 
 // ─── Derived Face + Port Colors ──────────────────────────────
 
 export interface ConnectionColors {
   base: string;
-  topFaceColor: string;
-  topFaceStroke: string;
-  leftSideColor: string;
-  rightSideColor: string;
+  stroke: string; // inner trace color
+  casing: string; // outer casing color (darker)
 }
 
 export function getConnectionColors(semantic: ConnectionRenderSemantic): ConnectionColors {
   const base = CONNECTION_SEMANTIC_BASE_COLORS[semantic];
-  const derived = deriveFaceColors(base);
+  // Derive casing by darkening the base by ~30%
+  const r = parseInt(base.slice(1, 3), 16);
+  const g = parseInt(base.slice(3, 5), 16);
+  const b = parseInt(base.slice(5, 7), 16);
+  const darken = (v: number) => Math.round(v * 0.7);
+  const casing = `#${darken(r).toString(16).padStart(2, '0')}${darken(g).toString(16).padStart(2, '0')}${darken(b).toString(16).padStart(2, '0')}`;
 
   return {
     base,
-    topFaceColor: derived.top,
-    topFaceStroke: derived.topStroke,
-    leftSideColor: derived.left,
-    rightSideColor: derived.right,
+    stroke: base,
+    casing,
   };
 }
 

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.css
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.css
@@ -124,3 +124,27 @@
 .container-img.is-dropping {
   animation: bounce-drop-container 300ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
 }
+
+/* ── Screen-aligned label chip ─ */
+.container-label-chip {
+  position: absolute;
+  left: 12px;
+  top: -14px;
+  padding: 1px 8px;
+  background: rgba(15, 23, 42, 0.78);
+  color: rgba(255, 255, 255, 0.88);
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
@@ -237,6 +237,7 @@ export const ContainerBlockSprite = memo(function PlateSprite({
           />
         </div>
       </button>
+      <span className="container-label-chip">{label}</span>
     </div>
   );
 });

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
@@ -25,19 +25,19 @@ function renderPlateSvg(props?: Partial<ComponentProps<typeof ContainerBlockSvg>
 // ─── Label & Icon Rendering ─────────────────────────────────
 
 describe('PlateSvg — label and icon', () => {
-  it('renders both label and icon when both props are provided', () => {
+  it('renders icon when both label and icon props are provided', () => {
     const { container } = renderPlateSvg({ label: 'Subnet 1', iconUrl: 'test-icon.svg' });
 
-    expect(screen.getByText('Subnet 1')).toBeInTheDocument();
+    // Label is now rendered as HTML chip outside SVG, so no SVG <text>
     const images = container.querySelectorAll('image');
     expect(images.length).toBe(1);
     expect(images[0]).toHaveAttribute('href', 'test-icon.svg');
   });
 
-  it('renders label only when iconUrl is omitted', () => {
+  it('renders no icon when iconUrl is omitted', () => {
     const { container } = renderPlateSvg({ label: 'Subnet 2' });
 
-    expect(screen.getByText('Subnet 2')).toBeInTheDocument();
+    // Label is now HTML chip — no SVG text element
     expect(container.querySelectorAll('image').length).toBe(0);
   });
 
@@ -115,11 +115,11 @@ describe('PlateSvg — CU-based dimensions', () => {
 // ─── SVG Structure ──────────────────────────────────────────
 
 describe('PlateSvg — SVG structure', () => {
-  it('renders 3 face polygons (top, left side, right side)', () => {
+  it('renders 5 face polygons (top + 2 inset + left side + right side)', () => {
     const { container } = renderPlateSvg();
     // Exclude polygons inside <clipPath> (used by PlateSurfaceGrid)
     const polygons = container.querySelectorAll('polygon:not(clipPath polygon)');
-    expect(polygons.length).toBe(3);
+    expect(polygons.length).toBe(5);
   });
 
   it('applies correct fill colors to face polygons', () => {
@@ -127,8 +127,9 @@ describe('PlateSvg — SVG structure', () => {
     const polygons = container.querySelectorAll('polygon');
 
     expect(polygons[0].getAttribute('fill')).toBe('#22C55E'); // top
-    expect(polygons[1].getAttribute('fill')).toBe('#16A34A'); // left
-    expect(polygons[2].getAttribute('fill')).toBe('#15803D'); // right
+    // polygons[1] = inset-highlight (fill=none), polygons[2] = inset-shadow (fill=none)
+    expect(polygons[3].getAttribute('fill')).toBe('#16A34A'); // left
+    expect(polygons[4].getAttribute('fill')).toBe('#15803D'); // right
   });
 });
 
@@ -177,13 +178,21 @@ describe('PlateSvg — layer-type visuals', () => {
     }
   });
 
-  it('global container label uses larger font than subnet', () => {
-    const { container: globalC } = renderPlateSvg({ containerLayer: 'global', label: 'Global' });
-    const { container: subnetC } = renderPlateSvg({ containerLayer: 'subnet', label: 'Subnet' });
+  it('global container uses larger icon than subnet (text labels are now HTML chips)', () => {
+    // SVG text labels were removed — labels are now screen-aligned HTML chips.
+    // Verify icon size differentiation instead.
+    const { container: globalC } = renderPlateSvg({
+      containerLayer: 'global',
+      iconUrl: 'icon-g.svg',
+    });
+    const { container: subnetC } = renderPlateSvg({
+      containerLayer: 'subnet',
+      iconUrl: 'icon-s.svg',
+    });
 
-    const globalFontSize = Number(globalC.querySelector('text')?.getAttribute('font-size'));
-    const subnetFontSize = Number(subnetC.querySelector('text')?.getAttribute('font-size'));
-    expect(globalFontSize).toBeGreaterThan(subnetFontSize);
+    const globalSize = Number(globalC.querySelector('image')?.getAttribute('width'));
+    const subnetSize = Number(subnetC.querySelector('image')?.getAttribute('width'));
+    expect(globalSize).toBeGreaterThan(subnetSize);
   });
 
   it('global container icon uses larger size than zone', () => {
@@ -214,8 +223,9 @@ describe('PlateSvg — colors are independent of containerLayer', () => {
     const polygons = container.querySelectorAll('polygon');
 
     expect(polygons[0].getAttribute('fill')).toBe('#FF0000');
-    expect(polygons[1].getAttribute('fill')).toBe('#CC0000');
-    expect(polygons[2].getAttribute('fill')).toBe('#990000');
+    // polygons[1] = inset-highlight, polygons[2] = inset-shadow
+    expect(polygons[3].getAttribute('fill')).toBe('#CC0000');
+    expect(polygons[4].getAttribute('fill')).toBe('#990000');
   });
 });
 

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
@@ -86,7 +86,7 @@ export const ContainerBlockSvg = memo(function PlateSvg({
   topFaceStroke,
   leftSideColor,
   rightSideColor,
-  label,
+  label: _label,
   iconUrl,
 }: ContainerBlockSvgProps) {
   // CU-based pixel conversion: 1 CU = 1 unit, rendered via TILE_W/H/Z
@@ -111,7 +111,6 @@ export const ContainerBlockSvg = memo(function PlateSvg({
   const rightSidePoints = `${cx},${bottomY} ${rightX},${midY} ${rightX},${midY + sideWallPx} ${cx},${bottomY + sideWallPx}`;
 
   // Label positioning on side walls
-  const leftLabelX = (leftX + cx) / 2;
   const rightLabelX = (cx + rightX) / 2;
   const wallCenterY = (midY + bottomY + sideWallPx) / 2;
 
@@ -131,23 +130,31 @@ export const ContainerBlockSvg = memo(function PlateSvg({
         strokeWidth={visuals.strokeWidth}
         strokeOpacity={visuals.strokeOpacity}
       />
+
+      {/* Fake inset — inner highlight ring */}
+      <polygon
+        points={topFacePoints}
+        fill="none"
+        stroke="rgba(203,213,225,0.16)"
+        strokeWidth={1}
+        strokeLinejoin="round"
+        transform={`translate(0, 0.5)`}
+        pointerEvents="none"
+        data-layer="inset-highlight"
+      />
+      {/* Fake inset — inner shadow ring */}
+      <polygon
+        points={topFacePoints}
+        fill="none"
+        stroke="rgba(2,6,23,0.45)"
+        strokeWidth={1}
+        strokeLinejoin="round"
+        transform={`translate(0, -0.5)`}
+        pointerEvents="none"
+        data-layer="inset-shadow"
+      />
       <polygon points={leftSidePoints} fill={leftSideColor} />
       <polygon points={rightSidePoints} fill={rightSideColor} />
-
-      {label ? (
-        <text
-          transform={`matrix(0.8975,0.4410,0,1,${leftLabelX},${wallCenterY})`}
-          fontFamily="system-ui, -apple-system, sans-serif"
-          fontSize={visuals.labelFontSize}
-          fontWeight="700"
-          fill="#ffffff"
-          fillOpacity="0.9"
-          textAnchor="middle"
-          dominantBaseline="middle"
-        >
-          {label}
-        </text>
-      ) : null}
 
       {iconUrl ? (
         <image

--- a/apps/web/src/entities/container-block/containerBlockFaceColors.test.ts
+++ b/apps/web/src/entities/container-block/containerBlockFaceColors.test.ts
@@ -4,10 +4,10 @@ import { getContainerBlockFaceColors } from './containerBlockFaceColors';
 describe('getPlateFaceColors', () => {
   it('returns region colors for region container type', () => {
     expect(getContainerBlockFaceColors({ type: 'region' })).toEqual({
-      topFaceColor: '#90CAF9',
-      topFaceStroke: '#BBDEFB',
-      leftSideColor: '#64B5F6',
-      rightSideColor: '#42A5F5',
+      topFaceColor: '#162537',
+      topFaceStroke: '#4B6886',
+      leftSideColor: '#0F1B2A',
+      rightSideColor: '#0B1420',
     });
   });
 
@@ -38,12 +38,12 @@ describe('getPlateFaceColors', () => {
     });
   });
 
-  it('returns unified indigo subnet colors', () => {
+  it('returns unified navy subnet colors', () => {
     expect(getContainerBlockFaceColors({ type: 'subnet' })).toEqual({
-      topFaceColor: '#6366F1',
-      topFaceStroke: '#818CF8',
-      leftSideColor: '#4F46E5',
-      rightSideColor: '#4338CA',
+      topFaceColor: '#22364B',
+      topFaceStroke: '#7F9BB6',
+      leftSideColor: '#182A3D',
+      rightSideColor: '#122030',
     });
   });
 });

--- a/apps/web/src/entities/container-block/containerBlockFaceColors.ts
+++ b/apps/web/src/entities/container-block/containerBlockFaceColors.ts
@@ -31,11 +31,12 @@ export function getContainerBlockFaceColors(container: {
   }
 
   if (container.type === 'region') {
+    // Navy ramp — VNet level (dark navy)
     return {
-      topFaceColor: '#90CAF9',
-      topFaceStroke: '#BBDEFB',
-      leftSideColor: '#64B5F6',
-      rightSideColor: '#42A5F5',
+      topFaceColor: '#162537',
+      topFaceStroke: '#4B6886',
+      leftSideColor: '#0F1B2A',
+      rightSideColor: '#0B1420',
     };
   }
 
@@ -48,11 +49,11 @@ export function getContainerBlockFaceColors(container: {
     };
   }
 
-  // Subnet — unified indigo
+  // Subnet — navy ramp (lighter than VNet)
   return {
-    topFaceColor: '#6366F1',
-    topFaceStroke: '#818CF8',
-    leftSideColor: '#4F46E5',
-    rightSideColor: '#4338CA',
+    topFaceColor: '#22364B',
+    topFaceStroke: '#7F9BB6',
+    leftSideColor: '#182A3D',
+    rightSideColor: '#122030',
   };
 }

--- a/apps/web/src/shared/tokens/designTokens.ts
+++ b/apps/web/src/shared/tokens/designTokens.ts
@@ -16,29 +16,24 @@ export const BLOCK_PADDING = (RENDER_SCALE * 5) / 16; // 10
 
 // -- Edge Highlight --
 export const EDGE_HIGHLIGHT_STROKE_WIDTH = 2;
-export const EDGE_HIGHLIGHT_OPACITY = 0.3;
+export const EDGE_HIGHLIGHT_OPACITY = 0.18;
 export const EDGE_HIGHLIGHT_COLOR = '#ffffff';
 
-// -- Connection Block --
-// Flat isometric connection indicators on container block surfaces.
-// Width = 1 CU (same as block pitch), height = ⅓ block height.
+// -- Connection Trace --
+// Flat 2-layer SVG path connections on container block surfaces.
+// Replaces the previous 3D polygon beam system.
 export const CONNECTION_WIDTH_CU = 1;
 export const CONNECTION_HEIGHT_CU = 1 / 3;
 
-// -- Connector Beam --
-// Derived from block connector proportions.
-// Block pitch = 1 CU, container block height = ⅓ block.
-// We use a thin beam (0.5 CU wide) for visual clarity at our render scale.
-export const BEAM_WIDTH_CU = 0.5; // beam is half a block wide
-export const BEAM_THICKNESS_CU = 1 / 3; // container block height = ⅓ block
-export const BEAM_THICKNESS_PX = RENDER_SCALE * BEAM_THICKNESS_CU; // ~11px
-export const PIN_HOLE_SPACING_CU = 1.0; // 1 hole per block pitch
-export const PIN_HOLE_RX = (RENDER_SCALE * 3) / 20; // 4.8 (iso X radius)
-export const PIN_HOLE_RY = PIN_HOLE_RX / 2; // 2.4 (iso Y radius)
+// Trace stroke dimensions (screen-space px).
+export const TRACE_STROKE_PX = 2; // inner visible stroke
+export const TRACE_CASE_PX = 4; // outer casing stroke
+export const TRACE_HOVER_PX = 2.5; // inner stroke on hover/selected
+export const TRACE_FLASH_PX = 2; // snap-flash animation stroke
 
 // -- Face Stroke --
 export const TOP_FACE_STROKE_WIDTH = 1;
-export const TOP_FACE_STROKE_OPACITY = 0.6;
+export const TOP_FACE_STROKE_OPACITY = 0.45;
 
 // -- Port Visuals (Connection Anchor Points) --
 // Small screen-space offset so connector endpoints sit just outside block face.

--- a/apps/web/src/shared/vendor/reactHotToast.test.tsx
+++ b/apps/web/src/shared/vendor/reactHotToast.test.tsx
@@ -47,15 +47,15 @@ describe('shared/vendor/reactHotToast', () => {
     vi.clearAllMocks();
   });
 
-  it('renders top-center container and resolves message by default', () => {
+  it('renders bottom-right container and resolves message by default', () => {
     setupToaster([makeToast()]);
 
     const { container } = render(<Toaster />);
 
     expect(screen.getByRole('status')).toHaveTextContent('hello');
     const root = container.firstElementChild as HTMLElement;
-    expect(root.style.top).toBe('12px');
-    expect(root.style.alignItems).toBe('center');
+    expect(root.style.bottom).toBe('12px');
+    expect(root.style.alignItems).toBe('flex-end');
     expect(vi.mocked(resolveValue)).toHaveBeenCalled();
   });
 

--- a/apps/web/src/shared/vendor/reactHotToast.tsx
+++ b/apps/web/src/shared/vendor/reactHotToast.tsx
@@ -6,12 +6,13 @@ const DEFAULT_GUTTER = 8;
 const TOAST_TRANSITION_MS = 180;
 
 const BASE_TOAST_STYLE: CSSProperties = {
-  borderRadius: '8px',
-  boxShadow: '0 10px 24px rgba(0, 0, 0, 0.22)',
+  borderRadius: '6px',
+  boxShadow: '0 6px 16px rgba(0, 0, 0, 0.18)',
   color: '#f0f0f0',
+  background: 'rgba(15, 23, 42, 0.92)',
   fontSize: '0.875rem',
   lineHeight: 1.4,
-  maxWidth: 'min(480px, calc(100vw - 24px))',
+  maxWidth: '320px',
   pointerEvents: 'auto',
 };
 
@@ -54,7 +55,7 @@ export function Toaster({
   containerClassName,
   containerStyle,
   gutter = DEFAULT_GUTTER,
-  position = 'top-center',
+  position = 'bottom-right',
   reverseOrder,
   toastOptions,
   toasterId,


### PR DESCRIPTION
## Summary

Implements the full isometric scene visual redesign (Epic #1445, Milestone 30) across 5 design phases plus test updates:

- **Phase 1 — Connection Traces (#1446)**: Replace 3D polygon beam connections with clean 2-layer SVG path traces (casing + stroke). Muted color palette for http/event/data connection types.
- **Phase 2 — Container Hierarchy (#1447)**: Navy ramp colors for region/subnet containers with fake inset highlight/shadow ring effects.
- **Phase 3 — Resource Block Quieting (#1448)**: Reduced grid line opacity (0.10→0.06) and edge highlight opacity (0.3→0.18) for quieter resource blocks.
- **Phase 4 — Screen-Aligned Label Chips (#1449)**: Replace isometric SVG text labels with screen-aligned HTML pill chips (dark background, centered below blocks / top-left on containers).
- **Phase 5 — Toast Downshift (#1450)**: Move toast position to bottom-right with updated styling (rounded corners, darker background, tighter shadow).
- **Phase 6 — Test Updates (#1451)**: Update ConnectionRenderer, connectionFaceColors, ContainerBlockSvg, BlockSvg, and reactHotToast tests to match new visual system.

## Files Changed (17)

| File | Phase | Change |
|---|---|---|
| `designTokens.ts` | 1,3 | Add TRACE_* tokens, quiet grid/edge opacities |
| `ConnectionRenderer.tsx` | 1 | Complete rewrite to 2-layer SVG paths |
| `connectionFaceColors.ts` | 1 | Muted palette, simplified interface |
| `containerBlockFaceColors.ts` | 2 | Navy ramp colors for region/subnet |
| `ContainerBlockSvg.tsx` | 2,4 | Inset highlight/shadow + remove SVG text |
| `BlockSvg.tsx` | 3,4 | Grid opacity + remove SVG text + clean imports |
| `BlockSprite.tsx` | 4 | Add `.block-label-chip` HTML element |
| `BlockSprite.css` | 4 | Label chip styles |
| `ContainerBlockSprite.tsx` | 4 | Add `.container-label-chip` HTML element |
| `ContainerBlockSprite.css` | 4 | Label chip styles |
| `reactHotToast.tsx` | 5 | Position and style updates |
| `ConnectionRenderer.test.tsx` | 6 | Full rewrite for path-based traces |
| `connectionFaceColors.test.ts` | 6 | Updated expected colors |
| `ContainerBlockSvg.test.tsx` | 6 | Updated for inset polygons + no SVG text |
| `BlockSvg.test.tsx` | 6 | Updated for no SVG text labels |
| `containerBlockFaceColors.test.ts` | 6 | Updated for navy ramp values |
| `reactHotToast.test.tsx` | 6 | Updated for bottom-right default |

## Test Results

- ✅ 129 test files passed, 2135 tests passed
- ✅ Branch coverage: 90.13% (threshold: 90%)
- ✅ TypeScript type check: clean

Closes #1446, #1447, #1448, #1449, #1450, #1451
Epic: #1445
Milestone: 30