### PR TITLE
feat(web): connection overlap detection and perpendicular offset nudge

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -32,6 +32,7 @@ import { getConnectionSurfaceRoute } from './surfaceRouting';
 import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
 import { getConnectionColorsForType } from './connectionFaceColors';
 import type { ConnectionRenderSemantic } from './connectionFaceColors';
+import { offsetScreenPoints } from './overlapOffset';
 
 interface ConnectionRendererProps {
   connection: Connection;
@@ -39,6 +40,7 @@ interface ConnectionRendererProps {
   plates: ContainerBlock[];
   originX: number;
   originY: number;
+  overlapOffset?: number;
 }
 
 /** Resolved colors for the 2-layer trace rendering. */
@@ -200,6 +202,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   plates,
   originX,
   originY,
+  overlapOffset = 0,
 }: ConnectionRendererProps) {
   const [isHovered, setIsHovered] = useState(false);
   const drawInRef = useRef<SVGPathElement>(null);
@@ -262,7 +265,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const surfaceRender = useMemo(() => {
     if (!surfaceRoute) return null;
 
-    const hitPoints = getRouteCenterlinePoints(surfaceRoute, originX, originY);
+    const rawPoints = getRouteCenterlinePoints(surfaceRoute, originX, originY);
+    const hitPoints = overlapOffset ? offsetScreenPoints(rawPoints, overlapOffset) : rawPoints;
     const hitPath = pointsToPath(hitPoints);
 
     if (hitPoints.length < 2) return null;
@@ -273,7 +277,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
       sourcePos: hitPoints[0],
       targetPos: hitPoints[hitPoints.length - 1],
     };
-  }, [surfaceRoute, originX, originY]);
+  }, [surfaceRoute, originX, originY, overlapOffset]);
 
   if (!surfaceRender) return null;
 

