### PR TITLE
docs: truth cleanup — align docs and metadata with beginner learning tool positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Most diagram tools produce static images. CloudBlocks produces a **live architec
 
 ## Features
 
-- 🧱 **Block-based modeling** — Container blocks (boundaries) + Resource blocks (resources) + typed Connections
 - 📋 **Guided templates** — Start from 6 built-in architecture patterns with step-by-step learning scenarios
 - 📚 **Learning mode** — Interactive guided scenarios to learn cloud architecture patterns (beginner → advanced)
+- 🧱 **Block-based modeling** — Container blocks (boundaries) + Resource blocks (resources) + typed Connections
 - ✅ **Validation engine** — Real-time rule checking for placement and connections
 - 📦 **8 resource categories** — Network, Delivery, Compute, Data, Messaging, Security, Identity, Operations
-- 🌐 **Multi-cloud preview** — Visual preview for Azure, AWS, and GCP
 - ⚡ **Terraform starter export** — Export your design to Terraform starter code for learning and prototyping
+- 🌐 **Multi-cloud preview** — Visual preview for Azure, AWS, and GCP
 - 🎨 **Dual theme system** — Workshop (light, enterprise) and Blueprint (dark, creative)
 - ⚗️ **Bicep & Pulumi** _(Experimental)_ — Additional IaC export formats
 - 🔗 **GitHub integration** _(Backend required)_ — OAuth login, repo sync, PR creation

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,7 +47,7 @@
 | **1** | Open the builder (live demo or local)          | [Quick Start](user-guide/quick-start.md)               |
 | **2** | Load a guided template and follow the steps    | [First Architecture](user-guide/first-architecture.md) |
 | **3** | Customize — add blocks, connect, validate      | [Editor Basics](user-guide/editor-basics.md)           |
-| **4** | Export Terraform starter code to keep learning | [Workspaces](user-guide/workspaces.md)                 |
+| **4** | Export Terraform starter code to keep learning | [Code Generation](advanced/code-generation.md)         |
 
 ---
 
@@ -79,13 +79,13 @@ CloudBlocks uses a **block-based composition model** where everything snaps toge
 
 | Feature                      | Description                                                                 |
 | ---------------------------- | --------------------------------------------------------------------------- |
-| **Visual Builder**           | Drag-and-drop editor with grid snapping and auto-layout                     |
 | **Guided Templates**         | 6 built-in architecture patterns with step-by-step learning scenarios       |
 | **Learning Mode**            | Interactive guided scenarios to learn cloud architecture patterns (V1 Core) |
-| **8 Resource Categories**    | Network, Delivery, Compute, Data, Messaging, Security, Identity, Operations |
-| **Multi-Cloud Preview**      | Visual preview for Azure, AWS, and GCP                                      |
+| **Visual Builder**           | Drag-and-drop editor with grid snapping and auto-layout                     |
 | **Validation Engine**        | Real-time rule checking for placement, connections, and constraints         |
+| **8 Resource Categories**    | Network, Delivery, Compute, Data, Messaging, Security, Identity, Operations |
 | **Terraform Starter Export** | Export your design to Terraform starter code for learning and prototyping   |
+| **Multi-Cloud Preview**      | Visual preview for Azure, AWS, and GCP                                      |
 | **Dual Theme System**        | Workshop (light) and Blueprint (dark) themes                                |
 | **Bicep & Pulumi**           | Additional IaC export formats _(Experimental)_                              |
 

--- a/docs/design/ANALYTICS_INSTRUMENTATION_PLAN.md
+++ b/docs/design/ANALYTICS_INSTRUMENTATION_PLAN.md
@@ -2,6 +2,10 @@
 
 > Covers Gate 6 (Beginner Usability) metrics from [`RELEASE_GATES.md`](RELEASE_GATES.md).
 
+!!! warning "Aspiration vs Implementation"
+    This plan describes the **intended** analytics instrumentation. Most events listed here are not yet implemented. Persona-related events (`persona_selected`, `session_started.persona`) reference a feature that has been removed. This document will be updated when analytics instrumentation is prioritized.
+
+
 ## 1. Purpose
 
 Gate 6 defines four usability metrics that determine whether CloudBlocks succeeds as a visual cloud learning tool for beginners. This document specifies the events, code insertion points, tooling, and privacy constraints required to measure those metrics.

