### PR TITLE
fix(web): uniform rect silhouettes and fix external actor placement

### DIFF
--- a/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
+++ b/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
@@ -677,10 +677,10 @@ describe('persistenceSlice branches', () => {
         parentId: null,
         roles: ['external'],
       });
-      // Position fallback: actor had no position, so defaults to { x: -3, y: 0, z: 5 }
-      expect(architecture.nodes[0].position).toEqual({ x: -3, y: 0, z: 5 });
+      // Position fallback: actor had no position, so defaults to { x: -3, y: 0, z: -3 }
+      expect(architecture.nodes[0].position).toEqual({ x: -3, y: 0, z: -3 });
       expect(architecture.externalActors).toEqual([
-        { id: 'ext-1', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+        { id: 'ext-1', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
       ]);
     });
 

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -37,7 +37,7 @@ import {
 } from './helpers';
 
 const MAX_IMPORT_SIZE_BYTES = 5 * 1024 * 1024;
-const DEFAULT_EXTERNAL_ACTOR_POSITION = { x: -3, y: 0, z: 5 };
+const DEFAULT_EXTERNAL_ACTOR_POSITION = { x: -3, y: 0, z: -3 };
 type PlateLayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
 
 const VALID_PLATE_TYPES: PlateLayerType[] = ['global', 'edge', 'region', 'zone', 'subnet'];

--- a/apps/web/src/features/learning/scenarios/builtin.ts
+++ b/apps/web/src/features/learning/scenarios/builtin.ts
@@ -174,7 +174,7 @@ const threeTierCheckpointWithBlocks: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
   ],
 };
 
@@ -292,7 +292,7 @@ const serverlessApiInitialArchitecture: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
   ],
 };
 
@@ -343,7 +343,7 @@ const serverlessApiCheckpointWithSubnets: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
   ],
 };
 

--- a/apps/web/src/features/templates/builtin.ts
+++ b/apps/web/src/features/templates/builtin.ts
@@ -135,7 +135,7 @@ const threeTierTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: 5 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -148,7 +148,7 @@ const threeTierTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: 5 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -185,8 +185,8 @@ const threeTierTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -267,7 +267,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: 5 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -280,7 +280,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: 5 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -305,8 +305,8 @@ const simpleComputeTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -426,7 +426,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: 5 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -439,7 +439,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: 5 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -476,8 +476,8 @@ const dataStorageTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -601,7 +601,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: 5 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -614,7 +614,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: 5 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -651,8 +651,8 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -786,7 +786,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: 5 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -799,7 +799,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: 5 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -848,8 +848,8 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -1066,7 +1066,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: 5 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -1079,7 +1079,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: 5 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -1169,8 +1169,8 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };

--- a/apps/web/src/shared/types/schema.additional.test.ts
+++ b/apps/web/src/shared/types/schema.additional.test.ts
@@ -64,7 +64,7 @@ describe('schema deserialize additional branch coverage', () => {
         entry.kind === 'container',
     );
 
-    expect(actor?.position).toEqual({ x: -3, y: 0, z: 5 });
+    expect(actor?.position).toEqual({ x: -3, y: 0, z: -3 });
     expect(container?.profileId).toBeDefined();
   });
 

