### PR TITLE
style(web): external node dedicated lane and enhanced de-emphasis

### DIFF
--- a/apps/web/src/app/index.css
+++ b/apps/web/src/app/index.css
@@ -121,6 +121,13 @@
   /* ── Mounted block groove (#1581) ── */
   --groove-color: rgba(0, 0, 0, 0.25);
   --groove-opacity: 0.7;
+
+  /* ── External node de-emphasis (#1582) ── */
+  --external-block-opacity: 0.75;
+  --external-block-filter: saturate(0.65) brightness(0.95);
+  --shadow-block-external: drop-shadow(1px 2px 0px rgba(0, 0, 0, 0.06));
+  --external-lane-bg: rgba(255, 255, 255, 0.03);
+  --external-lane-border: rgba(255, 255, 255, 0.06);
 }
 
 [data-theme='workshop'] {
@@ -196,6 +203,13 @@
   /* ── Mounted block groove (#1581) ── */
   --groove-color: rgba(0, 0, 0, 0.12);
   --groove-opacity: 0.5;
+
+  /* ── External node de-emphasis (#1582) ── */
+  --external-block-opacity: 0.78;
+  --external-block-filter: saturate(0.7) brightness(0.97);
+  --shadow-block-external: drop-shadow(1px 2px 0px rgba(0, 0, 0, 0.04));
+  --external-lane-bg: rgba(0, 0, 0, 0.02);
+  --external-lane-border: rgba(0, 0, 0, 0.04);
 }
 
 * {

--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -232,9 +232,14 @@
   }
 }
 
-/* ── External actor de-emphasis (lighter than normal resource blocks) ─ */
+/* ── External actor de-emphasis (#1582 — desaturate + reduce shadow) ─ */
 .block-sprite.is-external .block-img {
-  opacity: 0.88;
+  opacity: var(--external-block-opacity);
+  filter: var(--external-block-filter);
+}
+
+.block-sprite.is-external {
+  --shadow-block-base: var(--shadow-block-external);
 }
 
 /* ── Mounted block groove shadow (#1581) ─ */

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -90,6 +90,29 @@
   z-index: 1;
 }
 