--- a/docs/design/CLOUDBLOCKS_SPEC_V2.md
+++ b/docs/design/CLOUDBLOCKS_SPEC_V2.md
@@ -6,6 +6,10 @@
 **Date**: 2026-03-19  
 **Supersedes**: Block design spec (v1.x), VISUAL_DESIGN_SPEC.md (v1.x)
 
+!!! warning "Aspiration vs Implementation"
+    This specification is a **design target**, not a description of current behavior. Many sections describe features that are planned but not yet built (e.g., pixel-perfect CU grid, sub-pixel prevention, full provider-specific icon sets). Check the [V1 Product Contract](../concept/V1_PRODUCT_CONTRACT.md) for what is actually implemented today.
+
+
 ---
 
 ## 0. Design Principles

--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -1,6 +1,6 @@
 # Core Concepts
 
-> **Audience**: All users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 CloudBlocks is a visual cloud learning tool that uses a block-based composition model. You learn cloud architecture by placing elements on the canvas, connecting them with typed protocols, and validating against real-world rules.
 

--- a/docs/user-guide/editor-basics.md
+++ b/docs/user-guide/editor-basics.md
@@ -1,6 +1,6 @@
 # Editor Basics
 
-> **Audience**: All users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 The CloudBlocks editor is a hands-on workspace for learning cloud architecture. Most beginners should start from a guided template or scenario, then use this page as a reference while they explore the canvas, palette, inspector, and validation tools.
 

--- a/docs/user-guide/first-architecture.md
+++ b/docs/user-guide/first-architecture.md
@@ -1,6 +1,6 @@
 # First Architecture from a Template
 
-> **Audience**: New users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 Learn your first cloud architecture in 5 minutes using a built-in template with guided learning. No cloud account or backend required — everything runs in your browser.
 
@@ -11,7 +11,7 @@ Learn your first cloud architecture in 5 minutes using a built-in template with 
 - **Live Demo**: Visit [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/)
 - **Local**: Clone and run (see [Quick Start](quick-start.md))
 
-When CloudBlocks opens, choose a persona (e.g., Developer) to enter the builder.
+When CloudBlocks opens, click **Get Started** to enter the builder.
 
 ---
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,6 +1,6 @@
 # What is CloudBlocks?
 
-> **Audience**: New users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 Welcome to CloudBlocks — a visual cloud learning tool for beginners. Start from guided templates, learn common architecture patterns step by step, and export Terraform starter code. Everything runs in your browser — no cloud account or backend required.
 

--- a/docs/user-guide/provider-support.md
+++ b/docs/user-guide/provider-support.md
@@ -1,0 +1,59 @@
+# Provider Support
+
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
+
+CloudBlocks supports three cloud providers: **Azure**, **AWS**, and **GCP**. This page explains what works for each provider in V1.
+
+---
+
+## Provider Coverage Summary
+
+| Feature                    | Azure       | AWS         | GCP         |
+| :------------------------- | :---------- | :---------- | :---------- |
+| **Visual builder**         | ✅ Full      | ✅ Full      | ✅ Full      |
+| **Templates & scenarios**  | ✅ Full      | ✅ Full      | ✅ Full      |
+| **Validation engine**      | ✅ Full      | ✅ Full      | ✅ Full      |
+| **Terraform starter code** | ✅ Full      | ✅ Full      | ✅ Full      |
+| **Bicep export**           | ✅ Azure-only | —           | —           |
+| **Pulumi export**          | ✅ Azure-only | —           | —           |
+
+---
+
+## How to Switch Providers
+
+1. Open the **menu bar** at the top of the builder.
+2. Click the **provider tabs** (Azure, AWS, GCP) to switch the active provider.
+3. The canvas, palette, and code preview update to reflect the selected provider.
+
+Your architecture model is **provider-neutral** — switching providers changes how blocks are rendered and what code is generated, but your design stays the same.
+
+---
+
+## What "Multi-Cloud Preview" Means
+
+CloudBlocks lets you **visualize** the same architecture across Azure, AWS, and GCP. This helps you compare how cloud providers name and organize equivalent services.
+
+!!! info "Learning focus"
+    Multi-cloud preview is a learning feature — it shows you the provider-specific names and structure for the same architecture pattern. It is not a deployment tool.
+
+---
+
+## Export Format by Provider
+
+| Export Format   | Providers Supported | Status       |
+| :-------------- | :------------------ | :----------- |
+| **Terraform**   | Azure, AWS, GCP     | V1 Core      |
+| **Bicep**       | Azure only          | Experimental |
+| **Pulumi**      | Azure only          | Experimental |
+
+For details on exporting code, see [Code Generation](../advanced/code-generation.md).
+
+---
+
+## What's Next?
+
+| Goal                             | Guide                                            |
+| :------------------------------- | :----------------------------------------------- |
+| Export Terraform starter code    | [Code Generation](../advanced/code-generation.md) |
+| Understand the building blocks   | [Core Concepts](core-concepts.md)                |
+| Browse architecture patterns     | [Templates](templates.md)                        |

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-> **Audience**: New users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 Build your first cloud architecture in under 5 minutes. No cloud account required. Everything runs in your browser.
 
