### PR TITLE
fix(web): restore external block positions to render outside VNet

### DIFF
--- a/apps/web/src/features/learning/scenarios/builtin.ts
+++ b/apps/web/src/features/learning/scenarios/builtin.ts
@@ -181,7 +181,7 @@ const threeTierCheckpointWithBlocks: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
   ],
 };
 
@@ -299,7 +299,7 @@ const serverlessApiInitialArchitecture: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
   ],
 };
 
@@ -350,7 +350,7 @@ const serverlessApiCheckpointWithSubnets: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
   ],
 };
 

--- a/apps/web/src/features/templates/builtin.ts
+++ b/apps/web/src/features/templates/builtin.ts
@@ -136,7 +136,7 @@ const threeTierTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 4, y: 0, z: 10 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -149,7 +149,7 @@ const threeTierTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 7, y: 0, z: 10 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -186,8 +186,8 @@ const threeTierTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -268,7 +268,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 4, y: 0, z: 10 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -281,7 +281,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 7, y: 0, z: 10 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -306,8 +306,8 @@ const simpleComputeTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -427,7 +427,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 4, y: 0, z: 10 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -440,7 +440,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 7, y: 0, z: 10 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -477,8 +477,8 @@ const dataStorageTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -602,7 +602,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 4, y: 0, z: 10 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -615,7 +615,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 7, y: 0, z: 10 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -652,8 +652,8 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -788,7 +788,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 4, y: 0, z: 10 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -801,7 +801,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 7, y: 0, z: 10 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -850,8 +850,8 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };
@@ -1068,7 +1068,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 4, y: 0, z: 10 },
+        position: { x: -6, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -1081,7 +1081,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 7, y: 0, z: 10 },
+        position: { x: -3, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -1171,8 +1171,8 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
     ],
   },
 };


### PR DESCRIPTION
## Summary

- Restores Client/Internet external block positions from `{x:4, y:0, z:10}` / `{x:7, y:0, z:10}` back to `{x:-6, y:0, z:-3}` / `{x:-3, y:0, z:-3}` across all 6 templates (24 values) and 3 learning scenario checkpoints
- PR #1625 inadvertently changed these coordinates, causing external blocks to render visually inside the VNet bounding box instead of outside/above it

## Verification

- Build passes (`pnpm build`)
- Lint passes (`pnpm lint`)
- All 2935 tests pass (139 test files)
- Playwright visual verification confirms external blocks now render in upper-left canvas area (y=44-85) clearly separated from VNet resources (y=151+)

## Isometric Projection Context

| Block | Wrong coords | Screen position | Correct coords | Screen position |
|-------|-------------|----------------|----------------|----------------|
| Client | `{x:4, y:0, z:10}` | `(-192, 224)` inside VNet | `{x:-6, y:0, z:-3}` | `(-96, -144)` above VNet |
| Internet | `{x:7, y:0, z:10}` | `(-96, 272)` inside VNet | `{x:-3, y:0, z:-3}` | `(0, -96)` above VNet |