### PR TITLE
style(web): placement anchor tiles and mounted block seating

### DIFF
--- a/apps/web/src/app/index.css
+++ b/apps/web/src/app/index.css
@@ -113,6 +113,14 @@
   --shadow-container-hover: drop-shadow(2px 4px 0px rgba(0, 0, 0, 0.15));
   --shadow-container-drag: drop-shadow(3px 6px 0px rgba(0, 0, 0, 0.18))
     drop-shadow(0px 8px 14px rgba(0, 0, 0, 0.14));
+
+  /* ── Placement anchor tiles (#1581) ── */
+  --anchor-marker-stroke: rgba(255, 255, 255, 0.1);
+  --anchor-marker-occupied-stroke: rgba(255, 255, 255, 0.04);
+
+  /* ── Mounted block groove (#1581) ── */
+  --groove-color: rgba(0, 0, 0, 0.25);
+  --groove-opacity: 0.7;
 }
 
 [data-theme='workshop'] {
@@ -180,6 +188,14 @@
   --shadow-container-hover: drop-shadow(1px 3px 0px rgba(0, 0, 0, 0.08));
   --shadow-container-drag: drop-shadow(2px 4px 0px rgba(0, 0, 0, 0.1))
     drop-shadow(0px 6px 10px rgba(0, 0, 0, 0.07));
+
+  /* ── Placement anchor tiles (#1581) ── */
+  --anchor-marker-stroke: rgba(0, 0, 0, 0.07);
+  --anchor-marker-occupied-stroke: rgba(0, 0, 0, 0.03);
+
+  /* ── Mounted block groove (#1581) ── */
+  --groove-color: rgba(0, 0, 0, 0.12);
+  --groove-opacity: 0.5;
 }
 
 * {

--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -237,6 +237,20 @@
   opacity: 0.88;
 }
 
