### PR TITLE
fix(web): prefix icon URLs with Vite base URL for GitHub Pages

### DIFF
--- a/apps/web/src/shared/presentation/blockPresentation.baseurl.test.ts
+++ b/apps/web/src/shared/presentation/blockPresentation.baseurl.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression tests for blockPresentation with non-root BASE_URL.
+ *
+ * EXTERNAL_PRESENTATIONS is evaluated at module load time, so we must
+ * set import.meta.env.BASE_URL BEFORE importing the module. This requires
+ * vi.resetModules() + dynamic import() for each test group.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const SUBPATH_BASE = '/cloudblocks/';
+
+describe('blockPresentation with non-root BASE_URL', () => {
+  beforeEach(() => {
+    vi.stubEnv('BASE_URL', SUBPATH_BASE);
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('resolveExternalPresentation prefixes internet icon with base URL', async () => {
+    const { resolveExternalPresentation } = await import('./blockPresentation');
+    const result = resolveExternalPresentation('internet');
+    expect(result.iconUrl).toBe('/cloudblocks/actor-sprites/internet.svg');
+  });
+
+  it('resolveExternalPresentation prefixes browser icon with base URL', async () => {
+    const { resolveExternalPresentation } = await import('./blockPresentation');
+    const result = resolveExternalPresentation('browser');
+    expect(result.iconUrl).toBe('/cloudblocks/actor-sprites/browser.svg');
+  });
+
+  it('unknown external type still returns null icon', async () => {
+    const { resolveExternalPresentation } = await import('./blockPresentation');
+    const result = resolveExternalPresentation('unknown-actor');
+    expect(result.iconUrl).toBeNull();
+  });
+
+  it('resolveBlockPresentation with internet infers external and uses base URL', async () => {
+    const { resolveBlockPresentation } = await import('./blockPresentation');
+    const result = resolveBlockPresentation('internet');
+    expect(result.kind).toBe('external');
+    expect(result.iconUrl).toBe('/cloudblocks/actor-sprites/internet.svg');
+  });
+
+  it('no double slashes in external icon URLs', async () => {
+    const { resolveExternalPresentation } = await import('./blockPresentation');
+    const internet = resolveExternalPresentation('internet');
+    const browser = resolveExternalPresentation('browser');
+    expect(internet.iconUrl).not.toContain('//');
+    expect(browser.iconUrl).not.toContain('//');
+  });
+});

--- a/apps/web/src/shared/presentation/blockPresentation.ts
+++ b/apps/web/src/shared/presentation/blockPresentation.ts
@@ -189,6 +189,12 @@ export function resolveContainerPresentation(
 
 // ─── External Block Presentation ─────────────────────────────
 
+/** Resolve a public asset path with Vite base URL prefix. */
+function resolvePublicUrl(rawPath: string): string {
+  const base = import.meta.env.BASE_URL ?? '/';
+  return base + rawPath.replace(/^\//, '');
+}
+
 const EXTERNAL_PRESENTATIONS: Record<
   string,
   { shortLabel: string; displayLabel: string; iconUrl: string }
@@ -196,12 +202,12 @@ const EXTERNAL_PRESENTATIONS: Record<
   internet: {
     shortLabel: 'Internet',
     displayLabel: 'Internet',
-    iconUrl: '/actor-sprites/internet.svg',
+    iconUrl: resolvePublicUrl('/actor-sprites/internet.svg'),
   },
   browser: {
     shortLabel: 'Browser',
     displayLabel: 'Browser',
-    iconUrl: '/actor-sprites/browser.svg',
+    iconUrl: resolvePublicUrl('/actor-sprites/browser.svg'),
   },
 };
 

--- a/apps/web/src/shared/utils/iconResolver.baseurl.test.ts
+++ b/apps/web/src/shared/utils/iconResolver.baseurl.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression tests for non-root BASE_URL (GitHub Pages subpath deployment).
+ *
+ * When Vite builds with --base /cloudblocks/, import.meta.env.BASE_URL is
+ * inlined as "/cloudblocks/".  All public-asset icon URLs must be prefixed
+ * with that base so the browser fetches the correct path.
+ *
+ * Because the helpers read import.meta.env.BASE_URL at call time, we can
+ * stub it via vi.stubEnv before each call without resetting modules.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderType } from '@cloudblocks/schema';
+import { getBlockIconUrl, getContainerBlockIconUrl, getResourceIconUrl } from './iconResolver';
+
+const SUBPATH_BASE = '/cloudblocks/';
+
+describe('iconResolver with non-root BASE_URL', () => {
+  beforeEach(() => {
+    vi.stubEnv('BASE_URL', SUBPATH_BASE);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('getBlockIconUrl', () => {
+    it('prefixes Azure subtype icon with base URL', () => {
+      const url = getBlockIconUrl('azure', 'compute', 'vm');
+      expect(url).toBe('/cloudblocks/azure-icons/virtual-machine.svg');
+    });
+
+    it('prefixes AWS subtype icon with base URL', () => {
+      const url = getBlockIconUrl('aws', 'compute', 'ec2');
+      expect(url).toBe('/cloudblocks/aws-icons/ec2.svg');
+    });
+
+    it('prefixes GCP subtype icon with base URL', () => {
+      const url = getBlockIconUrl('gcp', 'compute', 'compute-engine');
+      expect(url).toBe('/cloudblocks/gcp-icons/compute-engine.svg');
+    });
+
+    it('prefixes external block icon (internet) with base URL', () => {
+      const url = getBlockIconUrl('azure', undefined as never, undefined, 'internet');
+      expect(url).toBe('/cloudblocks/actor-sprites/internet.svg');
+    });
+
+    it('still returns null for unknown subtype', () => {
+      const url = getBlockIconUrl('azure', 'compute', 'nonexistent-thing');
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('getResourceIconUrl', () => {
+    it('prefixes Azure resource icon with base URL', () => {
+      const url = getResourceIconUrl('vm', 'azure');
+      expect(url).toBe('/cloudblocks/azure-icons/virtual-machine.svg');
+    });
+
+    it('prefixes AWS resource icon with base URL', () => {
+      const url = getResourceIconUrl('vm', 'aws');
+      expect(url).toBe('/cloudblocks/aws-icons/ec2.svg');
+    });
+
+    it('prefixes GCP resource icon with base URL', () => {
+      const url = getResourceIconUrl('vm', 'gcp');
+      expect(url).toBe('/cloudblocks/gcp-icons/compute-engine.svg');
+    });
+
+    it('still returns null for unknown resource', () => {
+      const url = getResourceIconUrl('definitely-unknown', 'azure');
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('getContainerBlockIconUrl', () => {
+    it('prefixes region container icon with base URL', () => {
+      const url = getContainerBlockIconUrl('region');
+      expect(url).toMatch(/^\/cloudblocks\//);
+      expect(url).toContain('azure-icons/');
+    });
+
+    it('prefixes subnet container icon with base URL', () => {
+      const url = getContainerBlockIconUrl('subnet');
+      expect(url).toMatch(/^\/cloudblocks\//);
+    });
+
+    const providers: ProviderType[] = ['azure', 'aws', 'gcp'];
+    for (const provider of providers) {
+      it(`prefixes ${provider} container icon with base URL`, () => {
+        const url = getContainerBlockIconUrl('region', provider);
+        expect(url).toMatch(/^\/cloudblocks\//);
+      });
+    }
+  });
+
+  describe('no double slashes', () => {
+    it('getBlockIconUrl does not produce double slashes', () => {
+      const url = getBlockIconUrl('azure', 'compute', 'vm');
+      expect(url).not.toContain('//');
+    });
+
+    it('getResourceIconUrl does not produce double slashes', () => {
+      const url = getResourceIconUrl('vm', 'azure');
+      expect(url).not.toContain('//');
+    });
+
+    it('getContainerBlockIconUrl does not produce double slashes', () => {
+      const url = getContainerBlockIconUrl('region');
+      expect(url).not.toContain('//');
+    });
+  });
+});

--- a/apps/web/src/shared/utils/iconResolver.ts
+++ b/apps/web/src/shared/utils/iconResolver.ts
@@ -1,5 +1,15 @@
 import type { LayerType, ProviderType, ResourceCategory } from '@cloudblocks/schema';
 
+/**
+ * Prefix a root-relative public asset path with the Vite base URL.
+ * In development this is "/"; on GitHub Pages it is "/cloudblocks/".
+ * The leading slash on the raw path is stripped to avoid double slashes.
+ */
+function resolvePublicUrl(rawPath: string): string {
+  const base = import.meta.env.BASE_URL ?? '/';
+  return base + rawPath.replace(/^\//, '');
+}
+
 const AZURE_SUBTYPE_ICONS: Record<string, string> = {
   vm: '/azure-icons/virtual-machine.svg',
   'app-service': '/azure-icons/app-service.svg',
@@ -214,16 +224,19 @@ export function getBlockIconUrl(
 ): string | null {
   // External blocks (internet/browser) have no subtype but use actor-sprite icons
   if (!subtype && resourceType) {
-    return EXTERNAL_BLOCK_ICONS[resourceType] ?? null;
+    const icon = EXTERNAL_BLOCK_ICONS[resourceType];
+    return icon ? resolvePublicUrl(icon) : null;
   }
   if (!subtype) return null;
-  return VENDOR_ICON_REGISTRY[provider]?.[subtype] ?? null;
+  const icon = VENDOR_ICON_REGISTRY[provider]?.[subtype];
+  return icon ? resolvePublicUrl(icon) : null;
 }
 
 export function getResourceIconUrl(resourceType: string, provider: ProviderType): string | null {
   // For Azure, use the legacy resource-type → icon mapping
   if (provider === 'azure') {
-    return AZURE_RESOURCE_ICONS[resourceType] ?? null;
+    const icon = AZURE_RESOURCE_ICONS[resourceType];
+    return icon ? resolvePublicUrl(icon) : null;
   }
   // For AWS/GCP, resolve via the subtype icon registry using remapSubtype
   // The resourceType from RESOURCE_DEFINITIONS has an azureSubtype field;
@@ -237,9 +250,10 @@ export function getResourceIconUrl(resourceType: string, provider: ProviderType)
   // and look up in the vendor registry.
   //
   // Simpler approach: build AWS/GCP resource-type → icon maps parallel to AZURE_RESOURCE_ICONS.
-  return (
-    (AWS_GCP_RESOURCE_ICONS[provider] as Record<string, string> | undefined)?.[resourceType] ?? null
-  );
+  const icon = (AWS_GCP_RESOURCE_ICONS[provider] as Record<string, string> | undefined)?.[
+    resourceType
+  ];
+  return icon ? resolvePublicUrl(icon) : null;
 }
 
 // ─── Subtype Display Labels ─────────────────────────────────
@@ -488,9 +502,10 @@ export function getContainerBlockIconUrl(
   containerLayer: LayerType,
   provider: ProviderType = 'azure',
 ): string {
-  const fallback = CONTAINER_LAYER_ICONS[provider].region;
+  const fallback = resolvePublicUrl(CONTAINER_LAYER_ICONS[provider].region);
   if (containerLayer === 'resource') {
     return fallback;
   }
-  return CONTAINER_LAYER_ICONS[provider][containerLayer as ContainerLayer] ?? fallback;
+  const icon = CONTAINER_LAYER_ICONS[provider][containerLayer as ContainerLayer];
+  return icon ? resolvePublicUrl(icon) : fallback;
 }


### PR DESCRIPTION
## Summary

- Fix block icons returning 404 on the GitHub Pages deployment at `/cloudblocks/` subpath
- Add `resolvePublicUrl()` helper that prepends `import.meta.env.BASE_URL` to public asset paths
- Applied to all icon URL return points in `iconResolver.ts` and `blockPresentation.ts`

## Problem

Icon URLs were hardcoded as root-relative paths (e.g., `/azure-icons/virtual-machine.svg`). On GitHub Pages, which serves at `/cloudblocks/`, the browser requested `https://yeongseon.github.io/azure-icons/...` (404) instead of `https://yeongseon.github.io/cloudblocks/azure-icons/...`.

Vite's `--base /cloudblocks/` flag only rewrites HTML/asset references — it does not rewrite runtime string literals.

## Solution

```typescript
function resolvePublicUrl(rawPath: string): string {
  const base = import.meta.env.BASE_URL ?? '/';
  return base + rawPath.replace(/^\//, '');
}
```

`import.meta.env.BASE_URL` is a compile-time constant that Vite inlines: `/` in dev, `/cloudblocks/` when built with `--base /cloudblocks/`.

## Verification

- ✅ TypeScript type check passes (`tsc --noEmit`)
- ✅ All 2,783 tests pass
- ✅ Build with `--base /cloudblocks/` succeeds
- ✅ Built JS confirmed: `resolvePublicUrl` is inlined with `/cloudblocks/` prefix

## Changed Files

| File | Change |
|------|--------|
| `apps/web/src/shared/utils/iconResolver.ts` | Added `resolvePublicUrl()`, applied to `getBlockIconUrl()`, `getResourceIconUrl()`, `getContainerBlockIconUrl()` |
| `apps/web/src/shared/presentation/blockPresentation.ts` | Added `resolvePublicUrl()`, applied to `EXTERNAL_PRESENTATIONS` iconUrl values |

Fixes #1569