### PR TITLE
style(web): unify palette iconography with blockPresentation resolvers

### DIFF
--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
@@ -135,7 +135,8 @@ describe('SidebarPalette additional coverage', () => {
 
     render(<SidebarPalette />);
 
-    await user.click(screen.getByTitle('Create Azure Virtual Network'));
+    // blockPresentation resolves 'network' → displayLabel 'Virtual Network'
+    await user.click(screen.getByTitle('Create Virtual Network'));
 
     expect(addNode).toHaveBeenCalledWith({
       kind: 'container',
@@ -193,7 +194,8 @@ describe('SidebarPalette additional coverage', () => {
     const { unmount } = render(<SidebarPalette />);
 
     // Use a starter-tier resource so drag listeners are registered on first render
-    const appServiceButton = screen.getByTitle('Create Azure App Service');
+    // blockPresentation resolves 'app-service' → displayLabel 'App Service'
+    const appServiceButton = screen.getByTitle('Create App Service');
 
     interactState.listenersByElement.get(appServiceButton)?.move?.({ target: appServiceButton });
     await user.click(appServiceButton);
@@ -267,13 +269,14 @@ describe('SidebarPalette additional coverage', () => {
 
     render(<SidebarPalette />);
 
-    const appServiceButton = screen.getByTitle('Create Azure App Service');
+    // blockPresentation resolves 'app-service' → displayLabel 'App Service'
+    const appServiceButton = screen.getByTitle('Create App Service');
 
     interactState.listenersByElement.get(appServiceButton)?.move?.({ target: appServiceButton });
 
     expect(startPlacing).toHaveBeenCalledWith(
       'compute',
-      'Azure App Service',
+      'App Service',
       'app_service',
       'app-service',
     );
@@ -293,7 +296,8 @@ describe('SidebarPalette additional coverage', () => {
 
     render(<SidebarPalette />);
 
-    const appServiceButton = screen.getByTitle('Create Azure App Service');
+    // blockPresentation resolves 'app-service' → displayLabel 'App Service'
+    const appServiceButton = screen.getByTitle('Create App Service');
     appServiceButton.removeAttribute('data-resource-type');
     interactState.listenersByElement.get(appServiceButton)?.move?.({ target: appServiceButton });
 
@@ -314,7 +318,8 @@ describe('SidebarPalette additional coverage', () => {
 
     render(<SidebarPalette />);
 
-    const appServiceButton = screen.getByTitle('Create Azure App Service');
+    // blockPresentation resolves 'app-service' → displayLabel 'App Service'
+    const appServiceButton = screen.getByTitle('Create App Service');
     appServiceButton.dataset.resourceType = 'non-existent-resource';
     interactState.listenersByElement.get(appServiceButton)?.move?.({ target: appServiceButton });
 
@@ -341,7 +346,9 @@ describe('SidebarPalette additional coverage', () => {
     // Enable advanced tier so VM/EC2 is visible
     await user.click(screen.getByRole('checkbox'));
 
-    await user.click(screen.getByTitle('Create EC2'));
+    // Both vm and app-service resolve to 'EC2' in AWS; select by data-resource-type
+    const vmButton = document.querySelector('button[data-resource-type="vm"]') as HTMLElement;
+    await user.click(vmButton);
     expect(addNode).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: 'resource',
@@ -349,5 +356,15 @@ describe('SidebarPalette additional coverage', () => {
         provider: 'aws',
       }),
     );
+  });
+
+  it('plays sound when adding external block', async () => {
+    const user = userEvent.setup();
+    render(<SidebarPalette />);
+
+    await user.click(screen.getByTitle('Add Internet'));
+
+    expect(addExternalBlock).toHaveBeenCalledWith('internet');
+    expect(playSoundMock).toHaveBeenCalledWith('block-snap');
   });
 });

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
@@ -367,4 +367,16 @@ describe('SidebarPalette additional coverage', () => {
     expect(addExternalBlock).toHaveBeenCalledWith('internet');
     expect(playSoundMock).toHaveBeenCalledWith('block-snap');
   });
+
+  it('does not attach drag listeners to external buttons', () => {
+    render(<SidebarPalette />);
+
+    const internetBtn = screen.getByTitle('Add Internet');
+    const browserBtn = screen.getByTitle('Add Browser');
+
+    // External buttons should NOT be in the interact listeners map
+    // because the selector scopes to [data-resource-type] only
+    expect(interactState.listenersByElement.has(internetBtn)).toBe(false);
+    expect(interactState.listenersByElement.has(browserBtn)).toBe(false);
+  });
 });

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
@@ -66,68 +66,13 @@
   overflow-y: auto;
 }
 
-.sidebar-palette-actor-section {
-  padding: 6px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--bg-surface-raised) 60%, transparent);
-}
-
-.sidebar-palette-actor-title {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 8px;
-  font: 700 var(--text-xs) / 1 var(--font-ui);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--text-secondary);
-}
-
-.sidebar-palette-actor-list {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.sidebar-palette-actor-btn {
-  width: 100%;
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  color: var(--text-primary);
-  background: var(--bg-surface);
-  cursor: pointer;
-  text-align: left;
-  transition:
-    border-color var(--duration-fast) var(--easing-standard),
-    background var(--duration-fast) var(--easing-standard),
-    transform var(--duration-fast) var(--easing-standard);
-}
-
-.sidebar-palette-actor-btn:hover {
-  border-color: color-mix(in srgb, var(--accent-primary) 48%, var(--border-default));
-  background: var(--bg-surface-raised);
-  transform: translateY(-1px);
-}
-
-.sidebar-palette-actor-img {
+/* Icon placeholder for resources without SVG icons */
+.sidebar-palette-icon-placeholder {
+  display: inline-block;
   width: 18px;
   height: 18px;
-  object-fit: contain;
-}
-
-.sidebar-palette-actor-name {
-  flex: 1;
-  font: 700 var(--text-xs) / 1.2 var(--font-ui);
-}
-
-.sidebar-palette-actor-add {
-  font: 600 var(--text-xs) / 1 var(--font-ui);
-  color: var(--text-secondary);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--text-muted) 20%, transparent);
 }
 
 .sidebar-palette-group {

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
@@ -154,6 +154,11 @@
     opacity var(--duration-fast) var(--easing-standard);
 }
 
+/* External buttons are click-only, not draggable */
+.sidebar-palette-resource-btn:not([data-resource-type]) {
+  cursor: pointer;
+}
+
 .sidebar-palette-resource-btn:hover:not(.disabled):not(:disabled) {
   border-color: color-mix(in srgb, var(--accent-primary) 48%, var(--border-default));
   background: var(--bg-surface-raised);

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.test.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.test.tsx
@@ -89,10 +89,11 @@ describe('SidebarPalette', () => {
     });
   });
 
-  it('renders category groups', () => {
+  it('renders category groups and external section', () => {
     render(<SidebarPalette />);
 
-    expect(screen.getByText('External Actors')).toBeInTheDocument();
+    // External group uses unified layout
+    expect(screen.getByText('External')).toBeInTheDocument();
     expect(screen.getByTitle('Add Internet')).toBeInTheDocument();
     expect(screen.getByTitle('Add Browser')).toBeInTheDocument();
 
@@ -117,7 +118,7 @@ describe('SidebarPalette', () => {
     expect(screen.getByText('Operations')).toBeInTheDocument();
   });
 
-  it('filters resources by search query', async () => {
+  it('filters resources by search query using resolved labels', async () => {
     const user = userEvent.setup();
     useArchitectureStore.setState({
       workspace: {
@@ -137,7 +138,14 @@ describe('SidebarPalette', () => {
 
     await user.type(screen.getByPlaceholderText('Search resources'), 'vault');
 
-    expect(screen.getByText((_content, el) => el?.textContent === 'Key Vault')).toBeInTheDocument();
+    expect(
+      screen.getByText((_content, el) =>
+        Boolean(
+          el?.classList.contains('sidebar-palette-resource-name') &&
+          el?.textContent === 'Key Vault',
+        ),
+      ),
+    ).toBeInTheDocument();
     expect(screen.queryByText('VM')).not.toBeInTheDocument();
   });
 
@@ -159,14 +167,29 @@ describe('SidebarPalette', () => {
 
     render(<SidebarPalette />);
 
+    // blockPresentation resolves 'network' → displayLabel 'Virtual Network'
     const toggle = screen.getByRole('button', { name: 'Collapse Network' });
-    expect(screen.getByTitle('Create Azure Virtual Network')).toBeInTheDocument();
+    expect(screen.getByTitle('Create Virtual Network')).toBeInTheDocument();
 
     await user.click(toggle);
-    expect(screen.queryByTitle('Create Azure Virtual Network')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Create Virtual Network')).not.toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Expand Network' }));
-    expect(screen.getByTitle('Create Azure Virtual Network')).toBeInTheDocument();
+    expect(screen.getByTitle('Create Virtual Network')).toBeInTheDocument();
+  });
+
+  it('collapses and expands external section', async () => {
+    const user = userEvent.setup();
+    render(<SidebarPalette />);
+
+    expect(screen.getByTitle('Add Internet')).toBeInTheDocument();
+
+    const toggle = screen.getByRole('button', { name: 'Collapse External' });
+    await user.click(toggle);
+    expect(screen.queryByTitle('Add Internet')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Expand External' }));
+    expect(screen.getByTitle('Add Internet')).toBeInTheDocument();
   });
 
   it('shows disabled resources with lock when network is missing', async () => {
@@ -236,9 +259,10 @@ describe('SidebarPalette', () => {
       expect(screen.getByText('Show Advanced')).toBeInTheDocument();
     });
 
-    it('shows only starter tier resources by default', () => {
+    it('shows only starter tier resources plus externals by default', () => {
       render(<SidebarPalette />);
-      expect(screen.getByText(/Showing 13 of 28/)).toBeInTheDocument();
+      // 13 starter resources + 2 external = 15 visible, total = 28 + 2 = 30
+      expect(screen.getByText(/Showing 15 of 30/)).toBeInTheDocument();
     });
 
     it('shows all resources when Show Advanced checkbox is checked', async () => {
@@ -248,7 +272,8 @@ describe('SidebarPalette', () => {
       const checkbox = screen.getByRole('checkbox');
       await user.click(checkbox);
 
-      expect(screen.getByText(/Showing 28 of 28/)).toBeInTheDocument();
+      // 28 resources + 2 external = 30 visible of 30 total
+      expect(screen.getByText(/Showing 30 of 30/)).toBeInTheDocument();
     });
 
     describe('drag-to-create interaction', () => {
@@ -390,4 +415,106 @@ it('highlights matching text in search results', async () => {
   const marks = container.querySelectorAll('mark.sidebar-palette-highlight');
   expect(marks.length).toBeGreaterThan(0);
   expect(marks[0].textContent?.toLowerCase()).toBe('vault');
+});
+
+describe('SidebarPalette — blockPresentation integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    useUIStore.setState({
+      activeProvider: 'azure',
+      isSoundMuted: true,
+      sidebar: { isOpen: true },
+    });
+
+    useArchitectureStore.setState({
+      addNode: vi.fn(),
+      addExternalBlock: vi.fn(),
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        provider: 'azure' as const,
+        architecture: baseArchitecture,
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+  });
+
+  it('renders SVG icons for all resource items (no emoji fallback)', () => {
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        provider: 'azure' as const,
+        architecture: {
+          ...baseArchitecture,
+          nodes: [networkPlate],
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+
+    render(<SidebarPalette />);
+
+    // All resource icons should be <img> elements, not emoji text
+    const resourceIcons = document.querySelectorAll('.sidebar-palette-resource-icon');
+    resourceIcons.forEach((icon) => {
+      const img = icon.querySelector('img');
+      const placeholder = icon.querySelector('.sidebar-palette-icon-placeholder');
+      // Each icon should be either an SVG img or a placeholder — never emoji text
+      expect(img || placeholder).toBeTruthy();
+    });
+  });
+
+  it('renders external items with SVG icons using blockPresentation', () => {
+    render(<SidebarPalette />);
+
+    const internetBtn = screen.getByTitle('Add Internet');
+    const browserBtn = screen.getByTitle('Add Browser');
+
+    // External items use blockPresentation's iconUrl
+    const internetImg = internetBtn.querySelector('img');
+    expect(internetImg).toBeTruthy();
+    expect(internetImg?.getAttribute('src')).toBe('/actor-sprites/internet.svg');
+
+    const browserImg = browserBtn.querySelector('img');
+    expect(browserImg).toBeTruthy();
+    expect(browserImg?.getAttribute('src')).toBe('/actor-sprites/browser.svg');
+  });
+
+  it('filters external items by search query', async () => {
+    const user = userEvent.setup();
+    render(<SidebarPalette />);
+
+    await user.type(screen.getByPlaceholderText('Search resources'), 'internet');
+    expect(screen.getByTitle('Add Internet')).toBeInTheDocument();
+    expect(screen.queryByTitle('Add Browser')).not.toBeInTheDocument();
+  });
+
+  it('uses resolved labels from blockPresentation for provider switching', async () => {
+    const user = userEvent.setup();
+
+    useUIStore.setState({ activeProvider: 'aws' });
+    useArchitectureStore.setState({
+      workspace: {
+        id: 'ws-1',
+        name: 'Test Workspace',
+        provider: 'azure' as const,
+        architecture: {
+          ...baseArchitecture,
+          nodes: [networkPlate],
+        },
+        createdAt: '',
+        updatedAt: '',
+      },
+    });
+
+    render(<SidebarPalette />);
+    await user.click(screen.getByRole('checkbox'));
+
+    // AWS-specific labels from blockPresentation should appear (multiple resources may resolve to EC2)
+    expect(screen.getAllByTitle('Create EC2').length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
@@ -9,8 +9,6 @@ import type { SoundName } from '../../shared/utils/audioService';
 import {
   useTechTree,
   RESOURCE_DEFINITIONS,
-  getResourceLabel,
-  getResourceShortLabel,
   type ResourceType,
   CREATION_GROUP_ORDER,
   getCreationGroupMeta,
@@ -18,7 +16,10 @@ import {
   type CreationGroupId,
   ALL_RESOURCES,
 } from '../../shared/hooks/useTechTree';
-import { getResourceIconUrl } from '../../shared/utils/iconResolver';
+import {
+  resolveResourcePresentation,
+  resolveExternalPresentation,
+} from '../../shared/presentation/blockPresentation';
 import { getContainerLabel, remapSubtype } from '../../shared/utils/providerMapping';
 import './SidebarPalette.css';
 import { useIsMobile } from '../../shared/hooks/useIsMobile';
@@ -33,6 +34,9 @@ const CATEGORY_COLOR_VARS: Record<CreationGroupId, string> = {
   identity: 'var(--cat-identity)',
   operations: 'var(--cat-operations)',
 };
+
+/** External block types rendered in the palette. */
+const EXTERNAL_TYPES = ['internet', 'browser'] as const;
 
 interface HighlightMatchProps {
   text: string;
@@ -151,8 +155,6 @@ function PaletteResourceItem({
   searchQuery,
   iconUrl,
 }: PaletteResourceItemProps) {
-  const def = RESOURCE_DEFINITIONS[type];
-
   return (
     <button
       key={type}
@@ -164,7 +166,11 @@ function PaletteResourceItem({
       title={enabled ? `Create ${providerLabel}` : (disabledReason ?? undefined)}
     >
       <span className="sidebar-palette-resource-icon" aria-hidden="true">
-        {iconUrl ? <img src={iconUrl} alt="" width={18} height={18} /> : def.icon}
+        {iconUrl ? (
+          <img src={iconUrl} alt="" width={18} height={18} />
+        ) : (
+          <span className="sidebar-palette-icon-placeholder" />
+        )}
       </span>
       <span className="sidebar-palette-resource-text">
         <span className="sidebar-palette-resource-name">
@@ -183,6 +189,92 @@ function PaletteResourceItem({
   );
 }
 
+/** External actors group rendered as a dedicated section using unified PaletteResourceItem layout. */
+interface PaletteExternalGroupProps {
+  collapsed: boolean;
+  onToggle: () => void;
+  searchQuery: string;
+  onAdd: (type: 'internet' | 'browser') => void;
+  activeProvider: 'azure' | 'aws' | 'gcp';
+}
+
+function PaletteExternalGroup({
+  collapsed,
+  onToggle,
+  searchQuery,
+  onAdd,
+  activeProvider,
+}: PaletteExternalGroupProps) {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+
+  const visibleTypes = useMemo(() => {
+    return EXTERNAL_TYPES.filter((type) => {
+      if (!normalizedQuery) return true;
+      const pres = resolveExternalPresentation(type, { provider: activeProvider });
+      return (
+        pres.displayLabel.toLowerCase().includes(normalizedQuery) ||
+        pres.shortLabel.toLowerCase().includes(normalizedQuery)
+      );
+    });
+  }, [normalizedQuery, activeProvider]);
+
+  if (visibleTypes.length === 0) return null;
+
+  return (
+    <section className="sidebar-palette-group" aria-label="External resources">
+      <button
+        type="button"
+        className="sidebar-palette-group-toggle"
+        style={{ '--category-color': 'var(--cat-network)' } as CSSProperties}
+        onClick={onToggle}
+        aria-expanded={!collapsed}
+        aria-label={`${collapsed ? 'Expand' : 'Collapse'} External`}
+      >
+        <span className="sidebar-palette-group-title">
+          <span className="sidebar-palette-group-icon" aria-hidden="true">
+            🔌
+          </span>
+          <span>External</span>
+        </span>
+        <span className="sidebar-palette-group-count">{visibleTypes.length}</span>
+      </button>
+
+      {!collapsed && (
+        <div className="sidebar-palette-group-list">
+          {visibleTypes.map((type) => {
+            const pres = resolveExternalPresentation(type, { provider: activeProvider });
+            return (
+              <button
+                key={type}
+                type="button"
+                className="sidebar-palette-resource-btn"
+                onClick={() => onAdd(type)}
+                title={`Add ${pres.displayLabel}`}
+              >
+                <span className="sidebar-palette-resource-icon" aria-hidden="true">
+                  {pres.iconUrl ? (
+                    <img src={pres.iconUrl} alt="" width={18} height={18} />
+                  ) : (
+                    <span className="sidebar-palette-icon-placeholder" />
+                  )}
+                </span>
+                <span className="sidebar-palette-resource-text">
+                  <span className="sidebar-palette-resource-name">
+                    <HighlightMatch text={pres.shortLabel} query={searchQuery} />
+                  </span>
+                  <span className="sidebar-palette-resource-subtitle">
+                    <HighlightMatch text={pres.displayLabel} query={searchQuery} />
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
 export function SidebarPalette() {
   const techTree = useTechTree();
   const addNode = useArchitectureStore((s) => s.addNode);
@@ -195,7 +287,9 @@ export function SidebarPalette() {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<CreationGroupId>>(() => new Set());
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<CreationGroupId | 'external'>>(
+    () => new Set(),
+  );
 
   const playSound = useCallback(
     (name: SoundName) => {
@@ -225,18 +319,20 @@ export function SidebarPalette() {
             if (def.tier === 'advanced') return false;
           }
           if (!normalizedQuery) return true;
-          const name = getResourceLabel(type, activeProvider).toLowerCase();
-          const shortName = getResourceShortLabel(type, activeProvider).toLowerCase();
+          // Use blockPresentation resolver for search to match displayed labels
+          const pres = resolveResourcePresentation(type, { provider: activeProvider });
           const category = meta.label.toLowerCase();
           return (
-            name.includes(normalizedQuery) ||
-            shortName.includes(normalizedQuery) ||
+            pres.displayLabel.toLowerCase().includes(normalizedQuery) ||
+            pres.shortLabel.toLowerCase().includes(normalizedQuery) ||
             category.includes(normalizedQuery)
           );
         })
-        .sort((a, b) =>
-          getResourceLabel(a, activeProvider).localeCompare(getResourceLabel(b, activeProvider)),
-        );
+        .sort((a, b) => {
+          const labelA = resolveResourcePresentation(a, { provider: activeProvider }).displayLabel;
+          const labelB = resolveResourcePresentation(b, { provider: activeProvider }).displayLabel;
+          return labelA.localeCompare(labelB);
+        });
 
       return { groupId, resources };
     }).filter((group) => group.resources.length > 0);
@@ -245,8 +341,23 @@ export function SidebarPalette() {
   const totalResourceCount = ALL_RESOURCES.length;
 
   const visibleResourceCount = useMemo(() => {
-    return groupedResources.reduce((total, group) => total + group.resources.length, 0);
-  }, [groupedResources]);
+    const resourceCount = groupedResources.reduce(
+      (total, group) => total + group.resources.length,
+      0,
+    );
+    // Include external types in visible count when they match search
+    const externalCount = EXTERNAL_TYPES.filter((type) => {
+      if (!normalizedQuery) return true;
+      const pres = resolveExternalPresentation(type, { provider: activeProvider });
+      return (
+        pres.displayLabel.toLowerCase().includes(normalizedQuery) ||
+        pres.shortLabel.toLowerCase().includes(normalizedQuery)
+      );
+    }).length;
+    return resourceCount + externalCount;
+  }, [groupedResources, normalizedQuery, activeProvider]);
+
+  const totalCount = totalResourceCount + EXTERNAL_TYPES.length;
 
   useEffect(() => {
     if (isMobile) return;
@@ -272,9 +383,11 @@ export function SidebarPalette() {
             const def = RESOURCE_DEFINITIONS[type];
             if (!def?.blockCategory) return;
 
+            const pres = resolveResourcePresentation(type, { provider: activeProvider });
+
             startPlacing(
               def.blockCategory,
-              getResourceLabel(type, activeProvider),
+              pres.displayLabel,
               def.schemaResourceType ?? def.blockCategory,
               remapSubtype(def.azureSubtype ?? def.schemaResourceType, activeProvider),
             );
@@ -353,7 +466,8 @@ export function SidebarPalette() {
       }
 
       counterRef.current += 1;
-      const name = `${getResourceLabel(type, activeProvider)} ${counterRef.current}`;
+      const pres = resolveResourcePresentation(type, { provider: activeProvider });
+      const name = `${pres.displayLabel} ${counterRef.current}`;
       addNode({
         kind: 'resource',
         resourceType: def.schemaResourceType ?? def.blockCategory,
@@ -367,7 +481,15 @@ export function SidebarPalette() {
     [activeProvider, addNode, playSound, techTree],
   );
 
-  const toggleGroup = useCallback((groupId: CreationGroupId) => {
+  const handleAddExternal = useCallback(
+    (type: 'internet' | 'browser') => {
+      addExternalBlock(type);
+      playSound('block-snap');
+    },
+    [addExternalBlock, playSound],
+  );
+
+  const toggleGroup = useCallback((groupId: CreationGroupId | 'external') => {
     setCollapsedGroups((prev) => {
       const next = new Set(prev);
       if (next.has(groupId)) {
@@ -385,7 +507,7 @@ export function SidebarPalette() {
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         visibleCount={visibleResourceCount}
-        totalCount={totalResourceCount}
+        totalCount={totalCount}
       />
 
       <label className="sidebar-palette-advanced-toggle">
@@ -398,40 +520,13 @@ export function SidebarPalette() {
       </label>
 
       <div className="sidebar-palette-content">
-        <section className="sidebar-palette-actor-section" aria-label="External actors">
-          <div className="sidebar-palette-actor-title">
-            <span aria-hidden="true">🔌</span>
-            <span>External Actors</span>
-          </div>
-          <div className="sidebar-palette-actor-list">
-            {(['internet', 'browser'] as const).map((type) => {
-              const name = type === 'internet' ? 'Internet' : 'Browser';
-              const emoji = type === 'internet' ? '🌐' : '💻';
-              return (
-                <button
-                  key={type}
-                  type="button"
-                  className="sidebar-palette-actor-btn"
-                  onClick={() => {
-                    addExternalBlock(type);
-                    playSound('block-snap');
-                  }}
-                  title={`Add ${name}`}
-                >
-                  <img
-                    className="sidebar-palette-actor-img"
-                    src={`/actor-sprites/${type}.svg`}
-                    alt=""
-                    width={18}
-                    height={18}
-                  />
-                  <span className="sidebar-palette-actor-name">{name}</span>
-                  <span className="sidebar-palette-actor-add">{emoji} Add</span>
-                </button>
-              );
-            })}
-          </div>
-        </section>
+        <PaletteExternalGroup
+          collapsed={collapsedGroups.has('external')}
+          onToggle={() => toggleGroup('external')}
+          searchQuery={normalizedQuery}
+          onAdd={handleAddExternal}
+          activeProvider={activeProvider}
+        />
 
         {groupedResources.map(({ groupId, resources }) => (
           <PaletteCategoryGroup
@@ -440,23 +535,26 @@ export function SidebarPalette() {
             resourceTypes={resources}
             collapsed={collapsedGroups.has(groupId)}
             onToggle={() => toggleGroup(groupId)}
-            renderItem={(type) => (
-              <PaletteResourceItem
-                key={type}
-                type={type}
-                providerLabel={getResourceLabel(type, activeProvider)}
-                providerShortLabel={getResourceShortLabel(type, activeProvider)}
-                enabled={techTree.isEnabled(type)}
-                disabledReason={techTree.getDisabledReason(type)}
-                searchQuery={normalizedQuery}
-                iconUrl={getResourceIconUrl(type, activeProvider)}
-                onClick={() => {
-                  if (techTree.isEnabled(type)) {
-                    handleCreate(type);
-                  }
-                }}
-              />
-            )}
+            renderItem={(type) => {
+              const pres = resolveResourcePresentation(type, { provider: activeProvider });
+              return (
+                <PaletteResourceItem
+                  key={type}
+                  type={type}
+                  providerLabel={pres.displayLabel}
+                  providerShortLabel={pres.shortLabel}
+                  enabled={techTree.isEnabled(type)}
+                  disabledReason={techTree.getDisabledReason(type)}
+                  searchQuery={normalizedQuery}
+                  iconUrl={pres.iconUrl}
+                  onClick={() => {
+                    if (techTree.isEnabled(type)) {
+                      handleCreate(type);
+                    }
+                  }}
+                />
+              );
+            }}
           />
         ))}
       </div>

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
@@ -364,7 +364,7 @@ export function SidebarPalette() {
     if (!containerRef.current) return;
 
     const buttons = containerRef.current.querySelectorAll<HTMLButtonElement>(
-      '.sidebar-palette-resource-btn:not(.disabled):not(:disabled)',
+      '.sidebar-palette-resource-btn[data-resource-type]:not(.disabled):not(:disabled)',
     );
     const interactables = Array.from(buttons).map((button) =>
       interact(button).draggable({

--- a/docs/design/PROVIDER_RESOURCES.md
+++ b/docs/design/PROVIDER_RESOURCES.md
@@ -254,7 +254,7 @@ Lives in `shared/presentation/` — importable from any layer (`entities/`, `fea
 
 ### Migration Path
 
-Existing consumers (`SidebarPalette.tsx`, `BlockSvg.tsx`, `ContainerBlockSprite.tsx`) currently import directly from `useTechTree`, `iconResolver`, and `providerMapping`. Future issues (#1558, #1559) will migrate these consumers to use `blockPresentation.ts` instead, consolidating the resolution path.
+Existing consumers (`SidebarPalette.tsx`, `BlockSvg.tsx`, `ContainerBlockSprite.tsx`) previously imported directly from `useTechTree`, `iconResolver`, and `providerMapping`. Issues #1558 and #1559 migrated these consumers to use `blockPresentation.ts`, consolidating the resolution path. `SidebarPalette.tsx` now exclusively uses `resolveResourcePresentation` and `resolveExternalPresentation` for all label, icon, and search operations.
 
 ## 6. Container Block Color System (#1557)
 
@@ -360,3 +360,56 @@ Block and container labels used divergent typography tokens:
 | `shared/tokens/designTokens.ts` | Added `LABEL_FACE_MIN_PX` and `LABEL_FACE_SCALE` exports |
 | `entities/block/BlockSvg.tsx` | Replaced inline `Math.max(8, ...)` with token-based formula |
 | `entities/container-block/ContainerBlockSvg.tsx` | Replaced inline `Math.max(10, ...)` with token-based formula |
+
+## 8. Palette Iconography Unification (#1559)
+
+### Problem
+
+The sidebar palette used three separate resolution paths for labels and icons:
+
+| Element | Previous Source | Problem |
+| --- | --- | --- |
+| Resource labels | `getResourceLabel()` / `getResourceShortLabel()` (useTechTree) | Different resolution path than canvas blocks |
+| Resource icons | `getResourceIconUrl()` (iconResolver) | Direct iconResolver call bypasses blockPresentation |
+| External actors | Hardcoded names + emoji in JSX | Bespoke section with unique CSS, no shared resolver |
+| Search matching | `getResourceLabel()` / `getResourceShortLabel()` | Labels could differ from what was displayed |
+
+### Resolution
+
+**Single source of truth**: All palette label/icon resolution now goes through `blockPresentation.ts`:
+
+- `resolveResourcePresentation(type, { provider })` — resource items (labels, icons, search)
+- `resolveExternalPresentation(type, { provider })` — external items (Internet, Browser)
+
+**External actors unified**: The bespoke external actors section (custom CSS, hardcoded names, emoji badges) was replaced by `PaletteExternalGroup`, which uses the same `sidebar-palette-resource-btn` layout as resource items. External items now support collapse/expand and search filtering.
+
+**Emoji fallback removed**: Resource items no longer fall back to emoji when `iconUrl` is null. A neutral `sidebar-palette-icon-placeholder` span (18×18 rounded muted block) is shown instead.
+
+**Count updates**: Total count includes external types (`ALL_RESOURCES.length + EXTERNAL_TYPES.length = 30`). Visible count includes external items matching the current search query.
+
+### Label Changes
+
+Switching from `getResourceLabel` to `resolveResourcePresentation` changes some Azure labels:
+
+| Old Label (useTechTree) | New Label (blockPresentation) |
+| --- | --- |
+| Azure Virtual Network | Virtual Network |
+| Azure Functions | Functions |
+| Azure SQL Database | SQL Database |
+| Azure App Service | App Service |
+
+These shorter labels match what canvas blocks already display, ensuring palette–canvas consistency.
+
+### Files Modified
+
+| File | Change |
+| --- | --- |
+| `widgets/sidebar-palette/SidebarPalette.tsx` | Switched to `resolveResourcePresentation` / `resolveExternalPresentation`; added `PaletteExternalGroup` component; removed emoji fallback; updated search, sort, drag, and create to use resolved labels |
+| `widgets/sidebar-palette/SidebarPalette.css` | Removed 63 lines of bespoke `.sidebar-palette-actor-*` CSS; added `.sidebar-palette-icon-placeholder` |
+
+### Invariants
+
+1. **Single resolution path**: All displayed labels and icons in the palette come from `blockPresentation.ts` resolvers.
+2. **No emoji in items**: Resource and external items never render emoji. Group headers (e.g., 🔌 External) are explicitly preserved.
+3. **External items searchable**: External items participate in search filtering via resolved `displayLabel` and `shortLabel`.
+4. **Palette–canvas consistency**: Labels in the palette match labels on canvas blocks because both use the same `blockPresentation` resolver.


### PR DESCRIPTION
## Summary

- Switch all resource palette items from `useTechTree`/`iconResolver` label helpers to `resolveResourcePresentation` from the shared `blockPresentation` module, establishing a single source of truth for labels, icons, and search
- Replace bespoke external actors section with unified `PaletteExternalGroup` using `resolveExternalPresentation` and the shared `sidebar-palette-resource-btn` layout — now supports collapse/expand and search filtering
- Remove item-level emoji fallback, replacing with neutral `icon-placeholder` span; prevent drag leakage on external (click-only) buttons

## Changes

| File | Change |
| --- | --- |
| `SidebarPalette.tsx` | Switched to `resolveResourcePresentation`/`resolveExternalPresentation`; added `PaletteExternalGroup`; scoped interact drag to `[data-resource-type]` only |
| `SidebarPalette.css` | Removed 63 lines of bespoke actor CSS; added icon-placeholder + external cursor override |
| `SidebarPalette.test.tsx` | Updated label/count assertions; added 7 new tests (external collapse, SVG icons, search, provider switching) |
| `SidebarPalette.additional.test.tsx` | Updated label assertions; added drag-leakage regression test + external sound test |
| `PROVIDER_RESOURCES.md` | Documented §8 palette iconography unification; updated migration path as complete |

## Validation

- TypeScript: ✅ clean
- ESLint: ✅ clean  
- Build: ✅ passes
- Tests: ✅ 2746/2746 pass (132 files)
- Oracle review: NO-GO → fixed (drag leakage) → all items addressed

Fixes #1559
Part of #1554