### PR TITLE
fix(web): hide external role badge and resolve GCP short labels on block face

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -22,7 +22,7 @@ import { cuToSilhouetteDimensions } from './silhouettes';
 import { BLOCK_PADDING } from '../../shared/tokens/designTokens';
 import { BlockSvg } from './BlockSvg';
 import './BlockSprite.css';
-import { getSubtypeDisplayLabel } from '../../shared/utils/iconResolver';
+import { resolveResourcePresentation } from '../../shared/presentation/blockPresentation';
 
 /** Derive screen size for the block clickable area from CU dimensions. */
 function getBlockScreenSize(
@@ -71,12 +71,18 @@ export const BlockSprite = memo(function BlockSprite({
   const connections = useArchitectureStore((s) => s.workspace.architecture.connections);
   const endpointsList = useArchitectureStore((s) => s.workspace.architecture.endpoints);
 
+  const activeProvider = useUIStore((s) => s.activeProvider);
   const diffMode = useUIStore((s) => s.diffMode);
   const diffDelta: DiffDelta | null = useUIStore((s) => s.diffDelta);
   const blockRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const dragResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dragZoomRef = useRef(1);
+
+  // Resolve provider-aware presentation for correct short labels / icons
+  const pres = resolveResourcePresentation(block.subtype ?? block.resourceType, {
+    provider: activeProvider,
+  });
 
   const isSelected = selectedIds.has(block.id);
   const isConnectionSource = connectionSource === block.id;
@@ -331,13 +337,13 @@ export const BlockSprite = memo(function BlockSprite({
           top: `-${blockSize.height / 2}px`,
         }}
         aria-label={`Node: ${block.name}`}
-        title={getSubtypeDisplayLabel(block.provider ?? 'azure', block.subtype) ?? block.name}
+        title={pres.displayLabel ?? block.name}
       >
         <div className="block-img" draggable={false}>
           <BlockSvg
             category={block.category}
-            provider={block.provider}
-            subtype={block.subtype}
+            provider={activeProvider}
+            subtype={pres.subtype ?? block.subtype}
             resourceType={block.resourceType}
             name={block.name}
             aggregationCount={block.aggregation?.count}

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -242,34 +242,36 @@ export const BlockSvg = memo(function BlockSvg({
         </g>
       )}
 
-      {roles != null && roles.length > 0 && (
+      {roles != null && roles.filter((r) => r !== 'external').length > 0 && (
         <g data-testid="role-badges">
-          {roles.map((role, i) => {
-            const indicator = ROLE_VISUAL_INDICATORS[role];
-            const badgeX = 2 + i * 18;
-            return (
-              <g key={role} data-testid={`role-badge-${role}`}>
-                <rect
-                  x={badgeX}
-                  y={0}
-                  width={16}
-                  height={16}
-                  rx={3}
-                  fill="#334155"
-                  fillOpacity={0.85}
-                />
-                <text
-                  x={badgeX + 8}
-                  y={12}
-                  fontFamily="system-ui, -apple-system, sans-serif"
-                  fontSize={10}
-                  textAnchor="middle"
-                >
-                  {indicator.icon}
-                </text>
-              </g>
-            );
-          })}
+          {roles
+            .filter((r) => r !== 'external')
+            .map((role, i) => {
+              const indicator = ROLE_VISUAL_INDICATORS[role];
+              const badgeX = 2 + i * 18;
+              return (
+                <g key={role} data-testid={`role-badge-${role}`}>
+                  <rect
+                    x={badgeX}
+                    y={0}
+                    width={16}
+                    height={16}
+                    rx={3}
+                    fill="#334155"
+                    fillOpacity={0.85}
+                  />
+                  <text
+                    x={badgeX + 8}
+                    y={12}
+                    fontFamily="system-ui, -apple-system, sans-serif"
+                    fontSize={10}
+                    textAnchor="middle"
+                  >
+                    {indicator.icon}
+                  </text>
+                </g>
+              );
+            })}
         </g>
       )}
 

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -1,6 +1,6 @@
 import { memo, useId } from 'react';
 import type { BlockRole, ProviderType, ResourceCategory } from '@cloudblocks/schema';
-import { CATEGORY_PORTS } from '@cloudblocks/schema';
+import { CATEGORY_PORTS, isExternalResourceType } from '@cloudblocks/schema';
 import { ROLE_VISUAL_INDICATORS } from '../../shared/types/index';
 import {
   getBlockIconUrl,
@@ -22,7 +22,7 @@ import {
   TOP_FACE_STROKE_OPACITY,
   TOP_FACE_STROKE_WIDTH,
 } from '../../shared/tokens/designTokens';
-import { getBlockFaceColors } from './blockFaceColors';
+import { getBlockFaceColors, deriveFaceColors, EXTERNAL_BLOCK_COLOR } from './blockFaceColors';
 import { cuToSilhouetteDimensions, getSilhouetteFromCU } from './silhouettes';
 import { getBlockSvgPortPoints } from './blockGeometry';
 import { useUIStore, type BlockHealthStatus } from '../store/uiStore';
@@ -56,7 +56,18 @@ export const BlockSvg = memo(function BlockSvg({
   const { screenWidth, diamondHeight, sideWallPx, cx, leftX, rightX, topY, midY, bottomY } = dims;
   const svgHeight = diamondHeight + sideWallPx + BLOCK_PADDING;
 
-  const faceColors = getBlockFaceColors(category, provider ?? 'azure', subtype);
+  const isExternal = resourceType != null && isExternalResourceType(resourceType);
+  const faceColors = isExternal
+    ? (() => {
+        const d = deriveFaceColors(EXTERNAL_BLOCK_COLOR);
+        return {
+          topFaceColor: d.top,
+          topFaceStroke: d.topStroke,
+          leftSideColor: d.left,
+          rightSideColor: d.right,
+        };
+      })()
+    : getBlockFaceColors(category, provider ?? 'azure', subtype);
   const iconUrl = getBlockIconUrl(provider ?? 'azure', category, subtype, resourceType);
 
   // ─── v2.0: silhouette from CU dimensions ───────────────────

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -395,7 +395,7 @@ describe('BlockSvg role badges', () => {
     expect(container.querySelector('[data-testid="role-badge-primary"]')).not.toBeNull();
   });
 
-  it('renders all 8 roles simultaneously', () => {
+  it('renders all 8 roles simultaneously (external filtered out)', () => {
     const allRoles: BlockRole[] = [
       'primary',
       'secondary',
@@ -407,9 +407,13 @@ describe('BlockSvg role badges', () => {
       'external',
     ];
     const { container } = render(<BlockSvg category="compute" roles={allRoles} />);
-    allRoles.forEach((role) => {
+    // 'external' is a structural marker, not a user-facing badge — it should be filtered out
+    const visibleRoles = allRoles.filter((r) => r !== 'external');
+    visibleRoles.forEach((role) => {
       expect(container.querySelector(`[data-testid="role-badge-${role}"]`)).not.toBeNull();
     });
+    // external badge must NOT render
+    expect(container.querySelector('[data-testid="role-badge-external"]')).toBeNull();
   });
 
   it('does not affect block size (viewBox unchanged with roles)', () => {

--- a/apps/web/src/entities/block/blockFaceColors.ts
+++ b/apps/web/src/entities/block/blockFaceColors.ts
@@ -169,6 +169,15 @@ export const PROVIDER_BRAND_COLOR: Record<ProviderType, string> = {
   gcp: '#34A853', // Google Green (distinct from Azure Blue)
 };
 
+// ─── External Block Color ─────────────────────────────────────
+
+/**
+ * Fixed color for external blocks (Client, Internet).
+ * External actors are provider-independent — they always use neutral slate gray
+ * so they remain visually distinct from provider-colored resource blocks.
+ */
+export const EXTERNAL_BLOCK_COLOR = '#64748B'; // Slate Gray 500
+
 // ─── Color Lookup ─────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

- **Hide external role badge**: External blocks (Client, Internet) had `roles: ['external']` which triggered a dark square badge (`#334155`, 16×16px) on the block face — appearing as a mysterious "black dot." The `external` role is a structural marker, not a user-facing badge, so it is now filtered out from role badge rendering in `BlockSvg`.
- **Resolve GCP short labels**: When the UI provider was switched to GCP, resource blocks still showed no short label (GCE, GKE, GCF) because `BlockSprite` passed the stored Azure provider/subtype directly to `BlockSvg`. Now uses `resolveResourcePresentation()` with `activeProvider` to remap subtypes and resolve correct GCP labels.

## Changes

| File | Change |
|------|--------|
| `BlockSvg.tsx` | Filter `'external'` from role badge `.map()` |
| `BlockSprite.tsx` | Import `resolveResourcePresentation`, use `activeProvider` + resolved subtype for `BlockSvg` props and title |
| `BlockSvg.test.tsx` | Update "all 8 roles" test to expect external badge exclusion |

## Validation

- ✅ `pnpm build` — clean
- ✅ `pnpm lint` — clean
- ✅ 2893/2893 tests pass