### PR TITLE
style(web): resource type silhouettes and block shadow token systematization

### DIFF
--- a/apps/web/src/app/index.css
+++ b/apps/web/src/app/index.css
@@ -100,6 +100,19 @@
   /* ── Connection neutral (base wire color, recedes behind blocks) ── */
   --connection-neutral-stroke: #64748b;
   --connection-neutral-casing: #334155;
+
+  /* ── Block shadow tokens (systematized #1580) ── */
+  --shadow-block-base: drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3))
+    drop-shadow(0px 10px 15px rgba(0, 0, 0, 0.2));
+  --shadow-block-hover: drop-shadow(2px 8px 0px rgba(0, 0, 0, 0.3))
+    drop-shadow(0px 12px 18px rgba(0, 0, 0, 0.25));
+  --shadow-block-drag: drop-shadow(4px 12px 0px rgba(0, 0, 0, 0.35))
+    drop-shadow(0px 16px 24px rgba(0, 0, 0, 0.25));
+  --shadow-block-glow: drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+  --shadow-container-base: drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+  --shadow-container-hover: drop-shadow(2px 4px 0px rgba(0, 0, 0, 0.15));
+  --shadow-container-drag: drop-shadow(3px 6px 0px rgba(0, 0, 0, 0.18))
+    drop-shadow(0px 8px 14px rgba(0, 0, 0, 0.14));
 }
 
 [data-theme='workshop'] {
@@ -154,6 +167,19 @@
   /* ── Connection neutral (base wire color, recedes behind blocks) ── */
   --connection-neutral-stroke: #94a3b8;
   --connection-neutral-casing: #64748b;
+
+  /* ── Block shadow tokens (systematized #1580) ── */
+  --shadow-block-base: drop-shadow(1px 4px 0px rgba(0, 0, 0, 0.08))
+    drop-shadow(0px 6px 10px rgba(0, 0, 0, 0.06));
+  --shadow-block-hover: drop-shadow(1px 5px 0px rgba(0, 0, 0, 0.1))
+    drop-shadow(0px 8px 14px rgba(0, 0, 0, 0.08));
+  --shadow-block-drag: drop-shadow(2px 8px 0px rgba(0, 0, 0, 0.12))
+    drop-shadow(0px 12px 18px rgba(0, 0, 0, 0.1));
+  --shadow-block-glow: drop-shadow(1px 4px 0px rgba(0, 0, 0, 0.08));
+  --shadow-container-base: drop-shadow(1px 2px 0px rgba(0, 0, 0, 0.06));
+  --shadow-container-hover: drop-shadow(1px 3px 0px rgba(0, 0, 0, 0.08));
+  --shadow-container-drag: drop-shadow(2px 4px 0px rgba(0, 0, 0, 0.1))
+    drop-shadow(0px 6px 10px rgba(0, 0, 0, 0.07));
 }
 
 * {

--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -22,19 +22,17 @@
   transition:
     filter 0.2s ease,
     transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
-  filter: drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3)) drop-shadow(0px 10px 15px rgba(0, 0, 0, 0.2));
+  filter: var(--shadow-block-base);
 }
 
 .block-button:hover .block-img,
 .block-img:hover {
-  filter: drop-shadow(2px 8px 0px rgba(0, 0, 0, 0.3)) drop-shadow(0px 12px 18px rgba(0, 0, 0, 0.25))
-    brightness(1.08);
+  filter: var(--shadow-block-hover) brightness(1.08);
   transform: translateY(-3px);
 }
 
 .block-img.is-dragging {
-  filter: drop-shadow(4px 12px 0px rgba(0, 0, 0, 0.35))
-    drop-shadow(0px 16px 24px rgba(0, 0, 0, 0.25));
+  filter: var(--shadow-block-drag);
   transform: translateY(-6px) scale(1.05);
   cursor: grabbing;
   z-index: 9999;
@@ -42,12 +40,12 @@
 
 .block-sprite.is-selected .block-img {
   filter: drop-shadow(0 0 8px var(--state-selection-stroke))
-    drop-shadow(0 0 16px var(--state-selection-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 0 16px var(--state-selection-glow)) var(--shadow-block-glow);
 }
 
 .block-sprite.is-connection-source .block-img {
   filter: drop-shadow(0 0 10px var(--state-snap-stroke))
-    drop-shadow(0 0 20px var(--state-snap-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 0 20px var(--state-snap-glow)) var(--shadow-block-glow);
 }
 
 .block-sprite.is-delete-mode .block-img {
@@ -56,30 +54,29 @@
 
 .block-sprite.is-delete-mode .block-button:hover .block-img,
 .block-sprite.is-delete-mode .block-img:hover {
-  filter: drop-shadow(0 0 10px var(--state-delete-stroke))
-    drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3)) sepia(1) hue-rotate(-50deg) saturate(3)
-    brightness(1.1);
+  filter: drop-shadow(0 0 10px var(--state-delete-stroke)) var(--shadow-block-glow) sepia(1)
+    hue-rotate(-50deg) saturate(3) brightness(1.1);
 }
 
 .block-sprite.is-valid-target .block-img {
   filter: drop-shadow(0 0 8px var(--state-snap-stroke)) drop-shadow(0 0 16px var(--state-snap-glow))
-    drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    var(--shadow-block-glow);
   animation: pulse-valid 1.5s ease-in-out infinite;
 }
 
 .block-sprite.is-invalid-target .block-img {
-  filter: drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3)) brightness(0.6) saturate(0.3);
+  filter: var(--shadow-block-glow) brightness(0.6) saturate(0.3);
   cursor: not-allowed;
 }
 
 .block-sprite.is-connected .block-img {
   filter: drop-shadow(0 0 6px var(--state-connected-stroke))
-    drop-shadow(0 0 12px var(--state-connected-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 0 12px var(--state-connected-glow)) var(--shadow-block-glow);
 }
 
 .block-sprite.is-warning .block-img {
   filter: drop-shadow(0 0 8px var(--state-warning-stroke))
-    drop-shadow(0 0 16px var(--state-warning-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 0 16px var(--state-warning-glow)) var(--shadow-block-glow);
   animation: pulse-warning 1.5s ease-in-out infinite;
 }
 
@@ -87,11 +84,11 @@
   0%,
   100% {
     filter: drop-shadow(0 0 8px var(--state-snap-stroke))
-      drop-shadow(0 0 16px var(--state-snap-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      drop-shadow(0 0 16px var(--state-snap-glow)) var(--shadow-block-glow);
   }
   50% {
     filter: drop-shadow(0 0 12px var(--state-snap-stroke))
-      drop-shadow(0 0 24px var(--state-snap-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      drop-shadow(0 0 24px var(--state-snap-glow)) var(--shadow-block-glow);
   }
 }
 
@@ -99,28 +96,28 @@
   0%,
   100% {
     filter: drop-shadow(0 0 8px var(--state-warning-stroke))
-      drop-shadow(0 0 16px var(--state-warning-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      drop-shadow(0 0 16px var(--state-warning-glow)) var(--shadow-block-glow);
   }
   50% {
     filter: drop-shadow(0 0 12px var(--state-warning-stroke))
-      drop-shadow(0 0 24px var(--state-warning-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      drop-shadow(0 0 24px var(--state-warning-glow)) var(--shadow-block-glow);
   }
 }
 
 .block-sprite.diff-added .block-img {
   filter: drop-shadow(0 0 8px #22c55e) drop-shadow(0 0 16px rgba(34, 197, 94, 0.5))
-    drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    var(--shadow-block-glow);
   animation: pulse-diff-added 2s ease-in-out infinite;
 }
 
 .block-sprite.diff-modified .block-img {
   filter: drop-shadow(0 0 8px #eab308) drop-shadow(0 0 16px rgba(234, 179, 8, 0.5))
-    drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    var(--shadow-block-glow);
   animation: pulse-diff-modified 2s ease-in-out infinite;
 }
 
 .block-sprite.diff-removed .block-img {
-  filter: drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3)) brightness(0.5) saturate(0.2);
+  filter: var(--shadow-block-glow) brightness(0.5) saturate(0.2);
   opacity: 0.5;
   pointer-events: none;
 }
@@ -129,11 +126,11 @@
   0%,
   100% {
     filter: drop-shadow(0 0 8px #22c55e) drop-shadow(0 0 16px rgba(34, 197, 94, 0.5))
-      drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      var(--shadow-block-glow);
   }
   50% {
     filter: drop-shadow(0 0 14px #22c55e) drop-shadow(0 0 28px rgba(34, 197, 94, 0.7))
-      drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      var(--shadow-block-glow);
   }
 }
 
@@ -141,11 +138,11 @@
   0%,
   100% {
     filter: drop-shadow(0 0 8px #eab308) drop-shadow(0 0 16px rgba(234, 179, 8, 0.5))
-      drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      var(--shadow-block-glow);
   }
   50% {
     filter: drop-shadow(0 0 14px #eab308) drop-shadow(0 0 28px rgba(234, 179, 8, 0.7))
-      drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+      var(--shadow-block-glow);
   }
 }
 
@@ -170,7 +167,7 @@
 
 .block-sprite.is-building .block-img {
   opacity: calc(0.3 + 0.7 * var(--build-progress, 1));
-  filter: saturate(var(--build-progress, 1)) drop-shadow(2px 8px 0 rgba(0, 0, 0, 0.25));
+  filter: saturate(var(--build-progress, 1)) var(--shadow-block-glow);
   transition:
     opacity 0.3s ease,
     filter 0.3s ease;
@@ -179,11 +176,11 @@
 @keyframes block-upgrade-glow {
   0%,
   100% {
-    filter: drop-shadow(0 0 6px var(--state-success-glow)) drop-shadow(2px 6px 0 rgba(0, 0, 0, 0.3));
+    filter: drop-shadow(0 0 6px var(--state-success-glow)) var(--shadow-block-glow);
   }
   50% {
     filter: drop-shadow(0 0 14px var(--state-success-stroke))
-      drop-shadow(0 0 24px var(--state-success-glow)) drop-shadow(2px 6px 0 rgba(0, 0, 0, 0.3));
+      drop-shadow(0 0 24px var(--state-success-glow)) var(--shadow-block-glow);
   }
 }
 
@@ -195,16 +192,15 @@
 @keyframes port-snap-pulse {
   0% {
     transform: scale(1);
-    filter: drop-shadow(0 0 0 transparent) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    filter: drop-shadow(0 0 0 transparent) var(--shadow-block-glow);
   }
   30% {
     transform: scale(1.08);
-    filter: drop-shadow(0 0 12px var(--state-success-stroke, #22c55e))
-      drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    filter: drop-shadow(0 0 12px var(--state-success-stroke, #22c55e)) var(--shadow-block-glow);
   }
   100% {
     transform: scale(1);
-    filter: drop-shadow(0 0 0 transparent) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    filter: drop-shadow(0 0 0 transparent) var(--shadow-block-glow);
   }
 }
 
@@ -215,7 +211,7 @@
 /* ── Pre-drop affordance: enlarge valid target during drag ─ */
 .block-sprite.is-drag-hover-valid .block-img {
   filter: drop-shadow(0 0 10px var(--state-snap-stroke))
-    drop-shadow(0 0 20px var(--state-snap-glow)) drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3));
+    drop-shadow(0 0 20px var(--state-snap-glow)) var(--shadow-block-glow);
   transform: translateY(-2px) scale(1.03);
   transition:
     filter 150ms ease,

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -1,5 +1,6 @@
 import { memo, useId } from 'react';
 import type { BlockRole, ProviderType, ResourceCategory } from '@cloudblocks/schema';
+import { CATEGORY_PORTS } from '@cloudblocks/schema';
 import { ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
 import {
   getBlockIconUrl,
@@ -72,8 +73,8 @@ export const BlockSvg = memo(function BlockSvg({
   const labelMode = useUIStore((s) => s.labelMode);
   const faceLabel = labelMode === 'compact' ? shortLabel : (displayLabel ?? shortLabel);
   const showPorts = useUIStore((s) => s.showPorts);
-  const portPoints = getBlockSvgPortPoints(cu, 3, 3);
-
+  const ports = CATEGORY_PORTS[category] ?? { inbound: 1, outbound: 1 };
+  const portPoints = getBlockSvgPortPoints(cu, ports.inbound, ports.outbound);
   return (
     <svg
       viewBox={`0 0 ${screenWidth} ${svgHeight}`}

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.css
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.css
@@ -23,61 +23,60 @@
   transition:
     filter 0.2s ease,
     transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
-  filter: drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+  filter: var(--shadow-container-base);
 }
 
 .container-button:hover .container-img,
 .container-img:hover {
-  filter: drop-shadow(2px 4px 0px rgba(0, 0, 0, 0.15)) brightness(1.03);
+  filter: var(--shadow-container-hover) brightness(1.03);
 }
 
 .container-img.is-dragging {
-  filter: drop-shadow(3px 6px 0px rgba(0, 0, 0, 0.18)) drop-shadow(0px 8px 14px rgba(0, 0, 0, 0.14));
+  filter: var(--shadow-container-drag);
   transform: translateY(-3px) scale(1.02);
   cursor: grabbing;
 }
 
 .container-sprite.is-selected .container-img {
-  filter: drop-shadow(0 0 10px var(--state-selection-glow))
-    drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+  filter: drop-shadow(0 0 10px var(--state-selection-glow)) var(--shadow-container-base);
 }
 
 .container-sprite.is-drop-target .container-img {
   filter: drop-shadow(0 0 10px var(--state-snap-stroke))
-    drop-shadow(0 0 20px var(--state-snap-glow)) drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+    drop-shadow(0 0 20px var(--state-snap-glow)) var(--shadow-container-base);
   animation: pulse-drop-target 1.5s ease-in-out infinite;
 }
 
 .container-sprite.is-drop-target-invalid .container-img {
-  filter: drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12)) brightness(0.7) saturate(0.4);
+  filter: var(--shadow-container-base) brightness(0.7) saturate(0.4);
 }
 
 @keyframes pulse-drop-target {
   0%,
   100% {
     filter: drop-shadow(0 0 10px var(--state-snap-stroke))
-      drop-shadow(0 0 20px var(--state-snap-glow)) drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+      drop-shadow(0 0 20px var(--state-snap-glow)) var(--shadow-container-base);
   }
   50% {
     filter: drop-shadow(0 0 16px var(--state-snap-stroke))
-      drop-shadow(0 0 30px var(--state-snap-glow)) drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+      drop-shadow(0 0 30px var(--state-snap-glow)) var(--shadow-container-base);
   }
 }
 
 .container-sprite.diff-added .container-img {
   filter: drop-shadow(0 0 10px #22c55e) drop-shadow(0 0 20px rgba(34, 197, 94, 0.4))
-    drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+    var(--shadow-container-base);
   animation: pulse-diff-container-added 2s ease-in-out infinite;
 }
 
 .container-sprite.diff-modified .container-img {
   filter: drop-shadow(0 0 10px #eab308) drop-shadow(0 0 20px rgba(234, 179, 8, 0.4))
-    drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+    var(--shadow-container-base);
   animation: pulse-diff-container-modified 2s ease-in-out infinite;
 }
 
 .container-sprite.diff-removed .container-img {
-  filter: drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12)) brightness(0.5) saturate(0.2);
+  filter: var(--shadow-container-base) brightness(0.5) saturate(0.2);
   opacity: 0.5;
   pointer-events: none;
 }
@@ -86,11 +85,11 @@
   0%,
   100% {
     filter: drop-shadow(0 0 10px #22c55e) drop-shadow(0 0 20px rgba(34, 197, 94, 0.4))
-      drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+      var(--shadow-container-base);
   }
   50% {
     filter: drop-shadow(0 0 16px #22c55e) drop-shadow(0 0 32px rgba(34, 197, 94, 0.6))
-      drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+      var(--shadow-container-base);
   }
 }
 
@@ -98,11 +97,11 @@
   0%,
   100% {
     filter: drop-shadow(0 0 10px #eab308) drop-shadow(0 0 20px rgba(234, 179, 8, 0.4))
-      drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+      var(--shadow-container-base);
   }
   50% {
     filter: drop-shadow(0 0 16px #eab308) drop-shadow(0 0 32px rgba(234, 179, 8, 0.6))
-      drop-shadow(2px 3px 0px rgba(0, 0, 0, 0.12));
+      var(--shadow-container-base);
   }
 }
 

--- a/apps/web/src/shared/types/visualProfile.ts
+++ b/apps/web/src/shared/types/visualProfile.ts
@@ -56,26 +56,74 @@ export interface BlockVisualProfile {
   appCapacity: number;
 }
 
-// Unified: all resource blocks use the same rect silhouette, medium tier,
-// and 3×4 footprint. Only color and icon distinguish resources.
-const UNIFORM_BLOCK_PROFILE: BlockVisualProfile = {
-  tier: 'medium',
-  surface: 'ported',
-  silhouette: 'rect',
-  footprint: [3, 4],
-  hostable: false,
-  appCapacity: 0,
-};
-
+// Per-category silhouette differentiation (Phase 3, #1580).
+// data→cylinder, delivery→gateway, security→shield, messaging→hex, others→rect.
+// All blocks use medium tier and 3×4 footprint. Only shape, color, and icon differ.
 export const BLOCK_VISUAL_PROFILES: Record<ResourceCategory, BlockVisualProfile> = {
-  network: { ...UNIFORM_BLOCK_PROFILE },
-  security: { ...UNIFORM_BLOCK_PROFILE },
-  delivery: { ...UNIFORM_BLOCK_PROFILE },
-  compute: { ...UNIFORM_BLOCK_PROFILE, hostable: true, appCapacity: 4 },
-  data: { ...UNIFORM_BLOCK_PROFILE },
-  messaging: { ...UNIFORM_BLOCK_PROFILE },
-  identity: { ...UNIFORM_BLOCK_PROFILE },
-  operations: { ...UNIFORM_BLOCK_PROFILE },
+  network: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'rect',
+    footprint: [3, 4],
+    hostable: false,
+    appCapacity: 0,
+  },
+  security: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'shield',
+    footprint: [3, 4],
+    hostable: false,
+    appCapacity: 0,
+  },
+  delivery: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'gateway',
+    footprint: [3, 4],
+    hostable: false,
+    appCapacity: 0,
+  },
+  compute: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'rect',
+    footprint: [3, 4],
+    hostable: true,
+    appCapacity: 4,
+  },
+  data: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'cylinder',
+    footprint: [3, 4],
+    hostable: false,
+    appCapacity: 0,
+  },
+  messaging: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'hex',
+    footprint: [3, 4],
+    hostable: false,
+    appCapacity: 0,
+  },
+  identity: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'rect',
+    footprint: [3, 4],
+    hostable: false,
+    appCapacity: 0,
+  },
+  operations: {
+    tier: 'medium',
+    surface: 'ported',
+    silhouette: 'rect',
+    footprint: [3, 4],
+    hostable: false,
+    appCapacity: 0,
+  },
 };
 
 export function getBlockVisualProfile(category: ResourceCategory): BlockVisualProfile {


### PR DESCRIPTION
## Summary

- Map per-category resource block silhouettes: `data→cylinder`, `delivery→gateway`, `security→shield`, `messaging→hex` (compute/network/identity/operations stay `rect`)
- Fix port dot count to use `CATEGORY_PORTS` from `@cloudblocks/schema` instead of hardcoded `3, 3`
- Add shadow CSS custom properties (`--shadow-block-base/hover/drag/glow`, `--shadow-container-base/hover/drag`) for both Blueprint and Workshop themes
- Replace **all** hardcoded `drop-shadow()` values in `BlockSprite.css` (~28 occurrences) and `ContainerBlockSprite.css` (~15 occurrences) with tokenized `var(--shadow-*)` references

## Files Changed

| File | Change |
|---|---|
| `visualProfile.ts` | Per-category silhouette mapping |
| `BlockSvg.tsx` | Import `CATEGORY_PORTS`, use dynamic port counts |
| `index.css` | Shadow token CSS custom properties (both themes) |
| `BlockSprite.css` | Replace all hardcoded block shadows with tokens |
| `ContainerBlockSprite.css` | Replace all hardcoded container shadows with tokens |

## Testing

- ✅ 2815/2815 tests passing
- ✅ Lint clean
- ✅ Build succeeds

## Design Spec Items

Implements items **#3** (resource type silhouettes), **#12** (block shadow systematization), and partial **#15** (shadow token forward-declaration) from the visual design spec.

Part of #1554. Fixes #1580.