--- a/apps/web/src/shared/types/schema.test.ts
+++ b/apps/web/src/shared/types/schema.test.ts
@@ -373,7 +373,7 @@ describe('schema utilities', () => {
 
     const result = deserialize(JSON.stringify(legacyData));
 
-    expect(result[0].architecture.externalActors?.[0]?.position).toEqual({ x: -3, y: 0, z: 5 });
+    expect(result[0].architecture.externalActors?.[0]?.position).toEqual({ x: -3, y: 0, z: -3 });
   });
 
   it('rejects legacy 0.1.0 schema (clean start — no migration)', () => {
@@ -594,7 +594,7 @@ describe('schema utilities', () => {
           provider: 'azure',
           parentId: null,
           roles: ['external'],
-          position: { x: -6, y: 0, z: 5 },
+          position: { x: -6, y: 0, z: -3 },
           metadata: {},
         },
         {
@@ -607,7 +607,7 @@ describe('schema utilities', () => {
           provider: 'azure',
           parentId: null,
           roles: ['external'],
-          position: { x: -3, y: 0, z: 5 },
+          position: { x: -3, y: 0, z: -3 },
           metadata: {},
         },
       ],
@@ -694,8 +694,13 @@ describe('schema utilities', () => {
         },
       ],
       externalActors: [
-        { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-        { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+        { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+        {
+          id: 'ext-internet',
+          name: 'Internet',
+          type: 'internet',
+          position: { x: -3, y: 0, z: -3 },
+        },
       ],
       createdAt: '2026-02-03T04:05:06.000Z',
       updatedAt: '2026-02-03T04:05:06.000Z',
@@ -1072,7 +1077,7 @@ describe('migrateExternalActorsToBlocks', () => {
     const result = migrateExternalActorsToBlocks(actors, new Set(), 'gcp');
 
     expect(result).toHaveLength(1);
-    expect(result[0].position).toEqual({ x: -3, y: 0, z: 5 });
+    expect(result[0].position).toEqual({ x: -3, y: 0, z: -3 });
   });
 });
 

--- a/apps/web/src/shared/types/schema.ts
+++ b/apps/web/src/shared/types/schema.ts
@@ -23,7 +23,7 @@ import {
   generateEndpointsForBlock,
 } from '@cloudblocks/schema';
 
-const DEFAULT_EXTERNAL_ACTOR_POSITION = { x: -3, y: 0, z: 5 };
+const DEFAULT_EXTERNAL_ACTOR_POSITION = { x: -3, y: 0, z: -3 };
 
 /**
  * Migrate ExternalActor[] entries into ResourceBlock nodes.
@@ -496,7 +496,7 @@ export function createBlankArchitecture(id: string, name: string): ArchitectureM
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: 5 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -509,7 +509,7 @@ export function createBlankArchitecture(id: string, name: string): ArchitectureM
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: 5 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -526,8 +526,8 @@ export function createBlankArchitecture(id: string, name: string): ArchitectureM
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
+      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
     createdAt: now,
     updatedAt: now,

--- a/apps/web/src/shared/types/visualProfile.ts
+++ b/apps/web/src/shared/types/visualProfile.ts
@@ -56,9 +56,9 @@ export interface BlockVisualProfile {
   appCapacity: number;
 }
 
-// Per-category silhouette differentiation (Phase 3, #1580).
-// data→cylinder, delivery→gateway, security→shield, messaging→hex, others→rect.
-// All blocks use medium tier and 3×4 footprint. Only shape, color, and icon differ.
+// All resource blocks use uniform rect (cube) silhouette.
+// Silhouette differentiation was removed — all blocks are cubes.
+// All blocks use medium tier and 3×4 footprint. Only color and icon differ.
 export const BLOCK_VISUAL_PROFILES: Record<ResourceCategory, BlockVisualProfile> = {
   network: {
     tier: 'medium',
@@ -71,7 +71,7 @@ export const BLOCK_VISUAL_PROFILES: Record<ResourceCategory, BlockVisualProfile>
   security: {
     tier: 'medium',
     surface: 'ported',
-    silhouette: 'shield',
+    silhouette: 'rect',
     footprint: [3, 4],
     hostable: false,
     appCapacity: 0,
@@ -79,7 +79,7 @@ export const BLOCK_VISUAL_PROFILES: Record<ResourceCategory, BlockVisualProfile>
   delivery: {
     tier: 'medium',
     surface: 'ported',
-    silhouette: 'gateway',
+    silhouette: 'rect',
     footprint: [3, 4],
     hostable: false,
     appCapacity: 0,
@@ -95,7 +95,7 @@ export const BLOCK_VISUAL_PROFILES: Record<ResourceCategory, BlockVisualProfile>
   data: {
     tier: 'medium',
     surface: 'ported',
-    silhouette: 'cylinder',
+    silhouette: 'rect',
     footprint: [3, 4],
     hostable: false,
     appCapacity: 0,
@@ -103,7 +103,7 @@ export const BLOCK_VISUAL_PROFILES: Record<ResourceCategory, BlockVisualProfile>
   messaging: {
     tier: 'medium',
     surface: 'ported',
-    silhouette: 'hex',
+    silhouette: 'rect',
     footprint: [3, 4],
     hostable: false,
     appCapacity: 0,


### PR DESCRIPTION
## Summary

- Revert all block silhouettes (security, delivery, data, messaging) from category-specific shapes (shield, gateway, cylinder, hex) to uniform `'rect'` — consistent cube appearance across all block categories
- Move external actors (browser, internet) from `z:5` (inside VNet visual boundary) to `z:-3` (clearly in front of VNet) so they no longer visually overlap the network container

## Changes

### Block Silhouettes → Uniform Rect
- `BLOCK_VISUAL_PROFILES` in `visualProfile.ts`: all 4 non-rect silhouettes changed to `'rect'`
- Silhouette generator functions (cylinder, gateway, shield, hex) remain available for future use

### External Actor Placement Fix
- `DEFAULT_EXTERNAL_ACTOR_POSITION` in both `schema.ts` and `persistenceSlice.ts`: `z: 5` → `z: -3`
- All 6 built-in templates updated (24 position values)
- All 3 learning scenarios updated
- `createBlankArchitecture()` browser/internet default positions updated

### Tests
- 10 test assertions updated to match new `z: -3` positions
- All 2869 tests pass, build and lint clean

Fixes #1609
Fixes #1610