### PR TITLE
feat(web): connection type taxonomy alignment — display labels and ADR-0016

### DIFF
--- a/apps/web/src/shared/tokens/__tests__/connectionTypeLabels.test.ts
+++ b/apps/web/src/shared/tokens/__tests__/connectionTypeLabels.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONNECTION_TYPE_LABELS,
+  ENDPOINT_SEMANTIC_LABELS,
+  resolveSemanticLabel,
+} from '../connectionTypeLabels';
+
+describe('connectionTypeLabels', () => {
+  describe('CONNECTION_TYPE_LABELS', () => {
+    it('should map all 5 ConnectionType values to display labels', () => {
+      expect(Object.keys(CONNECTION_TYPE_LABELS).length).toBe(5);
+      expect(CONNECTION_TYPE_LABELS.dataflow).toBe('Data Flow');
+      expect(CONNECTION_TYPE_LABELS.http).toBe('HTTP');
+      expect(CONNECTION_TYPE_LABELS.internal).toBe('Internal');
+      expect(CONNECTION_TYPE_LABELS.data).toBe('Data');
+      expect(CONNECTION_TYPE_LABELS.async).toBe('Async');
+    });
+
+    it('should have non-empty string values for all keys', () => {
+      Object.values(CONNECTION_TYPE_LABELS).forEach((label) => {
+        expect(typeof label).toBe('string');
+        expect(label.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('ENDPOINT_SEMANTIC_LABELS', () => {
+    it('should map all 3 EndpointSemantic values to display labels', () => {
+      expect(Object.keys(ENDPOINT_SEMANTIC_LABELS).length).toBe(3);
+      expect(ENDPOINT_SEMANTIC_LABELS.http).toBe('HTTP');
+      expect(ENDPOINT_SEMANTIC_LABELS.event).toBe('Event');
+      expect(ENDPOINT_SEMANTIC_LABELS.data).toBe('Data');
+    });
+
+    it('should have non-empty string values for all keys', () => {
+      Object.values(ENDPOINT_SEMANTIC_LABELS).forEach((label) => {
+        expect(typeof label).toBe('string');
+        expect(label.length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  describe('resolveSemanticLabel', () => {
+    it('should resolve valid EndpointSemantic values to display labels', () => {
+      expect(resolveSemanticLabel('http')).toBe('HTTP');
+      expect(resolveSemanticLabel('event')).toBe('Event');
+      expect(resolveSemanticLabel('data')).toBe('Data');
+    });
+
+    it('should return "Unknown" for undefined', () => {
+      expect(resolveSemanticLabel(undefined)).toBe('Unknown');
+    });
+
+    it('should return "Unknown" for empty string', () => {
+      expect(resolveSemanticLabel('')).toBe('Unknown');
+    });
+
+    it('should fall back to raw value for unknown strings', () => {
+      expect(resolveSemanticLabel('unknown-semantic')).toBe('unknown-semantic');
+      expect(resolveSemanticLabel('custom-value')).toBe('custom-value');
+    });
+
+    it('should handle null as empty', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(resolveSemanticLabel(null as any)).toBe('Unknown');
+    });
+  });
+});

--- a/apps/web/src/shared/tokens/connectionTypeLabels.ts
+++ b/apps/web/src/shared/tokens/connectionTypeLabels.ts
@@ -1,0 +1,23 @@
+import type { ConnectionType, EndpointSemantic } from '@cloudblocks/schema';
+
+/** Human-readable display labels for legacy ConnectionType values. */
+export const CONNECTION_TYPE_LABELS: Record<ConnectionType, string> = {
+  dataflow: 'Data Flow',
+  http: 'HTTP',
+  internal: 'Internal',
+  data: 'Data',
+  async: 'Async',
+};
+
+/** Human-readable display labels for v4 EndpointSemantic values. */
+export const ENDPOINT_SEMANTIC_LABELS: Record<EndpointSemantic, string> = {
+  http: 'HTTP',
+  event: 'Event',
+  data: 'Data',
+};
+
+/** Resolve a display label for an EndpointSemantic. Falls back to the raw value. */
+export function resolveSemanticLabel(semantic: EndpointSemantic | string | undefined): string {
+  if (!semantic) return 'Unknown';
+  return (ENDPOINT_SEMANTIC_LABELS as Record<string, string>)[semantic] ?? semantic;
+}

--- a/apps/web/src/widgets/right-drawer/panels/PropertiesDrawerPanel.tsx
+++ b/apps/web/src/widgets/right-drawer/panels/PropertiesDrawerPanel.tsx
@@ -5,6 +5,7 @@ import { useArchitectureStore } from '../../../entities/store/architectureStore'
 import { useUIStore } from '../../../entities/store/uiStore';
 import { audioService } from '../../../shared/utils/audioService';
 import { BLOCK_FRIENDLY_NAMES } from '../../../shared/types';
+import { resolveSemanticLabel } from '../../../shared/tokens/connectionTypeLabels';
 import './PropertiesDrawerPanel.css';
 
 // ── Main Panel ───────────────────────────────────────────────────────────
@@ -270,7 +271,9 @@ function ConnectionProperties({ connection }: { connection: Connection }) {
             value={sourceNode?.name ?? fromParsed?.blockId ?? 'Unknown'}
           />
           <ReadOnlyField label="To" value={targetNode?.name ?? toParsed?.blockId ?? 'Unknown'} />
-          {fromParsed && <ReadOnlyField label="Semantic" value={fromParsed.semantic} />}
+          {fromParsed && (
+            <ReadOnlyField label="Semantic" value={resolveSemanticLabel(fromParsed.semantic)} />
+          )}
           {fromParsed && (
             <ReadOnlyField
               label="Direction"
@@ -313,7 +316,7 @@ function ConnectionSummaryItem({
   const otherNodeId =
     fromParsed?.blockId === currentNodeId ? toParsed?.blockId : fromParsed?.blockId;
   const direction = fromParsed?.blockId === currentNodeId ? 'outbound' : 'inbound';
-  const semantic = fromParsed?.semantic ?? '?';
+  const semantic = resolveSemanticLabel(fromParsed?.semantic);
 
   const otherNode = otherNodeId
     ? (architecture.nodes.find((n) => n.id === otherNodeId) ?? null)

--- a/apps/web/src/widgets/right-drawer/panels/__tests__/PropertiesDrawerPanel.test.tsx
+++ b/apps/web/src/widgets/right-drawer/panels/__tests__/PropertiesDrawerPanel.test.tsx
@@ -290,6 +290,36 @@ describe('PropertiesDrawerPanel', () => {
       expect(screen.getByText('Compute')).toBeDefined();
     });
 
+    it('displays semantic display label in connection properties', () => {
+      const container = makePlate();
+      const blockA = makeBlock({ id: 'block-a', name: 'Gateway' });
+      const blockB = makeBlock({ id: 'block-b', name: 'Compute' });
+      useArchitectureStore.setState({
+        workspace: {
+          ...useArchitectureStore.getState().workspace,
+          architecture: {
+            ...useArchitectureStore.getState().workspace.architecture,
+            nodes: [container, blockA, blockB],
+            connections: [
+              {
+                id: 'conn-1',
+                from: 'endpoint-block-a-output-http',
+                to: 'endpoint-block-b-input-http',
+                metadata: {},
+              },
+            ],
+            endpoints: [],
+          },
+        },
+      });
+      useUIStore.setState({ selectedId: 'conn-1' });
+
+      render(<PropertiesDrawerPanel />);
+      expect(screen.getByTestId('props-connection')).toBeDefined();
+      // Should display "HTTP" (display label) not "http" (raw semantic)
+      expect(screen.getByText('HTTP')).toBeDefined();
+    });
+
     it('connection delete requires double-click', async () => {
       const user = userEvent.setup();
       const container = makePlate();

--- a/docs/adr/0016-connection-type-taxonomy-alignment.md
+++ b/docs/adr/0016-connection-type-taxonomy-alignment.md
@@ -1,0 +1,62 @@
+# ADR-0016: Connection Type Taxonomy Alignment
+
+**Status**: Accepted
+**Date**: 2026-04
+**Related**: [#1595](https://github.com/yeongseon/cloudblocks/issues/1595), [Epic #1590](https://github.com/yeongseon/cloudblocks/issues/1590)
+
+## Context
+
+The visual editor uses two type systems for connections:
+
+1. **Legacy `ConnectionType`** (v3) — `dataflow`, `http`, `internal`, `data`, `async`. Used by `connectionVisualTokens.ts` for stroke styles. Deprecated in schema.
+2. **Current `EndpointSemantic`** (v4) — `http`, `event`, `data`. Used by the endpoint-based connection model.
+
+A UX checklist proposed a third taxonomy (`ingress`, `internal`, `data`, `management`) but this would require breaking schema changes with no proportional user benefit.
+
+The properties panel currently displayed raw semantic strings (e.g., "http", "event", "data") without user-friendly labels, reducing UI polish and clarity.
+
+## Decision
+
+**Option A: Alias mapping (chosen).**
+
+Keep the existing schema types unchanged. Add a display label layer (`connectionTypeLabels.ts`) that maps raw enum values to human-readable names in the UI. This preserves all saved workspaces, avoids schema migration, and makes the UI more accessible without backend changes.
+
+### Implementation
+
+- Create `apps/web/src/shared/tokens/connectionTypeLabels.ts` with two mapping exports:
+  - `CONNECTION_TYPE_LABELS: Record<ConnectionType, string>` — Maps legacy types to display names
+  - `ENDPOINT_SEMANTIC_LABELS: Record<EndpointSemantic, string>` — Maps current types to display names
+  - `resolveSemanticLabel(semantic: EndpointSemantic | string | undefined): string` — Helper for safe resolution with fallback to raw value
+- Update `PropertiesDrawerPanel.tsx` to use `resolveSemanticLabel()` when rendering connection semantic in the properties panel and connection summary items
+- Full test coverage (100%) for all label mappings and the resolution helper
+
+### Rejected Alternatives
+
+- **Option B (Schema migration)** — Replace `EndpointSemantic` with new taxonomy. Breaking change to saved workspaces, requires migration, disproportionate risk for cosmetic improvement.
+- **Option C (Hybrid)** — Add new enum types alongside old ones. Increases schema complexity without clear benefit; creates confusion about which type to use.
+
+## Consequences
+
+### Positive
+
+- No breaking changes to saved workspaces or schema versioning.
+- UI shows clear, human-readable labels ("HTTP", "Data", "Event") instead of raw enum values.
+- Single source of truth for display names in `connectionTypeLabels.ts` — future UI improvements need only update this file.
+- Label values are independently testable; resolveSemanticLabel() has graceful fallback for unknown types.
+- Supports future taxonomy refinements without code changes — additional aliases can be added to the mappings.
+
+### Negative
+
+- Legacy `ConnectionType` labels remain in code alongside `EndpointSemantic` labels until the deprecated type is fully removed from the schema.
+- Minor indirection when rendering — semantic values must be resolved through the label function instead of displayed directly.
+
+### Neutral
+
+- The UX checklist's proposed taxonomy terms (`ingress`, `internal`, `data`, `management`) can be introduced as additional aliases in a future label refinement without schema changes.
+- No impact on connection validation, rendering, or code generation — this is purely a display-layer concern.
+
+## Related Documents
+
+- [Domain Model §5 — Connection Types](../model/DOMAIN_MODEL.md) — Overview of EndpointSemantic and ConnectionType
+- [Issue #1595](https://github.com/yeongseon/cloudblocks/issues/1595) — GitHub tracking issue
+- [Epic #1590](https://github.com/yeongseon/cloudblocks/issues/1590) — UX Polish Epic (parent issue)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,6 +21,7 @@ This directory contains Architecture Decision Records (ADRs) for CloudBlocks. AD
 | [0013](0013-block-unification.md)                       | Block Unification — Unified Block Model   | Accepted           | 2026-03 |
 | [0014](0014-promote-rollback-static-data.md)            | Promote/Rollback Static Data Placeholders | Accepted           | 2026-03 |
 | [0015](0015-external-actor-to-block-migration.md)       | ExternalActor-to-Block Migration          | Accepted           | 2026-03 |
+| [0016](0016-connection-type-taxonomy-alignment.md)     | Connection Type Taxonomy Alignment        | Accepted           | 2026-04 |
 
 ## ADR Template
 


### PR DESCRIPTION
## Summary

Implements **Option A (alias mapping)** for connection type taxonomy alignment. Adds human-readable display labels for connection types in the UI without any schema changes.

Fixes #1595
Part of #1590

## Changes

- **New**: `connectionTypeLabels.ts` — display name mappings for legacy `ConnectionType` (5 values) and current `EndpointSemantic` (3 values) with `resolveSemanticLabel()` helper
- **Updated**: `PropertiesDrawerPanel.tsx` — connection properties and summary items now show display labels ("HTTP", "Data", "Event") instead of raw enum values
- **New**: ADR-0016 documenting the taxonomy alignment design decision
- **Tests**: Full coverage for the new labels module + updated properties panel test assertions

## Design Decision (ADR-0016)

**Option A: Alias mapping** — Keep existing schema types unchanged, add a display label layer. No breaking changes to saved workspaces, no schema migration needed.

Rejected: Option B (schema migration) and Option C (hybrid) — disproportionate risk for cosmetic improvement.

## Verification

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 2,833 tests pass
- [x] No TypeScript errors on changed files
- [x] ADR-0016 follows project ADR format
- [x] ADR README index updated