### PR TITLE
fix(web): rename external block Browser→Client and add descriptions

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -1136,7 +1136,7 @@ describe('BlockSprite', () => {
   it('adds is-external class when block has external role', () => {
     const externalBlock: ResourceBlock = {
       id: 'actor-browser',
-      name: 'Browser',
+      name: 'Client',
       kind: 'resource',
       layer: 'resource',
       resourceType: 'browser',

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -43,7 +43,7 @@ export const BlockSvg = memo(function BlockSvg({
   provider,
   subtype,
   resourceType,
-  name: _name,
+  name,
   aggregationCount,
   roles,
   healthStatus,
@@ -73,7 +73,8 @@ export const BlockSvg = memo(function BlockSvg({
   const shortLabel = getSubtypeShortLabel(provider ?? 'azure', subtype);
   const displayLabel = getSubtypeDisplayLabel(provider ?? 'azure', subtype);
   const labelMode = useUIStore((s) => s.effectiveLabelMode);
-  const faceLabel = labelMode === 'compact' ? shortLabel : (displayLabel ?? shortLabel);
+  const faceLabel =
+    labelMode === 'compact' ? (shortLabel ?? name) : (displayLabel ?? shortLabel ?? name);
   const showPorts = useUIStore((s) => s.showPorts);
   const ports = CATEGORY_PORTS[category] ?? { inbound: 1, outbound: 1 };
   const portPoints = getBlockSvgPortPoints(cu, ports.inbound, ports.outbound);

--- a/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
+++ b/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
@@ -646,7 +646,7 @@ describe('persistenceSlice branches', () => {
       });
       expect(queue).toMatchObject({ resourceType: 'message_queue', provider: 'azure' });
       expect(architecture.externalActors).toEqual([
-        { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: 5 } },
+        { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: 5 } },
         { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: 5 } },
       ]);
     });
@@ -1054,7 +1054,7 @@ describe('persistenceSlice branches', () => {
             },
             {
               id: 'ext-browser',
-              name: 'Browser',
+              name: 'Client',
               kind: 'resource',
               layer: 'resource',
               resourceType: 'browser',
@@ -1095,7 +1095,7 @@ describe('persistenceSlice branches', () => {
 
       // External blocks: provider remapped, name/subtype preserved
       expect(browser).toMatchObject({
-        name: 'Browser',
+        name: 'Client',
         provider: 'aws',
         resourceType: 'browser',
         roles: ['external'],
@@ -1138,7 +1138,7 @@ describe('validateArchitectureShape — external resource blocks', () => {
         },
         {
           id: 'ext-browser',
-          name: 'Browser',
+          name: 'Client',
           kind: 'resource',
           layer: 'resource',
           resourceType: 'browser',

--- a/apps/web/src/entities/store/slices/domainSlice.test.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.test.ts
@@ -122,7 +122,7 @@ function makeExternalBlock(
 ): ResourceBlock {
   return {
     id,
-    name: resourceType === 'internet' ? 'Internet' : 'Browser',
+    name: resourceType === 'internet' ? 'Internet' : 'Client',
     kind: 'resource',
     layer: 'resource',
     resourceType,
@@ -385,7 +385,7 @@ describe('domainSlice – targeted branch coverage', () => {
               },
               {
                 id: 'ext-other',
-                name: 'Browser',
+                name: 'Client',
                 type: 'browser',
                 position: { x: 9, y: 0, z: 9 },
               },

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -850,7 +850,7 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
     get().addNode({
       kind: 'resource',
       resourceType: type,
-      name: type === 'internet' ? 'Internet' : 'Browser',
+      name: type === 'internet' ? 'Internet' : 'Client',
       parentId: null,
     });
 

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -596,7 +596,7 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
         ) ?? [
           {
             id: 'ext-browser',
-            name: 'Browser',
+            name: 'Client',
             type: 'browser',
             position: { x: -6, y: 0, z: 5 },
           },

--- a/apps/web/src/features/generate/bicep.test.ts
+++ b/apps/web/src/features/generate/bicep.test.ts
@@ -347,7 +347,7 @@ describe('bicep generator', () => {
     model.nodes.push(
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource' as const,
         layer: 'resource' as const,
         resourceType: 'browser',

--- a/apps/web/src/features/generate/pulumi.test.ts
+++ b/apps/web/src/features/generate/pulumi.test.ts
@@ -337,7 +337,7 @@ describe('pulumi generator', () => {
     model.nodes.push(
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource' as const,
         layer: 'resource' as const,
         resourceType: 'browser',

--- a/apps/web/src/features/generate/terraform.test.ts
+++ b/apps/web/src/features/generate/terraform.test.ts
@@ -166,7 +166,7 @@ describe('normalize', () => {
     model.nodes.push(
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource' as const,
         layer: 'resource' as const,
         resourceType: 'browser',
@@ -677,7 +677,7 @@ describe('generateMainTf', () => {
     model.nodes.push(
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource' as const,
         layer: 'resource' as const,
         resourceType: 'browser',
@@ -993,7 +993,7 @@ describe('GCP external block exclusion', () => {
     model.nodes.push(
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource' as const,
         layer: 'resource' as const,
         resourceType: 'browser',

--- a/apps/web/src/features/generate/terraformPlugin.test.ts
+++ b/apps/web/src/features/generate/terraformPlugin.test.ts
@@ -150,7 +150,7 @@ describe('terraformPlugin', () => {
         ...testArchitecture.nodes,
         {
           id: 'ext-browser',
-          name: 'Browser',
+          name: 'Client',
           kind: 'resource',
           layer: 'resource',
           resourceType: 'browser',

--- a/apps/web/src/features/templates/builtin.ts
+++ b/apps/web/src/features/templates/builtin.ts
@@ -127,7 +127,7 @@ const threeTierTemplate: ArchitectureTemplate = {
       },
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource',
         layer: 'resource',
         resourceType: 'browser',
@@ -185,7 +185,7 @@ const threeTierTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
@@ -259,7 +259,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
       },
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource',
         layer: 'resource',
         resourceType: 'browser',
@@ -305,7 +305,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
@@ -418,7 +418,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
       },
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource',
         layer: 'resource',
         resourceType: 'browser',
@@ -476,7 +476,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
@@ -593,7 +593,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
       },
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource',
         layer: 'resource',
         resourceType: 'browser',
@@ -651,7 +651,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
@@ -778,7 +778,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
       },
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource',
         layer: 'resource',
         resourceType: 'browser',
@@ -848,7 +848,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
@@ -1058,7 +1058,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
       },
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource',
         layer: 'resource',
         resourceType: 'browser',
@@ -1169,7 +1169,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },

--- a/apps/web/src/shared/presentation/blockPresentation.test.ts
+++ b/apps/web/src/shared/presentation/blockPresentation.test.ts
@@ -177,8 +177,8 @@ describe('resolveExternalPresentation', () => {
   it('browser resolves correctly', () => {
     const result = resolveExternalPresentation('browser');
     expect(result.kind).toBe('external');
-    expect(result.shortLabel).toBe('Browser');
-    expect(result.displayLabel).toBe('Browser');
+    expect(result.shortLabel).toBe('Client');
+    expect(result.displayLabel).toBe('Client');
     expect(result.iconUrl).toBe('/actor-sprites/browser.svg');
     expect(result.isFallback).toBe(false);
   });

--- a/apps/web/src/shared/presentation/blockPresentation.ts
+++ b/apps/web/src/shared/presentation/blockPresentation.ts
@@ -41,6 +41,8 @@ export interface BlockPresentation {
   readonly layer?: string;
   /** True if iconUrl is a fallback (not an exact match) */
   readonly isFallback: boolean;
+  /** Human-readable description (e.g. for tooltips or properties panel) */
+  readonly description?: string;
 }
 
 // ─── Options ─────────────────────────────────────────────────
@@ -197,16 +199,18 @@ function resolvePublicUrl(rawPath: string): string {
 
 const EXTERNAL_PRESENTATIONS: Record<
   string,
-  { shortLabel: string; displayLabel: string; iconUrl: string }
+  { shortLabel: string; displayLabel: string; description: string; iconUrl: string }
 > = {
   internet: {
     shortLabel: 'Internet',
     displayLabel: 'Internet',
+    description: 'Public network boundary for traffic entering or leaving the architecture.',
     iconUrl: resolvePublicUrl('/actor-sprites/internet.svg'),
   },
   browser: {
-    shortLabel: 'Browser',
-    displayLabel: 'Browser',
+    shortLabel: 'Client',
+    displayLabel: 'Client',
+    description: 'External client that initiates HTTP requests to your application.',
     iconUrl: resolvePublicUrl('/actor-sprites/browser.svg'),
   },
 };
@@ -227,6 +231,7 @@ export function resolveExternalPresentation(
       subtype: resourceType,
       shortLabel: ext.shortLabel,
       displayLabel: ext.displayLabel,
+      description: ext.description,
       iconUrl: ext.iconUrl,
       category: 'external',
       provider,

--- a/apps/web/src/shared/types/schema.test.ts
+++ b/apps/web/src/shared/types/schema.test.ts
@@ -21,7 +21,7 @@ function createWorkspace(id: string): Workspace {
       nodes: [
         {
           id: 'ext-browser',
-          name: 'Browser',
+          name: 'Client',
           kind: 'resource',
           layer: 'resource',
           resourceType: 'browser',
@@ -586,7 +586,7 @@ describe('schema utilities', () => {
       nodes: [
         {
           id: 'ext-browser',
-          name: 'Browser',
+          name: 'Client',
           kind: 'resource',
           layer: 'resource',
           resourceType: 'browser',
@@ -694,7 +694,7 @@ describe('schema utilities', () => {
         },
       ],
       externalActors: [
-        { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+        { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
         {
           id: 'ext-internet',
           name: 'Internet',
@@ -1026,7 +1026,7 @@ describe('migrateExternalActorsToBlocks', () => {
       },
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         type: 'browser' as const,
         position: { x: -6, y: 0, z: 5 },
       },
@@ -1100,7 +1100,7 @@ describe('deserialize — externalActors migration', () => {
             externalActors: [
               {
                 id: 'ext-browser',
-                name: 'Browser',
+                name: 'Client',
                 type: 'browser',
                 position: { x: -6, y: 0, z: 5 },
               },
@@ -1215,7 +1215,7 @@ describe('deserialize — externalActors migration', () => {
             nodes: [
               {
                 id: 'ext-browser',
-                name: 'Browser',
+                name: 'Client',
                 kind: 'resource',
                 layer: 'resource',
                 resourceType: 'browser',

--- a/apps/web/src/shared/types/schema.ts
+++ b/apps/web/src/shared/types/schema.ts
@@ -491,7 +491,7 @@ export function createBlankArchitecture(id: string, name: string): ArchitectureM
     nodes: [
       {
         id: 'ext-browser',
-        name: 'Browser',
+        name: 'Client',
         kind: 'resource',
         layer: 'resource',
         resourceType: 'browser',
@@ -529,7 +529,7 @@ export function createBlankArchitecture(id: string, name: string): ArchitectureM
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Browser', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
     createdAt: now,

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
@@ -181,7 +181,7 @@ describe('SceneCanvas external lane zone', () => {
   it('renders external lane zone when root external blocks exist', () => {
     const externalBlock: ResourceBlock = {
       id: 'external-1',
-      name: 'Browser',
+      name: 'Client',
       kind: 'resource',
       layer: 'resource',
       resourceType: 'browser',

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.additional.test.tsx
@@ -372,7 +372,7 @@ describe('SidebarPalette additional coverage', () => {
     render(<SidebarPalette />);
 
     const internetBtn = screen.getByTitle('Add Internet');
-    const browserBtn = screen.getByTitle('Add Browser');
+    const browserBtn = screen.getByTitle('Add Client');
 
     // External buttons should NOT be in the interact listeners map
     // because the selector scopes to [data-resource-type] only

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.test.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.test.tsx
@@ -95,7 +95,7 @@ describe('SidebarPalette', () => {
     // External group uses unified layout
     expect(screen.getByText('External')).toBeInTheDocument();
     expect(screen.getByTitle('Add Internet')).toBeInTheDocument();
-    expect(screen.getByTitle('Add Browser')).toBeInTheDocument();
+    expect(screen.getByTitle('Add Client')).toBeInTheDocument();
 
     // Groups with starter-tier resources appear by default
     expect(screen.getByText('Network')).toBeInTheDocument();
@@ -245,7 +245,7 @@ describe('SidebarPalette', () => {
     render(<SidebarPalette />);
 
     await user.click(screen.getByTitle('Add Internet'));
-    await user.click(screen.getByTitle('Add Browser'));
+    await user.click(screen.getByTitle('Add Client'));
 
     expect(addExternalBlockMock).toHaveBeenNthCalledWith(1, 'internet');
     expect(addExternalBlockMock).toHaveBeenNthCalledWith(2, 'browser');
@@ -472,7 +472,7 @@ describe('SidebarPalette — blockPresentation integration', () => {
     render(<SidebarPalette />);
 
     const internetBtn = screen.getByTitle('Add Internet');
-    const browserBtn = screen.getByTitle('Add Browser');
+    const browserBtn = screen.getByTitle('Add Client');
 
     // External items use blockPresentation's iconUrl
     const internetImg = internetBtn.querySelector('img');
@@ -490,7 +490,7 @@ describe('SidebarPalette — blockPresentation integration', () => {
 
     await user.type(screen.getByPlaceholderText('Search resources'), 'internet');
     expect(screen.getByTitle('Add Internet')).toBeInTheDocument();
-    expect(screen.queryByTitle('Add Browser')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Add Client')).not.toBeInTheDocument();
   });
 
   it('uses resolved labels from blockPresentation for provider switching', async () => {


### PR DESCRIPTION
## Summary

- Rename external block display label "Browser" → "Client" across all user-facing surfaces (presentation metadata, templates, default names)
- Add `description` field to external block presentation: Internet and Client blocks now have human-readable descriptions
- Fix `BlockSvg` face label rendering: external blocks now show `block.name` as fallback when no subtype label exists

## Changes

### Source (6 files)
| File | Change |
|------|--------|
| `blockPresentation.ts` | `Browser`→`Client` labels, add `description` field to type + data |
| `BlockSvg.tsx` | Use `name` prop as face label fallback (was `_name` unused) |
| `domainSlice.ts` | Default name `'Browser'`→`'Client'` in `addExternalBlock` |
| `persistenceSlice.ts` | Fallback name `'Browser'`→`'Client'` |
| `schema.ts` | Default external actor names `'Browser'`→`'Client'` |
| `builtin.ts` | All 6 templates: `name: 'Browser'`→`name: 'Client'` (12 occurrences) |

### Tests (12 files)
All test expectations updated to match `'Client'` display name. No test logic changed.

### Design Notes
- **Display-only rename**: `resourceType: 'browser'` kept internally — no schema migration required
- **SVG sprite unchanged**: `browser.svg` filename stays (cosmetically acceptable)
- **Connection rules unchanged**: `browser->internet`, `browser->delivery` etc. still work identically
- **Backward compatibility**: Existing saved architectures serialized with `name: 'Browser'` continue to display "Browser" until the user renames the block; new and template-based architectures use "Client"
- **`description` field**: Wired through `resolveExternalPresentation` and available for future use in tooltips or a properties panel; not yet rendered in UI

## Type

- [ ] Feature (new functionality)
- [x] Bug fix (non-breaking fix)
- [ ] Refactor (no functional changes)
- [ ] Documentation
- [ ] CI / Build / Tooling
- [ ] Other

## Related Issues

## Verification Checklist

- [x] `npx tsc -b` passes (zero errors)
- [x] `npx vite build` succeeds
- [x] No `as any`, `@ts-ignore`, or `@ts-expect-error`
- [x] No unused imports or variables
- [x] `import type` used for type-only imports (`verbatimModuleSyntax`)
- [x] Existing patterns followed (FSD layer rules, naming conventions)
- [ ] Documentation updated (if behavior changed)

## Screenshots

<!-- No visual changes to canvas rendering; the rename affects only the text label on the block face and palette entries. -->