### PR TITLE
docs: align documentation with current UI reality

### DIFF
--- a/docs/advanced/code-generation.md
+++ b/docs/advanced/code-generation.md
@@ -1,6 +1,6 @@
 # Code Generation
 
-> **Audience**: All users | **Status**: V1 Core (Terraform) / Experimental (Bicep, Pulumi) | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core (Terraform) / Experimental (Bicep, Pulumi) | **Verified against**: v0.26.0
 
 !!! info "Terraform Starter Export"
     Terraform starter export is a V1 Core feature — it helps you learn what your visual architecture looks like as infrastructure-as-code. Bicep and Pulumi are available as Experimental features. The UI currently labels Generate Code as "Experimental" — it generates Terraform starter code using the V1 Core pipeline.
@@ -38,7 +38,7 @@ Use the format selector to switch between output formats. Click **Copy** to copy
 
 ## Multi-Cloud Output
 
-CloudBlocks generates code for the currently active provider tab (Azure, AWS, or GCP). Switch provider tabs in the menu bar to generate code for different cloud platforms.
+CloudBlocks generates code for the currently active provider. Azure is active by default; AWS and GCP tabs are visible but marked Coming Soon. The code generation engine supports all three providers for Terraform output.
 
 !!! info "Provider Coverage"
     Provider coverage varies by template, resource, and export path. Terraform starter export supports all three providers. Bicep is Azure-only. Pulumi is Azure-only.
@@ -75,4 +75,4 @@ This is designed for learning — review the code to deepen your understanding o
 | Browse architecture patterns    | [Templates](../user-guide/templates.md)         |
 | Build from a blank canvas       | [Blank Canvas Mode](blank-canvas.md)            |
 | Understand connection semantics | [Core Concepts](../user-guide/core-concepts.md) |
-| Try guided learning scenarios   | **Build → Browse Scenarios** in the menu bar    |
+| Try guided learning scenarios   | Click the **Learn** button in the menu bar      |

--- a/docs/concept/COMPATIBILITY.md
+++ b/docs/concept/COMPATIBILITY.md
@@ -1,6 +1,6 @@
 # CloudBlocks Compatibility & Migration Policy
 
-> **Audience**: All Users | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
 
 This document defines how CloudBlocks handles versioning, backward compatibility, and data migration. Compatibility guarantees are scoped to **blessed (built-in) templates and the Terraform starter export flow**. Experimental features (Bicep, Pulumi) and custom blank-canvas architectures may change without a major version bump.
 

--- a/docs/concept/PRODUCT_DIRECTION_SPEC.md
+++ b/docs/concept/PRODUCT_DIRECTION_SPEC.md
@@ -1,6 +1,6 @@
 # CloudBlocks — Product Direction & Implementation Specification
 
-> **Status**: Active — guides M21+ development
+> **Status**: Active — guides M27+ development
 > **Last Updated**: 2026-03-28
 
 ## Vision

--- a/docs/concept/UI_FLOW.md
+++ b/docs/concept/UI_FLOW.md
@@ -2,7 +2,7 @@
 
 > **Audience**: Contributors | **Status**: Stable — Internal | **Verified against**: v0.26.0
 
-> Describes the actual user interaction flows implemented in CloudBlocks (Milestones 1–18).
+> Describes the actual user interaction flows implemented in CloudBlocks (Milestones 1–26).
 
 ---
 

--- a/docs/concept/V1_PRODUCT_CONTRACT.md
+++ b/docs/concept/V1_PRODUCT_CONTRACT.md
@@ -1,6 +1,6 @@
 # CloudBlocks V1 Product Contract
 
-> **Audience**: All Users | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
 
 This document defines what CloudBlocks v1.0.0 guarantees to its users.
 

--- a/docs/design/LEARNING_MODE_SPEC.md
+++ b/docs/design/LEARNING_MODE_SPEC.md
@@ -1,6 +1,6 @@
 # Learning Mode — Technical Design Specification
 
-> **Audience**: All Users / Contributors | **Status**: Stable — **V1 Core** | **Verified against**: v0.26.0
+> **Audience**: Beginners / Contributors | **Status**: Stable — **V1 Core** | **Verified against**: v0.26.0
 
 > **Milestone**: 6C — Learning Mode
 > **Last Updated**: 2026-03-28

--- a/docs/design/RELEASE_GATES.md
+++ b/docs/design/RELEASE_GATES.md
@@ -275,7 +275,7 @@ All Milestone 6 gates plus:
 - Release management: CHANGELOG.md, annotated tags, GitHub Releases
 - Versioning convention: Milestone N = v0.N.0
 
-### Milestone 17 (In Progress)
+### Milestone 17 (Completed)
 
 All Milestone 16 gates plus:
 