+/* ── Mounted block groove shadow (#1581) ─ */
+.block-sprite.is-mounted .block-img::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 15%;
+  right: 15%;
+  height: 6px;
+  background: radial-gradient(ellipse at center, var(--groove-color) 0%, transparent 70%);
+  opacity: var(--groove-opacity);
+  pointer-events: none;
+  border-radius: 50%;
+}
+
 /* ── Screen-aligned label chip ─ */
 .block-label-chip {
   position: absolute;

--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -374,6 +374,26 @@ describe('BlockSprite', () => {
     expect(container.firstElementChild).toHaveClass('is-selected');
   });
 
+  it('adds is-mounted class when parentContainer is provided', () => {
+    const block = makeBlock('block-mounted', 'compute');
+    const { container } = render(
+      <BlockSprite
+        block={block}
+        parentContainer={parentContainer}
+        screenX={0}
+        screenY={0}
+        zIndex={1}
+      />,
+    );
+    expect(container.firstElementChild).toHaveClass('is-mounted');
+  });
+
+  it('does not add is-mounted class when no parentContainer', () => {
+    const block = makeBlock('block-unmounted', 'compute');
+    const { container } = render(<BlockSprite block={block} screenX={0} screenY={0} zIndex={1} />);
+    expect(container.firstElementChild).not.toHaveClass('is-mounted');
+  });
+
   it('adds is-delete-mode class when in delete mode', () => {
     const block = makeBlock('block-delete-class', 'event');
     useUIStore.setState({ toolMode: 'delete' });

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -259,6 +259,7 @@ export const BlockSprite = memo(function BlockSprite({
 
   const className = [
     'block-sprite',
+    parentContainer && 'is-mounted',
     isSelected && 'is-selected',
     isConnectionSource && 'is-connection-source',
     isDeleteMode && 'is-delete-mode',

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
@@ -24,6 +24,7 @@ interface PlateSpriteProps {
   screenX: number;
   screenY: number;
   zIndex: number;
+  occupiedCells?: Set<string>;
 }
 
 export const ContainerBlockSprite = memo(function PlateSprite({
@@ -31,6 +32,7 @@ export const ContainerBlockSprite = memo(function PlateSprite({
   screenX,
   screenY,
   zIndex,
+  occupiedCells,
 }: PlateSpriteProps) {
   type PlateLayer = Exclude<LayerType, 'resource'>;
 
@@ -236,6 +238,7 @@ export const ContainerBlockSprite = memo(function PlateSprite({
             label={label}
             iconUrl={iconUrl}
             provider={activeProvider}
+            occupiedCells={occupiedCells}
           />
         </div>
       </button>

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
@@ -118,13 +118,17 @@ describe('PlateSvg — SVG structure', () => {
   it('renders 5 face polygons (top + 2 inset + left side + right side)', () => {
     const { container } = renderPlateSvg();
     // Exclude polygons inside <clipPath> (used by PlateSurfaceGrid)
-    const polygons = container.querySelectorAll('polygon:not(clipPath polygon)');
+    const polygons = container.querySelectorAll(
+      'polygon:not(clipPath polygon):not([data-anchor-cell])',
+    );
     expect(polygons.length).toBe(5);
   });
 
   it('applies correct fill colors to face polygons', () => {
     const { container } = renderPlateSvg();
-    const polygons = container.querySelectorAll('polygon');
+    const polygons = container.querySelectorAll(
+      'polygon:not(clipPath polygon):not([data-anchor-cell])',
+    );
 
     expect(polygons[0].getAttribute('fill')).toBe('#22C55E'); // top
     // polygons[1] = inset-highlight (fill=none), polygons[2] = inset-shadow (fill=none)
@@ -220,7 +224,9 @@ describe('PlateSvg — colors are independent of containerLayer', () => {
     };
 
     const { container } = renderPlateSvg({ containerLayer: 'global', ...customColors });
-    const polygons = container.querySelectorAll('polygon');
+    const polygons = container.querySelectorAll(
+      'polygon:not(clipPath polygon):not([data-anchor-cell])',
+    );
 
     expect(polygons[0].getAttribute('fill')).toBe('#FF0000');
     // polygons[1] = inset-highlight, polygons[2] = inset-shadow
@@ -306,6 +312,46 @@ describe('PlateSvg — profile-based rendering', () => {
 
     const svg = container.querySelector('svg');
     expect(svg?.getAttribute('viewBox')).toBe(`0 0 ${expectedWidth} ${expectedHeight}`);
+  });
+});
+
+describe('PlateSvg — placement anchor tiles (#1581)', () => {
+  it('renders anchor markers clipped to top face when no occupied cells', () => {
+    const { container } = renderPlateSvg({ unitsX: 3, unitsY: 3 });
+    const markerGroup = container.querySelector('[data-layer="anchor-markers"]');
+    expect(markerGroup).toBeInTheDocument();
+
+    const markers = container.querySelectorAll('[data-anchor-cell]');
+    expect(markers.length).toBe(16);
+  });
+
+  it('marks occupied cells with data-anchor-state="occupied"', () => {
+    const occupied = new Set(['1:1', '1:2', '2:1', '2:2']);
+    const { container } = renderPlateSvg({ unitsX: 3, unitsY: 3, occupiedCells: occupied });
+
+    const occupiedMarkers = container.querySelectorAll('[data-anchor-state="occupied"]');
+    expect(occupiedMarkers.length).toBe(4);
+
+    const emptyMarkers = container.querySelectorAll('[data-anchor-state="empty"]');
+    expect(emptyMarkers.length).toBe(12);
+  });
+
+  it('occupied markers have lower opacity than empty markers', () => {
+    const occupied = new Set(['1:1']);
+    const { container } = renderPlateSvg({ unitsX: 2, unitsY: 2, occupiedCells: occupied });
+
+    const occupiedMarker = container.querySelector('[data-anchor-state="occupied"]');
+    const emptyMarker = container.querySelector('[data-anchor-state="empty"]');
+
+    const occupiedOpacity = Number(occupiedMarker?.getAttribute('opacity'));
+    const emptyOpacity = Number(emptyMarker?.getAttribute('opacity'));
+    expect(occupiedOpacity).toBeLessThan(emptyOpacity);
+  });
+
+  it('renders clipPath for anchor markers', () => {
+    const { container } = renderPlateSvg({ unitsX: 3, unitsY: 3 });
+    const clipPath = container.querySelector('clipPath');
+    expect(clipPath).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
@@ -124,7 +124,7 @@ export const ContainerBlockSvg = memo(function PlateSvg({
 
   const shortLabel = getContainerShortLabel(containerLayer, provider ?? 'azure');
   const markerClipSeed = useId();
-  const clipId = `plate-top-clip-${containerLayer}-${markerClipSeed.replace(/:/g, '')}`;
+  const clipId = `container-top-clip-${containerLayer}-${markerClipSeed.replace(/:/g, '')}`;
 
   const markers: React.ReactNode[] = [];
   for (let cellX = 0; cellX <= unitsX; cellX++) {

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useId } from 'react';
 import type { LayerType, ProviderType } from '@cloudblocks/schema';
 import {
   TILE_W,
@@ -77,6 +77,7 @@ export interface ContainerBlockSvgProps {
   label?: string;
   iconUrl?: string;
   provider?: ProviderType;
+  occupiedCells?: Set<string>;
 }
 
 // ─── Component ─────────────────────────────────────────────
@@ -93,6 +94,7 @@ export const ContainerBlockSvg = memo(function PlateSvg({
   label,
   iconUrl,
   provider,
+  occupiedCells,
 }: ContainerBlockSvgProps) {
   // CU-based pixel conversion: 1 CU = 1 unit, rendered via TILE_W/H/Z
   const screenWidth = ((unitsX + unitsY) * TILE_W) / 2;
@@ -121,6 +123,36 @@ export const ContainerBlockSvg = memo(function PlateSvg({
   const leftLabelX = (cx + leftX) / 2;
 
   const shortLabel = getContainerShortLabel(containerLayer, provider ?? 'azure');
+  const markerClipSeed = useId();
+  const clipId = `plate-top-clip-${containerLayer}-${markerClipSeed.replace(/:/g, '')}`;
+
+  const markers: React.ReactNode[] = [];
+  for (let cellX = 0; cellX <= unitsX; cellX++) {
+    for (let cellZ = 0; cellZ <= unitsY; cellZ++) {
+      const mX = cx + ((cellX - cellZ) * TILE_W) / 2;
+      const mY = topY + ((cellX + cellZ) * TILE_H) / 2;
+      const cellKey = `${cellX}:${cellZ}`;
+      const isOccupied = occupiedCells?.has(cellKey) ?? false;
+      const halfW = 4;
+      const halfH = 2;
+
+      markers.push(
+        <polygon
+          key={cellKey}
+          points={`${mX},${mY - halfH} ${mX + halfW},${mY} ${mX},${mY + halfH} ${mX - halfW},${mY}`}
+          fill="none"
+          stroke={
+            isOccupied ? 'var(--anchor-marker-occupied-stroke)' : 'var(--anchor-marker-stroke)'
+          }
+          strokeWidth={0.5}
+          opacity={isOccupied ? 0.4 : 1}
+          data-anchor-state={isOccupied ? 'occupied' : 'empty'}
+          data-anchor-cell={cellKey}
+          pointerEvents="none"
+        />,
+      );
+    }
+  }
 
   return (
     <svg
@@ -161,6 +193,14 @@ export const ContainerBlockSvg = memo(function PlateSvg({
         pointerEvents="none"
         data-layer="inset-shadow"
       />
+      <defs>
+        <clipPath id={clipId}>
+          <polygon points={topFacePoints} />
+        </clipPath>
+      </defs>
+      <g clipPath={`url(#${clipId})`} data-layer="anchor-markers" pointerEvents="none">
+        {markers}
+      </g>
       <polygon points={leftSidePoints} fill={leftSideColor} />
       <polygon points={rightSidePoints} fill={rightSideColor} />
 

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -1,9 +1,10 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type { PointerEvent as ReactPointerEvent } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { canPlaceBlock, ROOT_ALLOWED_RESOURCE_TYPES } from '../../entities/validation/placement';
 import { worldToScreen, depthKey } from '../../shared/utils/isometric';
+import { getBlockDimensions } from '../../shared/types/visualProfile';
 import { audioService } from '../../shared/utils/audioService';
 import type { SoundName } from '../../shared/utils/audioService';
 
@@ -31,6 +32,28 @@ export function SceneCanvas() {
       b.parentId === null &&
       (Boolean(b.roles?.includes('external')) || isExternalResourceType(b.resourceType)),
   );
+  const occupiedCellsByContainer = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const node of architecture.nodes) {
+      if (node.kind !== 'resource' || node.parentId === null) {
+        continue;
+      }
+      const block = node;
+      const parentId = block.parentId;
+      if (parentId === null) {
+        continue;
+      }
+      const dims = getBlockDimensions(block.category, block.provider, block.subtype);
+      const set = map.get(parentId) ?? new Set<string>();
+      for (let dx = 0; dx < dims.width; dx++) {
+        for (let dz = 0; dz < dims.depth; dz++) {
+          set.add(`${block.position.x + dx}:${block.position.z + dz}`);
+        }
+      }
+      map.set(parentId, set);
+    }
+    return map;
+  }, [architecture.nodes]);
   const addNode = useArchitectureStore((s) => s.addNode);
   const moveExternalBlockPosition = useArchitectureStore((s) => s.moveExternalBlockPosition);
   const setSelectedId = useUIStore((s) => s.setSelectedId);
@@ -240,6 +263,7 @@ export function SceneCanvas() {
                   screenX={screenPos.x}
                   screenY={screenPos.y}
                   zIndex={zIndex}
+                  occupiedCells={occupiedCellsByContainer.get(container.id)}
                 />
               );
             })}


### PR DESCRIPTION
## Summary

Add visual placement anchor tiles and mounted block seating grooves to container blocks, implementing design spec items 5 (placement anchor tiles) and 6 (mounted block seating).

- **Anchor tile markers**: Isometric diamond markers rendered at each CU position on container block top faces, clipped to the top face polygon. Occupied cells show reduced opacity with a distinct stroke color.
- **Mounted block groove**: Radial-gradient pseudo-element on blocks placed inside containers provides visual "seating" feedback.
- **Occupancy tracking**: `useMemo`-based `occupiedCellsByContainer` map in SceneCanvas computes which cells are occupied by resource blocks using `getBlockDimensions()` 2×2 footprint.
- **Theme tokens**: New CSS custom properties (`--anchor-marker-stroke`, `--anchor-marker-occupied-stroke`, `--groove-color`, `--groove-opacity`) in both blueprint and workshop themes.
- **6 new tests** covering anchor marker rendering, occupied/empty states, opacity comparison, clipPath presence, and `is-mounted` class behavior.

All 2821 tests pass. Lint and build clean.

Closes #1581
Part of #1554