### PR TITLE
style(web): align connection dash patterns, add port pinholes, and consume neutral tokens

### DIFF
--- a/apps/web/src/entities/block/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/BlockSvg.test.tsx
@@ -15,9 +15,9 @@ describe('BlockSvg', () => {
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
-  it('does not render port dots group (port dots removed)', () => {
+  it('renders port dots group when showPorts is enabled (default)', () => {
     const { container } = render(<BlockSvg category="compute" provider="azure" />);
 
-    expect(container.querySelector('[data-testid="port-dots"]')).toBeNull();
+    expect(container.querySelector('[data-testid="port-dots"]')).not.toBeNull();
   });
 });

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -14,11 +14,16 @@ import {
   EDGE_HIGHLIGHT_STROKE_WIDTH,
   LABEL_FACE_MIN_PX,
   LABEL_FACE_SCALE,
+  PORT_DOT_OPACITY,
+  PORT_DOT_RX,
+  PORT_DOT_RY,
+  PORT_DOT_STROKE_WIDTH,
   TOP_FACE_STROKE_OPACITY,
   TOP_FACE_STROKE_WIDTH,
 } from '../../shared/tokens/designTokens';
 import { getBlockFaceColors } from './blockFaceColors';
 import { cuToSilhouetteDimensions, getSilhouetteFromCU } from './silhouettes';
+import { getBlockSvgPortPoints } from './blockGeometry';
 import { useUIStore } from '../store/uiStore';
 
 interface BlockSvgProps {
@@ -66,6 +71,8 @@ export const BlockSvg = memo(function BlockSvg({
   const displayLabel = getSubtypeDisplayLabel(provider ?? 'azure', subtype);
   const labelMode = useUIStore((s) => s.labelMode);
   const faceLabel = labelMode === 'compact' ? shortLabel : (displayLabel ?? shortLabel);
+  const showPorts = useUIStore((s) => s.showPorts);
+  const portPoints = getBlockSvgPortPoints(cu, 3, 3);
 
   return (
     <svg
@@ -259,6 +266,38 @@ export const BlockSvg = memo(function BlockSvg({
               </g>
             );
           })}
+        </g>
+      )}
+
+      {/* ─── Port dots: generic indicators on block side walls ─── */}
+      {showPorts && (
+        <g data-testid="port-dots">
+          {portPoints.inbound.map((p, i) => (
+            <ellipse
+              key={`in-${i}`}
+              cx={p.x}
+              cy={p.y}
+              rx={PORT_DOT_RX}
+              ry={PORT_DOT_RY}
+              fill="none"
+              stroke="rgba(255,255,255,0.5)"
+              strokeWidth={PORT_DOT_STROKE_WIDTH}
+              opacity={PORT_DOT_OPACITY}
+            />
+          ))}
+          {portPoints.outbound.map((p, i) => (
+            <ellipse
+              key={`out-${i}`}
+              cx={p.x}
+              cy={p.y}
+              rx={PORT_DOT_RX}
+              ry={PORT_DOT_RY}
+              fill="none"
+              stroke="rgba(255,255,255,0.5)"
+              strokeWidth={PORT_DOT_STROKE_WIDTH}
+              opacity={PORT_DOT_OPACITY}
+            />
+          ))}
         </g>
       )}
     </svg>

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -244,7 +244,7 @@ describe('BlockSvg subtype size overrides', () => {
 // ─── SVG Structure Tests ──────────────────────────────────────
 
 describe('BlockSvg SVG structure', () => {
-  it('renders 3 face polygons plus port dot polygons even when showPorts is not enabled', () => {
+  it('renders 3+ face polygons (port dots in separate group)', () => {
     const { container } = render(<BlockSvg category="compute" />);
     const polygons = getPolygons(container);
     expect(polygons.length).toBeGreaterThanOrEqual(3);

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -23,6 +23,9 @@ vi.mock('../../shared/tokens/designTokens', () => ({
   ARROW_MARKER_W: 6,
   ARROW_MARKER_H: 6,
   ARROW_MARKER_REF_X: 5.5,
+  PORT_DOT_RX: 4,
+  PORT_DOT_RY: 2.5,
+  PORT_DOT_STROKE_WIDTH: 1.5,
 }));
 
 vi.mock('../../features/diff/engine', () => ({
@@ -360,9 +363,9 @@ describe('ConnectionRenderer', () => {
     }> = [
       { type: 'dataflow', baseWidth: 2 },
       { type: 'http', baseWidth: 3 },
-      { type: 'internal', baseWidth: 2, dash: '4 4' },
-      { type: 'data', baseWidth: 2, dash: '8 4' },
-      { type: 'async', baseWidth: 2, dash: '8 4 2 4' },
+      { type: 'internal', baseWidth: 2.5 },
+      { type: 'data', baseWidth: 1.5, dash: '6 3' },
+      { type: 'async', baseWidth: 2, dash: '2 3' },
     ];
 
     for (const spec of typedSpecs) {

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -17,6 +17,9 @@ import {
   ARROW_MARKER_W,
   ARROW_MARKER_H,
   ARROW_MARKER_REF_X,
+  PORT_DOT_RX,
+  PORT_DOT_RY,
+  PORT_DOT_STROKE_WIDTH,
 } from '../../shared/tokens/designTokens';
 import {
   resolveConnectionVisualStyle,
@@ -24,10 +27,10 @@ import {
   CASING_WIDTH_OFFSET,
   HOVER_WIDTH_OFFSET,
 } from '../../shared/tokens/connectionVisualTokens';
-import { DIFF_THEMES, lightenColor } from './connectorTheme';
+import { CONNECTOR_THEMES, DIFF_THEMES, lightenColor } from './connectorTheme';
 import { getConnectionSurfaceRoute } from './surfaceRouting';
 import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
-import { getConnectionColors } from './connectionFaceColors';
+import { getConnectionColorsForType } from './connectionFaceColors';
 import type { ConnectionRenderSemantic } from './connectionFaceColors';
 
 interface ConnectionRendererProps {
@@ -51,8 +54,9 @@ function getColors(
   semantic: ConnectionRenderSemantic,
   diffState: string,
   isHighlighted: boolean,
+  isNeutral: boolean,
 ): TraceColors {
-  const base = getConnectionColors(semantic);
+  const base = getConnectionColorsForType(semantic, isNeutral);
   const diffOverride = diffState !== 'unchanged' ? DIFF_THEMES[diffState] : null;
 
   // Diff mode uses hardcoded hex values that can be lightened.
@@ -115,6 +119,78 @@ function getLabelPosition(points: readonly ScreenPoint[]): ScreenPoint | null {
   const a = points[mid];
   const b = points[mid + 1] ?? a;
   return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+import type { PinHoleStyle } from './connectorTheme';
+
+/** Render a pinhole glyph at a connection endpoint. */
+function renderPinhole(
+  x: number,
+  y: number,
+  style: PinHoleStyle,
+  stroke: string,
+  key: string,
+): React.ReactElement {
+  const r = PORT_DOT_RX;
+  const ry = PORT_DOT_RY;
+  const sw = PORT_DOT_STROKE_WIDTH;
+
+  switch (style) {
+    case 'filled':
+      return <ellipse key={key} cx={x} cy={y} rx={r} ry={ry} fill={stroke} opacity={0.8} />;
+    case 'cross':
+      return (
+        <g key={key} opacity={0.8}>
+          <line x1={x - r} y1={y} x2={x + r} y2={y} stroke={stroke} strokeWidth={sw} />
+          <line x1={x} y1={y - ry} x2={x} y2={y + ry} stroke={stroke} strokeWidth={sw} />
+        </g>
+      );
+    case 'double':
+      return (
+        <g key={key} opacity={0.8}>
+          <ellipse cx={x} cy={y} rx={r} ry={ry} fill="none" stroke={stroke} strokeWidth={sw} />
+          <ellipse
+            cx={x}
+            cy={y}
+            rx={r * 0.5}
+            ry={ry * 0.5}
+            fill="none"
+            stroke={stroke}
+            strokeWidth={sw * 0.8}
+          />
+        </g>
+      );
+    case 'dashed':
+      return (
+        <ellipse
+          key={key}
+          cx={x}
+          cy={y}
+          rx={r}
+          ry={ry}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={sw}
+          strokeDasharray="2 2"
+          opacity={0.8}
+        />
+      );
+    case 'open':
+    default:
+      return (
+        <ellipse
+          key={key}
+          cx={x}
+          cy={y}
+          rx={r}
+          ry={ry}
+          fill="none"
+          stroke={stroke}
+          strokeWidth={sw}
+          opacity={0.8}
+        />
+      );
+  }
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: rendering component with dual path requires unified control flow
@@ -194,14 +270,12 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     return {
       hitPath,
       labelPos: getLabelPosition(hitPoints),
+      sourcePos: hitPoints[0],
+      targetPos: hitPoints[hitPoints.length - 1],
     };
   }, [surfaceRoute, originX, originY]);
 
   if (!surfaceRender) return null;
-
-  const colors = getColors(renderSemantic, diffState, isHighlighted);
-  const hitPath = surfaceRender.hitPath;
-  const labelPos = surfaceRender.labelPos;
 
   // Resolve per-type stroke width and dash pattern.
   const rawType = connection.metadata?.type;
@@ -209,6 +283,13 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     typeof rawType === 'string' && Object.hasOwn(CONNECTION_VISUAL_STYLES, rawType)
       ? (rawType as ConnectionType)
       : undefined;
+  const isNeutral = connectionType === 'dataflow' || connectionType === undefined;
+  const colors = getColors(renderSemantic, diffState, isHighlighted, isNeutral);
+  const hitPath = surfaceRender.hitPath;
+  const labelPos = surfaceRender.labelPos;
+  const sourcePos = surfaceRender.sourcePos;
+  const targetPos = surfaceRender.targetPos;
+
   const visualStyle = resolveConnectionVisualStyle(connectionType);
   const innerWidth = isHighlighted
     ? visualStyle.strokeWidth + HOVER_WIDTH_OFFSET
@@ -217,7 +298,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     ? visualStyle.strokeWidth + CASING_WIDTH_OFFSET + HOVER_WIDTH_OFFSET
     : visualStyle.strokeWidth + CASING_WIDTH_OFFSET;
   const markerId = `arrow-${connection.id}`;
-
+  const pinHoleStyle = CONNECTOR_THEMES[connectionType ?? 'dataflow'].pinHoleStyle;
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     e.stopPropagation();
@@ -329,6 +410,14 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
         }}
         data-testid="connection-snap-flash"
       />
+
+      {/* Port pinhole indicators at connection endpoints */}
+      {diffState === 'unchanged' && (
+        <g data-testid="connection-pinholes" pointerEvents="none">
+          {renderPinhole(sourcePos.x, sourcePos.y, pinHoleStyle, colors.stroke, 'src')}
+          {renderPinhole(targetPos.x, targetPos.y, pinHoleStyle, colors.stroke, 'tgt')}
+        </g>
+      )}
 
       {hasValidationError && (
         <path

--- a/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
+++ b/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   CONNECTION_SEMANTIC_BASE_COLORS,
   getConnectionColors,
+  getConnectionColorsForType,
+  NEUTRAL_CONNECTION_COLORS,
   DEFAULT_CONNECTION_SEMANTIC,
 } from '../connectionFaceColors';
 import type { ConnectionRenderSemantic } from '../connectionFaceColors';
@@ -65,6 +67,36 @@ describe('connectionFaceColors', () => {
 
     it('is a valid key in CONNECTION_SEMANTIC_BASE_COLORS', () => {
       expect(CONNECTION_SEMANTIC_BASE_COLORS[DEFAULT_CONNECTION_SEMANTIC]).toBeDefined();
+    });
+  });
+
+  describe('NEUTRAL_CONNECTION_COLORS', () => {
+    it('uses CSS neutral variables', () => {
+      expect(NEUTRAL_CONNECTION_COLORS.stroke).toContain('--connection-neutral-stroke');
+      expect(NEUTRAL_CONNECTION_COLORS.casing).toContain('--connection-neutral-casing');
+    });
+
+    it('has a valid base hex color', () => {
+      expect(NEUTRAL_CONNECTION_COLORS.base).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    });
+  });
+
+  describe('getConnectionColorsForType', () => {
+    it('returns neutral colors when isNeutral is true', () => {
+      const colors = getConnectionColorsForType('http', true);
+      expect(colors).toBe(NEUTRAL_CONNECTION_COLORS);
+    });
+
+    it('returns semantic colors when isNeutral is false', () => {
+      const colors = getConnectionColorsForType('http', false);
+      expect(colors.stroke).toContain('--connection-http-stroke');
+    });
+
+    it('returns neutral colors regardless of semantic when isNeutral is true', () => {
+      const semantics: ConnectionRenderSemantic[] = ['http', 'event', 'data'];
+      for (const semantic of semantics) {
+        expect(getConnectionColorsForType(semantic, true)).toBe(NEUTRAL_CONNECTION_COLORS);
+      }
     });
   });
 });

--- a/apps/web/src/entities/connection/connectionFaceColors.ts
+++ b/apps/web/src/entities/connection/connectionFaceColors.ts
@@ -58,3 +58,24 @@ export function getConnectionColors(semantic: ConnectionRenderSemantic): Connect
 }
 
 export const DEFAULT_CONNECTION_SEMANTIC: ConnectionRenderSemantic = 'http';
+
+// ─── Neutral Colors (dataflow / untyped connections) ────────
+// Consumed via --connection-neutral-* CSS tokens in index.css.
+// These recede maximally behind blocks — pure slate, no hue bias.
+export const NEUTRAL_CONNECTION_COLORS: ConnectionColors = {
+  base: '#64748b',
+  stroke: 'var(--connection-neutral-stroke, #64748b)',
+  casing: 'var(--connection-neutral-casing, #334155)',
+};
+
+/**
+ * Get colors for a connection, preferring neutral colors
+ * when the connection type is 'dataflow' (default) or unresolved.
+ */
+export function getConnectionColorsForType(
+  semantic: ConnectionRenderSemantic,
+  isNeutral: boolean,
+): ConnectionColors {
+  if (isNeutral) return NEUTRAL_CONNECTION_COLORS;
+  return getConnectionColors(semantic);
+}

--- a/apps/web/src/entities/validation/connection.test.ts
+++ b/apps/web/src/entities/validation/connection.test.ts
@@ -829,18 +829,18 @@ describe('CONNECTION_VISUAL_STYLES', () => {
     expect(CONNECTION_VISUAL_STYLES.http.strokeDasharray).toBeUndefined();
   });
 
-  it('internal has short dash pattern', () => {
-    expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(2);
-    expect(CONNECTION_VISUAL_STYLES.internal.strokeDasharray).toBe('4 4');
+  it('internal is solid with strokeWidth 2.5', () => {
+    expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(2.5);
+    expect(CONNECTION_VISUAL_STYLES.internal.strokeDasharray).toBeUndefined();
   });
 
-  it('data has long dash pattern', () => {
-    expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(2);
-    expect(CONNECTION_VISUAL_STYLES.data.strokeDasharray).toBe('8 4');
+  it('data has thin dash pattern', () => {
+    expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(1.5);
+    expect(CONNECTION_VISUAL_STYLES.data.strokeDasharray).toBe('6 3');
   });
 
-  it('async has dot-dash pattern', () => {
+  it('async has dotted pattern', () => {
     expect(CONNECTION_VISUAL_STYLES.async.strokeWidth).toBe(2);
-    expect(CONNECTION_VISUAL_STYLES.async.strokeDasharray).toBe('8 4 2 4');
+    expect(CONNECTION_VISUAL_STYLES.async.strokeDasharray).toBe('2 3');
   });
 });

--- a/apps/web/src/shared/tokens/__tests__/connectionVisualTokens.test.ts
+++ b/apps/web/src/shared/tokens/__tests__/connectionVisualTokens.test.ts
@@ -28,19 +28,19 @@ describe('connectionVisualTokens', () => {
       expect(CONNECTION_VISUAL_STYLES.http.strokeDasharray).toBeUndefined();
     });
 
-    it('internal has short dash pattern', () => {
-      expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(2);
-      expect(CONNECTION_VISUAL_STYLES.internal.strokeDasharray).toBe('4 4');
+    it('internal is solid with strokeWidth 2.5', () => {
+      expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(2.5);
+      expect(CONNECTION_VISUAL_STYLES.internal.strokeDasharray).toBeUndefined();
     });
 
-    it('data has long dash pattern', () => {
-      expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(2);
-      expect(CONNECTION_VISUAL_STYLES.data.strokeDasharray).toBe('8 4');
+    it('data has thin dash pattern', () => {
+      expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(1.5);
+      expect(CONNECTION_VISUAL_STYLES.data.strokeDasharray).toBe('6 3');
     });
 
-    it('async has dot-dash pattern', () => {
+    it('async has dotted pattern', () => {
       expect(CONNECTION_VISUAL_STYLES.async.strokeWidth).toBe(2);
-      expect(CONNECTION_VISUAL_STYLES.async.strokeDasharray).toBe('8 4 2 4');
+      expect(CONNECTION_VISUAL_STYLES.async.strokeDasharray).toBe('2 3');
     });
   });
 

--- a/apps/web/src/shared/tokens/connectionVisualTokens.ts
+++ b/apps/web/src/shared/tokens/connectionVisualTokens.ts
@@ -1,18 +1,18 @@
-// ═══════════════════════════════════════════════════════════════
+// ═════════════════════════════════════════════════════════════════
 // Connection Visual Tokens — single source of truth for
 // per-ConnectionType stroke width and dash pattern.
 //
-// Spec §11.1:
-//   dataflow → solid line (default)
-//   http     → thicker solid line
-//   internal → short dash
-//   data     → long dash
-//   async    → dot-dash
+// Spec §11.1 (updated — Phase 3 alignment):
+//   dataflow  → solid line (default)
+//   http      → thicker solid line
+//   internal  → medium solid (no dash)
+//   data      → thin dash
+//   async     → pure dotted
 //
 // Consumed by:
 //   - ConnectionRenderer.tsx (rendering)
 //   - validation/connection.ts (re-export for backward compat)
-// ═══════════════════════════════════════════════════════════════
+// ═════════════════════════════════════════════════════════════════
 
 import type { ConnectionType } from '@cloudblocks/schema';
 
@@ -28,9 +28,9 @@ export interface ConnectionVisualStyle {
 export const CONNECTION_VISUAL_STYLES: Record<ConnectionType, ConnectionVisualStyle> = {
   dataflow: { strokeWidth: 2 },
   http: { strokeWidth: 3 },
-  internal: { strokeWidth: 2, strokeDasharray: '4 4' },
-  data: { strokeWidth: 2, strokeDasharray: '8 4' },
-  async: { strokeWidth: 2, strokeDasharray: '8 4 2 4' },
+  internal: { strokeWidth: 2.5 },
+  data: { strokeWidth: 1.5, strokeDasharray: '6 3' },
+  async: { strokeWidth: 2, strokeDasharray: '2 3' },
 };
 
 /** Casing width offset added to the base stroke width. */


### PR DESCRIPTION
## Summary

Implements #1579 — Phase 3, Sub-issue 2 of Epic #1554.

- **Connection dash patterns aligned to spec §11.1**: `internal` → solid 2.5px (was dashed 2px), `data` → thin dash '6 3' 1.5px (was '8 4' 2px), `async` → pure dotted '2 3' 2px (was '8 4 2 4' 2px). `dataflow` and `http` unchanged.
- **Port dot indicators on block faces**: Generic port ellipses rendered on BlockSvg left/right walls when `showPorts` is enabled (default: true). Uses `getBlockSvgPortPoints()` for 3 inbound + 3 outbound positions with `PORT_DOT_*` design tokens.
- **Pinhole glyphs at connection endpoints**: 5 styles (open/filled/cross/double/dashed) rendered at source and target positions via `renderPinhole()` in ConnectionRenderer. Style resolved per connection type from `CONNECTOR_THEMES`. Only shown when `diffState === 'unchanged'`.
- **Neutral color system for dataflow/untyped connections**: `NEUTRAL_CONNECTION_COLORS` uses `--connection-neutral-stroke/casing` CSS custom properties. `getConnectionColorsForType()` routes to neutral colors when `isNeutral=true` (dataflow type or undefined).

## Changes

| File | Change |
|---|---|
| `connectionVisualTokens.ts` | Updated dash patterns and stroke widths for internal/data/async |
| `BlockSvg.tsx` | Added port dot rendering with `PORT_DOT_*` tokens, gated by `showPorts` |
| `ConnectionRenderer.tsx` | Added `renderPinhole()`, neutral color consumption, reordered `connectionType` resolution above `getColors` |
| `connectionFaceColors.ts` | Added `NEUTRAL_CONNECTION_COLORS` and `getConnectionColorsForType()` |
| 6 test files | Updated expectations for new dash patterns, port dots, and neutral colors |

## Testing

- 2815/2815 tests passing
- Lint clean, build clean
- Branch coverage maintained

Fixes #1579
Part of #1554