### PR TITLE
chore: unify schema versioning and extend VERSION_POLICY.md

### DIFF
--- a/apps/web/src/shared/types/schema.ts
+++ b/apps/web/src/shared/types/schema.ts
@@ -21,6 +21,7 @@ import {
   connectionTypeToSemantic,
   endpointId,
   generateEndpointsForBlock,
+  SCHEMA_VERSION,
 } from '@cloudblocks/schema';
 
 const DEFAULT_EXTERNAL_ACTOR_POSITION = { x: -3, y: 0, z: -3 };
@@ -60,6 +61,7 @@ export function migrateExternalActorsToBlocks(
 }
 /**
  * SCHEMA_VERSION: Controls the serialization/storage format.
+ * Canonical source: packages/schema/src/index.ts
  * Bump when the shape of SerializedData or Workspace changes.
  * Used to detect incompatible localStorage data and trigger migrations.
  *
@@ -68,9 +70,10 @@ export function migrateExternalActorsToBlocks(
  *
  * v2.0.0 — Clean start: CU-based dimensions, 6-layer hierarchy,
  *          10 categories, aggregation, roles. No v1.x migration.
+ * v4.0.0 — Endpoint-based connections (M22)
+ * v4.1.0 — External actor migration to block nodes
  */
-export const CURRENT_SCHEMA_VERSION = '4.0.0';
-export const SCHEMA_VERSION = CURRENT_SCHEMA_VERSION;
+export { SCHEMA_VERSION };
 
 /**
  * v1.x schema versions that are explicitly rejected (clean start, no migration).
@@ -78,7 +81,7 @@ export const SCHEMA_VERSION = CURRENT_SCHEMA_VERSION;
  */
 const LEGACY_VERSIONS = ['0.1.0', '0.2.0'];
 
