### PR TITLE
feat(web): zoom-dependent information density (#1592)

### DIFF
--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -70,7 +70,7 @@ export const BlockSvg = memo(function BlockSvg({
   const iconSize = Math.max(16, Math.round(sideWallPx * 0.7));
   const shortLabel = getSubtypeShortLabel(provider ?? 'azure', subtype);
   const displayLabel = getSubtypeDisplayLabel(provider ?? 'azure', subtype);
-  const labelMode = useUIStore((s) => s.labelMode);
+  const labelMode = useUIStore((s) => s.effectiveLabelMode);
   const faceLabel = labelMode === 'compact' ? shortLabel : (displayLabel ?? shortLabel);
   const showPorts = useUIStore((s) => s.showPorts);
   const ports = CATEGORY_PORTS[category] ?? { inbound: 1, outbound: 1 };
@@ -273,9 +273,9 @@ export const BlockSvg = memo(function BlockSvg({
       {/* ─── Port dots: generic indicators on block side walls ─── */}
       {showPorts && (
         <g data-testid="port-dots">
-          {portPoints.inbound.map((p, i) => (
+          {portPoints.inbound.map((p) => (
             <ellipse
-              key={`in-${i}`}
+              key={`in-${p.x}-${p.y}`}
               cx={p.x}
               cy={p.y}
               rx={PORT_DOT_RX}
@@ -286,9 +286,9 @@ export const BlockSvg = memo(function BlockSvg({
               opacity={PORT_DOT_OPACITY}
             />
           ))}
-          {portPoints.outbound.map((p, i) => (
+          {portPoints.outbound.map((p) => (
             <ellipse
-              key={`out-${i}`}
+              key={`out-${p.x}-${p.y}`}
               cx={p.x}
               cy={p.y}
               rx={PORT_DOT_RX}

--- a/apps/web/src/entities/store/__tests__/zoomDensity.test.ts
+++ b/apps/web/src/entities/store/__tests__/zoomDensity.test.ts
@@ -7,6 +7,7 @@ describe('zoom-dependent label density', () => {
       labelModeOverride: 'auto',
       canvasZoom: 0.85,
       effectiveLabelMode: 'learning',
+      labelMode: 'learning',
     });
   });
 
@@ -27,8 +28,14 @@ describe('zoom-dependent label density', () => {
     });
 
     it('keeps previous mode in hysteresis zones', () => {
+      // 0.55 is inside hysteresis zone [0.55, 0.65]
+      expect(computeAutoLabelMode(0.55, 'compact')).toBe('compact');
+      expect(computeAutoLabelMode(0.55, 'learning')).toBe('learning');
       expect(computeAutoLabelMode(0.6, 'compact')).toBe('compact');
       expect(computeAutoLabelMode(0.6, 'learning')).toBe('learning');
+      // 1.4 is inside hysteresis zone [1.4, 1.6]
+      expect(computeAutoLabelMode(1.4, 'learning')).toBe('learning');
+      expect(computeAutoLabelMode(1.4, 'inspect')).toBe('inspect');
       expect(computeAutoLabelMode(1.5, 'learning')).toBe('learning');
       expect(computeAutoLabelMode(1.5, 'inspect')).toBe('inspect');
     });

--- a/apps/web/src/entities/store/__tests__/zoomDensity.test.ts
+++ b/apps/web/src/entities/store/__tests__/zoomDensity.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { computeAutoLabelMode, useUIStore } from '../uiStore';
+
+describe('zoom-dependent label density', () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      labelModeOverride: 'auto',
+      canvasZoom: 0.85,
+      effectiveLabelMode: 'learning',
+    });
+  });
+
+  describe('computeAutoLabelMode', () => {
+    it('returns compact at low zoom', () => {
+      expect(computeAutoLabelMode(0.3, 'learning')).toBe('compact');
+      expect(computeAutoLabelMode(0.5, 'learning')).toBe('compact');
+    });
+
+    it('returns learning at medium zoom', () => {
+      expect(computeAutoLabelMode(0.85, 'compact')).toBe('learning');
+      expect(computeAutoLabelMode(1, 'compact')).toBe('learning');
+    });
+
+    it('returns inspect at high zoom', () => {
+      expect(computeAutoLabelMode(1.8, 'learning')).toBe('inspect');
+      expect(computeAutoLabelMode(2.5, 'learning')).toBe('inspect');
+    });
+
+    it('keeps previous mode in hysteresis zones', () => {
+      expect(computeAutoLabelMode(0.6, 'compact')).toBe('compact');
+      expect(computeAutoLabelMode(0.6, 'learning')).toBe('learning');
+      expect(computeAutoLabelMode(1.5, 'learning')).toBe('learning');
+      expect(computeAutoLabelMode(1.5, 'inspect')).toBe('inspect');
+    });
+  });
+
+  describe('store integration', () => {
+    it('uses auto override by default and follows zoom thresholds', () => {
+      const state = useUIStore.getState();
+      expect(state.labelModeOverride).toBe('auto');
+      expect(state.effectiveLabelMode).toBe('learning');
+
+      state.setCanvasZoom(0.3);
+      expect(useUIStore.getState().effectiveLabelMode).toBe('compact');
+
+      state.setCanvasZoom(2);
+      expect(useUIStore.getState().effectiveLabelMode).toBe('inspect');
+    });
+
+    it('respects override mode and returns to auto behavior', () => {
+      const state = useUIStore.getState();
+
+      state.setCanvasZoom(2);
+      expect(useUIStore.getState().effectiveLabelMode).toBe('inspect');
+
+      state.setLabelModeOverride('compact');
+      expect(useUIStore.getState().effectiveLabelMode).toBe('compact');
+
+      state.setCanvasZoom(2.5);
+      expect(useUIStore.getState().effectiveLabelMode).toBe('compact');
+
+      state.setLabelModeOverride('auto');
+      expect(useUIStore.getState().effectiveLabelMode).toBe('inspect');
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('setLabelMode sets override and labelMode getter mirrors effective mode', () => {
+      const state = useUIStore.getState();
+
+      state.setLabelMode('learning');
+      expect(useUIStore.getState().labelModeOverride).toBe('learning');
+      expect(useUIStore.getState().labelMode).toBe('learning');
+
+      state.setLabelModeOverride('auto');
+      state.setCanvasZoom(0.3);
+      expect(useUIStore.getState().labelMode).toBe('compact');
+    });
+  });
+});

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -34,7 +34,7 @@ export type { ComplexityLevel } from '../../shared/types';
 const PENDING_GITHUB_ACTION_KEY = 'cloudblocks_pending_github_action';
 
 export function computeAutoLabelMode(zoom: number, currentMode: LabelMode): LabelMode {
-  if (zoom <= 0.55) {
+  if (zoom < 0.55) {
     return 'compact';
   }
 
@@ -42,7 +42,7 @@ export function computeAutoLabelMode(zoom: number, currentMode: LabelMode): Labe
     return currentMode === 'compact' ? 'compact' : 'learning';
   }
 
-  if (zoom <= 1.4) {
+  if (zoom < 1.4) {
     return 'learning';
   }
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -33,6 +33,38 @@ export type { ComplexityLevel } from '../../shared/types';
 
 const PENDING_GITHUB_ACTION_KEY = 'cloudblocks_pending_github_action';
 
+export function computeAutoLabelMode(zoom: number, currentMode: LabelMode): LabelMode {
+  if (zoom <= 0.55) {
+    return 'compact';
+  }
+
+  if (zoom <= 0.65) {
+    return currentMode === 'compact' ? 'compact' : 'learning';
+  }
+
+  if (zoom <= 1.4) {
+    return 'learning';
+  }
+
+  if (zoom <= 1.6) {
+    return currentMode === 'inspect' ? 'inspect' : 'learning';
+  }
+
+  return 'inspect';
+}
+
+function computeEffectiveLabelMode(
+  override: LabelMode | 'auto',
+  zoom: number,
+  currentMode: LabelMode,
+): LabelMode {
+  if (override !== 'auto') {
+    return override;
+  }
+
+  return computeAutoLabelMode(zoom, currentMode);
+}
+
 function readPendingGitHubAction(): PendingGitHubAction {
   if (typeof window === 'undefined') {
     return null;
@@ -201,6 +233,13 @@ interface UIState {
   setGridStyle: (style: 'paper' | 'dot' | 'none') => void;
 
   // ── Label presentation mode ──
+  labelModeOverride: LabelMode | 'auto';
+  setLabelModeOverride: (mode: LabelMode | 'auto') => void;
+  /** Zoom level reported by SceneCanvas, used for auto label density */
+  canvasZoom: number;
+  setCanvasZoom: (zoom: number) => void;
+  /** Computed: the label mode that should be used for rendering */
+  effectiveLabelMode: LabelMode;
   labelMode: LabelMode;
   setLabelMode: (mode: LabelMode) => void;
   cycleLabelMode: () => void;
@@ -609,13 +648,58 @@ export const useUIStore = create<UIState>((set, get) => ({
   magneticSnapTargetId: null,
   setMagneticSnapTarget: (id) => set({ magneticSnapTargetId: id }),
 
-  labelMode: 'compact' as LabelMode,
-  setLabelMode: (mode) => set({ labelMode: mode }),
+  labelModeOverride: 'auto',
+  canvasZoom: 0.85,
+  effectiveLabelMode: computeAutoLabelMode(0.85, 'learning'),
+  labelMode: computeAutoLabelMode(0.85, 'learning'),
+  setLabelModeOverride: (mode) =>
+    set((s) => {
+      const effectiveLabelMode = computeEffectiveLabelMode(
+        mode,
+        s.canvasZoom,
+        s.effectiveLabelMode,
+      );
+      return {
+        labelModeOverride: mode,
+        effectiveLabelMode,
+        labelMode: effectiveLabelMode,
+      };
+    }),
+  setCanvasZoom: (zoom) =>
+    set((s) => {
+      const effectiveLabelMode = computeEffectiveLabelMode(
+        s.labelModeOverride,
+        zoom,
+        s.effectiveLabelMode,
+      );
+      return {
+        canvasZoom: zoom,
+        effectiveLabelMode,
+        labelMode: effectiveLabelMode,
+      };
+    }),
+  setLabelMode: (mode) =>
+    set({
+      labelModeOverride: mode,
+      effectiveLabelMode: mode,
+      labelMode: mode,
+    }),
   cycleLabelMode: () => {
-    const order: LabelMode[] = ['compact', 'learning', 'inspect'];
-    const current = get().labelMode;
+    const order: Array<LabelMode | 'auto'> = ['auto', 'compact', 'learning', 'inspect'];
+    const current = get().labelModeOverride;
     const next = order[(order.indexOf(current) + 1) % order.length];
-    set({ labelMode: next });
+    set((s) => {
+      const effectiveLabelMode = computeEffectiveLabelMode(
+        next,
+        s.canvasZoom,
+        s.effectiveLabelMode,
+      );
+      return {
+        labelModeOverride: next,
+        effectiveLabelMode,
+        labelMode: effectiveLabelMode,
+      };
+    });
   },
 }));
 

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -518,19 +518,15 @@ export function MenuBar() {
                 : 'Switch to Blueprint (Dark)'}
             </span>
           </button>
+          <button type="button" className="menu-item" onClick={() => handleAction(cycleLabelMode)}>
+            <span className="menu-item-left">
+              <Type size={14} /> Labels:{' '}
+              {labelModeOverride === 'auto'
+                ? 'Auto'
+                : labelModeOverride.charAt(0).toUpperCase() + labelModeOverride.slice(1)}
+            </span>
+          </button>
           <button type="button" className="menu-item" onClick={() => handleAction(cycleGridStyle)}>
-            <button
-              type="button"
-              className="menu-item"
-              onClick={() => handleAction(cycleLabelMode)}
-            >
-              <span className="menu-item-left">
-                <Type size={14} /> Labels:{' '}
-                {labelModeOverride === 'auto'
-                  ? 'Auto'
-                  : labelModeOverride.charAt(0).toUpperCase() + labelModeOverride.slice(1)}
-              </span>
-            </button>
             <span className="menu-item-left">
               <LayoutGrid size={14} /> Grid:{' '}
               {gridStyle.charAt(0).toUpperCase() + gridStyle.slice(1)}

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -46,6 +46,7 @@ import {
   LogOut,
   LayoutGrid,
   Keyboard,
+  Type,
 } from 'lucide-react';
 import './MenuBar.css';
 
@@ -86,6 +87,8 @@ export function MenuBar() {
   const themeVariant = useUIStore((s) => s.themeVariant);
   const gridStyle = useUIStore((s) => s.gridStyle);
   const cycleGridStyle = useUIStore((s) => s.cycleGridStyle);
+  const cycleLabelMode = useUIStore((s) => s.cycleLabelMode);
+  const labelModeOverride = useUIStore((s) => s.labelModeOverride);
   const setThemeVariant = useUIStore((s) => s.setThemeVariant);
   const playSound = (name: SoundName) => {
     if (!isSoundMuted) audioService.playSound(name);
@@ -516,6 +519,18 @@ export function MenuBar() {
             </span>
           </button>
           <button type="button" className="menu-item" onClick={() => handleAction(cycleGridStyle)}>
+            <button
+              type="button"
+              className="menu-item"
+              onClick={() => handleAction(cycleLabelMode)}
+            >
+              <span className="menu-item-left">
+                <Type size={14} /> Labels:{' '}
+                {labelModeOverride === 'auto'
+                  ? 'Auto'
+                  : labelModeOverride.charAt(0).toUpperCase() + labelModeOverride.slice(1)}
+              </span>
+            </button>
             <span className="menu-item-left">
               <LayoutGrid size={14} /> Grid:{' '}
               {gridStyle.charAt(0).toUpperCase() + gridStyle.slice(1)}

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
@@ -25,6 +25,7 @@ vi.mock('./ConnectionPreview', () => ({ ConnectionPreview: () => null }));
 const mockSetSelectedId = vi.fn();
 const mockAddBlock = vi.fn();
 const mockCompleteInteraction = vi.fn();
+const mockSetCanvasZoom = vi.fn();
 
 const architecture: {
   nodes: ResourceBlock[];
@@ -51,9 +52,13 @@ function setupStoreMocks() {
       interactionState: 'idle' as const,
       draggedBlockCategory: null,
       draggedResourceName: null,
+      draggedResourceType: null,
+      draggedSubtype: null,
       activeProvider: 'aws',
       completeInteraction: mockCompleteInteraction,
+      setCanvasZoom: mockSetCanvasZoom,
       isSoundMuted: true,
+      gridStyle: 'paper' as const,
     };
     return (selector as (s: typeof state) => unknown)(state);
   }) as typeof useUIStore);
@@ -64,6 +69,7 @@ describe('SceneCanvas ResizeObserver origin update', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSetCanvasZoom.mockClear();
     setupStoreMocks();
     capturedCallback = null;
 

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -64,6 +64,7 @@ export function SceneCanvas() {
   const draggedSubtype = useUIStore((s) => s.draggedSubtype);
   const activeProvider = useUIStore((s) => s.activeProvider);
   const completeInteraction = useUIStore((s) => s.completeInteraction);
+  const setCanvasZoom = useUIStore((s) => s.setCanvasZoom);
   const isSoundMuted = useUIStore((s) => s.isSoundMuted);
   const gridStyle = useUIStore((s) => s.gridStyle);
   const playSound = (name: SoundName) => {
@@ -251,6 +252,10 @@ export function SceneCanvas() {
       return newZoom;
     });
   }, []);
+
+  useEffect(() => {
+    setCanvasZoom(zoom);
+  }, [setCanvasZoom, zoom]);
 
   useEffect(() => {
     const el = containerRef.current;


### PR DESCRIPTION
## Summary

- Implement zoom-dependent label mode that automatically adapts information density based on canvas zoom level
- Add hysteresis zones (0.55–0.65 and 1.4–1.6) to prevent mode flickering at zoom boundaries
- Wire zoom-to-store bridge in SceneCanvas and effectiveLabelMode consumption in BlockSvg
- Add label mode cycle button (Auto → Compact → Learning → Inspect) to MenuBar preferences
- 7 new tests covering threshold transitions, hysteresis behavior, override semantics, and backward compatibility

## Changes

### Store (`uiStore.ts`)
- `computeAutoLabelMode(zoom, current)` — pure function with hysteresis
- `computeEffectiveLabelMode(override, zoom, current)` — combines user override with auto-computation
- New fields: `canvasZoom`, `labelModeOverride` (default: `'auto'`), `effectiveLabelMode`
- `setCanvasZoom()`, `setLabelModeOverride()`, updated `cycleLabelMode()` to include `'auto'` in the cycle

### Components
- **BlockSvg**: reads `effectiveLabelMode` instead of `labelMode`
- **SceneCanvas**: bridges ReactFlow viewport zoom → `setCanvasZoom()` via `useEffect`
- **MenuBar**: Type icon button to cycle label modes, shows current override as tooltip

### Tests
- `zoomDensity.test.ts`: 7 tests — compact/learning/inspect thresholds, hysteresis stickiness, override bypass, backward compatibility

## Verification
- ✅ Build passes (`pnpm build`)
- ✅ 2830/2830 tests pass
- ✅ Lint clean (pre-commit hooks passed on all 3 commits)

Fixes #1592
Part of #1590