### PR TITLE
style(web): standardize block and container label tokens (#1558)

### DIFF
--- a/apps/web/src/app/index.css
+++ b/apps/web/src/app/index.css
@@ -41,6 +41,10 @@
   --cat-messaging: #eab308;
   --cat-identity: #0078d4;
   --cat-operations: #64748b;
+
+  /* ── Label chip tokens (shared by block + container chips) ── */
+  --cb-label-chip-font-size: 10px;
+  --cb-label-chip-font-weight: 600;
 }
 
 :root,

--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -248,8 +248,8 @@
     system-ui,
     -apple-system,
     sans-serif;
-  font-size: 10px;
-  font-weight: 500;
+  font-size: var(--cb-label-chip-font-size, 10px);
+  font-weight: var(--cb-label-chip-font-weight, 600);
   line-height: 1.4;
   border-radius: 4px;
   white-space: nowrap;

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -8,6 +8,8 @@ import {
   EDGE_HIGHLIGHT_COLOR,
   EDGE_HIGHLIGHT_OPACITY,
   EDGE_HIGHLIGHT_STROKE_WIDTH,
+  LABEL_FACE_MIN_PX,
+  LABEL_FACE_SCALE,
   TOP_FACE_STROKE_OPACITY,
   TOP_FACE_STROKE_WIDTH,
 } from '../../shared/tokens/designTokens';
@@ -184,7 +186,7 @@ export const BlockSvg = memo(function BlockSvg({
           y={0}
           transform={`matrix(0.8975,-0.4410,0,1,${rightLabelX},${wallCenterY})`}
           fontFamily="system-ui, -apple-system, sans-serif"
-          fontSize={Math.max(8, Math.round(sideWallPx * 0.28))}
+          fontSize={Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE))}
           fontWeight="700"
           fill="rgba(255,255,255,0.85)"
           textAnchor="middle"

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.css
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.css
@@ -136,8 +136,8 @@
     system-ui,
     -apple-system,
     sans-serif;
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--cb-label-chip-font-size, 10px);
+  font-weight: var(--cb-label-chip-font-weight, 600);
   line-height: 1.4;
   border-radius: 4px;
   white-space: nowrap;

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
@@ -6,6 +6,8 @@ import {
   TILE_Z,
   BLOCK_MARGIN,
   BLOCK_PADDING,
+  LABEL_FACE_MIN_PX,
+  LABEL_FACE_SCALE,
 } from '../../shared/tokens/designTokens';
 import { getContainerShortLabel } from '../../shared/utils/providerMapping';
 