@@ -288,7 +288,7 @@ All Milestone 16 gates plus:
 - CI pipeline builds and tests extracted packages
 - Version alignment policy enforced: all packages at single version
 
-### Milestone 17 (In Progress) — Additional Gate
+### Milestone 17 (Completed) — Additional Gate
 
 #### Gate 6: Beginner Usability
 

--- a/docs/model/DOMAIN_MODEL.md
+++ b/docs/model/DOMAIN_MODEL.md
@@ -1,6 +1,6 @@
 # CloudBlocks Platform — Domain Model
 
-> **Audience**: All Users / Contributors | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners / Contributors | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
 
 > **Canonical Source Declaration**
 >

--- a/docs/user-guide/core-concepts.md
+++ b/docs/user-guide/core-concepts.md
@@ -88,13 +88,13 @@ Templates provide pre-configured architecture patterns to help you learn common 
 
 ## Cloud Providers
 
-CloudBlocks supports multiple cloud providers, adapting resource names and icons automatically. Provider coverage varies by template, resource, and export path.
+CloudBlocks supports multiple cloud providers, adapting resource names and icons automatically.
 
-- **Azure**: Full resource coverage across all 8 categories.
-- **AWS**: Resource names adapt to AWS terminology (e.g., VPC, EC2, Lambda, S3, RDS).
-- **GCP**: Resource names adapt to GCP terminology (e.g., Compute Engine, Cloud Functions, Cloud Storage).
+- **Azure**: Full resource coverage across all 8 categories (active).
+- **AWS**: Resource names adapt to AWS terminology (e.g., VPC, EC2, Lambda, S3, RDS). _(Coming Soon)_
+- **GCP**: Resource names adapt to GCP terminology (e.g., Compute Engine, Cloud Functions, Cloud Storage). _(Coming Soon)_
 
-Use the provider tabs in the menu bar to switch the active provider for your workspace.
+Azure is the default active provider. AWS and GCP tabs are visible in the menu bar but marked Coming Soon.
 
 ---
 
@@ -128,7 +128,7 @@ Learning Mode is the **primary way beginners interact with CloudBlocks**. Intera
 - **Serverless HTTP API**: Intermediate scenario, approximately 8 minutes.
 - **Event-Driven Data Pipeline**: Advanced scenario, approximately 12 minutes.
 
-Access these guided scenarios via **Build → Browse Scenarios** in the menu bar, or by clicking **Start from Template** on an empty canvas.
+Access these guided scenarios by clicking the **Learn** button in the menu bar, or by clicking **Start Learning** on an empty canvas.
 
 ---
 

--- a/docs/user-guide/create-architecture.md
+++ b/docs/user-guide/create-architecture.md
@@ -1,6 +1,6 @@
 # Create an Architecture
 
-> **Audience**: All users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 CloudBlocks is template-first. If you are new to cloud architecture, start from a guided template so you can learn a real pattern before practicing on a blank canvas.
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-> **Audience**: All Users | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
 
 Find answers to frequently asked questions about CloudBlocks.
 
@@ -34,15 +34,17 @@ No. CloudBlocks is a learning tool, not a deployment platform. It exports Terraf
 
 ### How do I start learning?
 
-Click **Start from Template** on the empty canvas, or go to **Build → Browse Scenarios** in the menu bar. Choose a scenario that matches your level (beginner, intermediate, or advanced) and follow the guided steps.
+Click **Start Learning** on the empty canvas, or click the **Learn** button in the menu bar. Choose a scenario that matches your level (beginner, intermediate, or advanced) and follow the guided steps.
 
 ### What scenarios are available?
 
-Three built-in scenarios are available:
+Three built-in guided scenarios are available:
 
 1. **Three-Tier Web Application** (Beginner, ~10 min) — Build a classic frontend + API + database architecture
 2. **Serverless HTTP API** (Intermediate, ~8 min) — Build a serverless function architecture
 3. **Event-Driven Data Pipeline** (Advanced, ~12 min) — Build an event processing pattern
+
+In addition, there are 6 built-in templates (including the 3 scenario templates plus Simple Compute Setup, Data Storage Backend, and Full-Stack Serverless with Event Processing) that you can load from the template gallery.
 
 ### Can I exit a scenario early?
 
@@ -54,7 +56,7 @@ Yes. You can exit Learning Mode at any time and keep the architecture you have b
 
 ### What cloud providers are supported?
 
-CloudBlocks supports Azure, AWS, and GCP for visual preview. Provider coverage varies by template, resource, and export path.
+Azure is the active provider with full resource coverage across all 8 categories. AWS and GCP tabs are visible in the menu bar but marked Coming Soon. The code generation engine supports all three providers for Terraform output.
 
 ### What are the 8 resource categories?
 
