### PR TITLE
docs: defer Bicep/Pulumi stable promotion until Terraform kill switch passes

### DIFF
--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -76,7 +76,7 @@ After v1.0.0, development continues with backward-compatible minor releases (v1.
 - Code generation validation pipeline
 - CI/CD template integration
 - **Kill switch**: If template→edit→export completion < 30%, re-evaluate export UX before continuing
-- Bicep & Pulumi export promoted from Experimental to Stable
+- Bicep & Pulumi exports remain Experimental — promote only after Terraform kill switch passes
 
 ---
 

--- a/docs/concept/V1_PRODUCT_CONTRACT.md
+++ b/docs/concept/V1_PRODUCT_CONTRACT.md
@@ -52,6 +52,7 @@ These features require the backend API and are not part of the default V1 experi
 | Server-side features (GitHub, AI) | V3     |
 | Learning paths with progress      | V3     |
 | Educator distribution             | V4     |
+| Bicep & Pulumi promoted to Stable | V2+ (after Terraform kill switch passes) |
 
 ## Version Transition
 


### PR DESCRIPTION
## Summary

- **ROADMAP.md**: Changed V2 scope — Bicep & Pulumi exports remain Experimental instead of being promoted to Stable. Promotion is conditional on Terraform kill switch passing (template→edit→export completion ≥ 30%).
- **V1_PRODUCT_CONTRACT.md**: Added Bicep/Pulumi stable promotion to the Deferred table with the condition "after Terraform kill switch passes".

## Context

Oracle data-driven analysis recommended focusing V2 exclusively on Terraform export quality. Bicep/Pulumi stable promotion is deferred until the Terraform export flow is validated with real usage data (kill switch: completion rate ≥ 30%).

This aligns with the scope reduction strategy: **Terraform-first, validate, then expand**.