--- a/apps/web/src/entities/connection/__tests__/overlapOffset.test.ts
+++ b/apps/web/src/entities/connection/__tests__/overlapOffset.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest';
+import { endpointId } from '@cloudblocks/schema';
+import type { Connection } from '@cloudblocks/schema';
+import { computeOverlapOffsets, getOverlapGroupKey, offsetScreenPoints } from '../overlapOffset';
+
+function makeConnection(id: string, fromBlockId: string, toBlockId: string): Connection {
+  return {
+    id,
+    from: endpointId(fromBlockId, 'output', 'data'),
+    to: endpointId(toBlockId, 'input', 'data'),
+    metadata: {},
+  };
+}
+
+describe('overlapOffset', () => {
+  describe('getOverlapGroupKey', () => {
+    it('returns null when endpoints cannot be parsed', () => {
+      const invalid: Connection = {
+        id: 'c-invalid',
+        from: 'invalid-from',
+        to: 'invalid-to',
+        metadata: {},
+      };
+
+      expect(getOverlapGroupKey(invalid)).toBeNull();
+    });
+
+    it('returns sorted block id pair as key', () => {
+      const connection = makeConnection('c1', 'block-z', 'block-a');
+
+      expect(getOverlapGroupKey(connection)).toBe('block-a::block-z');
+    });
+
+    it('returns same key for bidirectional connections', () => {
+      const forward = makeConnection('c1', 'block-a', 'block-b');
+      const backward = makeConnection('c2', 'block-b', 'block-a');
+
+      expect(getOverlapGroupKey(forward)).toBe('block-a::block-b');
+      expect(getOverlapGroupKey(backward)).toBe('block-a::block-b');
+    });
+  });
+
+  describe('computeOverlapOffsets', () => {
+    it('returns empty map for empty input', () => {
+      const offsets = computeOverlapOffsets([], 5);
+
+      expect(offsets.size).toBe(0);
+    });
+
+    it('assigns zero offset for a single connection', () => {
+      const c1 = makeConnection('c1', 'block-a', 'block-b');
+
+      const offsets = computeOverlapOffsets([c1], 5);
+
+      expect(offsets.get('c1')).toBe(0);
+    });
+
+    it('assigns centered offsets for two overlapping connections', () => {
+      const c1 = makeConnection('c1', 'block-a', 'block-b');
+      const c2 = makeConnection('c2', 'block-b', 'block-a');
+
+      const offsets = computeOverlapOffsets([c1, c2], 6);
+
+      expect(offsets.get('c1')).toBe(-3);
+      expect(offsets.get('c2')).toBe(3);
+    });
+
+    it('assigns centered offsets for three overlapping connections', () => {
+      const c1 = makeConnection('c1', 'block-a', 'block-b');
+      const c2 = makeConnection('c2', 'block-a', 'block-b');
+      const c3 = makeConnection('c3', 'block-b', 'block-a');
+
+      const offsets = computeOverlapOffsets([c1, c2, c3], 4);
+
+      expect(offsets.get('c1')).toBe(-4);
+      expect(offsets.get('c2')).toBe(0);
+      expect(offsets.get('c3')).toBe(4);
+    });
+
+    it('computes offsets independently per block pair', () => {
+      const a1 = makeConnection('a1', 'block-a', 'block-b');
+      const a2 = makeConnection('a2', 'block-a', 'block-b');
+      const b1 = makeConnection('b1', 'block-c', 'block-d');
+      const b2 = makeConnection('b2', 'block-c', 'block-d');
+      const b3 = makeConnection('b3', 'block-c', 'block-d');
+
+      const offsets = computeOverlapOffsets([a1, a2, b1, b2, b3], 5);
+
+      expect(offsets.get('a1')).toBe(-2.5);
+      expect(offsets.get('a2')).toBe(2.5);
+      expect(offsets.get('b1')).toBe(-5);
+      expect(offsets.get('b2')).toBe(0);
+      expect(offsets.get('b3')).toBe(5);
+    });
+
+    it('skips connections with unparseable endpoints', () => {
+      const valid = makeConnection('valid', 'block-a', 'block-b');
+      const invalid: Connection = {
+        id: 'invalid',
+        from: 'bad',
+        to: 'still-bad',
+        metadata: {},
+      };
+
+      const offsets = computeOverlapOffsets([invalid, valid], 5);
+
+      expect(offsets.get('valid')).toBe(0);
+      expect(offsets.has('invalid')).toBe(false);
+    });
+  });
+
+  describe('offsetScreenPoints', () => {
+    it('returns empty array for empty input', () => {
+      expect(offsetScreenPoints([], 5)).toEqual([]);
+    });
+
+    it('returns same single point regardless of offset', () => {
+      expect(offsetScreenPoints([{ x: 10, y: 20 }], 7)).toEqual([{ x: 10, y: 20 }]);
+    });
+
+    it('returns a copy of original points for zero offset', () => {
+      const points = [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ];
+
+      const shifted = offsetScreenPoints(points, 0);
+
+      expect(shifted).toEqual(points);
+      expect(shifted).not.toBe(points);
+      expect(shifted[0]).not.toBe(points[0]);
+    });
+
+    it('offsets horizontal line to a parallel vertical shift', () => {
+      const shifted = offsetScreenPoints(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+        ],
+        5,
+      );
+
+      expect(shifted[0].x).toBeCloseTo(0);
+      expect(shifted[0].y).toBeCloseTo(5);
+      expect(shifted[1].x).toBeCloseTo(10);
+      expect(shifted[1].y).toBeCloseTo(5);
+    });
+
+    it('offsets vertical line to a parallel horizontal shift', () => {
+      const shifted = offsetScreenPoints(
+        [
+          { x: 0, y: 0 },
+          { x: 0, y: 10 },
+        ],
+        5,
+      );
+
+      expect(shifted[0].x).toBeCloseTo(-5);
+      expect(shifted[0].y).toBeCloseTo(0);
+      expect(shifted[1].x).toBeCloseTo(-5);
+      expect(shifted[1].y).toBeCloseTo(10);
+    });
+
+    it('uses averaged corner normal for an L-shaped path', () => {
+      const shifted = offsetScreenPoints(
+        [
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+          { x: 10, y: 10 },
+        ],
+        5,
+      );
+
+      expect(shifted[0].x).toBeCloseTo(0);
+      expect(shifted[0].y).toBeCloseTo(5);
+      expect(shifted[1].x).toBeCloseTo(10 - Math.SQRT1_2 * 5);
+      expect(shifted[1].y).toBeCloseTo(Math.SQRT1_2 * 5);
+      expect(shifted[2].x).toBeCloseTo(5);
+      expect(shifted[2].y).toBeCloseTo(10);
+    });
+  });
+});