@@ -181,7 +183,7 @@ export const ContainerBlockSvg = memo(function PlateSvg({
           y={0}
           transform={`matrix(0.8975,-0.4410,0,1,${rightLabelX},${wallCenterY})`}
           fontFamily="system-ui, -apple-system, sans-serif"
-          fontSize={Math.max(10, Math.round(sideWallPx * 0.32))}
+          fontSize={Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE))}
           fontWeight="700"
           fill="rgba(255,255,255,0.85)"
           textAnchor="middle"

--- a/apps/web/src/shared/tokens/__tests__/designTokens.test.ts
+++ b/apps/web/src/shared/tokens/__tests__/designTokens.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { BLOCK_MARGIN, BLOCK_PADDING, RENDER_SCALE, TILE_H, TILE_W, TILE_Z } from '../designTokens';
+import {
+  BLOCK_MARGIN,
+  BLOCK_PADDING,
+  LABEL_FACE_MIN_PX,
+  LABEL_FACE_SCALE,
+  RENDER_SCALE,
+  TILE_H,
+  TILE_W,
+  TILE_Z,
+} from '../designTokens';
 
 describe('design tokens - RENDER_SCALE derivation chain', () => {
   it('derives RENDER_SCALE as 32 px/CU', () => {
@@ -25,5 +34,48 @@ describe('design tokens - RENDER_SCALE derivation chain', () => {
     expect(TILE_Z).toBe(32);
     expect(BLOCK_MARGIN).toBe(10);
     expect(BLOCK_PADDING).toBe(10);
+  });
+});
+
+describe('design tokens - face label typography', () => {
+  it('exports LABEL_FACE_MIN_PX as 8', () => {
+    expect(LABEL_FACE_MIN_PX).toBe(8);
+  });
+
+  it('exports LABEL_FACE_SCALE as 0.28', () => {
+    expect(LABEL_FACE_SCALE).toBe(0.28);
+  });
+
+  it('face label formula produces floor value for small walls', () => {
+    // sideWallPx = 16 → 16 * 0.28 = 4.48 → round = 4 → clamped to 8
+    const fontSize = Math.max(LABEL_FACE_MIN_PX, Math.round(16 * LABEL_FACE_SCALE));
+    expect(fontSize).toBe(8);
+  });
+
+  it('face label formula scales up for large walls', () => {
+    // sideWallPx = 64 → 64 * 0.28 = 17.92 → round = 18 → above floor
+    const fontSize = Math.max(LABEL_FACE_MIN_PX, Math.round(64 * LABEL_FACE_SCALE));
+    expect(fontSize).toBe(18);
+  });
+
+  it('face label formula works at typical block sideWallPx (64)', () => {
+    // Standard medium block: height=2, TILE_Z=32 → sideWallPx=64
+    const sideWallPx = Math.round(2 * TILE_Z);
+    const fontSize = Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE));
+    expect(fontSize).toBe(18); // 64 * 0.28 = 17.92 → 18
+  });
+
+  it('face label formula works at typical container sideWallPx (16)', () => {
+    // Standard subnet container: worldHeight=0.5, TILE_Z=32 → sideWallPx=16
+    const sideWallPx = Math.round(0.5 * TILE_Z);
+    const fontSize = Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE));
+    expect(fontSize).toBe(8); // 16 * 0.28 = 4.48 → floor 8
+  });
+
+  it('face label formula works at region container sideWallPx (22)', () => {
+    // Region container: worldHeight=0.7, TILE_Z=32 → sideWallPx=22
+    const sideWallPx = Math.round(0.7 * TILE_Z);
+    const fontSize = Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE));
+    expect(fontSize).toBe(8); // 22 * 0.28 = 6.16 → round 6 → floor 8
   });
 });

--- a/apps/web/src/shared/tokens/designTokens.ts
+++ b/apps/web/src/shared/tokens/designTokens.ts
@@ -58,3 +58,9 @@ export const PORT_COLOR_EVENT = '#F59E0B'; // Amber — event/async
 export const PORT_COLOR_DATA = '#14B8A6'; // Teal — data/dataflow
 export const PORT_COLOR_OCCUPIED = '#475569'; // Slate — occupied port (dimmed)
 export const PORT_GLOW_RADIUS = 4; // SVG filter blur radius for port glow
+
+// -- Face Label Typography (SVG text on block/container side walls) --
+// Shared floor and scale factor for the face label font-size formula:
+//   fontSize = Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE))
+export const LABEL_FACE_MIN_PX = 8;
+export const LABEL_FACE_SCALE = 0.28;

--- a/docs/design/PROVIDER_RESOURCES.md
+++ b/docs/design/PROVIDER_RESOURCES.md
@@ -318,3 +318,45 @@ brand hex → adjustColorHsl(brand, { saturationScale, lightnessBoost }) → der
 3. **Lightness boost**: Container top face lightness is always greater than brand lightness.
 4. **Narrow deltas**: Container face top-to-left luminance delta is <15 units (vs resource blocks which have wider spread).
 5. **Provider distinguishability**: Azure, AWS, and GCP container colors for the same layer are always visually distinct.
