### PR TITLE
feat(web): add GCP Terraform starter generation

### DIFF
--- a/apps/web/src/entities/validation/providerValidation.ts
+++ b/apps/web/src/entities/validation/providerValidation.ts
@@ -27,10 +27,11 @@ const KNOWN_SUBTYPES: Record<string, Partial<Record<ResourceCategory, string[]>>
   gcp: {
     compute: ['compute-engine', 'cloud-run', 'cloud-functions'],
     data: ['cloud-sql-postgres', 'firestore', 'cloud-storage'],
-    delivery: ['cloud-load-balancing', 'api-gateway'],
-    messaging: ['pub-sub', 'eventarc'],
-    operations: ['cloud-monitoring', 'cloud-iam'],
-    identity: ['service_account'],
+    delivery: ['cloud-load-balancing', 'api-gateway', 'nat-gateway'],
+    messaging: ['pubsub', 'eventarc'],
+    operations: ['bigquery', 'monitoring'],
+    security: ['iam', 'nsg'],
+    identity: ['managed-identity', 'managed_identity', 'service-account', 'service_account'],
     network: ['vpc', 'cloud-dns'],
   },
   azure: {
@@ -69,8 +70,9 @@ function validateBlockProviderRules(
     warnings.push({
       ruleId: 'rule-provider-gcp-sql-public',
       severity: 'warning',
-      message: `GCP Cloud SQL "${block.name}" is on a subnet. Database instances should typically be secured with appropriate NSG rules.`,
-      suggestion: 'Ensure proper network security group rules are applied to the subnet.',
+      message: `GCP Cloud SQL "${block.name}" is on a subnet. Database instances should typically be secured with appropriate VPC firewall rules or private service access.`,
+      suggestion:
+        'Ensure proper VPC firewall rules or private service access are configured for this subnet.',
       targetId: block.id,
     });
   }

--- a/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
+++ b/apps/web/src/features/generate/__tests__/providerAdapters.test.ts
@@ -229,7 +229,7 @@ describe('provider definitions', () => {
     expect(mainTf?.content).toContain('resource "aws_vpc"');
   });
 
-  it('throws when gcp provider is used with terraform (not yet supported)', () => {
+  it('gcp adapter generates non-empty terraform output', () => {
     const architecture: ArchitectureModel = {
       id: 'arch-adapter-gcp-1',
       name: 'Provider Adapter GCP Terraform Test',
@@ -283,14 +283,26 @@ describe('provider definitions', () => {
       updatedAt: '2026-01-01T00:00:00Z',
     };
 
-    expect(() =>
-      generateCode(architecture, {
-        provider: 'gcp',
-        mode: 'draft',
-        projectName: 'adapter-test',
-        region: 'eastus',
-        generator: 'terraform',
-      }),
-    ).toThrow(/does not support provider/);
+    const output = generateCode(architecture, {
+      provider: 'gcp',
+      mode: 'draft',
+      projectName: 'adapter-test',
+      region: 'us-central1',
+      generator: 'terraform',
+    });
+
+    const mainTf = output.files.find((file) => file.path === 'main.tf');
+    const variablesTf = output.files.find((file) => file.path === 'variables.tf');
+
+    expect(mainTf).toBeDefined();
+    expect(mainTf?.content.trim().length).toBeGreaterThan(0);
+    expect(mainTf?.content).toContain('provider "google"');
+    expect(mainTf?.content).toContain('resource "google_compute_network"');
+    expect(mainTf?.content).toContain('resource "google_compute_subnetwork"');
+    expect(mainTf?.content).toContain('resource "google_cloud_run_v2_service"');
+
+    expect(variablesTf).toBeDefined();
+    expect(variablesTf?.content).toContain('variable "project_id"');
+    expect(variablesTf?.content).toContain('variable "zone"');
   });
 });

--- a/apps/web/src/features/generate/pipeline.test.ts
+++ b/apps/web/src/features/generate/pipeline.test.ts
@@ -377,15 +377,16 @@ describe('pipeline', () => {
       expect(result.metadata.provider).toBe('aws');
     });
 
-    it('throws when GCP provider is used with terraform (not yet supported)', () => {
-      expect(() =>
-        generateCode(validModel, {
-          ...validOptions,
-          provider: 'gcp',
-          region: 'us-central1',
-          generator: 'terraform',
-        }),
-      ).toThrow(/does not support provider/);
+    it('supports GCP provider when generator is terraform', () => {
+      const result = generateCode(validModel, {
+        ...validOptions,
+        provider: 'gcp',
+        region: 'us-central1',
+        generator: 'terraform',
+      });
+
+      expect(result.files.map((f) => f.path)).toEqual(['main.tf', 'variables.tf', 'outputs.tf']);
+      expect(result.metadata.provider).toBe('gcp');
     });
     it('throws GenerationError when provider is not supported by selected generator', () => {
       expect(() =>

--- a/apps/web/src/features/generate/provider.test.ts
+++ b/apps/web/src/features/generate/provider.test.ts
@@ -476,18 +476,596 @@ describe('gcpProviderDefinition', () => {
     });
   });
 
-  it('exposes terraform hook stubs', () => {
+  it('exposes terraform hooks with GCP starter bodies', () => {
     const terraformConfig = gcpProviderDefinition.generators.terraform;
-    const blockContext: TerraformBlockContext = {
-      ...stubBlockContext,
-      mapping: { resourceType: 'google_compute_instance', namePrefix: 'gce' },
-    };
-
     expect(terraformConfig.requiredProviders()).toContain('hashicorp/google');
     expect(terraformConfig.providerBlock('us-central1')).toContain('provider "google" {');
-    expect(terraformConfig.renderContainerBody(stubContainerContext)).toEqual([]);
-    expect(terraformConfig.renderBlockBody(blockContext)).toEqual([
-      '  # TODO: Configure google_compute_instance',
+    expect(terraformConfig.providerBlock('us-central1')).toContain('project = var.project_id');
+    expect(terraformConfig.providerBlock('us-central1')).toContain('region');
+    expect(terraformConfig.regionVariableDescription).toBe('GCP region for resource deployment');
+  });
+
+  it('renders VPC and subnet container bodies', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const vpcBody = terraformConfig.renderContainerBody({
+      ...stubContainerContext,
+      container: { ...stubContainerContext.container, layer: 'region' },
+      mapping: { resourceType: 'google_compute_network', namePrefix: 'network' },
+    });
+    expect(vpcBody).toEqual([
+      '  name                    = "vpc-main"',
+      '  auto_create_subnetworks = false',
+      '  depends_on    = [google_project_service.compute]',
     ]);
+
+    const subnetContext: TerraformContainerContext = {
+      ...stubContainerContext,
+      normalized: {
+        architecture: {
+          ...stubArchitecture,
+          nodes: [
+            {
+              ...stubContainerContext.container,
+              id: 'vpc-1',
+              layer: 'region',
+              parentId: null,
+            },
+            {
+              ...stubContainerContext.container,
+              id: 'sub-1',
+              layer: 'subnet',
+              parentId: 'vpc-1',
+            },
+          ],
+          connections: [],
+          endpoints: [],
+          externalActors: [],
+        },
+        resourceNames: new Map([
+          ['vpc-1', 'vpc_main'],
+          ['sub-1', 'subnet_main'],
+        ]),
+      },
+      container: {
+        ...stubContainerContext.container,
+        id: 'sub-1',
+        layer: 'subnet',
+        parentId: 'vpc-1',
+      },
+      mapping: { resourceType: 'google_compute_subnetwork', namePrefix: 'subnet' },
+      resourceName: 'subnet_main',
+      parentResourceName: 'vpc_main',
+    };
+
+    const subnetBody = terraformConfig.renderContainerBody(subnetContext).join('\n');
+    expect(subnetBody).toContain('network       = google_compute_network.vpc_main.id');
+    expect(subnetBody).toContain('ip_cidr_range = "10.0.1.0/24"');
+    expect(subnetBody).toContain('region        = var.location');
+  });
+
+  it('renders GCP compute and service resource bodies', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+
+    const computeBody = terraformConfig
+      .renderBlockBody({
+        ...stubBlockContext,
+        mapping: { resourceType: 'google_compute_instance', namePrefix: 'gce' },
+        parentResourceName: 'subnet_main',
+      })
+      .join('\n');
+    expect(computeBody).toContain('machine_type = "e2-micro"');
+    expect(computeBody).toContain('zone         = var.zone');
+    expect(computeBody).toContain('boot_disk {');
+    expect(computeBody).toContain('network_interface {');
+
+    const runBody = terraformConfig
+      .renderBlockBody({
+        ...stubBlockContext,
+        mapping: { resourceType: 'google_cloud_run_v2_service', namePrefix: 'run' },
+      })
+      .join('\n');
+    expect(runBody).toContain('us-docker.pkg.dev/cloudrun/container/hello');
+    expect(runBody).toContain('location = var.location');
+
+    const sqlBody = terraformConfig
+      .renderBlockBody({
+        ...stubBlockContext,
+        mapping: { resourceType: 'google_sql_database_instance', namePrefix: 'sql' },
+      })
+      .join('\n');
+    expect(sqlBody).toContain('POSTGRES_14');
+    expect(sqlBody).toContain('db-f1-micro');
+    expect(sqlBody).toContain('deletion_protection = false');
+
+    const storageBody = terraformConfig
+      .renderBlockBody({
+        ...stubBlockContext,
+        mapping: { resourceType: 'google_storage_bucket', namePrefix: 'gcs' },
+      })
+      .join('\n');
+    expect(storageBody).toContain('force_destroy');
+    expect(storageBody).toContain('uniform_bucket_level_access');
+    expect(storageBody).toContain('public_access_prevention');
+  });
+
+  it('renders firewall body with VPC ancestor and emits error without ancestor', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const withVpcContext: TerraformBlockContext = {
+      ...stubBlockContext,
+      normalized: {
+        architecture: {
+          ...stubArchitecture,
+          nodes: [
+            {
+              ...stubContainerContext.container,
+              id: 'vpc-1',
+              name: 'VPC',
+              layer: 'region',
+              parentId: null,
+            },
+            {
+              ...stubContainerContext.container,
+              id: 'sub-1',
+              name: 'Subnet',
+              layer: 'subnet',
+              parentId: 'vpc-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'fw-1',
+              category: 'security',
+              parentId: 'sub-1',
+            },
+          ],
+          connections: [],
+          endpoints: [],
+          externalActors: [],
+        },
+        resourceNames: new Map([
+          ['vpc-1', 'vpc_main'],
+          ['sub-1', 'subnet_main'],
+          ['fw-1', 'fw_main'],
+        ]),
+      },
+      resourceNames: new Map([
+        ['vpc-1', 'vpc_main'],
+        ['sub-1', 'subnet_main'],
+        ['fw-1', 'fw_main'],
+      ]),
+      block: { ...stubBlockContext.block, id: 'fw-1', parentId: 'sub-1', category: 'security' },
+      mapping: { resourceType: 'google_compute_firewall', namePrefix: 'fw' },
+      resourceName: 'fw_main',
+      parentResourceName: 'subnet_main',
+    };
+
+    const withVpc = terraformConfig.renderBlockBody(withVpcContext).join('\n');
+    expect(withVpc).toContain('google_compute_network.vpc_main.id');
+
+    const withoutVpc = terraformConfig
+      .renderBlockBody({
+        ...stubBlockContext,
+        mapping: { resourceType: 'google_compute_firewall', namePrefix: 'fw' },
+        block: { ...stubBlockContext.block, parentId: null, category: 'security' },
+      })
+      .join('\n');
+    expect(withoutVpc).toContain('# ERROR: Firewall requires a VPC ancestor');
+  });
+
+  it('emits planning guidance for Cloud Functions', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const functionBody = terraformConfig
+      .renderBlockBody({
+        ...stubBlockContext,
+        mapping: { resourceType: 'google_cloudfunctions2_function', namePrefix: 'gcf' },
+      })
+      .join('\n');
+    expect(functionBody).toContain('cannot be planned');
+  });
+
+  it('renders shared resources and extra variables for GCP', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const sharedResources = terraformConfig.renderSharedResources?.({
+      normalized: {
+        architecture: {
+          ...stubArchitecture,
+          nodes: [
+            {
+              ...stubContainerContext.container,
+              id: 'net-1',
+              layer: 'region',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'run-1',
+              category: 'compute',
+              subtype: 'cloud-run',
+              parentId: 'net-1',
+            },
+          ],
+          connections: [],
+          endpoints: [],
+          externalActors: [],
+        },
+        resourceNames: new Map([
+          ['net-1', 'network_main'],
+          ['run-1', 'run_main'],
+        ]),
+      },
+      options: stubContainerContext.options,
+      resourceNames: new Map([
+        ['net-1', 'network_main'],
+        ['run-1', 'run_main'],
+      ]),
+    });
+
+    expect(sharedResources).toBeDefined();
+    expect(sharedResources!.join('\n')).toContain('google_project_service');
+
+    const extraVariables = terraformConfig.extraVariables?.({
+      normalized: stubContainerContext.normalized,
+      options: stubContainerContext.options,
+      resourceNames: stubContainerContext.resourceNames,
+    });
+    expect(extraVariables).toBeDefined();
+    expect(extraVariables!.join('\n')).toContain('project_id');
+    expect(extraVariables!.join('\n')).toContain('zone');
+  });
+
+  it('renders all uncovered GCP block body variants', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const cases: Array<{ resourceType: string; expected: string }> = [
+      { resourceType: 'google_firestore_database', expected: 'FIRESTORE_NATIVE' },
+      {
+        resourceType: 'google_compute_url_map',
+        expected: 'URL map requires backend service wiring',
+      },
+      { resourceType: 'google_api_gateway_api', expected: 'api_id = "gcp_block_main"' },
+      {
+        resourceType: 'google_compute_router_nat',
+        expected: 'Cloud NAT requires google_compute_router',
+      },
+      {
+        resourceType: 'google_pubsub_topic',
+        expected: 'name = "${var.project_name}-gcp-block-main"',
+      },
+      {
+        resourceType: 'google_eventarc_trigger',
+        expected: 'Eventarc trigger requires destination service',
+      },
+      { resourceType: 'google_service_account', expected: 'account_id   = "gcp-block-main"' },
+      { resourceType: 'google_bigquery_dataset', expected: 'dataset_id = "gcp_block_main"' },
+      { resourceType: 'google_monitoring_dashboard', expected: 'dashboard_json = jsonencode({' },
+      {
+        resourceType: 'google_compute_backend_service',
+        expected: '# Configure google_compute_backend_service',
+      },
+    ];
+
+    for (const testCase of cases) {
+      const body = terraformConfig.renderBlockBody({
+        ...stubBlockContext,
+        resourceName: 'gcp_block_main',
+        mapping: { resourceType: testCase.resourceType, namePrefix: 'gcp' },
+        parentResourceName: 'subnet_main',
+      });
+
+      expect(body.join('\n')).toContain(testCase.expected);
+    }
+  });
+
+  it('renders compute instance guidance when subnet parent is missing', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const body = terraformConfig
+      .renderBlockBody({
+        ...stubBlockContext,
+        mapping: { resourceType: 'google_compute_instance', namePrefix: 'gce' },
+        parentResourceName: null,
+      })
+      .join('\n');
+
+    expect(body).toContain('Compute instance requires a subnet parent');
+  });
+
+  it('renders GCP subnet container without parent network reference', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const body = terraformConfig
+      .renderContainerBody({
+        ...stubContainerContext,
+        container: { ...stubContainerContext.container, layer: 'subnet', parentId: null },
+        mapping: { resourceType: 'google_compute_subnetwork', namePrefix: 'subnet' },
+        parentResourceName: null,
+      })
+      .join('\n');
+
+    expect(body).toContain('region        = var.location');
+    expect(body).not.toContain('network       = google_compute_network');
+    expect(body).not.toContain('ip_cidr_range');
+  });
+
+  it('renders shared resources for all GCP API prefix mappings', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const shared = terraformConfig.renderSharedResources?.({
+      normalized: {
+        architecture: {
+          ...stubArchitecture,
+          nodes: [
+            {
+              ...stubContainerContext.container,
+              id: 'net-1',
+              kind: 'container',
+              layer: 'region',
+              parentId: null,
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'run-1',
+              category: 'compute',
+              subtype: 'cloud-run',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'func-1',
+              category: 'compute',
+              subtype: 'cloud-functions',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'sql-1',
+              category: 'data',
+              subtype: 'cloud-sql-postgres',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'storage-1',
+              category: 'data',
+              subtype: 'cloud-storage',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'topic-1',
+              category: 'messaging',
+              subtype: 'pubsub',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'eventarc-1',
+              category: 'messaging',
+              subtype: 'eventarc',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'bq-1',
+              category: 'operations',
+              subtype: 'bigquery',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'dash-1',
+              category: 'operations',
+              subtype: 'monitoring',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'api-1',
+              category: 'delivery',
+              subtype: 'api-gateway',
+              parentId: 'net-1',
+            },
+            {
+              ...stubBlockContext.block,
+              id: 'iam-1',
+              category: 'identity',
+              subtype: 'service-account',
+              parentId: 'net-1',
+            },
+          ],
+          connections: [],
+          endpoints: [],
+          externalActors: [],
+        },
+        resourceNames: new Map([
+          ['net-1', 'network_main'],
+          ['run-1', 'run_main'],
+          ['func-1', 'func_main'],
+          ['sql-1', 'sql_main'],
+          ['storage-1', 'storage_main'],
+          ['topic-1', 'topic_main'],
+          ['eventarc-1', 'eventarc_main'],
+          ['bq-1', 'analytics_main'],
+          ['dash-1', 'dashboard_main'],
+          ['api-1', 'apigw_main'],
+          ['iam-1', 'identity_main'],
+        ]),
+      },
+      options: stubContainerContext.options,
+      resourceNames: new Map([
+        ['net-1', 'network_main'],
+        ['run-1', 'run_main'],
+        ['func-1', 'func_main'],
+        ['sql-1', 'sql_main'],
+        ['storage-1', 'storage_main'],
+        ['topic-1', 'topic_main'],
+        ['eventarc-1', 'eventarc_main'],
+        ['bq-1', 'analytics_main'],
+        ['dash-1', 'dashboard_main'],
+        ['api-1', 'apigw_main'],
+        ['iam-1', 'identity_main'],
+      ]),
+    });
+
+    const joined = shared!.join('\n');
+    expect(joined).toContain('compute.googleapis.com');
+    expect(joined).toContain('run.googleapis.com');
+    expect(joined).toContain('sqladmin.googleapis.com');
+    expect(joined).toContain('storage.googleapis.com');
+    expect(joined).toContain('cloudfunctions.googleapis.com');
+    expect(joined).toContain('pubsub.googleapis.com');
+    expect(joined).toContain('eventarc.googleapis.com');
+    expect(joined).toContain('bigquery.googleapis.com');
+    expect(joined).toContain('monitoring.googleapis.com');
+    expect(joined).toContain('apigateway.googleapis.com');
+    expect(joined).toContain('iam.googleapis.com');
+  });
+
+  it('skips unresolved container/resource mappings in shared resources', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const originalRegionMapping = gcpProviderDefinition.containerLayerMappings.region;
+    const originalComputeMapping = gcpProviderDefinition.blockMappings.compute;
+
+    Object.defineProperty(gcpProviderDefinition.containerLayerMappings, 'region', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(gcpProviderDefinition.blockMappings, 'compute', {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const shared = terraformConfig.renderSharedResources?.({
+        normalized: {
+          architecture: {
+            ...stubArchitecture,
+            nodes: [
+              {
+                ...stubContainerContext.container,
+                id: 'container-resource-layer',
+                kind: 'container',
+                layer: 'resource',
+                parentId: null,
+              },
+              {
+                ...stubBlockContext.block,
+                id: 'compute-node',
+                category: 'compute',
+                subtype: undefined,
+                parentId: null,
+              },
+            ],
+            connections: [],
+            endpoints: [],
+            externalActors: [],
+          },
+          resourceNames: new Map([
+            ['container-resource-layer', 'container_resource_layer'],
+            ['compute-node', 'compute_node'],
+          ]),
+        },
+        options: stubContainerContext.options,
+        resourceNames: new Map([
+          ['container-resource-layer', 'container_resource_layer'],
+          ['compute-node', 'compute_node'],
+        ]),
+      });
+
+      expect(shared).toEqual([]);
+    } finally {
+      Object.defineProperty(gcpProviderDefinition.containerLayerMappings, 'region', {
+        configurable: true,
+        value: originalRegionMapping,
+      });
+      Object.defineProperty(gcpProviderDefinition.blockMappings, 'compute', {
+        configurable: true,
+        value: originalComputeMapping,
+      });
+    }
+  });
+
+  it('handles missing node lookups while building shared resources', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const nodes = [
+      {
+        ...stubBlockContext.block,
+        id: 'lookup-miss-1',
+        category: 'compute' as const,
+      },
+    ];
+
+    Object.defineProperty(nodes, 'find', {
+      configurable: true,
+      value: () => undefined,
+    });
+
+    const shared = terraformConfig.renderSharedResources?.({
+      normalized: {
+        architecture: {
+          ...stubArchitecture,
+          nodes,
+          connections: [],
+          endpoints: [],
+          externalActors: [],
+        },
+        resourceNames: new Map([['lookup-miss-1', 'lookup_miss_1']]),
+      },
+      options: stubContainerContext.options,
+      resourceNames: new Map([['lookup-miss-1', 'lookup_miss_1']]),
+    });
+
+    expect(shared).toEqual([]);
+  });
+
+  it('omits unknown API prefixes from shared resources', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+    const originalComputeMapping = gcpProviderDefinition.blockMappings.compute;
+
+    gcpProviderDefinition.blockMappings.compute = {
+      resourceType: 'google_custom_runtime',
+      namePrefix: 'custom',
+    };
+
+    try {
+      const shared = terraformConfig.renderSharedResources?.({
+        normalized: {
+          architecture: {
+            ...stubArchitecture,
+            nodes: [
+              {
+                ...stubBlockContext.block,
+                id: 'custom-1',
+                category: 'compute',
+                subtype: undefined,
+                parentId: null,
+              },
+            ],
+            connections: [],
+            endpoints: [],
+            externalActors: [],
+          },
+          resourceNames: new Map([['custom-1', 'custom_1']]),
+        },
+        options: stubContainerContext.options,
+        resourceNames: new Map([['custom-1', 'custom_1']]),
+      });
+
+      expect(shared).toEqual([]);
+    } finally {
+      gcpProviderDefinition.blockMappings.compute = originalComputeMapping;
+    }
+  });
+
+  it('renders compute companions and no companions for non-compute resources', () => {
+    const terraformConfig = gcpProviderDefinition.generators.terraform;
+
+    const computeCompanions = terraformConfig.renderBlockCompanions?.({
+      ...stubBlockContext,
+      mapping: { resourceType: 'google_compute_instance', namePrefix: 'gce' },
+      resourceName: 'gce_main',
+    });
+    expect(computeCompanions).toBeDefined();
+    expect(computeCompanions!.join('\n')).toContain('data "google_compute_image" "gce_main_image"');
+
+    const storageCompanions = terraformConfig.renderBlockCompanions?.({
+      ...stubBlockContext,
+      mapping: { resourceType: 'google_storage_bucket', namePrefix: 'gcs' },
+    });
+    expect(storageCompanions).toEqual([]);
   });
 });