@@ -22,7 +22,7 @@ pnpm dev
 
 Open [http://localhost:5173](http://localhost:5173) in your browser.
 
-When CloudBlocks opens, you will see a landing page. Choose a persona (e.g., Developer) to enter the builder.
+When CloudBlocks opens, you will see a landing page with a brief introduction. Click **Get Started** to enter the builder.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
       - Workspaces & Save/Load: user-guide/workspaces.md
       - Keyboard Shortcuts: user-guide/keyboard-shortcuts.md
       - FAQ: user-guide/faq.md
+      - Provider Support: user-guide/provider-support.md
 
   - Advanced:
       - Blank Canvas Mode: advanced/blank-canvas.md


### PR DESCRIPTION
## Summary

Aligns all documentation, GitHub metadata, and feature ordering with the V1 "visual cloud learning tool for beginners" positioning established in the M27 positioning reset.

## Changes (6 truth fixes)

### Truth #1 — GitHub repo metadata
- Updated repo description from "Preset-driven visual cloud architecture design tool" to "Visual cloud learning tool for beginners..."
- Updated homepage from `/docs/` to `/` (the app itself)
- Replaced stale topics (`lego-style`, `architecture-compiler`, `devops`) with learning-focused ones (`cloud-learning`, `beginner`, `learning-tool`, `guided-templates`, `terraform-starter`)

### Truth #2 — Remove persona references
- Removed "Choose a persona" instructions from `quick-start.md` and `first-architecture.md` (persona system was removed in #1491)
- Replaced with "Click **Get Started** to enter the builder"

### Truth #3 — Create provider-support.md
- Created `docs/user-guide/provider-support.md` with provider coverage matrix (Azure/AWS/GCP × features)
- Added to MkDocs nav under Build section

### Truth #4 — Audience metadata
- Changed `Audience: New users` / `Audience: All users` → `Audience: Beginners` in 5 user-facing docs (index, quick-start, first-architecture, core-concepts, editor-basics)

### Truth #5 — Export link + feature ordering
- Fixed docs home step 4 link: `workspaces.md` → `advanced/code-generation.md`
- Reordered features in README.md and docs/README.md: learning features (Guided Templates, Learning Mode) now listed first

### Truth #6 — Aspiration vs implementation banners
- Added `!!! warning "Aspiration vs Implementation"` banners to `CLOUDBLOCKS_SPEC_V2.md` and `ANALYTICS_INSTRUMENTATION_PLAN.md`
- Noted persona-related analytics events reference removed feature

## Files Changed

- `README.md` — feature list reordering
- `docs/README.md` — export link fix + feature table reordering
- `docs/user-guide/provider-support.md` — **new file**
- `docs/user-guide/quick-start.md` — persona removal + audience metadata
- `docs/user-guide/first-architecture.md` — persona removal + audience metadata
- `docs/user-guide/index.md` — audience metadata
- `docs/user-guide/core-concepts.md` — audience metadata
- `docs/user-guide/editor-basics.md` — audience metadata
- `docs/design/CLOUDBLOCKS_SPEC_V2.md` — aspiration banner
- `docs/design/ANALYTICS_INSTRUMENTATION_PLAN.md` — aspiration banner
- `mkdocs.yml` — nav entry for provider-support

## Verification

- `pnpm build` ✅ clean
- `pnpm format:check` ✅ all files formatted
- GitHub repo metadata updated via API ✅