--- a/apps/web/src/entities/connection/overlapOffset.ts
+++ b/apps/web/src/entities/connection/overlapOffset.ts
@@ -1,0 +1,111 @@
+import type { Connection } from '@cloudblocks/schema';
+import { parseEndpointId } from '@cloudblocks/schema';
+
+/**
+ * Generate a grouping key for a connection based on source and target block IDs.
+ * Connections between the same pair of blocks (regardless of direction) are grouped together.
+ * Returns null if endpoints cannot be parsed.
+ */
+export function getOverlapGroupKey(connection: Connection): string | null {
+  const from = parseEndpointId(connection.from);
+  const to = parseEndpointId(connection.to);
+  if (!from || !to) return null;
+  const ids = [from.blockId, to.blockId].sort();
+  return `${ids[0]}::${ids[1]}`;
+}
+
+/**
+ * Compute overlap offsets for a list of connections.
+ * Returns a Map from connection.id to a screen-space perpendicular offset (px).
+ * Single connections (no overlap) get offset 0.
+ */
+export function computeOverlapOffsets(
+  connections: readonly Connection[],
+  offsetPx: number,
+): Map<string, number> {
+  const groups = new Map<string, Connection[]>();
+  for (const conn of connections) {
+    const key = getOverlapGroupKey(conn);
+    if (!key) continue;
+    const group = groups.get(key);
+    if (group) {
+      group.push(conn);
+    } else {
+      groups.set(key, [conn]);
+    }
+  }
+
+  const offsets = new Map<string, number>();
+  for (const group of groups.values()) {
+    if (group.length <= 1) {
+      offsets.set(group[0].id, 0);
+      continue;
+    }
+    const center = (group.length - 1) / 2;
+    for (let i = 0; i < group.length; i++) {
+      offsets.set(group[i].id, (i - center) * offsetPx);
+    }
+  }
+
+  return offsets;
+}
+
+/**
+ * Apply a perpendicular offset to a polyline path in screen space.
+ * For each segment, computes the perpendicular direction and shifts both endpoints.
+ * This produces a parallel path offset by `offsetPx` pixels perpendicular to the path direction.
+ */
+export function offsetScreenPoints(
+  points: readonly { x: number; y: number }[],
+  offsetPx: number,
+): { x: number; y: number }[] {
+  if (points.length === 0 || offsetPx === 0) return points.map((p) => ({ x: p.x, y: p.y }));
+  if (points.length === 1) return [{ x: points[0].x, y: points[0].y }];
+
+  const result: { x: number; y: number }[] = [];
+
+  for (let i = 0; i < points.length; i++) {
+    let nx = 0;
+    let ny = 0;
+    let count = 0;
+
+    if (i > 0) {
+      const dx = points[i].x - points[i - 1].x;
+      const dy = points[i].y - points[i - 1].y;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len > 1e-6) {
+        nx += -dy / len;
+        ny += dx / len;
+        count++;
+      }
+    }
+
+    if (i < points.length - 1) {
+      const dx = points[i + 1].x - points[i].x;
+      const dy = points[i + 1].y - points[i].y;
+      const len = Math.sqrt(dx * dx + dy * dy);
+      if (len > 1e-6) {
+        nx += -dy / len;
+        ny += dx / len;
+        count++;
+      }
+    }
+
+    if (count > 0) {
+      nx /= count;
+      ny /= count;
+      const nLen = Math.sqrt(nx * nx + ny * ny);
+      if (nLen > 1e-6) {
+        nx /= nLen;
+        ny /= nLen;
+      }
+    }
+
+    result.push({
+      x: points[i].x + nx * offsetPx,
+      y: points[i].y + ny * offsetPx,
+    });
+  }
+
+  return result;
+}

