### PR TITLE
feat(web): restore external actors with sidebar palette integration (#1454)

### DIFF
--- a/apps/web/src/entities/store/slices/domainSlice.test.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.test.ts
@@ -281,6 +281,112 @@ describe('domainSlice – targeted branch coverage', () => {
     });
   });
 
+  describe('external actor add/remove actions', () => {
+    it('adds an internet actor with generated id and default position', () => {
+      seedState({ externalActors: [] });
+
+      getState().addExternalActor('internet');
+
+      const actors = getArch().externalActors ?? [];
+      expect(actors).toHaveLength(1);
+      expect(actors[0]).toEqual({
+        id: 'ext-internet-00000001',
+        name: 'Internet',
+        type: 'internet',
+        position: { x: -3, y: 0, z: -3 },
+      });
+    });
+
+    it('adds a browser actor with custom position', () => {
+      seedState({ externalActors: [] });
+
+      getState().addExternalActor('browser', { x: 1, y: 0, z: 1 });
+
+      const actors = getArch().externalActors ?? [];
+      expect(actors).toHaveLength(1);
+      expect(actors[0]).toEqual({
+        id: 'ext-browser-00000001',
+        name: 'Browser',
+        type: 'browser',
+        position: { x: 1, y: 0, z: 1 },
+      });
+    });
+
+    it('removes an external actor by id', () => {
+      seedState({
+        externalActors: [
+          {
+            id: 'ext-browser-1',
+            name: 'Browser',
+            type: 'browser',
+            position: { x: -6, y: 0, z: 5 },
+          },
+          {
+            id: 'ext-internet-1',
+            name: 'Internet',
+            type: 'internet',
+            position: { x: -3, y: 0, z: 5 },
+          },
+        ],
+      });
+
+      getState().removeExternalActor('ext-browser-1');
+
+      expect(getArch().externalActors).toEqual([
+        {
+          id: 'ext-internet-1',
+          name: 'Internet',
+          type: 'internet',
+          position: { x: -3, y: 0, z: 5 },
+        },
+      ]);
+    });
+
+    it('removes connections that reference the removed actor', () => {
+      seedState({
+        externalActors: [
+          {
+            id: 'ext-browser-1',
+            name: 'Browser',
+            type: 'browser',
+            position: { x: -6, y: 0, z: 5 },
+          },
+          {
+            id: 'ext-internet-1',
+            name: 'Internet',
+            type: 'internet',
+            position: { x: -3, y: 0, z: 5 },
+          },
+        ],
+        connections: [
+          makeLegacyConnection('conn-remove', 'ext-browser-1', 'gw1', 'http'),
+          makeLegacyConnection('conn-keep', 'ext-internet-1', 'gw1', 'dataflow'),
+        ],
+      });
+
+      getState().removeExternalActor('ext-browser-1');
+
+      expect(getArch().connections).toHaveLength(1);
+      expect(getArch().connections[0].id).toBe('conn-keep');
+    });
+
+    it('supports undo/redo after addExternalActor', () => {
+      seedState({ externalActors: [] });
+
+      expect(getState().canUndo).toBe(false);
+      getState().addExternalActor('internet');
+      expect(getState().canUndo).toBe(true);
+      expect(getArch().externalActors).toHaveLength(1);
+
+      getState().undo();
+      expect(getArch().externalActors).toHaveLength(0);
+
+      getState().redo();
+      expect(getArch().externalActors).toHaveLength(1);
+      expect(getArch().externalActors?.[0]?.id).toBe('ext-internet-00000001');
+    });
+  });
+
   // ── updateConnectionType (lines 718-724) ──
 
   describe('updateConnectionType', () => {
@@ -728,6 +834,53 @@ describe('domainSlice – targeted branch coverage', () => {
       expect(getState().addConnection('compute-1', 'ext-internet')).toBe(false);
 
       expect(getState().addConnection('ext-internet', 'delivery-1')).toBe(true);
+    });
+
+    it('uses parseEndpointId fallback for capacity counting when endpoints are missing', () => {
+      const subnet = makeContainerNode('container-1', {
+        layer: 'subnet',
+        resourceType: 'subnet',
+        frame: { width: 8, height: 0.3, depth: 10 },
+      });
+      const delivery = makeLeafNode('delivery-1', 'container-1', 'delivery', {
+        resourceType: 'load_balancer',
+      });
+      const compute = makeLeafNode('compute-1', 'container-1', 'compute', {
+        resourceType: 'web_compute',
+      });
+
+      const deliveryDataOutput = generateEndpointsForBlock(delivery.id).find(
+        (endpoint) => endpoint.id === endpointId(delivery.id, 'output', 'data'),
+      );
+      const computeDataInput = generateEndpointsForBlock(compute.id).find(
+        (endpoint) => endpoint.id === endpointId(compute.id, 'input', 'data'),
+      );
+
+      expect(deliveryDataOutput).toBeDefined();
+      expect(computeDataInput).toBeDefined();
+
+      seedState({
+        nodes: [subnet, delivery, compute],
+        endpoints: [deliveryDataOutput!, computeDataInput!],
+        connections: [
+          {
+            id: 'conn-http',
+            from: endpointId(delivery.id, 'output', 'http'),
+            to: endpointId(compute.id, 'input', 'http'),
+            metadata: {
+              type: 'http',
+              sourceId: delivery.id,
+              targetId: compute.id,
+            },
+          },
+        ],
+      });
+
+      expect(getState().addConnection('delivery-1', 'compute-1')).toBe(true);
+
+      const createdConnection = getArch().connections.at(-1);
+      expect(createdConnection?.metadata?.sourcePort).toBe(1);
+      expect(createdConnection?.metadata?.targetPort).toBe(1);
     });
 
     it('returns false when endpoint-backed source/target cannot be resolved', () => {

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -58,6 +58,8 @@ type DomainSlice = Pick<
   | 'movePlatePosition'
   | 'moveBlockPosition'
   | 'moveActorPosition'
+  | 'addExternalActor'
+  | 'removeExternalActor'
   | 'addConnection'
   | 'removeConnection'
   | 'updateConnectionType'
@@ -782,6 +784,34 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
       });
 
       return withHistory(state, { ...arch, externalActors });
+    });
+  },
+
+  addExternalActor: (type, position) => {
+    set((state) => {
+      const arch = state.workspace.architecture;
+      const currentActors = arch.externalActors ?? [];
+      const actorSuffix = generateId('ext').slice(4);
+      const newActor: ExternalActor = {
+        id: `ext-${type}-${actorSuffix}`,
+        name: type === 'internet' ? 'Internet' : 'Browser',
+        type,
+        position: position ?? { x: -3, y: 0, z: -3 },
+      };
+      return withHistory(state, { ...arch, externalActors: [...currentActors, newActor] });
+    });
+  },
+
+  removeExternalActor: (id) => {
+    set((state) => {
+      const arch = state.workspace.architecture;
+      const currentActors = arch.externalActors ?? [];
+      const externalActors = currentActors.filter((actor) => actor.id !== id);
+      const connections = arch.connections.filter(
+        (connection) =>
+          connection.metadata['sourceId'] !== id && connection.metadata['targetId'] !== id,
+      );
+      return withHistory(state, { ...arch, externalActors, connections });
     });
   },
 

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -93,6 +93,11 @@ export interface ArchitectureState {
   /** @deprecated Use moveNodePosition(id, dx, dz) */
   moveBlockPosition: (id: string, deltaX: number, deltaZ: number) => void;
   moveActorPosition: (id: string, deltaX: number, deltaZ: number) => void;
+  addExternalActor: (
+    type: 'internet' | 'browser',
+    position?: { x: number; y: number; z: number },
+  ) => void;
+  removeExternalActor: (id: string) => void;
 
   addConnection: (from: string, to: string) => boolean;
   removeConnection: (id: string) => void;

--- a/apps/web/src/shared/assets/actor-sprites/browser.svg
+++ b/apps/web/src/shared/assets/actor-sprites/browser.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 158 140">
+  <defs>
+    <linearGradient id="browser-screen" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#A29BFE" />
+      <stop offset="55%" stop-color="#6C5CE7" />
+      <stop offset="100%" stop-color="#4B3FB5" />
+    </linearGradient>
+    <linearGradient id="browser-frame" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#E3E0FF" />
+      <stop offset="100%" stop-color="#8D88B8" />
+    </linearGradient>
+    <linearGradient id="browser-base" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#D6D3F2" />
+      <stop offset="100%" stop-color="#7A759F" />
+    </linearGradient>
+    <linearGradient id="browser-highlight" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+
+  <ellipse cx="79" cy="118" rx="58" ry="18" fill="rgba(0,0,0,0.2)" />
+
+  <rect x="33" y="26" width="92" height="60" rx="12" ry="12" fill="url(#browser-frame)" />
+  <rect x="38" y="31" width="82" height="50" rx="8" ry="8" fill="url(#browser-screen)" />
+
+  <rect x="42" y="35" width="74" height="8" rx="4" ry="4" fill="rgba(255,255,255,0.18)" />
+  <circle cx="48" cy="39" r="1.4" fill="#F9F7FF" />
+  <circle cx="54" cy="39" r="1.4" fill="#F0EDFF" opacity="0.9" />
+  <circle cx="60" cy="39" r="1.4" fill="#E6E2FF" opacity="0.8" />
+
+  <rect x="50" y="49" width="58" height="24" rx="5" ry="5" fill="rgba(17,16,40,0.26)" />
+  <path d="M54 67h50" stroke="rgba(255,255,255,0.24)" stroke-width="1" />
+  <path d="M54 63h38" stroke="rgba(255,255,255,0.22)" stroke-width="1" />
+  <path d="M54 59h44" stroke="rgba(255,255,255,0.2)" stroke-width="1" />
+
+  <path d="M41 90h76l18 14H23z" fill="url(#browser-base)" />
+  <rect x="70" y="93" width="18" height="3" rx="1.5" ry="1.5" fill="rgba(79,70,141,0.55)" />
+
+  <ellipse cx="62" cy="48" rx="20" ry="24" fill="url(#browser-highlight)" />
+</svg>

--- a/apps/web/src/shared/utils/metricsService.test.ts
+++ b/apps/web/src/shared/utils/metricsService.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { metricsService } from './metricsService';
+
+const METRICS_KEY = 'cloudblocks_funnel_metrics';
+const HEALTH_KEY = 'cloudblocks_health_snapshots';
 
 describe('metricsService', () => {
   beforeEach(() => {
@@ -77,5 +80,86 @@ describe('metricsService', () => {
     metricsService.trackEvent('first_plate_placed');
     const log = metricsService.getMetricsLog();
     expect(log[0].sessionId).toBe(log[1].sessionId);
+  });
+
+  it('returns empty metrics log when persisted JSON is invalid', () => {
+    localStorage.setItem(METRICS_KEY, '{invalid-json');
+    expect(metricsService.getMetricsLog()).toEqual([]);
+  });
+
+  it('keeps only latest 200 metrics', () => {
+    for (let i = 0; i < 205; i += 1) {
+      metricsService.trackEvent('app_loaded', { index: i });
+    }
+
+    const log = metricsService.getMetricsLog();
+    expect(log).toHaveLength(200);
+    expect(log[0].metadata).toEqual({ index: 5 });
+    expect(log[199].metadata).toEqual({ index: 204 });
+  });
+
+  it('swallows persist metric errors when localStorage.setItem fails', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    expect(() => metricsService.trackEvent('app_loaded')).not.toThrow();
+
+    setItemSpy.mockRestore();
+  });
+
+  it('reads navigation timing entries when available', () => {
+    const navigationEntry = {
+      domContentLoadedEventEnd: 123.6,
+      loadEventEnd: 456.2,
+    } as unknown as PerformanceNavigationTiming;
+    const navigationSpy = vi
+      .spyOn(performance, 'getEntriesByType')
+      .mockReturnValue([navigationEntry]);
+
+    const snapshot = metricsService.captureHealthSnapshot();
+
+    expect(snapshot.navigationTiming).toEqual({
+      domContentLoaded: 124,
+      loadComplete: 456,
+    });
+
+    navigationSpy.mockRestore();
+  });
+
+  it('keeps only latest 50 health snapshots', () => {
+    for (let i = 0; i < 52; i += 1) {
+      metricsService.captureHealthSnapshot(i);
+    }
+
+    const snapshots = metricsService.getHealthSnapshots();
+    expect(snapshots).toHaveLength(50);
+    expect(snapshots[0].connectionCount).toBe(2);
+    expect(snapshots[49].connectionCount).toBe(51);
+  });
+
+  it('returns empty health snapshots when persisted JSON is invalid', () => {
+    localStorage.setItem(HEALTH_KEY, '{invalid-json');
+    expect(metricsService.getHealthSnapshots()).toEqual([]);
+  });
+
+  it('swallows health snapshot persistence errors when localStorage.setItem fails', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    expect(() => metricsService.captureHealthSnapshot()).not.toThrow();
+
+    setItemSpy.mockRestore();
+  });
+
+  it('swallows clearMetrics errors when localStorage.removeItem fails', () => {
+    const removeItemSpy = vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error('storage unavailable');
+    });
+
+    expect(() => metricsService.clearMetrics()).not.toThrow();
+
+    removeItemSpy.mockRestore();
   });
 });

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
@@ -100,6 +100,7 @@ const subnetPlate: ContainerBlock = {
 
 describe('SidebarPalette additional coverage', () => {
   const addNode = vi.fn();
+  const addExternalActor = vi.fn();
   const startPlacing = vi.fn();
   const cancelInteraction = vi.fn();
 
@@ -117,6 +118,7 @@ describe('SidebarPalette additional coverage', () => {
 
     useArchitectureStore.setState({
       addNode,
+      addExternalActor,
       workspace: {
         id: 'ws-1',
         name: 'Test Workspace',

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
@@ -66,6 +66,70 @@
   overflow-y: auto;
 }
 
+.sidebar-palette-actor-section {
+  padding: 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-surface-raised) 60%, transparent);
+}
+
+.sidebar-palette-actor-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  font: 700 var(--text-xs) / 1 var(--font-ui);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.sidebar-palette-actor-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sidebar-palette-actor-btn {
+  width: 100%;
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color var(--duration-fast) var(--easing-standard),
+    background var(--duration-fast) var(--easing-standard),
+    transform var(--duration-fast) var(--easing-standard);
+}
+
+.sidebar-palette-actor-btn:hover {
+  border-color: color-mix(in srgb, var(--accent-primary) 48%, var(--border-default));
+  background: var(--bg-surface-raised);
+  transform: translateY(-1px);
+}
+
+.sidebar-palette-actor-img {
+  width: 18px;
+  height: 18px;
+  object-fit: contain;
+}
+
+.sidebar-palette-actor-name {
+  flex: 1;
+  font: 700 var(--text-xs) / 1.2 var(--font-ui);
+}
+
+.sidebar-palette-actor-add {
+  font: 600 var(--text-xs) / 1 var(--font-ui);
+  color: var(--text-secondary);
+}
+
 .sidebar-palette-group {
   border: 1px solid var(--border-subtle);
   border-radius: 10px;

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.test.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.test.tsx
@@ -64,6 +64,7 @@ const publicSubnet: ContainerBlock = {
 
 describe('SidebarPalette', () => {
   const addNodeMock = vi.fn();
+  const addExternalActorMock = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -76,6 +77,7 @@ describe('SidebarPalette', () => {
 
     useArchitectureStore.setState({
       addNode: addNodeMock,
+      addExternalActor: addExternalActorMock,
       workspace: {
         id: 'ws-1',
         name: 'Test Workspace',
@@ -88,6 +90,10 @@ describe('SidebarPalette', () => {
 
   it('renders category groups', () => {
     render(<SidebarPalette />);
+
+    expect(screen.getByText('External Actors')).toBeInTheDocument();
+    expect(screen.getByTitle('Add Internet')).toBeInTheDocument();
+    expect(screen.getByTitle('Add Browser')).toBeInTheDocument();
 
     // Groups with starter-tier resources appear by default
     expect(screen.getByText('Network')).toBeInTheDocument();
@@ -208,6 +214,17 @@ describe('SidebarPalette', () => {
       provider: 'azure',
       subtype: 'vm',
     });
+  });
+
+  it('adds external actor from palette actions', async () => {
+    const user = userEvent.setup();
+    render(<SidebarPalette />);
+
+    await user.click(screen.getByTitle('Add Internet'));
+    await user.click(screen.getByTitle('Add Browser'));
+
+    expect(addExternalActorMock).toHaveBeenNthCalledWith(1, 'internet');
+    expect(addExternalActorMock).toHaveBeenNthCalledWith(2, 'browser');
   });
 
   describe('starter/advanced tier toggle', () => {

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
@@ -33,6 +33,15 @@ const CATEGORY_COLOR_VARS: Record<CreationGroupId, string> = {
   operations: 'var(--cat-operations)',
 };
 
+const EXTERNAL_ACTOR_OPTIONS: ReadonlyArray<{
+  type: 'internet' | 'browser';
+  name: string;
+  emoji: string;
+}> = [
+  { type: 'internet', name: 'Internet', emoji: '🌐' },
+  { type: 'browser', name: 'Browser', emoji: '💻' },
+];
+
 interface HighlightMatchProps {
   text: string;
   query: string;
@@ -185,6 +194,7 @@ function PaletteResourceItem({
 export function SidebarPalette() {
   const techTree = useTechTree();
   const addNode = useArchitectureStore((s) => s.addNode);
+  const addExternalActor = useArchitectureStore((s) => s.addExternalActor);
   const activeProvider = useUIStore((s) => s.activeProvider);
   const startPlacing = useUIStore((s) => s.startPlacing);
   const cancelInteraction = useUIStore((s) => s.cancelInteraction);
@@ -396,6 +406,37 @@ export function SidebarPalette() {
       </label>
 
       <div className="sidebar-palette-content">
+        <section className="sidebar-palette-actor-section" aria-label="External actors">
+          <div className="sidebar-palette-actor-title">
+            <span aria-hidden="true">🔌</span>
+            <span>External Actors</span>
+          </div>
+          <div className="sidebar-palette-actor-list">
+            {EXTERNAL_ACTOR_OPTIONS.map((actor) => (
+              <button
+                key={actor.type}
+                type="button"
+                className="sidebar-palette-actor-btn"
+                onClick={() => {
+                  addExternalActor(actor.type);
+                  playSound('block-snap');
+                }}
+                title={`Add ${actor.name}`}
+              >
+                <img
+                  className="sidebar-palette-actor-img"
+                  src={`/actor-sprites/${actor.type}.svg`}
+                  alt=""
+                  width={18}
+                  height={18}
+                />
+                <span className="sidebar-palette-actor-name">{actor.name}</span>
+                <span className="sidebar-palette-actor-add">{actor.emoji} Add</span>
+              </button>
+            ))}
+          </div>
+        </section>
+
         {groupedResources.map(({ groupId, resources }) => (
           <PaletteCategoryGroup
             key={groupId}


### PR DESCRIPTION
## Summary

- Restore `browser.svg` asset (deleted during visual overhaul commit `557cc4f`)
- Add `addExternalActor` / `removeExternalActor` store actions with undo/redo support
- Add "External Actors" section to sidebar palette (Internet + Browser buttons)
- Mobile support auto-propagated via `MobilePaletteSheet` wrapper
- Coverage fix: added branch tests for `metricsService` and `domainSlice` parseEndpointId fallback

## Sub-Issues

- Fixes #1460 — fix: restore browser.svg
- Fixes #1461 — feat: add/remove external actor store actions
- Fixes #1462 — feat: External Actors section in sidebar palette
- Fixes #1463 — feat: external actors in mobile palette
- Fixes #1464 — test: external actor tests

Part of Epic #1454

## Changes

| File | Change |
|---|---|
| `browser.svg` | New SVG asset — laptop/monitor icon with purple/gray theme |
| `domainSlice.ts` | Added `addExternalActor` and `removeExternalActor` actions |
| `types.ts` | Added type signatures for new store actions |
| `SidebarPalette.tsx` | Added External Actors section at top of palette |
| `SidebarPalette.css` | Added actor section styles |
| `domainSlice.test.ts` | Tests for add/remove/undo-redo + parseEndpointId fallback |
| `SidebarPalette.test.tsx` | Tests for External Actors section rendering |
| `SidebarPalette.additional.test.tsx` | Updated store mocks |
| `metricsService.test.ts` | Branch coverage tests for overflow/error paths |

## Design Decisions

- External Actors section placed **above** the 8 resource categories (per Oracle recommendation)
- Uses same click-to-place interaction as resource blocks
- `addExternalActor` follows `withHistory` pattern for undo/redo
- `removeExternalActor` cascades connection cleanup using `metadata.sourceId/targetId`
- Not a 9th category — external actors are a separate entity type (`ExternalActor`)