-const SUPPORTED_VERSIONS = [SCHEMA_VERSION, '3.0.0', '2.0.0'];
+const SUPPORTED_VERSIONS = [SCHEMA_VERSION, '4.0.0', '3.0.0', '2.0.0'];
 
 export type ArchitectureSnapshot = Omit<ArchitectureModel, 'id' | 'createdAt' | 'updatedAt'> & {
   endpoints: ArchitectureModel['endpoints'];

--- a/docs/concept/ARCHITECTURE.md
+++ b/docs/concept/ARCHITECTURE.md
@@ -337,7 +337,7 @@ The canonical model types are defined in `packages/schema` (`@cloudblocks/schema
 
 ### Serialization Format
 
-- Serialization for persisted app state (e.g. localStorage) is versioned through `schemaVersion` and currently uses `"4.0.0"` (source constant: `apps/web/src/shared/types/schema.ts` → `CURRENT_SCHEMA_VERSION`).
+- Serialization is versioned through `schemaVersion` and currently uses `"4.1.0"` (source constant: `packages/schema/src/index.ts` → `SCHEMA_VERSION`).
 - The persisted root payload shape is `{ schemaVersion, workspaces[] }`, where each workspace contains one `architecture: ArchitectureModel`.
 - For broader domain semantics and lifecycle rules, see [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md).
 

--- a/docs/design/VERSION_POLICY.md
+++ b/docs/design/VERSION_POLICY.md
@@ -110,7 +110,7 @@ Schema version bumps less frequently than app version. Many milestones may ship 
 
 ## Documentation Freshness Markers
 
-Living documentation files include a `Verified against` marker in their metadata header (line 3):
+Living documentation files include a `Verified against` marker in their metadata header immediately below the title:
 
 ```markdown
 > **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.35.0
@@ -118,9 +118,11 @@ Living documentation files include a `Verified against` marker in their metadata
 
 ### Rules
 
-1. **Format**: Always use the app version: `Verified against: v{X.Y.Z}`
-2. **Exception**: Schema-focused docs (e.g., `DOMAIN_MODEL.md`) may additionally note `v{schema} schema` when the schema version materially matters
-3. **Update only after review**: A marker means "a human verified this document accurately describes the codebase at version X". Do not bulk-update markers without actually reviewing content.
+1. **Default format (app version)**: For most docs, use the app version: `Verified against: v{X.Y.Z}`
+2. **Schema-focused docs**: Schema-focused docs (e.g., `DOMAIN_MODEL.md`) may instead use a schema marker or a combined marker, e.g.:
+   - `Verified against: v4.1.0 schema` (schema only), or
+   - `Verified against: app v0.40.0, schema v4.1.0` (both)
+3. **Update only after review**: A marker means "a human verified this document accurately describes the codebase at version X (and/or schema S)". Do not bulk-update markers without actually reviewing content.
 4. **Exempt documents**: ADRs (`docs/decisions/ADR-*.md`) and documents marked "Historical (Superseded)" do not carry freshness markers — they are immutable records.
 5. **Staleness threshold**: A marker more than 5 milestones behind the current release is considered stale and should be prioritized for review.
 

--- a/docs/design/VERSION_POLICY.md
+++ b/docs/design/VERSION_POLICY.md
@@ -1,6 +1,6 @@
 # Version Alignment Policy
 
-> Canonical reference for CloudBlocks monorepo versioning.
+> Canonical reference for all versioning in the CloudBlocks monorepo — app versions, schema versions, and documentation freshness markers.
 
 ## Single-Version Policy
 
@@ -51,6 +51,90 @@ CloudBlocks is pre-1.0 software. No stability guarantees are provided for:
 - File formats (architecture JSON schema may evolve)
 
 Consumers should pin to specific versions and review changelogs before upgrading.
+
+## Schema Versioning
+
+The **architecture serialization format** has its own version number, independent of the app version. Schema version tracks the shape of persisted data (`SerializedData`, `Workspace`, `ArchitectureModel`) and controls localStorage migration.
+
+### Canonical Source
+
+| What | Location | Example |
+| --- | --- | --- |
+| **Source of truth** | `packages/schema/src/index.ts` → `SCHEMA_VERSION` | `'4.1.0'` |
+| Runtime consumer | `apps/web/src/shared/types/schema.ts` → imports from `@cloudblocks/schema` | — |
+
+There must be **exactly one** `SCHEMA_VERSION` constant in the codebase. `apps/web` imports it; it must not define its own copy.
+
+### When to Bump Schema Version
+
+Bump `SCHEMA_VERSION` when the **persisted data shape** changes:
+
+- New required field added to `ArchitectureModel`, `Workspace`, or `SerializedData`
+- Field renamed, removed, or type changed
+- Container/resource block structure changes that affect serialization
+- Migration logic added for a new format transition
+
+Do **not** bump schema version for:
+
+- UI-only changes (CSS, layout, panel visibility)
+- New resource types added to `RESOURCE_RULES` (additive, backward-compatible)
+- Code generation changes (Terraform/Bicep/Pulumi output)
+- Backend API changes
+
+### Schema Version Convention
+
+```
+{major}.{minor}.{patch}
+
+Examples:
+  4.0.0  — v4 format (endpoint-based connections, M22)
+  4.1.0  — Added external actor migration to block nodes
+  5.0.0  — (future) Breaking format change requiring new migration
+```
+
+- **Major**: Breaking format change — old data cannot load without migration
+- **Minor**: Additive change — old data loads but may gain new defaults on save
+- **Patch**: Fix to migration logic with no format change
+
+### Relationship to App Version
+
+App version and schema version are **independent**:
+
+```
+App v0.22.0  →  Schema v4.0.0  (M22 introduced endpoint-based connections)
+App v0.35.0  →  Schema v4.1.0  (same schema, minor addition)
+App v0.40.0  →  Schema v4.1.0  (possible — no format change needed)
+```
+
+Schema version bumps less frequently than app version. Many milestones may ship on the same schema version.
+
+## Documentation Freshness Markers
+
+Living documentation files include a `Verified against` marker in their metadata header (line 3):
+
+```markdown
+> **Audience**: Beginners | **Status**: V1 Core | **Verified against**: v0.35.0
+```
+
+### Rules
+
+1. **Format**: Always use the app version: `Verified against: v{X.Y.Z}`
+2. **Exception**: Schema-focused docs (e.g., `DOMAIN_MODEL.md`) may additionally note `v{schema} schema` when the schema version materially matters
+3. **Update only after review**: A marker means "a human verified this document accurately describes the codebase at version X". Do not bulk-update markers without actually reviewing content.
+4. **Exempt documents**: ADRs (`docs/decisions/ADR-*.md`) and documents marked "Historical (Superseded)" do not carry freshness markers — they are immutable records.
+5. **Staleness threshold**: A marker more than 5 milestones behind the current release is considered stale and should be prioritized for review.
+
+### Release Checklist Integration
+
+During each milestone release, the release PR must review and update the `Verified against` marker for at least these **core documents**:
+
+- `docs/concept/ARCHITECTURE.md`
+- `docs/model/DOMAIN_MODEL.md`
+- `docs/concept/V1_PRODUCT_CONTRACT.md`
+- `docs/user-guide/quick-start.md`
+- `docs/user-guide/core-concepts.md`
+
+Other documents should be updated opportunistically when their content area is affected by the milestone.
 
 ## Enforcement
 
@@ -113,3 +197,4 @@ git commit -m "chore: release v$NEW_VERSION"
 - [AGENTS.md § Release Workflow](../../AGENTS.md) — Full release process
 - [RELEASE_GATES.md](RELEASE_GATES.md) — Pre-release gate checks
 - [CHANGELOG.md](../../CHANGELOG.md) — Release history
+- [DOMAIN_MODEL.md](../model/DOMAIN_MODEL.md) — Schema version referenced in model docs

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -61,13 +61,13 @@ echo "---"
 # packages/schema/src/index.ts is the canonical SCHEMA_VERSION.
 # apps/web must import it, not define its own constant.
 SCHEMA_DEFS=$(grep -r "SCHEMA_VERSION\s*=\s*'" "$REPO_ROOT/packages/schema/src/index.ts" "$REPO_ROOT/apps/web/src/shared/types/schema.ts" 2>/dev/null | grep -v 'import\|from\|export {' || true)
-SCHEMA_DEF_COUNT=$(echo "$SCHEMA_DEFS" | grep -c "SCHEMA_VERSION" 2>/dev/null || echo 0)
+SCHEMA_DEF_COUNT=$(echo "$SCHEMA_DEFS" | grep -c "SCHEMA_VERSION" 2>/dev/null || true)
 if [ "$SCHEMA_DEF_COUNT" -gt 1 ]; then
   echo "MISMATCH  Schema version: $SCHEMA_DEF_COUNT definitions found (expected 1 in packages/schema)"
   echo "          $SCHEMA_DEFS"
   ERRORS=$((ERRORS + 1))
 elif [ "$SCHEMA_DEF_COUNT" -eq 1 ]; then
-  SCHEMA_VER=$(echo "$SCHEMA_DEFS" | grep -oP "'\K[^']+" | head -1)
+  SCHEMA_VER=$(echo "$SCHEMA_DEFS" | sed -n "s/.*'\([^']*\)'.*/\1/p" | head -1)
   echo "OK        Schema version: $SCHEMA_VER (single source in packages/schema)"
 else
   echo "WARN      Schema version: no SCHEMA_VERSION definition found"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# check-versions.sh — Verify all package versions match the root package.json
+# check-versions.sh — Verify all package versions and schema version source
 # See docs/design/VERSION_POLICY.md for the single-version policy.
 set -euo pipefail
 
@@ -56,10 +56,28 @@ for pkg_json in "$REPO_ROOT"/packages/*/package.json; do
 done
 
 echo "---"
+
+# ── Schema version: must have exactly one canonical source ──
+# packages/schema/src/index.ts is the canonical SCHEMA_VERSION.
+# apps/web must import it, not define its own constant.
+SCHEMA_DEFS=$(grep -r "SCHEMA_VERSION\s*=\s*'" "$REPO_ROOT/packages/schema/src/index.ts" "$REPO_ROOT/apps/web/src/shared/types/schema.ts" 2>/dev/null | grep -v 'import\|from\|export {' || true)
+SCHEMA_DEF_COUNT=$(echo "$SCHEMA_DEFS" | grep -c "SCHEMA_VERSION" 2>/dev/null || echo 0)
+if [ "$SCHEMA_DEF_COUNT" -gt 1 ]; then
+  echo "MISMATCH  Schema version: $SCHEMA_DEF_COUNT definitions found (expected 1 in packages/schema)"
+  echo "          $SCHEMA_DEFS"
+  ERRORS=$((ERRORS + 1))
+elif [ "$SCHEMA_DEF_COUNT" -eq 1 ]; then
+  SCHEMA_VER=$(echo "$SCHEMA_DEFS" | grep -oP "'\K[^']+" | head -1)
+  echo "OK        Schema version: $SCHEMA_VER (single source in packages/schema)"
+else
+  echo "WARN      Schema version: no SCHEMA_VERSION definition found"
+fi
+
 if [ "$ERRORS" -gt 0 ]; then
   echo "FAIL: $ERRORS version mismatch(es) found."
-  echo "All versions must match root package.json ($EXPECTED)."
-  echo "See docs/design/VERSION_POLICY.md for the single-version policy."
+  echo "All package versions must match root package.json ($EXPECTED)."
+  echo "Schema version must have exactly one source in packages/schema."
+  echo "See docs/design/VERSION_POLICY.md for the version alignment policy."
   exit 1
 else
   echo "PASS: All versions aligned at $EXPECTED."


### PR DESCRIPTION
## Summary

- **Centralizes SCHEMA_VERSION**: `apps/web` now imports from `@cloudblocks/schema` instead of defining its own constant, eliminating the `4.0.0` vs `4.1.0` drift between packages
- **Extends VERSION_POLICY.md** with three new sections: Schema Versioning, Documentation Freshness Markers, and Release Checklist Integration
- **Adds duplicate detection** to `check-versions.sh` so CI can catch schema version re-declarations

## Changes

### `apps/web/src/shared/types/schema.ts`
- Removed local `CURRENT_SCHEMA_VERSION = '4.0.0'` constant
- Imports `SCHEMA_VERSION` from `@cloudblocks/schema` (canonical source: `4.1.0`)
- Re-exports `SCHEMA_VERSION` for existing consumers
- Added `'4.0.0'` to `SUPPORTED_VERSIONS` for backward compatibility with existing localStorage data

### `docs/design/VERSION_POLICY.md`
- **Schema Versioning**: Defines `packages/schema/src/index.ts` as the single canonical source. Documents bump criteria, convention, and relationship to app version.
- **Documentation Freshness Markers**: Formalizes the `Verified against: v{X.Y.Z}` pattern with rules on when/how to update. ADRs and historical docs are exempt.
- **Release Checklist Integration**: Lists 5 core docs that must have markers reviewed each release.

### `docs/concept/ARCHITECTURE.md`
- Updated schema version references from `4.0.0` to `4.1.0` (lines 370, 560)
- Updated source reference to point to `packages/schema/src/index.ts`

### `scripts/check-versions.sh`
- New section scans for `SCHEMA_VERSION` definitions across `packages/schema` and `apps/web`
- Fails if more than 1 definition found (indicating apps/web is defining its own instead of importing)
- Reports the single canonical schema version on success

## Verification

- ✅ `pnpm build` — all packages + web app succeed
- ✅ `pnpm --filter @cloudblocks/web test` — 139 files, 2893 tests passed
- ✅ `pnpm --filter @cloudblocks/schema test` — 3 files, 45 tests passed
- ✅ `./scripts/check-versions.sh` — correctly reports single schema source
- ✅ LSP diagnostics clean on all changed files

## Not in scope

- Bulk update of 30 stale "Verified against: v0.26.0" doc markers (intentionally deferred — each doc needs individual review per the new policy)
- `apps/api` version drift (0.19.2 vs 0.35.0) — pre-existing, tracked separately