--- a/apps/web/src/features/generate/providers/gcp/index.ts
+++ b/apps/web/src/features/generate/providers/gcp/index.ts
@@ -1,4 +1,350 @@
-import type { ProviderDefinition, SubtypeResourceMap } from '../../types';
+import type {
+  ProviderDefinition,
+  SubtypeResourceMap,
+  TerraformBlockContext,
+  TerraformContainerContext,
+  TerraformRenderContext,
+} from '../../types';
+
+// ─── Shared Resources ──────────────────────────────────────────
+
+function inferGcpApiShortName(resourceType: string): string | null {
+  if (resourceType === 'google_service_account') {
+    return 'iam';
+  }
+
+  if (resourceType.startsWith('google_compute_')) {
+    return 'compute';
+  }
+
+  if (resourceType.startsWith('google_sql_')) {
+    return 'sqladmin';
+  }
+
+  if (resourceType.startsWith('google_storage_')) {
+    return 'storage';
+  }
+
+  if (resourceType.startsWith('google_cloud_run_')) {
+    return 'run';
+  }
+
+  if (resourceType.startsWith('google_cloudfunctions2_')) {
+    return 'cloudfunctions';
+  }
+
+  if (resourceType.startsWith('google_pubsub_')) {
+    return 'pubsub';
+  }
+
+  if (resourceType.startsWith('google_eventarc_')) {
+    return 'eventarc';
+  }
+
+  if (resourceType.startsWith('google_bigquery_')) {
+    return 'bigquery';
+  }
+
+  if (resourceType.startsWith('google_monitoring_')) {
+    return 'monitoring';
+  }
+
+  if (resourceType.startsWith('google_firestore_')) {
+    return 'firestore';
+  }
+
+  if (resourceType.startsWith('google_api_gateway_')) {
+    return 'apigateway';
+  }
+
+  return null;
+}
+
+function toGcpName(name: string, maxLength = 63): string {
+  return name
+    .replace(/_/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/^-|-$/g, '')
+    .slice(0, maxLength);
+}
+
+function normalizeGcpContainerLayer(
+  layer: string,
+): 'global' | 'edge' | 'region' | 'zone' | 'subnet' {
+  if (layer === 'resource') {
+    return 'region';
+  }
+
+  return layer as 'global' | 'edge' | 'region' | 'zone' | 'subnet';
+}
+
+function getGcpResourceTypeForBlock(ctx: TerraformRenderContext, blockId: string): string | null {
+  const node = ctx.normalized.architecture.nodes.find((candidate) => candidate.id === blockId);
+  if (!node) {
+    return null;
+  }
+
+  if (node.kind === 'container') {
+    const mapping =
+      gcpProviderDefinition.containerLayerMappings[normalizeGcpContainerLayer(node.layer)];
+    return mapping?.resourceType ?? null;
+  }
+
+  const subtypeMapping =
+    node.subtype !== undefined ? gcpSubtypeBlockMappings[node.category]?.[node.subtype] : undefined;
+  const mapping = subtypeMapping ?? gcpProviderDefinition.blockMappings[node.category];
+
+  return mapping?.resourceType ?? null;
+}
+
+function buildGcpSharedResources(ctx: TerraformRenderContext): string[] {
+  const lines: string[] = [];
+  const requiredApis = new Set<string>();
+
+  for (const node of ctx.normalized.architecture.nodes) {
+    const resourceType = getGcpResourceTypeForBlock(ctx, node.id);
+    if (!resourceType) {
+      continue;
+    }
+
+    const apiShortName = inferGcpApiShortName(resourceType);
+    if (apiShortName) {
+      requiredApis.add(apiShortName);
+    }
+  }
+
+  for (const apiShortName of Array.from(requiredApis).sort()) {
+    lines.push(`resource "google_project_service" "${apiShortName}" {`);
+    lines.push(`  service            = "${apiShortName}.googleapis.com"`);
+    lines.push('  disable_on_destroy = false');
+    lines.push('}');
+    lines.push('');
+  }
+
+  return lines;
+}
+
+// ─── Container Body ────────────────────────────────────────────
+
+function buildGcpContainerBody(ctx: TerraformContainerContext): string[] {
+  const lines: string[] = [];
+
+  if (ctx.container.layer !== 'subnet') {
+    lines.push(`  name                    = "${toGcpName(ctx.resourceName)}"`);
+    lines.push('  auto_create_subnetworks = false');
+  } else {
+    lines.push(`  name          = "${toGcpName(ctx.resourceName)}"`);
+
+    if (ctx.parentResourceName) {
+      lines.push(`  network       = google_compute_network.${ctx.parentResourceName}.id`);
+
+      const containers = ctx.normalized.architecture.nodes.filter(
+        (node) => node.kind === 'container',
+      );
+      const siblingSubnets = containers.filter(
+        (container) =>
+          container.layer === 'subnet' && container.parentId === ctx.container.parentId,
+      );
+      const cidrIndex =
+        siblingSubnets.findIndex((container) => container.id === ctx.container.id) + 1;
+      lines.push(`  ip_cidr_range = "10.0.${cidrIndex}.0/24"`);
+    }
+
+    lines.push('  region        = var.location');
+  }
+  lines.push('  depends_on    = [google_project_service.compute]');
+
+  return lines;
+}
+
+// ─── Block Body ────────────────────────────────────────────────
+
+function findAncestorVpcName(ctx: TerraformBlockContext): string | null {
+  const nodeById = new Map(ctx.normalized.architecture.nodes.map((node) => [node.id, node]));
+  let cursorId = ctx.block.parentId;
+
+  while (cursorId) {
+    const node = nodeById.get(cursorId);
+    if (!node || node.kind !== 'container') {
+      break;
+    }
+
+    if (node.layer !== 'subnet') {
+      return ctx.resourceNames.get(node.id) ?? null;
+    }
+
+    cursorId = node.parentId;
+  }
+
+  return null;
+}
+
+function buildGcpBlockBody(ctx: TerraformBlockContext): string[] {
+  const lines: string[] = [];
+  const gcpName = toGcpName(ctx.resourceName);
+  const tagName = `${'${var.project_name}'}-${gcpName}`;
+
+  switch (ctx.mapping.resourceType) {
+    case 'google_compute_instance':
+      lines.push('  machine_type = "e2-micro"');
+      lines.push('  zone         = var.zone');
+      lines.push(`  name         = "${tagName}"`);
+      lines.push(`  boot_disk {`);
+      lines.push('    initialize_params {');
+      lines.push(`      image = data.google_compute_image.${ctx.resourceName}_image.self_link`);
+      lines.push('    }');
+      lines.push('  }');
+      lines.push('  network_interface {');
+      if (ctx.parentResourceName) {
+        lines.push(`    subnetwork = google_compute_subnetwork.${ctx.parentResourceName}.id`);
+      } else {
+        lines.push(
+          '    # ERROR: Compute instance requires a subnet parent. Place this block inside a subnet container.',
+        );
+      }
+      lines.push('  }');
+      break;
+    case 'google_cloud_run_v2_service':
+      lines.push(`  name     = "${tagName}"`);
+      lines.push('  location = var.location');
+      lines.push('  template {');
+      lines.push('    containers {');
+      lines.push(
+        '      image = "us-docker.pkg.dev/cloudrun/container/hello"  # TODO: Replace with your container image',
+      );
+      lines.push('    }');
+      lines.push('  }');
+      break;
+    case 'google_cloudfunctions2_function':
+      lines.push(
+        '  # TODO: Cloud Functions (2nd gen) requires source bucket/object and entry point',
+      );
+      lines.push('  # This resource cannot be planned without its dependencies.');
+      lines.push('  # Configure build_config, service_config, and source archive inputs');
+      break;
+    case 'google_sql_database_instance':
+      lines.push(`  name                = "${tagName}"`);
+      lines.push('  database_version    = "POSTGRES_14"');
+      lines.push('  region              = var.location');
+      lines.push(
+        '  deletion_protection = false  # WARNING: Set to true for production to prevent accidental database deletion',
+      );
+      lines.push('  settings {');
+      lines.push('    tier = "db-f1-micro"');
+      lines.push('  }');
+      lines.push(
+        '  # TODO: Configure connectivity (public IP / private service access) for your environment',
+      );
+      break;
+    case 'google_firestore_database':
+      lines.push('  # WARNING: Only one "(default)" Firestore database allowed per GCP project');
+      lines.push('  name        = "(default)"');
+      lines.push('  location_id = var.location');
+      lines.push('  type        = "FIRESTORE_NATIVE"');
+      break;
+    case 'google_storage_bucket': {
+      const gcpBucketName = toGcpName(ctx.resourceName);
+      lines.push(`  name                        = "${'${var.project_id}'}-${gcpBucketName}"`);
+      lines.push('  location                    = var.location');
+      lines.push('  force_destroy               = false');
+      lines.push('  uniform_bucket_level_access = true');
+      lines.push('  public_access_prevention    = "enforced"');
+      break;
+    }
+    case 'google_compute_url_map':
+      lines.push('  # TODO: Cloud Load Balancing URL map requires backend service wiring');
+      lines.push('  # This resource cannot be planned without backend and host/path matchers');
+      lines.push(`  name = "${tagName}"`);
+      break;
+    case 'google_api_gateway_api':
+      lines.push('  # TODO: API Gateway requires API config/OpenAPI specification');
+      lines.push('  # This resource cannot be planned without an API config dependency');
+      lines.push(`  api_id = "${ctx.resourceName}"`);
+      break;
+    case 'google_compute_router_nat':
+      lines.push('  # TODO: Cloud NAT requires google_compute_router and router association');
+      lines.push(
+        '  # This resource cannot be planned without router, subnet, and IP allocation settings',
+      );
+      break;
+    case 'google_pubsub_topic':
+      lines.push(`  name = "${tagName}"`);
+      break;
+    case 'google_eventarc_trigger':
+      lines.push('  # TODO: Eventarc trigger requires destination service and matching criteria');
+      lines.push('  # This resource cannot be planned without event source and destination wiring');
+      break;
+    case 'google_service_account': {
+      const accountId = toGcpName(ctx.resourceName, 28);
+      lines.push(`  account_id   = "${accountId}"`);
+      lines.push(`  display_name = "${tagName}"`);
+      break;
+    }
+    case 'google_compute_firewall': {
+      const vpcName = findAncestorVpcName(ctx);
+      lines.push(`  name    = "${tagName}"`);
+      if (vpcName) {
+        lines.push(`  network = google_compute_network.${vpcName}.id`);
+      } else {
+        lines.push(
+          '  # ERROR: Firewall requires a VPC ancestor. Place this block inside a VPC container.',
+        );
+      }
+      lines.push('  # TODO: Define firewall rules for required traffic');
+      lines.push('  direction     = "INGRESS"');
+      lines.push(
+        '  source_ranges = ["0.0.0.0/0"]  # WARNING: Restrict to your IP range for production',
+      );
+      lines.push('  allow {');
+      lines.push('    protocol = "tcp"');
+      lines.push('    ports    = ["22"]  # TODO: Adjust ports for your application');
+      lines.push('  }');
+      break;
+    }
+    case 'google_bigquery_dataset':
+      lines.push(`  dataset_id = "${ctx.resourceName}"`);
+      lines.push('  location   = var.location');
+      break;
+    case 'google_monitoring_dashboard':
+      lines.push('  dashboard_json = jsonencode({');
+      lines.push(`    displayName = "${tagName}"`);
+      lines.push('    gridLayout = {');
+      lines.push('      columns = "12"');
+      lines.push('      widgets = []');
+      lines.push('    }');
+      lines.push('  })');
+      break;
+    default:
+      lines.push(`  # Configure ${ctx.mapping.resourceType}`);
+      break;
+  }
+
+  const apiShortName = inferGcpApiShortName(ctx.mapping.resourceType);
+  if (apiShortName) {
+    lines.push(`  depends_on = [google_project_service.${apiShortName}]`);
+  }
+
+  return lines;
+}
+
+// ─── Block Companions ──────────────────────────────────────────
+
+function buildGcpBlockCompanions(ctx: TerraformBlockContext): string[] {
+  const sections: string[] = [];
+
+  if (ctx.mapping.resourceType === 'google_compute_instance') {
+    sections.push(`data "google_compute_image" "${ctx.resourceName}_image" {`);
+    sections.push('  family  = "debian-12"');
+    sections.push('  project = "debian-cloud"');
+    sections.push('  depends_on = [google_project_service.compute]');
+    sections.push('}');
+    sections.push('');
+  }
+
+  return sections;
+}
+
+// ─── Subtype Block Mappings ────────────────────────────────────
 
 const gcpSubtypeBlockMappings: SubtypeResourceMap = {
   compute: {
@@ -109,9 +455,28 @@ export const gcpProviderDefinition: ProviderDefinition = {
           '}',
         ].join('\n'),
       providerBlock: (region: string) =>
-        ['provider "google" {', `  region = "${region}"`, '}'].join('\n'),
-      renderContainerBody: () => [],
-      renderBlockBody: (ctx) => [`  # TODO: Configure ${ctx.mapping.resourceType}`],
+        ['provider "google" {', '  project = var.project_id', `  region  = "${region}"`, '}'].join(
+          '\n',
+        ),
+      regionVariableDescription: 'GCP region for resource deployment',
+      renderSharedResources: (ctx: TerraformRenderContext) => buildGcpSharedResources(ctx),
+      renderContainerBody: (ctx) => buildGcpContainerBody(ctx),
+      renderContainerCompanions: () => [],
+      extraVariables: () => [
+        'variable "project_id" {',
+        '  description = "GCP project ID for resource deployment"',
+        '  type        = string',
+        '}',
+        '',
+        'variable "zone" {',
+        '  description = "GCP zone for zonal resources (e.g., us-central1-a)"',
+        '  type        = string',
+        '  default     = "us-central1-a"',
+        '}',
+      ],
+      renderBlockCompanions: (ctx) => buildGcpBlockCompanions(ctx),
+      renderBlockBody: (ctx) => buildGcpBlockBody(ctx),
+      extraOutputs: () => [],
     },
     bicep: {
       targetScope: 'resourceGroup',

--- a/apps/web/src/features/generate/terraform.test.ts
+++ b/apps/web/src/features/generate/terraform.test.ts
@@ -7,7 +7,7 @@ import type {
   ContainerBlock,
   ResourceBlock,
 } from '@cloudblocks/schema';
-import { awsProviderDefinition, azureProviderDefinition } from './provider';
+import { awsProviderDefinition, azureProviderDefinition, gcpProviderDefinition } from './provider';
 import { generateMainTf, generateOutputsTf, generateVariablesTf, normalize } from './terraform';
 import {
   makeTestArchitecture,
@@ -86,6 +86,13 @@ const awsOptions = {
   mode: 'draft' as const,
   projectName: 'My Test Project',
   region: 'us-east-1',
+};
+
+const gcpOptions = {
+  provider: 'gcp' as const,
+  mode: 'draft' as const,
+  projectName: 'My Test Project',
+  region: 'us-central1',
 };
 
 describe('normalize', () => {
@@ -672,5 +679,116 @@ describe('AWS full-output HCL smoke test', () => {
     // Outputs file
     const outputs = generateOutputsTf(normalized, awsProviderDefinition, awsOptions);
     expect(outputs).toContain('output');
+  });
+});
+
+describe('GCP full-output HCL smoke test', () => {
+  it('generates valid main.tf with VPC, subnet, Cloud Run, and Cloud SQL', () => {
+    const model = createTestModel({
+      plates: [
+        createPlate({ id: 'vpc-1', name: 'Core VPC', type: 'region' }),
+        createPlate({ id: 'sub-1', name: 'App Subnet', type: 'subnet', parentId: 'vpc-1' }),
+      ],
+      blocks: [
+        createBlock({
+          id: 'run-1',
+          name: 'App Service',
+          category: 'compute',
+          subtype: 'cloud-run',
+          placementId: 'sub-1',
+        }),
+        createBlock({
+          id: 'sql-1',
+          name: 'App Database',
+          category: 'data',
+          subtype: 'cloud-sql-postgres',
+          placementId: 'sub-1',
+        }),
+      ],
+    });
+
+    const normalized = normalize(model, gcpProviderDefinition);
+    const hcl = generateMainTf(normalized, gcpProviderDefinition, gcpOptions);
+
+    expect(hcl).toContain('provider "google"');
+    expect(hcl).toContain('resource "google_project_service"');
+    expect(hcl).toContain('resource "google_compute_network"');
+    expect(hcl).toContain('resource "google_compute_subnetwork"');
+    expect(hcl).toContain('resource "google_cloud_run_v2_service"');
+    expect(hcl).toContain('resource "google_sql_database_instance"');
+    expect(hcl).toContain('google_project_service');
+    expect(hcl).not.toContain('undefined');
+    expect(hcl).not.toContain('null');
+
+    const vars = generateVariablesTf(gcpOptions, gcpProviderDefinition);
+    expect(vars).toContain('variable "project_name"');
+    expect(vars).toContain('variable "location"');
+    expect(vars).toContain('variable "project_id"');
+    expect(vars).toContain('variable "zone"');
+
+    const outputs = generateOutputsTf(normalized, gcpProviderDefinition, gcpOptions);
+    expect(outputs).toContain('output');
+  });
+});
+
+describe('GCP container rendering', () => {
+  it('renders VPC and subnet-specific attributes', () => {
+    const model = createTestModel({
+      plates: [
+        createPlate({ id: 'vpc-1', name: 'Core VPC', type: 'region' }),
+        createPlate({ id: 'sub-1', name: 'App Subnet', type: 'subnet', parentId: 'vpc-1' }),
+      ],
+      blocks: [],
+    });
+
+    const hcl = generateMainTf(
+      normalize(model, gcpProviderDefinition),
+      gcpProviderDefinition,
+      gcpOptions,
+    );
+
+    expect(hcl).toContain('auto_create_subnetworks = false');
+    expect(hcl).toContain('network       = google_compute_network.network_core_vpc.id');
+    expect(hcl).toContain('ip_cidr_range = "10.0.1.0/24"');
+    expect(hcl).toContain('region        = var.location');
+  });
+});
+
+describe('GCP compute with Debian image data source', () => {
+  it('renders data source companion before compute resource', () => {
+    const model = createTestModel({
+      plates: [
+        createPlate({ id: 'vpc-1', name: 'Core VPC', type: 'region' }),
+        createPlate({ id: 'sub-1', name: 'App Subnet', type: 'subnet', parentId: 'vpc-1' }),
+      ],
+      blocks: [
+        createBlock({
+          id: 'gce-1',
+          name: 'Web VM',
+          category: 'compute',
+          subtype: 'compute-engine',
+          placementId: 'sub-1',
+        }),
+      ],
+    });
+
+    const hcl = generateMainTf(
+      normalize(model, gcpProviderDefinition),
+      gcpProviderDefinition,
+      gcpOptions,
+    );
+
+    expect(hcl).toContain('data "google_compute_image" "gce_web_vm_image"');
+    expect(hcl).toContain('resource "google_compute_instance" "gce_web_vm"');
+    expect(hcl).toContain('machine_type = "e2-micro"');
+    expect(hcl).toContain('zone         = var.zone');
+    expect(hcl).toContain('boot_disk {');
+    expect(hcl).toContain('subnetwork = google_compute_subnetwork.subnet_app_subnet.id');
+
+    const dataIndex = hcl.indexOf('data "google_compute_image" "gce_web_vm_image"');
+    const resourceIndex = hcl.indexOf('resource "google_compute_instance" "gce_web_vm"');
+    expect(dataIndex).toBeGreaterThan(-1);
+    expect(resourceIndex).toBeGreaterThan(-1);
+    expect(dataIndex).toBeLessThan(resourceIndex);
   });
 });

--- a/apps/web/src/features/generate/terraformPlugin.test.ts
+++ b/apps/web/src/features/generate/terraformPlugin.test.ts
@@ -74,8 +74,8 @@ describe('terraformPlugin', () => {
     expect(terraformPlugin.displayName).toBe('Terraform (HCL)');
   });
 
-  it('supports azure and aws providers', () => {
-    expect(terraformPlugin.supportedProviders).toEqual(['azure', 'aws']);
+  it('supports azure, aws, and gcp providers', () => {
+    expect(terraformPlugin.supportedProviders).toEqual(['azure', 'aws', 'gcp']);
   });
 
   it('filePlan returns main.tf, variables.tf, outputs.tf with hcl language', () => {

--- a/apps/web/src/features/generate/terraformPlugin.ts
+++ b/apps/web/src/features/generate/terraformPlugin.ts
@@ -11,7 +11,7 @@ import { normalize, generateMainTf, generateVariablesTf, generateOutputsTf } fro
 export const terraformPlugin: GeneratorPlugin = {
   id: 'terraform',
   displayName: 'Terraform (HCL)',
-  supportedProviders: ['azure', 'aws'],
+  supportedProviders: ['azure', 'aws', 'gcp'],
 
   filePlan: () => [
     { path: 'main.tf', language: 'hcl' },

--- a/docs/engine/provider.md
+++ b/docs/engine/provider.md
@@ -1,6 +1,6 @@
 # Provider Definition Specification
 
-> **Audience**: Contributors | **Status**: Stable — Internal | **Verified against**: v0.28.0
+> **Audience**: Contributors | **Status**: Stable — Internal | **Verified against**: v0.29.0
 
 CloudBlocks uses `ProviderDefinition` as the canonical provider abstraction for generation.
 
@@ -129,10 +129,20 @@ All hooks receive context objects that provide the normalized model, generation 
 - S3 uses `bucket_prefix` with sanitized/trimmed name (24-char limit)
 - Security groups emit error comment when no ancestor VPC found
 
-## GCP (Pending Implementation)
+## GCP (V1 Starter)
 
-- All hooks return stubs (`[]` or `['  # TODO: Configure ...']`)
-- Awaiting #1512 for full implementation
+- `renderSharedResources`: Conditional `google_project_service` resources for each GCP API used (compute, run, cloudfunctions, sqladmin, firestore, storage, pubsub, eventarc, apigateway, iam, monitoring); uses `disable_on_destroy = false`
+- `renderContainerBody`: VPC with `name` (RFC 1035), `auto_create_subnetworks = false`, `depends_on`; subnet with `name`, `network` reference, indexed `ip_cidr_range`, `region`
+- `renderBlockBody`: Switch on `resourceType` — concrete bodies for Compute Engine, Cloud Run, Cloud SQL, Cloud Storage, Firestore, Pub/Sub, Service Account, Firewall, BigQuery, Monitoring Dashboard, API Gateway, Compute URL Map; explicit "cannot be planned" warnings for Cloud Functions, Cloud NAT, Eventarc
+- `renderBlockCompanions`: `google_compute_image` data source for Compute Engine instances (Debian 12)
+- `extraVariables`: `project_id` (GCP project ID) + `zone` (compute zone)
+- `extraOutputs`: `[]`
+- All GCP resource `name` attributes use RFC 1035 naming (hyphens, not underscores) via `toGcpName()` helper
+- Firewall emits minimal scaffold with `direction`, `source_ranges`, and `allow` block (with WARNING for production)
+- Cloud SQL uses `deletion_protection = false` with production WARNING
+- Storage bucket naming uses `var.project_id` prefix for global uniqueness
+- Firestore warns about `(default)` database singleton constraint
+- All resources include `depends_on` referencing their `google_project_service` API enablement resource
 
 
 # Subtype-Aware Resource Resolution


### PR DESCRIPTION
## Summary

Implements full GCP Terraform render hooks for CloudBlocks code generation, completing the third provider in the multi-cloud Terraform starter generation epic (#1509).

Fixes #1512

## Changes

### GCP Provider Implementation (`providers/gcp/index.ts`: 125 → ~490 lines)
- **`renderSharedResources`**: Conditional `google_project_service` resources for each GCP API used (compute, run, sqladmin, storage, pubsub, iam, monitoring, etc.) with `disable_on_destroy = false`
- **`renderContainerBody`**: VPC with RFC 1035-compliant `name`, `auto_create_subnetworks = false`; subnet with `name`, `network` reference, indexed CIDR
- **`renderBlockBody`**: 14 resource types — Compute Engine, Cloud Run, Cloud SQL, Cloud Storage, Firestore, Pub/Sub, Service Account, Firewall, BigQuery, Monitoring Dashboard, API Gateway, URL Map, NAT, Eventarc
- **`renderBlockCompanions`**: `google_compute_image` data source for Compute Engine (Debian 12)
- **`extraVariables`**: `project_id` + `zone`
- **`toGcpName()` helper**: Converts underscore-based Terraform identifiers to RFC 1035-compliant GCP names

### GCP-Specific Design Decisions (Oracle-Reviewed)
- All resources include `depends_on` referencing `google_project_service` API enablement
- Firewall uses minimal scaffold with explicit WARNING for production
- Cloud SQL uses `deletion_protection = false` with WARNING
- Storage bucket naming uses `var.project_id` prefix for global uniqueness
- Firestore warns about `(default)` database singleton constraint
- No labels in V1 (deferred to future iteration)

### Validation & Tests
- `providerValidation.ts`: Synced `KNOWN_SUBTYPES` for GCP; fixed "NSG" → "VPC firewall rules"
- `terraformPlugin.ts`: Added `'gcp'` to `supportedProviders`
- 97%+ branch coverage on GCP provider code
- All 2190 tests passing, 90.2% overall branch coverage

### Documentation
- Updated `docs/engine/provider.md` GCP section from placeholder to full specification

## Verification
- ✅ All 2190 tests pass
- ✅ Build passes
- ✅ Lint passes
- ✅ Branch coverage: 90.2% (≥90% requirement)
- ✅ Oracle architecture review completed (8 findings, all addressed)

Part of #1509