### PR TITLE
docs: document uniform block height decision (ADR-0017)

### DIFF
--- a/docs/adr/0017-uniform-block-height.md
+++ b/docs/adr/0017-uniform-block-height.md
@@ -1,0 +1,58 @@
+# ADR-0017: Uniform Block Height Across Resource Categories
+
+**Status**: Accepted
+**Date**: 2026-04
+**Related**: [#1596](https://github.com/yeongseon/cloudblocks/issues/1596), [Epic #1590](https://github.com/yeongseon/cloudblocks/issues/1590)
+
+## Context
+
+CloudBlocks defines five block tiers (`micro`, `small`, `medium`, `large`, `wide`) with corresponding grid dimensions, but currently maps all eight resource categories to the `medium` tier (2×2×2 CU). A UX checklist (§3-1.2) raised the question of whether categories should have distinct heights for visual differentiation.
+
+The current visual differentiation strategy relies on **silhouettes** (Phase 3, #1580):
+
+| Category   | Silhouette |
+| ---------- | ---------- |
+| compute    | rect       |
+| data       | cylinder   |
+| delivery   | gateway    |
+| security   | shield     |
+| messaging  | hex        |
+| network    | rect       |
+| identity   | circle     |
+| operations | rect       |
+
+Additionally, each category has a distinct color via the theme token system. Together, silhouette + color already provide strong visual category differentiation.
+
+## Decision
+
+**Option A: Keep uniform height (chosen).**
+
+All resource categories remain mapped to the `medium` tier in `CATEGORY_TIER_MAP`. The `SUBTYPE_SIZE_OVERRIDES` record remains empty.
+
+Rationale:
+
+1. **Silhouettes already differentiate.** Six distinct shapes across eight categories provide immediate visual category recognition without relying on height.
+2. **Grid alignment.** Uniform height ensures all blocks snap to the same grid and ports align predictably. Mixed heights would require complex snapping logic and risk breaking the Universal Port Standard (rx=12, ry=6, h=5).
+3. **Container layout.** Uniform block height simplifies container auto-sizing calculations. Variable heights would require per-child height tracking for container frame expansion.
+4. **Cognitive simplicity.** Users learn one block size. Height variation would add a dimension of meaning (what does "taller" mean?) without clear semantic justification.
+
+Rejected alternatives:
+- **Option B (Category-based heights)** — Map categories to different tiers. Risk: breaks grid alignment, complicates container layout, adds cognitive overhead for minimal UX benefit given existing silhouette/color differentiation.
+
+## Consequences
+
+### Positive
+
+- Grid snapping remains simple — one height for all resource blocks.
+- Universal Port Standard is trivially preserved — no height-dependent port calculations needed.
+- Container auto-sizing calculations remain straightforward.
+- Tier infrastructure (`BlockTier`, `TIER_DIMENSIONS`, `SUBTYPE_SIZE_OVERRIDES`) is preserved for future use if a specific subtype needs a size override.
+
+### Negative
+
+- Height cannot be used as a visual signal for category or importance. This is acceptable because silhouette + color already fill that role.
+
+### When to Revisit
+
+- If a new resource subtype has a genuine need for a different size (e.g., a wide dashboard widget), use `SUBTYPE_SIZE_OVERRIDES` for targeted overrides rather than changing the category-wide mapping.
+- If user research indicates that silhouette + color differentiation is insufficient, reconsider category-based heights with proper grid alignment validation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ This directory contains Architecture Decision Records (ADRs) for CloudBlocks. AD
 | [0014](0014-promote-rollback-static-data.md)            | Promote/Rollback Static Data Placeholders | Accepted           | 2026-03 |
 | [0015](0015-external-actor-to-block-migration.md)       | ExternalActor-to-Block Migration          | Accepted           | 2026-03 |
 | [0016](0016-connection-type-taxonomy-alignment.md)     | Connection Type Taxonomy Alignment        | Accepted           | 2026-04 |
+| [0017](0017-uniform-block-height.md)                   | Uniform Block Height Across Categories    | Accepted           | 2026-04 |
 
 ## ADR Template
 


### PR DESCRIPTION
## Summary

Documents the design decision to keep uniform block height across all resource categories (Option A).

Fixes #1596
Part of #1590

## Changes

- **New**: ADR-0017 — documents why all categories map to `medium` tier
- **Updated**: ADR index in `docs/adr/README.md`

## Design Decision (ADR-0017)

**Option A: Keep uniform height** — Silhouettes (rect, cylinder, gateway, shield, hex, circle) + category colors already provide strong visual differentiation. Variable heights would break grid alignment, complicate container layout, and add cognitive overhead for minimal UX benefit.

The tier infrastructure (`BlockTier`, `TIER_DIMENSIONS`, `SUBTYPE_SIZE_OVERRIDES`) is preserved for future per-subtype overrides if needed.

## Verification

- [x] No code changes — documentation only
- [x] ADR follows project format
- [x] ADR README index updated