+/* ── External lane zone (#1582) ── */
+.external-lane-zone {
+  position: absolute;
+  pointer-events: none;
+  background: var(--external-lane-bg);
+  border: 1px dashed var(--external-lane-border);
+  border-radius: 6px;
+  z-index: 0;
+  transition: opacity 0.2s ease;
+}
+
+.external-lane-zone .external-lane-label {
+  position: absolute;
+  top: -18px;
+  left: 8px;
+  font-size: 10px;
+  color: var(--external-lane-border);
+  opacity: 0.8;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 .connection-layer {
   position: absolute;
   top: 0;

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { SceneCanvas } from './SceneCanvas';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import type { ResourceBlock } from '@cloudblocks/schema';
 
 vi.mock('../../entities/store/architectureStore');
 vi.mock('../../entities/store/uiStore');
@@ -25,7 +26,11 @@ const mockSetSelectedId = vi.fn();
 const mockAddBlock = vi.fn();
 const mockCompleteInteraction = vi.fn();
 
-const architecture = {
+const architecture: {
+  nodes: ResourceBlock[];
+  connections: unknown[];
+  externalActors: unknown[];
+} = {
   nodes: [],
   connections: [],
   externalActors: [],
@@ -156,5 +161,53 @@ describe('SceneCanvas pointer capture handling', () => {
     fireEvent.pointerUp(viewport, { pointerId: 7, clientX: 10, clientY: 10 });
 
     expect(releasePointerCaptureMock).toHaveBeenCalledWith(7);
+  });
+});
+
+describe('SceneCanvas external lane zone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    architecture.nodes = [];
+    architecture.connections = [];
+    setupStoreMocks();
+  });
+
+  it('renders external lane zone when root external blocks exist', () => {
+    const externalBlock: ResourceBlock = {
+      id: 'external-1',
+      name: 'Browser',
+      kind: 'resource',
+      layer: 'resource',
+      resourceType: 'browser',
+      category: 'delivery',
+      provider: 'aws',
+      parentId: null,
+      position: { x: -2, y: 0, z: 4 },
+      metadata: {},
+      roles: ['external'],
+    };
+    architecture.nodes = [externalBlock];
+
+    const { getByTestId } = render(<SceneCanvas />);
+    expect(getByTestId('external-lane-zone')).toBeInTheDocument();
+  });
+
+  it('does not render external lane zone when no root external blocks exist', () => {
+    const internalBlock: ResourceBlock = {
+      id: 'internal-1',
+      name: 'Compute',
+      kind: 'resource',
+      layer: 'resource',
+      resourceType: 'web_compute',
+      category: 'compute',
+      provider: 'aws',
+      parentId: 'container-1',
+      position: { x: 1, y: 0, z: 1 },
+      metadata: {},
+    };
+    architecture.nodes = [internalBlock];
+
+    const { queryByTestId } = render(<SceneCanvas />);
+    expect(queryByTestId('external-lane-zone')).toBeNull();
   });
 });

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -76,6 +76,47 @@ export function SceneCanvas() {
   const [zoom, setZoom] = useState(0.85);
   const [origin, setOrigin] = useState({ x: 0, y: 0 });
 
+  const externalLaneBounds = useMemo(() => {
+    const externalBlocks = architecture.nodes.filter(
+      (node): node is ResourceBlock =>
+        node.kind === 'resource' &&
+        node.parentId === null &&
+        (Boolean(node.roles?.includes('external')) || isExternalResourceType(node.resourceType)),
+    );
+    if (externalBlocks.length === 0) return null;
+
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+
+    for (const block of externalBlocks) {
+      const sp = worldToScreen(
+        block.position.x,
+        block.position.y,
+        block.position.z,
+        origin.x,
+        origin.y,
+      );
+      minX = Math.min(minX, sp.x);
+      minY = Math.min(minY, sp.y);
+      maxX = Math.max(maxX, sp.x);
+      maxY = Math.max(maxY, sp.y);
+    }
+
+    const PAD_X = 48;
+    const PAD_Y = 36;
+    const BLOCK_W = 72;
+    const BLOCK_H = 96;
+
+    return {
+      left: minX - PAD_X,
+      top: minY - PAD_Y,
+      width: maxX - minX + BLOCK_W + PAD_X * 2,
+      height: maxY - minY + BLOCK_H + PAD_Y * 2,
+    };
+  }, [architecture.nodes, origin.x, origin.y]);
+
   const isDragging = useRef(false);
   const lastMouse = useRef({ x: 0, y: 0 });
 
@@ -297,6 +338,21 @@ export function SceneCanvas() {
             />
           </g>
         </svg>
+
+        {externalLaneBounds && (
+          <div
+            className="external-lane-zone"
+            style={{
+              left: externalLaneBounds.left,
+              top: externalLaneBounds.top,
+              width: externalLaneBounds.width,
+              height: externalLaneBounds.height,
+            }}
+            data-testid="external-lane-zone"
+          >
+            <span className="external-lane-label">External</span>
+          </div>
+        )}
 
         <div className="block-layer">
           {containerBlocks.map((block) => {


### PR DESCRIPTION
## Summary

- Add theme tokens for external node visual de-emphasis (`--external-block-opacity`, `--external-block-filter`, `--shadow-block-external`, `--external-lane-bg`, `--external-lane-border`) in both blueprint and workshop themes
- Enhance `.is-external` block styling: desaturation filter, reduced opacity, lighter shadow override (replaces hardcoded `opacity: 0.88`)
- Render a dedicated dashed-border lane zone around root external blocks on the canvas, computed via `worldToScreen()` bounding box with padding
- Lane is purely presentational (`pointer-events: none`), labeled "External", with smooth opacity transition
- 2 new tests: lane renders when external blocks exist, lane absent when none

## Spec Items Addressed

- **Item 7**: External node dedicated lane — visual separation zone
- **Item 11**: Enhanced de-emphasis — desaturation + reduced shadow for external actors

## Test Results

- 2823 tests passing (2 new, 0 regressions)
- Lint clean, build clean

Closes #1582
Part of #1554