--- a/apps/web/src/shared/tokens/connectionVisualTokens.ts
+++ b/apps/web/src/shared/tokens/connectionVisualTokens.ts
@@ -39,6 +39,9 @@ export const CASING_WIDTH_OFFSET = 2.5;
 /** Hover width offset added to the base stroke width. */
 export const HOVER_WIDTH_OFFSET = 1;
 
+/** Perpendicular offset (screen px) applied to each connection in an overlap group. */
+export const OVERLAP_OFFSET_PX = 5;
+
 /**
  * Resolve the visual style for a connection type.
  * Falls back to 'dataflow' when type is undefined or unrecognized.

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -11,10 +11,12 @@ import type { SoundName } from '../../shared/utils/audioService';
 import { ContainerBlockSprite } from '../../entities/container-block/ContainerBlockSprite';
 import { BlockSprite } from '../../entities/block/BlockSprite';
 import { ConnectionRenderer } from '../../entities/connection/ConnectionRenderer';
+import { computeOverlapOffsets } from '../../entities/connection/overlapOffset';
 import { DragGhost } from './DragGhost';
 import { ConnectionPreview } from './ConnectionPreview';
 import type { ContainerBlock, ResourceBlock } from '@cloudblocks/schema';
 import { isExternalResourceType } from '@cloudblocks/schema';
+import { OVERLAP_OFFSET_PX } from '../../shared/tokens/connectionVisualTokens';
 import './SceneCanvas.css';
 
 export function SceneCanvas() {
@@ -31,6 +33,10 @@ export function SceneCanvas() {
     (b) =>
       b.parentId === null &&
       (Boolean(b.roles?.includes('external')) || isExternalResourceType(b.resourceType)),
+  );
+  const overlapOffsets = useMemo(
+    () => computeOverlapOffsets(architecture.connections, OVERLAP_OFFSET_PX),
+    [architecture.connections],
   );
   const occupiedCellsByContainer = useMemo(() => {
     const map = new Map<string, Set<string>>();
@@ -320,6 +326,7 @@ export function SceneCanvas() {
               plates={plates}
               originX={origin.x}
               originY={origin.y}
+              overlapOffset={overlapOffsets.get(conn.id) ?? 0}
             />
           ))}
         </svg>


### PR DESCRIPTION
## Summary

Adds overlap detection and perpendicular offset for parallel connection lines. When multiple connections share the same source-target block pair, each connection is nudged perpendicular to its path so they are visually distinguishable instead of perfectly overlapping.

Fixes #1594
Part of #1590

## Changes

- **New**: `overlapOffset.ts` — grouping connections by shared block pairs and computing centered perpendicular offsets
- **New**: `OVERLAP_OFFSET_PX` token (5px) in `connectionVisualTokens.ts`
- **Updated**: `SceneCanvas.tsx` — computes overlap offset map via `useMemo` and passes per-connection offset
- **Updated**: `ConnectionRenderer.tsx` — accepts optional `overlapOffset` prop, applies screen-space perpendicular shift via `offsetScreenPoints()`
- **Tests**: 15 new tests covering grouping keys, offset computation, and geometric point shifting

## How It Works

1. **Group phase**: Connections are grouped by sorted source+target block ID pairs (bidirectional connections grouped together)
2. **Offset computation**: Each group of N connections gets offsets centered around 0: `(i - (N-1)/2) * 5px`
3. **Screen-space application**: Points are shifted perpendicular to each segment direction using averaged normals at corners

Single connections (no overlap) receive offset 0 — zero visual change from the current behavior.

## Verification

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 2,838 tests pass
- [x] Branch coverage: 90.28% (≥ 90%)
- [x] No TypeScript errors on changed files
- [x] Single connections render unchanged (offset = 0)