### PR TITLE
fix(api): propagate AI suggestion errors instead of masking them

### DIFF
--- a/apps/api/app/api/routes/ai.py
+++ b/apps/api/app/api/routes/ai.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -102,7 +102,10 @@ async def suggest_improvements(
         timeout=settings.llm_request_timeout,
     )
     engine = SuggestionEngine(client)
-    return await engine.analyze(request.architecture, request.provider)
+    try:
+        return await engine.analyze(request.architecture, request.provider)
+    except LLMError as exc:
+        raise GenerationError(f"Architecture analysis failed: {exc}") from exc
 
 
 SUBTYPE_TO_TF_RESOURCE: dict[str, str] = {
@@ -163,10 +166,11 @@ def _architecture_to_tf_json(architecture: dict[str, object]) -> dict[str, objec
     resources: dict[str, dict[str, dict[str, object]]] = {}
     _, blocks = extract_containers_and_resources(architecture)
 
-    for block in blocks:
+    for raw_block in blocks:
+        block = cast(dict[str, object], raw_block)
         subtype = block.get("subtype")
-        name = block.get("name", "unnamed")
-        block_id = block.get("id", "unknown")
+        name_value: object = block.get("name", "unnamed")
+        block_id_value: object = block.get("id", "unknown")
 
         if not isinstance(subtype, str):
             continue
@@ -175,10 +179,12 @@ def _architecture_to_tf_json(architecture: dict[str, object]) -> dict[str, objec
         if tf_type is None:
             continue
 
-        safe_name = str(block_id).replace("-", "_")
+        name = name_value if isinstance(name_value, str) else ""
+        block_id = block_id_value if isinstance(block_id_value, str) else str(block_id_value)
+        safe_name = block_id.replace("-", "_")
         if tf_type not in resources:
             resources[tf_type] = {}
-        resources[tf_type][safe_name] = {"tags": {"Name": name if isinstance(name, str) else ""}}
+        resources[tf_type][safe_name] = {"tags": {"Name": name}}
 
     return {"resource": resources}
 
@@ -195,7 +201,7 @@ async def estimate_cost(
     tmp_dir = tempfile.mkdtemp(prefix="cloudblocks_cost_")
     tf_path = Path(tmp_dir) / "main.tf.json"
     try:
-        tf_path.write_text(json.dumps(tf_json, indent=2))
+        _ = tf_path.write_text(json.dumps(tf_json, indent=2))
         client = InfracostClient(api_key=settings.infracost_api_key)
         return await client.estimate(tmp_dir)
     except InfracostError as exc:

--- a/apps/api/app/domain/models/ai_entities.py
+++ b/apps/api/app/domain/models/ai_entities.py
@@ -29,8 +29,10 @@ class AISuggestion(BaseModel):
 
 
 class AISuggestionsResponse(BaseModel):
+    status: str = "success"
     suggestions: list[AISuggestion] = Field(default_factory=list)
     score: dict[str, int | float] = Field(default_factory=dict)
+    error_message: str | None = None
 
 
 class CostResource(BaseModel):

--- a/apps/api/app/engines/suggestions.py
+++ b/apps/api/app/engines/suggestions.py
@@ -99,18 +99,14 @@ class SuggestionEngine:
         architecture_json = json.dumps(architecture, separators=(",", ":"))
         user_prompt = f"Analyze this {provider} architecture:\n{architecture_json}"
 
-        try:
-            response = await self._client.generate(
-                SUGGESTION_SYSTEM_PROMPT,
-                user_prompt,
-                response_schema=RESPONSE_SCHEMA,
-            )
-        except LLMError:
-            logger.exception("Failed to generate architecture suggestions")
-            return AISuggestionsResponse()
+        response = await self._client.generate(
+            SUGGESTION_SYSTEM_PROMPT,
+            user_prompt,
+            response_schema=RESPONSE_SCHEMA,
+        )
 
         try:
             return AISuggestionsResponse.model_validate(response)
-        except Exception:
+        except Exception as exc:
             logger.warning("Malformed suggestion response payload", exc_info=True)
-            return AISuggestionsResponse()
+            raise LLMError(f"Malformed suggestion response: {exc}") from exc

--- a/apps/api/app/tests/integration/test_ai_e2e.py
+++ b/apps/api/app/tests/integration/test_ai_e2e.py
@@ -624,14 +624,14 @@ async def test_e2e_generate_llm_failure_propagates(
 
 
 @pytest.mark.asyncio
-async def test_e2e_suggest_llm_failure_returns_empty(
+async def test_e2e_suggest_llm_failure_propagates(
     client: AsyncClient,
     auth_cookies: dict[str, str],
     test_user: User,
     db: Database,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """LLM errors during suggest return empty suggestions (graceful degradation)."""
+    """LLM errors during suggest propagate as 500 GENERATION_FAILED."""
     await _store_api_key(db, test_user.id)
 
     async def mock_generate_fail(
@@ -653,10 +653,11 @@ async def test_e2e_suggest_llm_failure_returns_empty(
         json={"architecture": VALID_THREE_TIER, "provider": "aws"},
     )
 
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["suggestions"] == []
-    assert payload["score"] == {}
+    assert response.status_code == 500
+    payload = cast(dict[str, object], response.json())
+    error_payload = cast(dict[str, object], payload["error"])
+    assert error_payload["code"] == "GENERATION_FAILED"
+    assert "Architecture analysis failed" in str(error_payload["message"])
 
 
 @pytest.mark.asyncio

--- a/apps/api/app/tests/integration/test_ai_routes.py
+++ b/apps/api/app/tests/integration/test_ai_routes.py
@@ -15,7 +15,7 @@ from app.domain.models.entities import User
 from app.infrastructure.cost.infracost_client import InfracostClient
 from app.infrastructure.db.connection import Database
 from app.infrastructure.db.repositories import SQLiteAIApiKeyRepository
-from app.infrastructure.llm.client import OpenAIClient
+from app.infrastructure.llm.client import LLMError, OpenAIClient
 from app.infrastructure.llm.key_manager import KeyManager
 
 
@@ -150,6 +150,7 @@ async def test_generate_returns_validation_warnings(
     ) -> dict[str, object]:
         _ = self
         _ = system_prompt
+        _ = user_prompt
         _ = response_schema
         return invalid_architecture
 
@@ -163,7 +164,7 @@ async def test_generate_returns_validation_warnings(
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
-    warnings = payload["warnings"]
+    warnings = cast(list[object], payload["warnings"])
     assert isinstance(warnings, list)
     assert len(warnings) >= 2
 
@@ -212,10 +213,48 @@ async def test_suggest_success(
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
-    suggestions = payload["suggestions"]
+    suggestions = cast(list[object], payload["suggestions"])
     assert isinstance(suggestions, list)
     assert len(suggestions) == 1
+    assert payload["status"] == "success"
     assert payload["score"] == {"security": 60, "reliability": 80, "best_practice": 70}
+
+
+@pytest.mark.asyncio
+async def test_suggest_llm_error(
+    client: AsyncClient,
+    auth_cookies: dict[str, str],
+    test_user: User,
+    db: Database,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _store_openai_key(db, test_user.id)
+
+    async def mock_generate(
+        self: OpenAIClient,
+        system_prompt: str,
+        user_prompt: str,
+        response_schema: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        _ = self
+        _ = system_prompt
+        _ = user_prompt
+        _ = response_schema
+        raise LLMError("model overloaded")
+
+    monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
+
+    response = await client.post(
+        "/api/v1/ai/suggest",
+        cookies=auth_cookies,
+        json={"architecture": {"blocks": []}, "provider": "aws"},
+    )
+
+    assert response.status_code == 500
+    payload = cast(dict[str, object], response.json())
+    error_payload = cast(dict[str, object], payload["error"])
+    assert error_payload["code"] == "GENERATION_FAILED"
+    assert "Architecture analysis failed" in str(error_payload["message"])
 
 
 @pytest.mark.asyncio
@@ -312,7 +351,7 @@ async def test_cost_success(
     payload = cast(dict[str, object], json.loads(response.text))
     assert payload["monthly_cost"] == 42.50
     assert payload["currency"] == "USD"
-    resources = payload["resources"]
+    resources = cast(list[object], payload["resources"])
     assert isinstance(resources, list)
     assert len(resources) == 2
 
@@ -394,6 +433,7 @@ async def test_cost_infracost_error(
         terraform_dir: str,
     ) -> CostEstimate:
         _ = self
+        _ = terraform_dir
         raise InfracostError("Infracost binary not found on PATH")
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)

--- a/apps/api/app/tests/unit/test_suggestions_engine.py
+++ b/apps/api/app/tests/unit/test_suggestions_engine.py
@@ -73,10 +73,8 @@ async def test_analyze_malformed_llm_response() -> None:
     }
     engine = SuggestionEngine(llm_client)
 
-    result = await engine.analyze(architecture={"plates": []})
-
-    assert result.suggestions == []
-    assert result.score == {}
+    with pytest.raises(LLMError, match="Malformed suggestion response"):
+        _ = await engine.analyze(architecture={"plates": []})
 
 
 @pytest.mark.asyncio
@@ -85,10 +83,8 @@ async def test_analyze_llm_error() -> None:
     generate.side_effect = LLMError("provider unavailable")
     engine = SuggestionEngine(llm_client)
 
-    result = await engine.analyze(architecture={"blocks": []})
-
-    assert result.suggestions == []
-    assert result.score == {}
+    with pytest.raises(LLMError, match="provider unavailable"):
+        _ = await engine.analyze(architecture={"blocks": []})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Stop masking AI errors**: `SuggestionEngine.analyze()` silently caught `LLMError` and returned empty defaults, hiding failures from callers. Now `LLMError` propagates to the route layer.
- **Route-level error handling**: `/suggest` route catches `LLMError` and converts it to `GenerationError` (HTTP 500, `GENERATION_FAILED`), matching the existing `/generate` and `/cost` patterns.
- **Malformed response handling**: Instead of silently returning empty results on malformed LLM output, raises `LLMError` with diagnostic detail.

## Changes

| File | Change |
|------|--------|
| `ai_entities.py` | Add `status` and `error_message` fields to `AISuggestionsResponse` |
| `suggestions.py` | Remove silent `LLMError` catch; raise `LLMError` on malformed responses |
| `ai.py` | Add `try/except LLMError → GenerationError` in `/suggest`; fix type narrowing in `_architecture_to_tf_json` |
| `test_suggestions_engine.py` | Update error tests to use `pytest.raises(LLMError)` |
| `test_ai_routes.py` | Add `test_suggest_llm_error` integration test; fix type narrowing with `cast` |

## Testing

- Unit tests verify `LLMError` propagation for both provider errors and malformed responses
- Integration test verifies HTTP 500 + `GENERATION_FAILED` error code on LLM failure
- All existing tests remain passing

Fixes #1691
Part of #1685