### PR TITLE
fix(web): address Copilot review on PR #1642

### DIFF
--- a/apps/web/e2e/screenshots/capture-all.spec.ts
+++ b/apps/web/e2e/screenshots/capture-all.spec.ts
@@ -17,12 +17,24 @@ const SCENARIOS = [
     firstStep: 'Create the Network',
   },
   {
+    name: 'Simple Compute Setup',
+    firstStep: 'Create the Network',
+  },
+  {
+    name: 'Data Storage Backend',
+    firstStep: 'Create the Network',
+  },
+  {
     name: 'Serverless HTTP API',
     firstStep: 'Set Up Network Zones',
   },
   {
     name: 'Event-Driven Data Pipeline',
     firstStep: 'Add Event Sources',
+  },
+  {
+    name: 'Full-Stack Web App with Event Processing',
+    firstStep: 'Build the Network Foundation',
   },
 ] as const;
 

--- a/apps/web/src/features/learning/scenarios/builtin.ts
+++ b/apps/web/src/features/learning/scenarios/builtin.ts
@@ -1,5 +1,9 @@
 import type { ArchitectureSnapshot, Scenario } from '../../../shared/types/learning';
-import type { ContainerCapableResourceType, ContainerLayer } from '@cloudblocks/schema';
+import {
+  type ContainerCapableResourceType,
+  type ContainerLayer,
+  endpointId,
+} from '@cloudblocks/schema';
 import { registerScenario } from './registry';
 
 const CONTAINER_RESOURCE_TYPE: Record<ContainerLayer, ContainerCapableResourceType> = {
@@ -925,6 +929,15 @@ const dataStorageInitialArchitecture: ArchitectureSnapshot = {
   name: 'Data Storage Learning Scenario',
   version: '1',
   endpoints: [],
+  nodes: [],
+  connections: [],
+  externalActors: [],
+};
+
+const dataStorageCheckpointNetworkOnly: ArchitectureSnapshot = {
+  name: 'Data Storage Learning Scenario',
+  version: '1',
+  endpoints: [],
   nodes: [
     {
       id: 'container-scndata-vnet',
@@ -1209,7 +1222,7 @@ const dataStorageScenario: Scenario = {
         'Create exactly two subnets inside the VNet.',
       ],
       validationRules: [{ type: 'min-container-count', containerLayer: 'subnet', count: 2 }],
-      checkpoint: dataStorageInitialArchitecture,
+      checkpoint: dataStorageCheckpointNetworkOnly,
     },
     {
       id: 'step-data-storage-deploy-app-tier',
@@ -1265,25 +1278,9 @@ const fullStackInitialArchitecture: ArchitectureSnapshot = {
   name: 'Full-Stack Event Processing Learning Scenario',
   version: '1',
   endpoints: [],
-  nodes: [
-    {
-      id: 'container-scnfs-vnet',
-      name: 'VNet',
-      kind: 'container',
-      layer: 'region',
-      resourceType: CONTAINER_RESOURCE_TYPE.region,
-      category: 'network',
-      provider: 'azure',
-      parentId: null,
-      position: { x: 0, y: 0, z: 0 },
-      frame: { width: 12, height: 0.3, depth: 10 },
-      metadata: {},
-    },
-  ],
+  nodes: [],
   connections: [],
-  externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
-  ],
+  externalActors: [],
 };
 
 const fullStackCheckpointFoundation: ArchitectureSnapshot = {
@@ -1437,26 +1434,26 @@ const fullStackCheckpointWebData: ArchitectureSnapshot = {
   connections: [
     {
       id: 'conn-scnfs-internet-gw',
-      from: 'ext-internet:output:data',
-      to: 'block-scnfs-gw:input:data',
+      from: endpointId('ext-internet', 'output', 'data'),
+      to: endpointId('block-scnfs-gw', 'input', 'data'),
       metadata: {},
     },
     {
       id: 'conn-scnfs-gw-vm',
-      from: 'block-scnfs-gw:output:data',
-      to: 'block-scnfs-vm:input:data',
+      from: endpointId('block-scnfs-gw', 'output', 'data'),
+      to: endpointId('block-scnfs-vm', 'input', 'data'),
       metadata: {},
     },
     {
       id: 'conn-scnfs-vm-db',
-      from: 'block-scnfs-vm:output:data',
-      to: 'block-scnfs-db:input:data',
+      from: endpointId('block-scnfs-vm', 'output', 'data'),
+      to: endpointId('block-scnfs-db', 'input', 'data'),
       metadata: {},
     },
     {
       id: 'conn-scnfs-vm-storage',
-      from: 'block-scnfs-vm:output:data',
-      to: 'block-scnfs-storage:input:data',
+      from: endpointId('block-scnfs-vm', 'output', 'data'),
+      to: endpointId('block-scnfs-storage', 'input', 'data'),
       metadata: {},
     },
   ],
@@ -1643,26 +1640,26 @@ const fullStackCheckpointWithServerless: ArchitectureSnapshot = {
   connections: [
     {
       id: 'conn-scnfs-internet-gw',
-      from: 'ext-internet:output:data',
-      to: 'block-scnfs-gw:input:data',
+      from: endpointId('ext-internet', 'output', 'data'),
+      to: endpointId('block-scnfs-gw', 'input', 'data'),
       metadata: {},
     },
     {
       id: 'conn-scnfs-gw-vm',
-      from: 'block-scnfs-gw:output:data',
-      to: 'block-scnfs-vm:input:data',
+      from: endpointId('block-scnfs-gw', 'output', 'data'),
+      to: endpointId('block-scnfs-vm', 'input', 'data'),
       metadata: {},
     },
     {
       id: 'conn-scnfs-vm-db',
-      from: 'block-scnfs-vm:output:data',
-      to: 'block-scnfs-db:input:data',
+      from: endpointId('block-scnfs-vm', 'output', 'data'),
+      to: endpointId('block-scnfs-db', 'input', 'data'),
       metadata: {},
     },
     {
       id: 'conn-scnfs-vm-storage',
-      from: 'block-scnfs-vm:output:data',
-      to: 'block-scnfs-storage:input:data',
+      from: endpointId('block-scnfs-vm', 'output', 'data'),
+      to: endpointId('block-scnfs-storage', 'input', 'data'),
       metadata: {},
     },
   ],


### PR DESCRIPTION
## Summary

Address 5 of 6 Copilot review comments from PR #1642. Comment #5 (timer-trigger `operations` category) is intentionally skipped — that was a deliberate design decision.

## Changes

### Empty Initial Architectures (Comments #1, #2)
- `dataStorageInitialArchitecture` → empty canvas (`nodes: [], connections: [], externalActors: []`)
- `fullStackInitialArchitecture` → empty canvas
- Created `dataStorageCheckpointNetworkOnly` for step 2 reset state (VNet + Internet)
- Matches existing pattern: all 6 scenarios now start from blank canvas

### endpointId() Format (Comments #3, #4)
- Converted 8 connection `from`/`to` fields from `'block-id:output:data'` string literals to `endpointId('block-id', 'output', 'data')` calls
- Matches template convention (`builtin.ts` templates all use `endpointId()`)
- Added `endpointId` import from `@cloudblocks/schema`

### Screenshot Coverage (Comment #6)
- Added 3 missing scenarios to `SCENARIOS` array in `capture-all.spec.ts`
- Now captures all 6 scenarios (was 3)

### Intentionally Skipped (Comment #5)
- Timer-trigger `category: 'operations'` is correct — changed from `messaging` intentionally in prior work

## Verification

- ✅ 2893/2893 unit tests pass
- ✅ Lint clean
- ✅ Build (tsc + vite) succeeds

Part of #1619