@@ -122,7 +124,7 @@ Check that your source category can initiate connections (Compute, Delivery, or 
 
 ### Where is Learning Mode?
 
-You can access Learning Mode via **Build → Browse Scenarios** in the menu bar, or by clicking **Start from Template** on the empty canvas. There are three built-in scenarios: Three-Tier Web Application, Serverless HTTP API, and Event-Driven Data Pipeline.
+You can access Learning Mode by clicking the **Learn** button in the menu bar, or by clicking **Start Learning** on the empty canvas. There are three built-in scenarios: Three-Tier Web Application, Serverless HTTP API, and Event-Driven Data Pipeline.
 
 ---
 

--- a/docs/user-guide/first-architecture.md
+++ b/docs/user-guide/first-architecture.md
@@ -11,7 +11,7 @@ Learn your first cloud architecture in 5 minutes using a built-in template with 
 - **Live Demo**: Visit [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/)
 - **Local**: Clone and run (see [Quick Start](quick-start.md))
 
-When CloudBlocks opens, click **Get Started** to enter the builder.
+When CloudBlocks opens, click **Start Learning** to enter the builder.
 
 ---
 
@@ -19,12 +19,12 @@ When CloudBlocks opens, click **Get Started** to enter the builder.
 
 On the empty canvas, you will see two options:
 
-| Option                  | What it does                                                     |
-| :---------------------- | :--------------------------------------------------------------- |
-| **Start from Template** | Opens the Scenario Gallery with guided architecture patterns     |
-| **Start from Scratch**  | Dismisses the overlay so you can build manually from the sidebar |
+| Option                          | What it does                                                     |
+| :------------------------------ | :--------------------------------------------------------------- |
+| **Start Learning**              | Opens the Scenario Gallery with guided architecture patterns     |
+| **Practice on Blank Canvas**    | Dismisses the overlay so you can build manually from the sidebar |
 
-**Recommended for beginners**: Click **Start from Template** to open the Scenario Gallery, then select **Three-Tier Web Application** to follow a guided learning scenario. You can also browse scenarios later via **Build → Browse Scenarios** in the menu bar.
+**Recommended for beginners**: Click **Start Learning** to open the Scenario Gallery, then select **Three-Tier Web Application** to follow a guided learning scenario. You can also browse scenarios later by clicking the **Learn** button in the menu bar.
 
 This loads a complete architecture with:
 
@@ -99,6 +99,6 @@ Your progress is automatically saved to your browser's local storage.
 | :----------------------------------- | :----------------------------------------------- |
 | Understand the building blocks       | [Core Concepts](core-concepts.md)                |
 | Browse all architecture patterns     | [Templates](templates.md)                        |
-| Try guided learning scenarios        | **Build → Browse Scenarios** in the menu bar     |
+| Try guided learning scenarios        | Click the **Learn** button in the menu bar      |
 | Build from a blank canvas (advanced) | [Blank Canvas Mode](../advanced/blank-canvas.md) |
 | Learn keyboard shortcuts             | [Keyboard Shortcuts](keyboard-shortcuts.md)      |

--- a/docs/user-guide/generate-code.md
+++ b/docs/user-guide/generate-code.md
@@ -1,6 +1,6 @@
 # Generating Code
 
-> **Audience**: All users | **Status**: Superseded reference | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: Superseded reference | **Verified against**: v0.26.0
 
 !!! info "Terraform starter export"
     Terraform starter export is a V1 Core learning feature. Bicep and Pulumi remain Experimental. For the current guide, use [Code Generation](../advanced/code-generation.md).

--- a/docs/user-guide/keyboard-shortcuts.md
+++ b/docs/user-guide/keyboard-shortcuts.md
@@ -1,6 +1,6 @@
 # Keyboard Shortcuts
 
-> **Audience**: All Users | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
 
 Use keyboard shortcuts to speed up your workflow in CloudBlocks.
 

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -22,7 +22,7 @@ pnpm dev
 
 Open [http://localhost:5173](http://localhost:5173) in your browser.
 
-When CloudBlocks opens, you will see a landing page with a brief introduction. Click **Get Started** to enter the builder.
+When CloudBlocks opens, you will see a landing page. Click **Start Learning** to enter the builder.
 
 ---
 
@@ -30,12 +30,12 @@ When CloudBlocks opens, you will see a landing page with a brief introduction. C
 
 On the empty canvas, you will see two options:
 
-| Option                  | What it does                                                     |
-| :---------------------- | :--------------------------------------------------------------- |
-| **Start from Template** | Opens the Scenario Gallery with guided architecture patterns     |
-| **Start from Scratch**  | Dismisses the overlay so you can build manually from the sidebar |
+| Option                          | What it does                                                     |
+| :------------------------------ | :--------------------------------------------------------------- |
+| **Start Learning**              | Opens the Scenario Gallery with guided architecture patterns     |
+| **Practice on Blank Canvas**    | Dismisses the overlay so you can build manually from the sidebar |
 
-Click **Start from Template** and select **Three-Tier Web Application**. This loads a guided scenario with an Application Gateway, VM, SQL Database, and Blob Storage — all pre-wired with connections.
+Click **Start Learning** and select **Three-Tier Web Application**. This loads a guided scenario with an Application Gateway, VM, SQL Database, and Blob Storage — all pre-wired with connections.
 
 ---
 
@@ -43,7 +43,7 @@ Click **Start from Template** and select **Three-Tier Web Application**. This lo
 
 The builder uses a 4-panel layout:
 
-- **Menu Bar** (top) — Access File, Edit, Build, and View menus. Switch between Provider tabs (Azure, AWS, GCP). Manage workspaces.
+- **Menu Bar** (top) — Access File, Edit, Build, and View menus. The provider selector shows Azure (active), AWS, and GCP (Coming Soon). Manage workspaces.
 - **Sidebar Palette** (left) — Resource palette grouped into 8 categories: Network, Delivery, Compute, Data, Messaging, Security, Identity, and Operations. Click or drag items to create resources.
 - **Canvas** (center) — The main isometric drawing area where you build your architecture.
 - **Inspector Panel** (right) — View and edit details for the selected block:

--- a/docs/user-guide/templates.md
+++ b/docs/user-guide/templates.md
@@ -1,6 +1,6 @@
 # Templates
 
-> **Audience**: All Users | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: Stable — V1 Core | **Verified against**: v0.26.0
 
 Templates are pre-built architecture patterns that provide a working starting point. Instead of building from scratch, load a template and customize it for your needs.
 

--- a/docs/user-guide/validation.md
+++ b/docs/user-guide/validation.md
@@ -1,6 +1,6 @@
 # Validation
 
-> **Audience**: All users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 Validation is part of the learning experience. As you place resources and create connections, CloudBlocks checks the architecture and teaches you when a pattern breaks common cloud rules.
 

--- a/docs/user-guide/workspaces.md
+++ b/docs/user-guide/workspaces.md
@@ -1,6 +1,6 @@
 # Workspaces & Save/Load
 
-> **Audience**: All users | **Status**: V1 Core | **Verified against**: v0.26.0
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.26.0
 
 Workspaces let you keep separate learning exercises, template variations, and practice architectures. All data is stored in your browser's local storage — no account or backend required.
 


### PR DESCRIPTION
## Summary

Systematically fixes documentation inconsistencies identified through Oracle-validated, code-verified analysis. All changes reflect the **current source code ground truth**, not aspirational specs.

## Changes (6 categories, 19 files)

### Issue 2: Stale UX references (5 files)
- **Button labels**: "Start from Template"/"Start from Scratch" → "Start Learning"/"Practice on Blank Canvas" (matches `EmptyCanvasCTA.tsx`)
- **Menu paths**: "Build → Browse Scenarios" → "Learn button" (matches `MenuBar.tsx` line 621)
- **Provider tabs**: Clarified Azure active, AWS/GCP visible but `comingSoon: true` (matches `PROVIDER_OPTIONS` in `MenuBar.tsx`)
- **Persona references**: Removed — persona system was fully deleted in PR #1491

### Issue 3: Audience metadata (11 files)
- Changed `> **Audience**: All Users` → `> **Audience**: Beginners` across all user-facing guides
- Changed dual-audience files to `Beginners / Contributors` (DOMAIN_MODEL, LEARNING_MODE_SPEC)

### Issue 4: Provider story (covered in Issue 2)
- `core-concepts.md`, `code-generation.md`, `faq.md` now correctly state Azure active, AWS/GCP Coming Soon

### Issue 5: Internal canon time alignment (3 files)
- `RELEASE_GATES.md`: M17 "In Progress" → "Completed"
- `UI_FLOW.md`: "Milestones 1–18" → "Milestones 1–26"
- `PRODUCT_DIRECTION_SPEC.md`: "guides M21+" → "guides M27+"

### Issue 6: README feature list
- Verified accurate — no changes needed

### FAQ clarification
- Distinguished 3 guided scenarios vs 6 templates (verified against `builtin.ts` files)

## Verification
- `pnpm build` ✅
- `pnpm lint` ✅
- All edits verified against source code (file paths and line numbers documented)
- Oracle consultation completed for validation

## Related
- Complements PR #1498 (`docs/truth-cleanup`)
- Follows PR #1491 persona removal and PR #1496 M32 UX alignment