### PR TITLE
fix(web): place template external actors outside network containers

### DIFF
--- a/apps/web/src/features/learning/scenarios/builtin.ts
+++ b/apps/web/src/features/learning/scenarios/builtin.ts
@@ -181,7 +181,7 @@ const threeTierCheckpointWithBlocks: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -299,7 +299,7 @@ const serverlessApiInitialArchitecture: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -350,7 +350,7 @@ const serverlessApiCheckpointWithSubnets: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -865,7 +865,7 @@ const simpleComputeCheckpointWithBlocks: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -966,7 +966,7 @@ const dataStorageCheckpointNetworkOnly: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -1017,7 +1017,7 @@ const dataStorageCheckpointWithSubnets: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -1094,7 +1094,7 @@ const dataStorageCheckpointAppTier: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -1197,7 +1197,7 @@ const dataStorageCheckpointFull: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -1341,7 +1341,7 @@ const fullStackCheckpointFoundation: ArchitectureSnapshot = {
   ],
   connections: [],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -1469,7 +1469,7 @@ const fullStackCheckpointWebData: ArchitectureSnapshot = {
     },
   ],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 
@@ -1675,7 +1675,7 @@ const fullStackCheckpointWithServerless: ArchitectureSnapshot = {
     },
   ],
   externalActors: [
-    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+    { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
   ],
 };
 

--- a/apps/web/src/features/templates/builtin.ts
+++ b/apps/web/src/features/templates/builtin.ts
@@ -136,7 +136,7 @@ const threeTierTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: -3 },
+        position: { x: -12, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -149,7 +149,7 @@ const threeTierTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: -3 },
+        position: { x: -9, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -186,8 +186,8 @@ const threeTierTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -12, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
     ],
   },
 };
@@ -268,7 +268,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: -3 },
+        position: { x: -12, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -281,7 +281,7 @@ const simpleComputeTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: -3 },
+        position: { x: -9, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -306,8 +306,8 @@ const simpleComputeTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -12, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
     ],
   },
 };
@@ -427,7 +427,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: -3 },
+        position: { x: -12, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -440,7 +440,7 @@ const dataStorageTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: -3 },
+        position: { x: -9, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -477,8 +477,8 @@ const dataStorageTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -12, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
     ],
   },
 };
@@ -602,7 +602,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: -3 },
+        position: { x: -12, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -615,7 +615,7 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: -3 },
+        position: { x: -9, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -652,8 +652,8 @@ const serverlessHttpApiTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -12, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
     ],
   },
 };
@@ -788,7 +788,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: -3 },
+        position: { x: -12, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -801,7 +801,7 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: -3 },
+        position: { x: -9, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -850,8 +850,8 @@ const eventDrivenPipelineTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -12, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
     ],
   },
 };
@@ -1068,7 +1068,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -6, y: 0, z: -3 },
+        position: { x: -12, y: 0, z: -3 },
         metadata: {},
       },
       {
@@ -1081,7 +1081,7 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: -3, y: 0, z: -3 },
+        position: { x: -9, y: 0, z: -3 },
         metadata: {},
       },
     ],
@@ -1171,8 +1171,8 @@ const fullStackServerlessTemplate: ArchitectureTemplate = {
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -6, y: 0, z: -3 } },
-      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -3, y: 0, z: -3 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: -12, y: 0, z: -3 } },
+      { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: -9, y: 0, z: -3 } },
     ],
   },
 };


### PR DESCRIPTION
Fixes #1645

## Summary

- Move template and scenario external actor positions outside VNet/VPC/Subnet containers
- Keep `parentId: null` for external blocks so they are not parented to any network container
- Validated with template and learning scenario tests

## Changed Files

- `apps/web/src/features/templates/builtin.ts` — adjust external actor coordinates in all cloud provider templates
- `apps/web/src/features/learning/scenarios/builtin.ts` — adjust external actor coordinates in learning scenarios