### PR TITLE
feat(schema): add internet/browser resource rules and external block helpers

### DIFF
--- a/packages/schema/src/__tests__/schema.test.ts
+++ b/packages/schema/src/__tests__/schema.test.ts
@@ -4,7 +4,12 @@ import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { SCHEMA_VERSION } from '../index.js';
-import { RESOURCE_RULES } from '../rules.js';
+import {
+  RESOURCE_RULES,
+  EXTERNAL_RESOURCE_TYPES,
+  isExternalResourceType,
+  KNOWN_RESOURCE_TYPES,
+} from '../rules.js';
 
 // All type re-exports — verify they are importable at runtime
 import type {
@@ -36,15 +41,59 @@ describe('SCHEMA_VERSION', () => {
     expect(SCHEMA_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
   });
 
-  it('should be 4.0.0', () => {
-    expect(SCHEMA_VERSION).toBe('4.0.0');
+  it('should be 4.1.0', () => {
+    expect(SCHEMA_VERSION).toBe('4.1.0');
   });
 });
 
 describe('Resource rule coverage', () => {
   it('RESOURCE_RULES covers all known resource types', () => {
     const knownTypes = Object.keys(RESOURCE_RULES);
-    expect(knownTypes.length).toBeGreaterThanOrEqual(30);
+    expect(knownTypes.length).toBeGreaterThanOrEqual(32);
+  });
+});
+
+describe('External block resource rules', () => {
+  it('internet should be a delivery resource at root level', () => {
+    expect(RESOURCE_RULES.internet).toBeDefined();
+    expect(RESOURCE_RULES.internet.category).toBe('delivery');
+    expect(RESOURCE_RULES.internet.containerCapable).toBe(false);
+    expect(RESOURCE_RULES.internet.allowedParents).toContain(null);
+    expect(RESOURCE_RULES.internet.canvasTier).toBe('web');
+  });
+
+  it('browser should be a delivery resource at root level', () => {
+    expect(RESOURCE_RULES.browser).toBeDefined();
+    expect(RESOURCE_RULES.browser.category).toBe('delivery');
+    expect(RESOURCE_RULES.browser.containerCapable).toBe(false);
+    expect(RESOURCE_RULES.browser.allowedParents).toContain(null);
+    expect(RESOURCE_RULES.browser.canvasTier).toBe('web');
+  });
+
+  it('EXTERNAL_RESOURCE_TYPES should contain internet and browser', () => {
+    expect(EXTERNAL_RESOURCE_TYPES.has('internet')).toBe(true);
+    expect(EXTERNAL_RESOURCE_TYPES.has('browser')).toBe(true);
+    expect(EXTERNAL_RESOURCE_TYPES.size).toBe(2);
+  });
+
+  it('isExternalResourceType should identify external types correctly', () => {
+    expect(isExternalResourceType('internet')).toBe(true);
+    expect(isExternalResourceType('browser')).toBe(true);
+    expect(isExternalResourceType('virtual_machine')).toBe(false);
+    expect(isExternalResourceType('load_balancer')).toBe(false);
+    expect(isExternalResourceType('')).toBe(false);
+  });
+  it('KNOWN_RESOURCE_TYPES includes internet and browser', () => {
+    expect(KNOWN_RESOURCE_TYPES.has('internet')).toBe(true);
+    expect(KNOWN_RESOURCE_TYPES.has('browser')).toBe(true);
+  });
+
+  it('EXTERNAL_RESOURCE_TYPES members are all valid RESOURCE_RULES keys', () => {
+    for (const ext of EXTERNAL_RESOURCE_TYPES) {
+      expect(Object.keys(RESOURCE_RULES), `External type '${ext}' not in RESOURCE_RULES`).toContain(
+        ext,
+      );
+    }
   });
 });
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -2,7 +2,7 @@
 // Shared between frontend and backend via JSON Schema bridge.
 
 /** Schema version for the ArchitectureModel wire format. */
-export const SCHEMA_VERSION = '4.0.0';
+export const SCHEMA_VERSION = '4.1.0';
 
 // Enumeration types
 export type {
@@ -58,8 +58,10 @@ export {
   RESOURCE_RULES,
   KNOWN_RESOURCE_TYPES,
   CONTAINER_CAPABLE_TYPES,
+  EXTERNAL_RESOURCE_TYPES,
   CATEGORY_PORTS,
   isContainerCapable,
+  isExternalResourceType,
   getAllowedParents,
   getCanvasTier,
   getDefaultCategory,

--- a/packages/schema/src/rules.ts
+++ b/packages/schema/src/rules.ts
@@ -96,6 +96,20 @@ export const RESOURCE_RULES = {
     canvasTier: 'web',
   },
 
+  // ── External Actors (folded into blocks — v4 unification) ────
+  internet: {
+    containerCapable: false,
+    allowedParents: [null],
+    category: 'delivery',
+    canvasTier: 'web',
+  },
+  browser: {
+    containerCapable: false,
+    allowedParents: [null],
+    category: 'delivery',
+    canvasTier: 'web',
+  },
+
   // ── Compute ─────────────────────────────────────────────────
   function_compute: {
     containerCapable: false,
@@ -297,6 +311,19 @@ export const CONTAINER_CAPABLE_TYPES: ReadonlySet<string> = new Set(
     .filter(([, rule]) => rule.containerCapable)
     .map(([key]) => key),
 );
+
+/** Resource types that represent external actors folded into the block model (v4 unification). */
+export const EXTERNAL_RESOURCE_TYPES: ReadonlySet<string> = new Set(['internet', 'browser']);
+
+/**
+ * Check whether a given resourceType is an external actor type
+ * (internet, browser) folded into the block model.
+ * Use this to filter external blocks from IaC output and apply
+ * non-deployable styling.
+ */
+export function isExternalResourceType(resourceType: string): boolean {
+  return EXTERNAL_RESOURCE_TYPES.has(resourceType);
+}
 
 /**
  * Check whether a given resourceType is allowed to be `kind: 'container'`.


### PR DESCRIPTION
## Summary

Add `internet` and `browser` entries to `RESOURCE_RULES` as delivery/web/root-level resource types, establishing the schema foundation for the ExternalActor-to-Block unification (Epic #1533).

- Add `internet` and `browser` to `RESOURCE_RULES` with `category: 'delivery'`, `canvasTier: 'web'`, `allowedParents: [null]`, `containerCapable: false`
- Add `EXTERNAL_RESOURCE_TYPES` constant (`ReadonlySet`) and `isExternalResourceType()` helper for downstream IaC filtering and non-deployable styling
- Export new symbols from `@cloudblocks/schema` package index
- Bump `SCHEMA_VERSION` from `4.0.0` to `4.1.0`
- Add 6 new tests: rule shape validation, derived registry inclusion (`KNOWN_RESOURCE_TYPES`), set membership consistency, and helper function positive/negative cases

## Architecture Decisions (Oracle-validated)

| Decision | Value | Rationale |
|---|---|---|
| BlockKind | `resource` | Reuse existing leaf-block path |
| Category | `delivery` | Keep 8-category taxonomy unchanged |
| canvasTier | `web` | Public-facing tier |
| allowedParents | `[null]` | Root-level placement |
| containerCapable | `false` | External actors cannot contain children |
| EXTERNAL_RESOURCE_TYPES | Explicit Set | No schema marker field needed for 2-item set |
| SCHEMA_VERSION | `4.1.0` | Additive change; breaking migration in #1535 |

## Verification

- ✅ `pnpm build` — all packages + web app
- ✅ `pnpm lint` — clean
- ✅ Schema tests: 45/45 passed
- ✅ Web app tests: 2207/2207 passed (129 files)
- ✅ LSP diagnostics: 0 errors
- ✅ Oracle review: no blocking findings

## Oracle Review Summary

- **Blocking**: None
- **Applied (should-fix)**: Added direct assertions for `KNOWN_RESOURCE_TYPES` inclusion and `EXTERNAL_RESOURCE_TYPES` ⊆ `RESOURCE_RULES` consistency
- **Accepted (suggestions)**: Keep explicit Set (no marker field), version bump is correct, runtime semantics deferred to #1535+

Part of #1533
Fixes #1534