### PR TITLE
docs: update ROADMAP.md with M32/M33 completion

### DIFF
--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -61,8 +61,8 @@ CloudBlocks evolves through four stages — from visual cloud learning tool to e
 | M29       | Mobile Responsive Layout                     | ✅ Done |
 | M30       | Isometric Scene Visual Redesign              | ✅ Done |
 | M31       | Palette Tier Audit & External Actor Restore  | ✅ Done |
-| M32       | UX–Documentation Alignment                   | Open    |
-| M33       | Learning Content Validation                  | Open    |
+| M32       | UX–Documentation Alignment                   | ✅ Done |
+| M33       | Learning Content Validation                  | ✅ Done |
 | M34       | ExternalActor-to-Block Unification           | ✅ Done |
 | M35       | Visual Hierarchy & Presentation Consistency  | ✅ Done |
 
@@ -118,8 +118,8 @@ After v1.0.0, development continues with backward-compatible minor releases (v1.
 
 | Metric                   | Value                                                                                                     |
 | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| 0.x milestones completed | 35 (M0–M35, excluding M32/M33 still open)                                                                 |
-| Tests passing            | 2,746                                                                                                     |
+| 0.x milestones completed | 35 (M0–M35, all closed)                                                                                   |
+| Tests passing            | 2,783                                                                                                     |
 | Branch coverage          | ≥ 90%                                                                                                     |
 | Codebase                 | TypeScript (React 19) + Python (FastAPI) monorepo                                                         |
 | Architecture             | Block-based composition with `kind` + `traits` type system ([ADR-0013](../adr/0013-block-unification.md)) |


### PR DESCRIPTION
## Summary

- Mark Milestone 32 (UX–Documentation Alignment) as ✅ Done in ROADMAP.md
- Mark Milestone 33 (Learning Content Validation) as ✅ Done in ROADMAP.md
- Update success metrics: milestones count to "35 (M0–M35, all closed)", tests to 2,783

All M32/M33 issues are closed, epics closed, milestones closed via API. This PR synchronizes ROADMAP.md per the Roadmap synchronization rules in AGENTS.md.