+
+## 7. Label Token Standardization (#1558)
+
+### Problem
+
+Block and container labels used divergent typography tokens:
+
+| Element | Block | Container | Problem |
+| --- | --- | --- | --- |
+| Chip `font-size` | `10px` | `11px` | Two different sizes for the same visual role |
+| Chip `font-weight` | `500` | `600` | Inconsistent weight |
+| Face label min | `8` | `10` | Two different floor values |
+| Face label scale | `0.28` | `0.32` | Two different scaling factors |
+
+### Resolution
+
+**Chip labels (CSS custom properties)**:
+- `--cb-label-chip-font-size: 10px` — shared by `.block-label-chip` and `.container-label-chip`
+- `--cb-label-chip-font-weight: 600` — shared weight (600 chosen for better legibility at 10px)
+
+**Face labels (JS design tokens in `designTokens.ts`)**:
+- `LABEL_FACE_MIN_PX = 8` — minimum font size floor
+- `LABEL_FACE_SCALE = 0.28` — multiplier applied to `sideWallPx`
+- Formula: `Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE))`
+
+### Design Decisions
+
+1. **CSS vars for CSS, JS tokens for JS**: Chip tokens live in `index.css` (consumed by CSS files). Face label tokens live in `designTokens.ts` (consumed by TSX computed expressions). No cross-runtime duplication.
+2. **Unified chip weight at 600**: `500` appeared too light at `10px` on both themes. `600` provides consistent readability.
+3. **No letter-spacing token**: Neither block nor container chip had `letter-spacing` before. Adding it would be a new design decision, not convergence. Deferred to a future issue if needed.
+4. **Container face labels use same formula**: Containers previously used `min 10 / scale 0.32` but this was not an intentional design decision — it was drift. Visual verification confirmed `min 8 / scale 0.28` remains legible on container side walls.
+
+### Files Modified
+
+| File | Change |
+| --- | --- |
+| `app/index.css` | Added `--cb-label-chip-font-size` and `--cb-label-chip-font-weight` CSS custom properties |
+| `entities/block/BlockSprite.css` | Replaced hardcoded `10px`/`500` with CSS variables |
+| `entities/container-block/ContainerBlockSprite.css` | Replaced hardcoded `11px`/`600` with CSS variables |
+| `shared/tokens/designTokens.ts` | Added `LABEL_FACE_MIN_PX` and `LABEL_FACE_SCALE` exports |
+| `entities/block/BlockSvg.tsx` | Replaced inline `Math.max(8, ...)` with token-based formula |
+| `entities/container-block/ContainerBlockSvg.tsx` | Replaced inline `Math.max(10, ...)` with token-based formula |


### PR DESCRIPTION
## Summary

Unifies divergent label typography tokens between resource blocks and container blocks, establishing a single source of truth for both chip labels (CSS) and face labels (SVG).

Fixes #1558
Part of #1554

## Changes

### CSS Custom Properties (chip labels)
- Added `--cb-label-chip-font-size: 10px` and `--cb-label-chip-font-weight: 600` to `:root`
- `BlockSprite.css` and `ContainerBlockSprite.css` now consume shared CSS vars instead of hardcoded values
- Container chip weight unified from divergent 500/600 to shared 600

### JS Design Tokens (face labels)
- Added `LABEL_FACE_MIN_PX = 8` and `LABEL_FACE_SCALE = 0.28` to `designTokens.ts`
- `BlockSvg.tsx` and `ContainerBlockSvg.tsx` now use `Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE))` instead of inline magic numbers
- Container face formula unified from divergent `min 10 / scale 0.32` to shared `min 8 / scale 0.28`

### Tests
- 7 new tests in `designTokens.test.ts` covering token values and formula behavior at typical block/container sideWallPx values

### Documentation
- Added §7 "Label Token Standardization" to `PROVIDER_RESOURCES.md`

## Design Decisions (Oracle-reviewed)
1. **CSS vars for CSS, JS tokens for JS** — no cross-runtime duplication
2. **Chip weight 600** — `500` too light at `10px`; `600` provides consistent readability
3. **No letter-spacing** — YAGNI (neither file had it before)
4. **True convergence** — container face labels use same formula as blocks (verified visually)