### PR TITLE
style(web): improve container block visual hierarchy

### DIFF
--- a/apps/web/src/app/index.css
+++ b/apps/web/src/app/index.css
@@ -126,8 +126,8 @@
     drop-shadow(0px 8px 14px rgba(0, 0, 0, 0.14));
 
   /* ── Placement anchor tiles (#1581) ── */
-  --anchor-marker-stroke: rgba(255, 255, 255, 0.1);
-  --anchor-marker-occupied-stroke: rgba(255, 255, 255, 0.04);
+  --anchor-marker-stroke: rgba(255, 255, 255, 0.06);
+  --anchor-marker-occupied-stroke: rgba(255, 255, 255, 0.02);
 
   /* ── Mounted block groove (#1581) ── */
   --groove-color: rgba(0, 0, 0, 0.25);
@@ -219,8 +219,8 @@
     drop-shadow(0px 6px 10px rgba(0, 0, 0, 0.07));
 
   /* ── Placement anchor tiles (#1581) ── */
-  --anchor-marker-stroke: rgba(0, 0, 0, 0.07);
-  --anchor-marker-occupied-stroke: rgba(0, 0, 0, 0.03);
+  --anchor-marker-stroke: rgba(0, 0, 0, 0.04);
+  --anchor-marker-occupied-stroke: rgba(0, 0, 0, 0.015);
 
   /* ── Mounted block groove (#1581) ── */
   --groove-color: rgba(0, 0, 0, 0.12);

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
@@ -140,22 +140,22 @@ describe('PlateSvg — SVG structure', () => {
 // ─── Layer-Type Visual Differentiation ──────────────────────
 
 describe('PlateSvg — layer-type visuals', () => {
-  it('global container has thicker border than subnet', () => {
+  it('subnet container has thicker border than global (inner layers are more prominent)', () => {
     const { container: globalC } = renderPlateSvg({ containerLayer: 'global' });
     const { container: subnetC } = renderPlateSvg({ containerLayer: 'subnet' });
 
     const globalStroke = Number(globalC.querySelector('polygon')?.getAttribute('stroke-width'));
     const subnetStroke = Number(subnetC.querySelector('polygon')?.getAttribute('stroke-width'));
-    expect(globalStroke).toBeGreaterThan(subnetStroke);
+    expect(subnetStroke).toBeGreaterThan(globalStroke);
   });
 
-  it('global container has higher stroke opacity than subnet', () => {
+  it('subnet container has higher stroke opacity than global (inner layers are more prominent)', () => {
     const { container: globalC } = renderPlateSvg({ containerLayer: 'global' });
     const { container: subnetC } = renderPlateSvg({ containerLayer: 'subnet' });
 
     const globalOpacity = Number(globalC.querySelector('polygon')?.getAttribute('stroke-opacity'));
     const subnetOpacity = Number(subnetC.querySelector('polygon')?.getAttribute('stroke-opacity'));
-    expect(globalOpacity).toBeGreaterThan(subnetOpacity);
+    expect(subnetOpacity).toBeGreaterThan(globalOpacity);
   });
 
   it('each container type gets a distinct stroke width', () => {
@@ -170,15 +170,16 @@ describe('PlateSvg — layer-type visuals', () => {
     expect(unique.size).toBe(types.length);
   });
 
-  it('stroke widths follow hierarchy: global > edge > region > zone > subnet', () => {
+  it('stroke widths follow hierarchy: subnet > zone > region > edge > global (inner = more prominent)', () => {
     const types: PlateLayerType[] = ['global', 'edge', 'region', 'zone', 'subnet'];
     const strokeWidths = types.map((type) => {
       const { container } = renderPlateSvg({ containerLayer: type });
       return Number(container.querySelector('polygon')?.getAttribute('stroke-width'));
     });
 
+    // Inner layers should have thicker strokes than outer layers
     for (let i = 0; i < strokeWidths.length - 1; i++) {
-      expect(strokeWidths[i]).toBeGreaterThan(strokeWidths[i + 1]);
+      expect(strokeWidths[i]).toBeLessThan(strokeWidths[i + 1]);
     }
   });
 

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.tsx
@@ -27,36 +27,36 @@ type PlateLayerType = Exclude<LayerType, 'resource'>;
 
 const LAYER_VISUALS: Record<PlateLayerType, LayerVisuals> = {
   global: {
-    strokeWidth: 1.2,
-    strokeOpacity: 0.35,
+    strokeWidth: 0.6,
+    strokeOpacity: 0.18,
     labelFontSize: 22,
     emojiFontSize: 28,
     cornerRadius: 0,
   },
   edge: {
-    strokeWidth: 1.0,
-    strokeOpacity: 0.3,
+    strokeWidth: 0.7,
+    strokeOpacity: 0.22,
     labelFontSize: 20,
     emojiFontSize: 26,
     cornerRadius: 0,
   },
   region: {
     strokeWidth: 0.8,
-    strokeOpacity: 0.25,
+    strokeOpacity: 0.28,
     labelFontSize: 18,
     emojiFontSize: 24,
     cornerRadius: 0,
   },
   zone: {
-    strokeWidth: 0.6,
-    strokeOpacity: 0.2,
+    strokeWidth: 1.1,
+    strokeOpacity: 0.4,
     labelFontSize: 16,
     emojiFontSize: 22,
     cornerRadius: 0,
   },
   subnet: {
-    strokeWidth: 0.5,
-    strokeOpacity: 0.18,
+    strokeWidth: 1.4,
+    strokeOpacity: 0.5,
     labelFontSize: 18,
     emojiFontSize: 24,
     cornerRadius: 0,
@@ -112,6 +112,16 @@ export const ContainerBlockSvg = memo(function PlateSvg({
   // Layer-specific visual config
   const visuals = LAYER_VISUALS[containerLayer];
 
+  // Depth factor: inner layers → stronger visual separation (0 = outermost, 1 = innermost)
+  const DEPTH_ORDER: Record<PlateLayerType, number> = {
+    global: 0,
+    edge: 0.25,
+    region: 0.5,
+    zone: 0.75,
+    subnet: 1.0,
+  };
+  const depthFactor = DEPTH_ORDER[containerLayer];
+
   // Isometric face polygons
   const topFacePoints = `${cx},${topY} ${rightX},${midY} ${cx},${bottomY} ${leftX},${midY}`;
   const leftSidePoints = `${leftX},${midY} ${cx},${bottomY} ${cx},${bottomY + sideWallPx} ${leftX},${midY + sideWallPx}`;
@@ -145,7 +155,7 @@ export const ContainerBlockSvg = memo(function PlateSvg({
             isOccupied ? 'var(--anchor-marker-occupied-stroke)' : 'var(--anchor-marker-stroke)'
           }
           strokeWidth={0.5}
-          opacity={isOccupied ? 0.4 : 1}
+          opacity={isOccupied ? 0.25 : 0.6}
           data-anchor-state={isOccupied ? 'occupied' : 'empty'}
           data-anchor-cell={cellKey}
           pointerEvents="none"
@@ -171,25 +181,25 @@ export const ContainerBlockSvg = memo(function PlateSvg({
         strokeOpacity={visuals.strokeOpacity}
       />
 
-      {/* Fake inset — inner highlight ring */}
+      {/* Fake inset — inner highlight ring (subtle, depth-independent) */}
       <polygon
         points={topFacePoints}
         fill="none"
-        stroke="rgba(203,213,225,0.08)"
+        stroke={`rgba(203,213,225,${(0.04 + depthFactor * 0.06).toFixed(2)})`}
         strokeWidth={1}
         strokeLinejoin="round"
-        transform={`translate(0, 0.5)`}
+        transform={`translate(0, ${0.5 + depthFactor * 0.5})`}
         pointerEvents="none"
         data-layer="inset-highlight"
       />
-      {/* Fake inset — inner shadow ring */}
+      {/* Fake inset — inner shadow ring (stronger for inner layers = depth cue) */}
       <polygon
         points={topFacePoints}
         fill="none"
-        stroke="rgba(2,6,23,0.25)"
-        strokeWidth={1}
+        stroke={`rgba(2,6,23,${(0.15 + depthFactor * 0.2).toFixed(2)})`}
+        strokeWidth={1 + depthFactor * 0.5}
         strokeLinejoin="round"
-        transform={`translate(0, -0.5)`}
+        transform={`translate(0, ${-0.5 - depthFactor * 1.0})`}
         pointerEvents="none"
         data-layer="inset-shadow"
       />

--- a/apps/web/src/shared/components/ContainerBlockSurfaceGrid.tsx
+++ b/apps/web/src/shared/components/ContainerBlockSurfaceGrid.tsx
@@ -79,7 +79,7 @@ export const ContainerBlockSurfaceGrid = memo(function PlateSurfaceGrid({
             y1={line.y1}
             x2={line.x2}
             y2={line.y2}
-            stroke="rgba(255,255,255,0.3)"
+            stroke="rgba(255,255,255,0.12)"
             strokeWidth={0.5}
             fill="none"
           />


### PR DESCRIPTION
## Summary

Improves visual hierarchy differentiation for container blocks (VPC/VNet → Subnet) per the design spec:

- **Inverted stroke ladder**: Inner layers (subnet/zone) now have thicker, more opaque borders than outer layers (global/edge), making container boundaries clearer
- **Depth-dependent inset shadow**: Inner containers get progressively stronger shadow offset and opacity, creating a visual "floating" effect
- **Reduced grid prominence**: Surface grid opacity reduced from 30% → 12% (spec target: 10-15%)
- **De-cluttered visual signals**: Anchor marker opacity significantly reduced to avoid competing with grid and border strokes

## Changes

| File | Change |
|---|---|
| `ContainerBlockSvg.tsx` | Inverted `LAYER_VISUALS` stroke ladder (subnet 1.4/0.50 > global 0.6/0.18); added `depthFactor` for dynamic inset shadow; reduced marker opacity |
| `ContainerBlockSurfaceGrid.tsx` | Grid stroke opacity 0.3 → 0.12 |
| `index.css` | Reduced `--anchor-marker-stroke` CSS vars for both blueprint and workshop themes |
| `ContainerBlockSvg.test.tsx` | Updated 3 test expectations to match inverted stroke hierarchy |

## Design Spec Compliance

| Spec Requirement | Implementation |
|---|---|
| ✅ Z-axis depth cue (서브넷 부양) | Depth-dependent inset shadow offset (0.5→1.5px) and opacity (0.15→0.35) |
| ✅ Clear borders (1-2px strokes) | Subnet: 1.4px/50% opacity, Zone: 1.1px/40% opacity |
| ✅ Grid ≤15% opacity | Surface grid at 12% (was 30%) |
| ✅ Signal de-duplication | Anchor markers reduced to near-invisible, single strong hierarchy cue per layer |

Fixes #1616