### PR TITLE
refactor(api): move route orchestration into application use cases

### DIFF
--- a/apps/api/app/api/routes/ai.py
+++ b/apps/api/app/api/routes/ai.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
-import json
-import tempfile
-from pathlib import Path
-from typing import Annotated, cast
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from app.core.config import settings
-from app.core.dependencies import get_ai_api_key_repo, get_current_user, get_key_manager
-from app.core.errors import GenerationError, ValidationError
+from app.application.use_cases.ai_use_cases import (
+    EstimateArchitectureCostUseCase,
+    GenerateArchitectureUseCase,
+    SuggestArchitectureImprovementsUseCase,
+)
+from app.core.dependencies import (
+    get_current_user,
+    get_estimate_architecture_cost_use_case,
+    get_generate_architecture_use_case,
+    get_suggest_architecture_improvements_use_case,
+)
 from app.domain.models.ai_entities import (
     AIGenerationRequest,
     AIGenerationResponse,
@@ -18,14 +23,6 @@ from app.domain.models.ai_entities import (
     CostEstimate,
 )
 from app.domain.models.entities import User
-from app.domain.models.repositories import AIApiKeyRepository
-from app.engines.architecture_normalizer import extract_containers_and_resources
-from app.engines.prompts.architecture_prompt import build_architecture_prompt
-from app.engines.suggestions import SuggestionEngine
-from app.engines.validation import ArchitectureValidator
-from app.infrastructure.cost.infracost_client import InfracostClient, InfracostError
-from app.infrastructure.llm.client import LLMError, OpenAIClient
-from app.infrastructure.llm.key_manager import KeyManager
 
 router = APIRouter(prefix="/ai", tags=["ai"])
 
@@ -40,44 +37,17 @@ class AICostRequest(BaseModel):
     provider: str = "aws"
 
 
-def build_system_prompt(provider: str, complexity: str) -> str:
-    prompt = build_architecture_prompt(provider)
-    return f"{prompt}\n\nComplexity target: {complexity}."
-
-
 @router.post("/generate")
 async def generate_architecture(
     request: AIGenerationRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
-    key_manager: Annotated[KeyManager, Depends(get_key_manager)],
+    use_case: Annotated[GenerateArchitectureUseCase, Depends(get_generate_architecture_use_case)],
 ) -> AIGenerationResponse:
-    api_keys = await ai_api_key_repo.list_by_user(current_user.id)
-    openai_key = next((item for item in api_keys if item.provider.lower() == "openai"), None)
-    if openai_key is None:
-        raise ValidationError("No OpenAI API key stored. Please add one via /api/v1/ai/keys")
-
-    decrypted_key = key_manager.decrypt(openai_key.encrypted_key)
-    client = OpenAIClient(
-        api_key=decrypted_key,
-        base_url=settings.llm_provider_url,
-        model=settings.llm_model,
-        max_tokens=settings.llm_max_tokens,
-        timeout=settings.llm_request_timeout,
-    )
-    system_prompt = build_system_prompt(request.provider, request.complexity)
-
-    try:
-        architecture = await client.generate(
-            system_prompt=system_prompt,
-            user_prompt=request.prompt,
-        )
-    except LLMError as exc:
-        raise GenerationError(f"AI generation failed: {exc}") from exc
-
-    return AIGenerationResponse(
-        architecture=architecture,
-        warnings=ArchitectureValidator().validate(architecture),
+    return await use_case.execute(
+        user_id=current_user.id,
+        prompt=request.prompt,
+        provider=request.provider,
+        complexity=request.complexity,
     )
 
 
@@ -85,128 +55,26 @@ async def generate_architecture(
 async def suggest_improvements(
     request: AISuggestRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
-    key_manager: Annotated[KeyManager, Depends(get_key_manager)],
+    use_case: Annotated[
+        SuggestArchitectureImprovementsUseCase,
+        Depends(get_suggest_architecture_improvements_use_case),
+    ],
 ) -> AISuggestionsResponse:
-    api_keys = await ai_api_key_repo.list_by_user(current_user.id)
-    openai_key = next((item for item in api_keys if item.provider.lower() == "openai"), None)
-    if openai_key is None:
-        raise ValidationError("No OpenAI API key stored. Please add one via /api/v1/ai/keys")
-
-    decrypted_key = key_manager.decrypt(openai_key.encrypted_key)
-    client = OpenAIClient(
-        api_key=decrypted_key,
-        base_url=settings.llm_provider_url,
-        model=settings.llm_model,
-        max_tokens=settings.llm_max_tokens,
-        timeout=settings.llm_request_timeout,
+    return await use_case.execute(
+        user_id=current_user.id,
+        architecture=request.architecture,
+        provider=request.provider,
     )
-    engine = SuggestionEngine(client)
-    try:
-        return await engine.analyze(request.architecture, request.provider)
-    except LLMError as exc:
-        raise GenerationError(f"Architecture analysis failed: {exc}") from exc
-
-
-SUBTYPE_TO_TF_RESOURCE: dict[str, str] = {
-    "ec2": "aws_instance",
-    "ecs": "aws_ecs_service",
-    "lambda": "aws_lambda_function",
-    "rds-postgres": "aws_db_instance",
-    "dynamodb": "aws_dynamodb_table",
-    "elasticache": "aws_elasticache_cluster",
-    "s3": "aws_s3_bucket",
-    "alb": "aws_lb",
-    "api-gateway": "aws_apigatewayv2_api",
-    "nat-gateway": "aws_nat_gateway",
-    "sqs": "aws_sqs_queue",
-    "sns": "aws_sns_topic",
-    "eventbridge": "aws_cloudwatch_event_bus",
-    "kinesis": "aws_kinesis_stream",
-    "redshift": "aws_redshift_cluster",
-    "iam": "aws_iam_role",
-    "cloudwatch": "aws_cloudwatch_log_group",
-    "vm": "azurerm_virtual_machine",
-    "container-instances": "azurerm_container_group",
-    "aks": "azurerm_kubernetes_cluster",
-    "sql-database": "azurerm_mssql_database",
-    "cosmos-db": "azurerm_cosmosdb_account",
-    "cache-for-redis": "azurerm_redis_cache",
-    "blob-storage": "azurerm_storage_account",
-    "application-gateway": "azurerm_application_gateway",
-    "api-management": "azurerm_api_management",
-    "firewall": "azurerm_firewall",
-    "functions": "azurerm_function_app",
-    "service-bus": "azurerm_servicebus_queue",
-    "event-grid": "azurerm_eventgrid_topic",
-    "event-hubs": "azurerm_eventhub",
-    "synapse": "azurerm_synapse_workspace",
-    "entra-id": "azurerm_user_assigned_identity",
-    "monitor": "azurerm_monitor_action_group",
-    "compute-engine": "google_compute_instance",
-    "cloud-run": "google_cloud_run_service",
-    "gke": "google_container_cluster",
-    "cloud-sql-postgres": "google_sql_database_instance",
-    "cloud-spanner": "google_spanner_instance",
-    "memorystore": "google_redis_instance",
-    "cloud-storage": "google_storage_bucket",
-    "cloud-load-balancing": "google_compute_url_map",
-    "cloud-armor": "google_compute_security_policy",
-    "cloud-functions": "google_cloudfunctions_function",
-    "pub-sub": "google_pubsub_topic",
-    "eventarc": "google_eventarc_trigger",
-    "bigquery": "google_bigquery_dataset",
-    "dataflow": "google_dataflow_job",
-    "cloud-iam": "google_project_iam_member",
-    "cloud-monitoring": "google_monitoring_alert_policy",
-}
-
-
-def _architecture_to_tf_json(architecture: dict[str, object]) -> dict[str, object]:
-    resources: dict[str, dict[str, dict[str, object]]] = {}
-    _, blocks = extract_containers_and_resources(architecture)
-
-    for raw_block in blocks:
-        block = cast(dict[str, object], raw_block)
-        subtype = block.get("subtype")
-        name_value: object = block.get("name", "unnamed")
-        block_id_value: object = block.get("id", "unknown")
-
-        if not isinstance(subtype, str):
-            continue
-
-        tf_type = SUBTYPE_TO_TF_RESOURCE.get(subtype)
-        if tf_type is None:
-            continue
-
-        name = name_value if isinstance(name_value, str) else ""
-        block_id = block_id_value if isinstance(block_id_value, str) else str(block_id_value)
-        safe_name = block_id.replace("-", "_")
-        if tf_type not in resources:
-            resources[tf_type] = {}
-        resources[tf_type][safe_name] = {"tags": {"Name": name}}
-
-    return {"resource": resources}
 
 
 @router.post("/cost")
 async def estimate_cost(
     request: AICostRequest,
     current_user: Annotated[User, Depends(get_current_user)],
+    use_case: Annotated[
+        EstimateArchitectureCostUseCase,
+        Depends(get_estimate_architecture_cost_use_case),
+    ],
 ) -> CostEstimate:
     _ = current_user
-
-    tf_json = _architecture_to_tf_json(request.architecture)
-
-    tmp_dir = tempfile.mkdtemp(prefix="cloudblocks_cost_")
-    tf_path = Path(tmp_dir) / "main.tf.json"
-    try:
-        _ = tf_path.write_text(json.dumps(tf_json, indent=2))
-        client = InfracostClient(api_key=settings.infracost_api_key)
-        return await client.estimate(tmp_dir)
-    except InfracostError as exc:
-        raise GenerationError(f"Cost estimation failed: {exc}") from exc
-    finally:
-        import shutil
-
-        shutil.rmtree(tmp_dir, ignore_errors=True)
+    return await use_case.execute(request.architecture)

--- a/apps/api/app/api/routes/ai_keys.py
+++ b/apps/api/app/api/routes/ai_keys.py
@@ -1,15 +1,22 @@
 from __future__ import annotations
 
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from app.core.dependencies import get_ai_api_key_repo, get_current_user, get_key_manager
-from app.core.security import generate_id
-from app.domain.models.ai_entities import AIApiKey
+from app.application.use_cases.ai_keys_use_cases import (
+    DeleteAIKeyUseCase,
+    ListAIKeysUseCase,
+    StoreAIKeyUseCase,
+)
+from app.core.dependencies import (
+    get_current_user,
+    get_delete_ai_key_use_case,
+    get_list_ai_keys_use_case,
+    get_store_ai_key_use_case,
+)
 from app.domain.models.entities import User
-from app.domain.models.repositories import AIApiKeyRepository
 
 router = APIRouter(prefix="/ai/keys", tags=["ai"])
 
@@ -33,25 +40,18 @@ class DeleteAIKeyResponse(BaseModel):
 async def store_ai_key(
     body: StoreAIKeyRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
-    key_manager: Annotated[Any, Depends(get_key_manager)],
+    use_case: Annotated[StoreAIKeyUseCase, Depends(get_store_ai_key_use_case)],
 ) -> StoredAIKeyResponse:
-    api_key = AIApiKey(
-        id=generate_id(),
-        user_id=current_user.id,
-        provider=body.provider,
-        encrypted_key=key_manager.encrypt(body.key),
-    )
-    saved = await ai_api_key_repo.upsert(api_key)
+    saved = await use_case.execute(current_user.id, body.provider, body.key)
     return StoredAIKeyResponse(provider=saved.provider, created_at=saved.created_at.isoformat())
 
 
 @router.get("")
 async def list_ai_keys(
     current_user: Annotated[User, Depends(get_current_user)],
-    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
+    use_case: Annotated[ListAIKeysUseCase, Depends(get_list_ai_keys_use_case)],
 ) -> list[StoredAIKeyResponse]:
-    api_keys = await ai_api_key_repo.list_by_user(current_user.id)
+    api_keys = await use_case.execute(current_user.id)
     return [
         StoredAIKeyResponse(provider=item.provider, created_at=item.created_at.isoformat())
         for item in api_keys
@@ -62,7 +62,7 @@ async def list_ai_keys(
 async def delete_ai_key(
     provider: str,
     current_user: Annotated[User, Depends(get_current_user)],
-    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
+    use_case: Annotated[DeleteAIKeyUseCase, Depends(get_delete_ai_key_use_case)],
 ) -> DeleteAIKeyResponse:
-    deleted = await ai_api_key_repo.delete_by_user_and_provider(current_user.id, provider)
+    deleted = await use_case.execute(current_user.id, provider)
     return DeleteAIKeyResponse(provider=provider, deleted=deleted)

--- a/apps/api/app/api/routes/auth.py
+++ b/apps/api/app/api/routes/auth.py
@@ -8,26 +8,21 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from pydantic import BaseModel
 
+from app.application.use_cases.auth_use_cases import (
+    CompleteGitHubOAuthUseCase,
+    GetSessionUserUseCase,
+    LogoutUseCase,
+    StartGitHubOAuthUseCase,
+)
 from app.core.config import settings
 from app.core.dependencies import (
+    get_complete_github_oauth_use_case,
     get_current_user,
-    get_github_service,
-    get_identity_repo,
-    get_session_repo,
-    get_user_repo,
+    get_logout_use_case,
+    get_session_user_use_case,
+    get_start_github_oauth_use_case,
 )
-from app.core.errors import UnauthorizedError
-from app.core.security import (
-    decrypt_oauth_state,
-    encrypt_oauth_state,
-    encrypt_token,
-    generate_id,
-    generate_session_token,
-    hash_token,
-)
-from app.domain.models.entities import Identity, Session, User
-from app.domain.models.repositories import IdentityRepository, SessionRepository, UserRepository
-from app.infrastructure.github_service import GitHubService
+from app.domain.models.entities import User
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -42,20 +37,14 @@ class UserResponse(BaseModel):
 
 @router.post("/github")
 async def start_github_oauth(
-    github: Annotated[GitHubService, Depends(get_github_service)],
+    use_case: Annotated[StartGitHubOAuthUseCase, Depends(get_start_github_oauth_use_case)],
 ) -> JSONResponse:
-    import time as time_mod
+    result = await use_case.execute()
 
-    state = generate_session_token()
-    state_data = {"state": state, "created_at": int(time_mod.time())}
-    encrypted = encrypt_oauth_state(state_data)
-
-    url = github.get_authorize_url(settings.github_redirect_uri, state)
-
-    response = JSONResponse(content={"authorize_url": url})
+    response = JSONResponse(content={"authorize_url": result.authorize_url})
     response.set_cookie(
         key=settings.oauth_cookie_name,
-        value=encrypted,
+        value=result.encrypted_state,
         httponly=True,
         secure=settings.session_cookie_secure,
         samesite="lax",
@@ -70,86 +59,18 @@ async def github_oauth_callback(
     code: Annotated[str, Query()],
     state: Annotated[str, Query()],
     request: Request,
-    github: Annotated[GitHubService, Depends(get_github_service)],
-    user_repo: Annotated[UserRepository, Depends(get_user_repo)],
-    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
-    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
+    use_case: Annotated[CompleteGitHubOAuthUseCase, Depends(get_complete_github_oauth_use_case)],
 ) -> RedirectResponse:
-    import time as time_mod
-
-    encrypted_state = request.cookies.get(settings.oauth_cookie_name)
-    if not encrypted_state:
-        raise UnauthorizedError("Missing OAuth state cookie")
-
-    state_data = decrypt_oauth_state(encrypted_state)
-    if not state_data or state_data.get("state") != state:
-        raise UnauthorizedError("Invalid OAuth state")
-
-    created_raw = state_data.get("created_at", 0)
-    created_at = int(created_raw) if isinstance(created_raw, (int, str)) else 0  # noqa: UP038
-    if int(time_mod.time()) - created_at > settings.oauth_state_ttl_minutes * 60:
-        raise UnauthorizedError("OAuth state expired")
-
-    token_data = await github.exchange_code(code)
-    access_token = token_data["access_token"]
-
-    gh_user = await github.get_user(access_token)
-    github_id = str(gh_user["id"])
-
-    emails = await github.get_user_emails(access_token)
-    primary_email = next(
-        (e["email"] for e in emails if e.get("primary")),
-        gh_user.get("email"),
+    result = await use_case.execute(
+        code=code,
+        state=state,
+        encrypted_state=request.cookies.get(settings.oauth_cookie_name),
     )
-
-    user = await user_repo.find_by_github_id(github_id)
-    if user:
-        user.github_username = gh_user.get("login")
-        user.email = primary_email
-        user.display_name = gh_user.get("name") or gh_user.get("login")
-        user.avatar_url = gh_user.get("avatar_url")
-        user = await user_repo.update(user)
-    else:
-        user = User(
-            id=generate_id(),
-            github_id=github_id,
-            github_username=gh_user.get("login"),
-            email=primary_email,
-            display_name=gh_user.get("name") or gh_user.get("login"),
-            avatar_url=gh_user.get("avatar_url"),
-        )
-        user = await user_repo.create(user)
-
-    identity = await identity_repo.find_by_provider("github", github_id)
-    if identity:
-        identity.access_token_hash = hash_token(access_token)
-        identity.encrypted_access_token = encrypt_token(access_token)
-        await identity_repo.update(identity)
-    else:
-        identity = Identity(
-            id=generate_id(),
-            user_id=user.id,
-            provider="github",
-            provider_id=github_id,
-            access_token_hash=hash_token(access_token),
-            encrypted_access_token=encrypt_token(access_token),
-        )
-        await identity_repo.create(identity)
-
-    now = int(time_mod.time())
-    session_token = generate_session_token()
-    session = Session(
-        id=session_token,
-        user_id=user.id,
-        created_at=now,
-        expires_at=now + settings.session_ttl_hours * 3600,
-    )
-    await session_repo.create(session)
 
     response = RedirectResponse(url=settings.frontend_url, status_code=302)
     response.set_cookie(
         key=settings.session_cookie_name,
-        value=session_token,
+        value=result.session_token,
         httponly=True,
         secure=settings.session_cookie_secure,
         samesite="lax",
@@ -167,31 +88,10 @@ async def github_oauth_callback(
 @router.get("/session")
 async def get_session(
     request: Request,
-    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
-    user_repo: Annotated[UserRepository, Depends(get_user_repo)],
+    use_case: Annotated[GetSessionUserUseCase, Depends(get_session_user_use_case)],
 ) -> UserResponse:
     """Bootstrap endpoint - returns current user if session cookie is valid."""
-    import time as time_mod
-
-    session_token = request.cookies.get(settings.session_cookie_name)
-    if not session_token:
-        raise UnauthorizedError("No active session")
-
-    session = await session_repo.get_by_id(session_token)
-    if not session:
-        raise UnauthorizedError("Invalid session")
-
-    now = int(time_mod.time())
-    if session.expires_at < now:
-        raise UnauthorizedError("Session expired")
-    if session.revoked_at is not None:
-        raise UnauthorizedError("Session revoked")
-
-    await session_repo.update_last_seen(session.id, now)
-
-    user = await user_repo.find_by_id(session.user_id)
-    if not user:
-        raise UnauthorizedError("User not found")
+    user = await use_case.execute(request.cookies.get(settings.session_cookie_name))
 
     return UserResponse(
         id=user.id,
@@ -205,14 +105,10 @@ async def get_session(
 @router.post("/logout")
 async def logout(
     request: Request,
-    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
+    use_case: Annotated[LogoutUseCase, Depends(get_logout_use_case)],
 ) -> JSONResponse:
     """Revoke session and clear cookie. Always returns 200."""
-    session_token = request.cookies.get(settings.session_cookie_name)
-    if session_token:
-        existing = await session_repo.get_by_id(session_token)
-        if existing and existing.revoked_at is None:
-            await session_repo.revoke(existing.id)
+    await use_case.execute(request.cookies.get(settings.session_cookie_name))
 
     response = JSONResponse(content={"message": "Logged out successfully"})
     response.delete_cookie(

--- a/apps/api/app/api/routes/generation.py
+++ b/apps/api/app/api/routes/generation.py
@@ -6,21 +6,23 @@ runs the generator, commits output back, optionally creates a PR.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
+from app.application.use_cases.generation_use_cases import (
+    GetGenerationStatusUseCase,
+    PreviewGenerationUseCase,
+    TriggerGenerationUseCase,
+)
 from app.core.dependencies import (
     get_current_user,
-    get_generation_run_repo,
-    get_workspace_repo,
+    get_generation_status_use_case,
+    get_preview_generation_use_case,
+    get_trigger_generation_use_case,
 )
-from app.core.errors import ForbiddenError, NotFoundError
-from app.core.security import generate_id
-from app.domain.models.entities import GenerationRun, GenerationStatus, User
-from app.domain.models.repositories import GenerationRunRepository, WorkspaceRepository
+from app.domain.models.entities import GenerationRun, User
 
 router = APIRouter(tags=["generation"])
 
@@ -66,8 +68,7 @@ async def trigger_generation(
     workspace_id: str,
     body: GenerateRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-    run_repo: Annotated[GenerationRunRepository, Depends(get_generation_run_repo)],
+    use_case: Annotated[TriggerGenerationUseCase, Depends(get_trigger_generation_use_case)],
 ) -> GenerationRunResponse:
     """Trigger code generation for a workspace.
 
@@ -75,20 +76,7 @@ async def trigger_generation(
     For v0.5 MVP, it creates the run record in "pending" status.
     The actual generation + GitHub commit would be handled by a worker.
     """
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-
-    run = GenerationRun(
-        id=generate_id(),
-        workspace_id=workspace_id,
-        status=GenerationStatus.PENDING,
-        generator=body.generator,
-        started_at=datetime.now(timezone.utc),
-    )
-    run = await run_repo.create(run)
+    run = await use_case.execute(workspace_id, current_user, body.generator)
     return _run_to_response(run)
 
 
@@ -97,19 +85,10 @@ async def get_generation_status(
     workspace_id: str,
     run_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-    run_repo: Annotated[GenerationRunRepository, Depends(get_generation_run_repo)],
+    use_case: Annotated[GetGenerationStatusUseCase, Depends(get_generation_status_use_case)],
 ) -> GenerationRunResponse:
     """Get the status of a generation run."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-
-    run = await run_repo.find_by_id(run_id)
-    if not run or run.workspace_id != workspace_id:
-        raise NotFoundError("GenerationRun", run_id)
+    run = await use_case.execute(workspace_id, run_id, current_user)
     return _run_to_response(run)
 
 
@@ -117,24 +96,12 @@ async def get_generation_status(
 async def preview_generation(
     workspace_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-) -> dict:
+    use_case: Annotated[PreviewGenerationUseCase, Depends(get_preview_generation_use_case)],
+) -> dict[str, object]:
     """Preview generated code without committing.
 
     For v0.5, this returns a placeholder. The actual generation
     engine integration will be added as the code generation
     pipeline is ported from the frontend.
     """
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-
-    return {
-        "workspace_id": workspace_id,
-        "generator": workspace.generator,
-        "provider": workspace.provider,
-        "files": [],
-        "message": "Code preview will be available when the generation engine is integrated",
-    }
+    return await use_case.execute(workspace_id, current_user)

--- a/apps/api/app/api/routes/github.py
+++ b/apps/api/app/api/routes/github.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from app.application.use_cases.github_use_cases import (
     CreateGitHubRepoUseCase,
@@ -76,12 +76,12 @@ class ArchitecturePayload(BaseModel):
     id: str
     name: str
     version: str
-    nodes: list[dict[str, object]] = []
-    endpoints: list[dict[str, object]] = []
-    plates: list[dict[str, object]] = []
-    blocks: list[dict[str, object]] = []
-    connections: list[dict[str, object]] = []
-    externalActors: list[dict[str, object]] = []  # noqa: N815
+    nodes: list[dict[str, object]] = Field(default_factory=list)
+    endpoints: list[dict[str, object]] = Field(default_factory=list)
+    plates: list[dict[str, object]] = Field(default_factory=list)
+    blocks: list[dict[str, object]] = Field(default_factory=list)
+    connections: list[dict[str, object]] = Field(default_factory=list)
+    externalActors: list[dict[str, object]] = Field(default_factory=list)  # noqa: N815
     createdAt: str  # noqa: N815
     updatedAt: str  # noqa: N815
 

--- a/apps/api/app/api/routes/github.py
+++ b/apps/api/app/api/routes/github.py
@@ -5,25 +5,30 @@ Manage GitHub repository connections, sync architecture, and create PRs.
 
 from __future__ import annotations
 
-import base64
-import json
-from datetime import datetime, timezone
-from typing import Annotated, Any
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, ValidationInfo, field_validator, model_validator
 
-from app.core.dependencies import (
-    get_current_user,
-    get_github_service,
-    get_identity_repo,
-    get_workspace_repo,
+from app.application.use_cases.github_use_cases import (
+    CreateGitHubRepoUseCase,
+    CreateWorkspacePullRequestUseCase,
+    ListGitHubReposUseCase,
+    ListWorkspaceCommitsUseCase,
+    PullWorkspaceArchitectureUseCase,
+    SyncWorkspaceToGitHubUseCase,
 )
-from app.core.errors import ForbiddenError, GitHubError, NotFoundError, ValidationError
-from app.core.security import decrypt_token
+from app.core.dependencies import (
+    get_create_github_repo_use_case,
+    get_create_workspace_pull_request_use_case,
+    get_current_user,
+    get_list_github_repos_use_case,
+    get_list_workspace_commits_use_case,
+    get_pull_workspace_architecture_use_case,
+    get_sync_workspace_to_github_use_case,
+)
+from app.core.errors import ValidationError
 from app.domain.models.entities import User
-from app.domain.models.repositories import IdentityRepository, WorkspaceRepository
-from app.infrastructure.github_service import GitHubService
 
 router = APIRouter(tags=["github"])
 
@@ -35,17 +40,17 @@ class CreateRepoRequest(BaseModel):
 
 
 class SyncRequest(BaseModel):
-    architecture: dict[str, Any]
+    architecture: dict[str, object]
     commit_message: str = "Update architecture"
 
     @field_validator("architecture")
     @classmethod
-    def validate_architecture(cls, v: Any) -> dict[str, Any]:
+    def validate_architecture(cls, v: object) -> dict[str, object]:
         return _validate_architecture(v)
 
 
 class PullRequestRequest(BaseModel):
-    architecture: dict[str, Any]
+    architecture: dict[str, object]
     title: str = "Update cloud architecture"
     body: str = ""
     branch: str | None = None
@@ -53,7 +58,7 @@ class PullRequestRequest(BaseModel):
 
     @field_validator("architecture")
     @classmethod
-    def validate_architecture(cls, v: Any) -> dict[str, Any]:
+    def validate_architecture(cls, v: object) -> dict[str, object]:
         return _validate_architecture(v)
 
 
@@ -71,12 +76,12 @@ class ArchitecturePayload(BaseModel):
     id: str
     name: str
     version: str
-    nodes: list[dict[str, Any]] = []
-    endpoints: list[dict[str, Any]] = []
-    plates: list[dict[str, Any]] = []
-    blocks: list[dict[str, Any]] = []
-    connections: list[dict[str, Any]] = []
-    externalActors: list[dict[str, Any]] = []  # noqa: N815
+    nodes: list[dict[str, object]] = []
+    endpoints: list[dict[str, object]] = []
+    plates: list[dict[str, object]] = []
+    blocks: list[dict[str, object]] = []
+    connections: list[dict[str, object]] = []
+    externalActors: list[dict[str, object]] = []  # noqa: N815
     createdAt: str  # noqa: N815
     updatedAt: str  # noqa: N815
 
@@ -90,10 +95,10 @@ class ArchitecturePayload(BaseModel):
         mode="before",
     )
     @classmethod
-    def must_be_list(cls, v: Any, info: Any) -> Any:
+    def must_be_list(cls, v: object, info: ValidationInfo) -> object:
         if not isinstance(v, list):
             raise ValueError(f"{info.field_name} must be a list")
-        return v
+        return cast(list[object], v)
 
     @model_validator(mode="after")
     def require_supported_structure(self) -> ArchitecturePayload:
@@ -101,75 +106,42 @@ class ArchitecturePayload(BaseModel):
         has_legacy_keys = "plates" in self.model_fields_set and "blocks" in self.model_fields_set
         if not has_nodes and not has_legacy_keys:
             raise ValueError(
-                "architecture must include non-empty 'nodes'"
-                " or both legacy 'plates' and 'blocks'"
+                "architecture must include non-empty 'nodes' or both legacy 'plates' and 'blocks'"
             )
         return self
 
 
-def _validate_architecture(data: dict[str, Any]) -> dict[str, Any]:
+def _validate_architecture(data: object) -> dict[str, object]:
     """Validate architecture payload, raising ValidationError on failure."""
     try:
-        ArchitecturePayload.model_validate(data)
+        _ = ArchitecturePayload.model_validate(data)
     except Exception as exc:
         raise ValidationError(
             f"Invalid architecture payload: {exc}",
             details={"validation_errors": str(exc)},
         ) from exc
-    return data
-
-async def _get_github_token(
-    user: User,
-    identity_repo: IdentityRepository,
-) -> str:
-    identities = await identity_repo.find_by_user_id(user.id)
-    github_identity = next((i for i in identities if i.provider == "github"), None)
-    if not github_identity:
-        raise GitHubError("No GitHub identity linked. Please sign in with GitHub first.")
-    if not github_identity.encrypted_access_token:
-        raise GitHubError("GitHub token not available. Please re-authenticate with GitHub.")
-    return decrypt_token(github_identity.encrypted_access_token)
+    if not isinstance(data, dict):
+        raise ValidationError("Invalid architecture payload: expected JSON object")
+    return cast(dict[str, object], data)
 
 
 @router.get("/github/repos")
 async def list_repos(
     current_user: Annotated[User, Depends(get_current_user)],
-    github: Annotated[GitHubService, Depends(get_github_service)],
-    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
-) -> dict[str, Any]:
+    use_case: Annotated[ListGitHubReposUseCase, Depends(get_list_github_repos_use_case)],
+) -> dict[str, object]:
     """List GitHub repositories the user has access to."""
-    token = await _get_github_token(current_user, identity_repo)
-    repos = await github.list_repos(token)
-    return {
-        "repos": [
-            {
-                "full_name": r["full_name"],
-                "name": r["name"],
-                "private": r["private"],
-                "default_branch": r.get("default_branch", "main"),
-                "html_url": r["html_url"],
-            }
-            for r in repos
-        ]
-    }
+    return {"repos": await use_case.execute(current_user)}
 
 
 @router.post("/github/repos", status_code=201)
 async def create_repo(
     body: CreateRepoRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    github: Annotated[GitHubService, Depends(get_github_service)],
-    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
-) -> dict[str, Any]:
+    use_case: Annotated[CreateGitHubRepoUseCase, Depends(get_create_github_repo_use_case)],
+) -> dict[str, object]:
     """Create a new GitHub repository."""
-    token = await _get_github_token(current_user, identity_repo)
-    repo = await github.create_repo(token, body.name, body.description, body.private)
-    return {
-        "full_name": repo["full_name"],
-        "name": repo["name"],
-        "html_url": repo["html_url"],
-        "default_branch": repo.get("default_branch", "main"),
-    }
+    return await use_case.execute(current_user, body.name, body.description, body.private)
 
 
 @router.post("/workspaces/{workspace_id}/sync")
@@ -177,98 +149,29 @@ async def sync_to_github(
     workspace_id: str,
     body: SyncRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-    github: Annotated[GitHubService, Depends(get_github_service)],
-    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
-) -> dict[str, Any]:
+    use_case: Annotated[
+        SyncWorkspaceToGitHubUseCase, Depends(get_sync_workspace_to_github_use_case)
+    ],
+) -> dict[str, object]:
     """Sync architecture.json to the linked GitHub repository."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-    if not workspace.github_repo:
-        raise GitHubError("Workspace is not linked to a GitHub repository")
-
-    token = await _get_github_token(current_user, identity_repo)
-    owner, repo = workspace.github_repo.split("/", 1)
-
-    # Prepare architecture.json content
-    arch_json = json.dumps(body.architecture, indent=2, sort_keys=True)
-    content_b64 = base64.b64encode(arch_json.encode()).decode()
-
-    # Check if file exists to get its SHA
-    sha: str | None = None
-    try:
-        existing = await github.get_repo_contents(
-            token, owner, repo, "cloudblocks/architecture.json", workspace.github_branch
-        )
-        if isinstance(existing, dict):
-            sha = existing.get("sha")
-    except GitHubError as exc:
-        if exc.details.get("status_code") == 404:
-            pass  # File doesn't exist yet
-        else:
-            raise
-
-    # Commit the file
-    result = await github.create_or_update_file(
-        token,
-        owner,
-        repo,
-        "cloudblocks/architecture.json",
-        content_b64,
+    return await use_case.execute(
+        workspace_id,
+        current_user,
+        body.architecture,
         body.commit_message,
-        workspace.github_branch,
-        sha,
     )
-
-    # Update last synced timestamp
-    workspace.last_synced_at = datetime.now(timezone.utc)
-    await workspace_repo.update(workspace)
-
-    return {
-        "message": "Architecture synced to GitHub",
-        "commit_sha": result.get("commit", {}).get("sha"),
-    }
 
 
 @router.post("/workspaces/{workspace_id}/pull")
 async def pull_from_github(
     workspace_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-    github: Annotated[GitHubService, Depends(get_github_service)],
-    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
-) -> dict[str, Any]:
+    use_case: Annotated[
+        PullWorkspaceArchitectureUseCase, Depends(get_pull_workspace_architecture_use_case)
+    ],
+) -> dict[str, object]:
     """Pull the latest architecture.json from the linked GitHub repository."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-    if not workspace.github_repo:
-        raise GitHubError("Workspace is not linked to a GitHub repository")
-
-    token = await _get_github_token(current_user, identity_repo)
-    owner, repo = workspace.github_repo.split("/", 1)
-
-    try:
-        content = await github.get_repo_contents(
-            token, owner, repo, "cloudblocks/architecture.json", workspace.github_branch
-        )
-    except GitHubError as exc:
-        if exc.details.get("status_code") == 404:
-            raise NotFoundError("File", "cloudblocks/architecture.json") from None
-        raise
-
-    if isinstance(content, dict) and content.get("content"):
-        decoded = base64.b64decode(content["content"]).decode()
-        architecture = json.loads(decoded)
-    else:
-        raise GitHubError("Unexpected response format from GitHub")
-
-    return {"architecture": architecture}
+    return await use_case.execute(workspace_id, current_user)
 
 
 @router.post("/workspaces/{workspace_id}/pr", status_code=201)
@@ -276,107 +179,27 @@ async def create_pull_request(
     workspace_id: str,
     body: PullRequestRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-    github: Annotated[GitHubService, Depends(get_github_service)],
-    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
-) -> dict[str, Any]:
+    use_case: Annotated[
+        CreateWorkspacePullRequestUseCase, Depends(get_create_workspace_pull_request_use_case)
+    ],
+) -> dict[str, object]:
     """Create a PR with architecture changes on a new branch."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-    if not workspace.github_repo:
-        raise GitHubError("Workspace is not linked to a GitHub repository")
-
-    token = await _get_github_token(current_user, identity_repo)
-    owner, repo = workspace.github_repo.split("/", 1)
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    branch_name = body.branch or f"cloudblocks/update-{timestamp}"
-
-    # Get default branch SHA
-    base_sha = await github.get_default_branch_sha(token, owner, repo, workspace.github_branch)
-
-    # Create new branch
-    await github.create_branch(token, owner, repo, branch_name, base_sha)
-
-    # Commit architecture.json to the new branch
-    arch_json = json.dumps(body.architecture, indent=2, sort_keys=True)
-    content_b64 = base64.b64encode(arch_json.encode()).decode()
-
-    # Check if file exists on the new branch (inherited from base)
-    sha: str | None = None
-    try:
-        existing = await github.get_repo_contents(
-            token, owner, repo, "cloudblocks/architecture.json", branch_name
-        )
-        if isinstance(existing, dict):
-            sha = existing.get("sha")
-    except GitHubError as exc:
-        if exc.details.get("status_code") == 404:
-            pass
-        else:
-            raise
-
-    await github.create_or_update_file(
-        token,
-        owner,
-        repo,
-        "cloudblocks/architecture.json",
-        content_b64,
-        body.commit_message,
-        branch_name,
-        sha,
-    )
-
-    # Create PR
-    pr = await github.create_pull_request(
-        token,
-        owner,
-        repo,
+    return await use_case.execute(
+        workspace_id,
+        current_user,
+        body.architecture,
         body.title,
-        branch_name,
-        workspace.github_branch,
         body.body,
+        body.branch,
+        body.commit_message,
     )
-
-    return {
-        "pull_request_url": pr["html_url"],
-        "number": pr["number"],
-        "branch": branch_name,
-    }
 
 
 @router.get("/workspaces/{workspace_id}/commits")
 async def list_commits(
     workspace_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-    github: Annotated[GitHubService, Depends(get_github_service)],
-    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
-) -> dict[str, Any]:
+    use_case: Annotated[ListWorkspaceCommitsUseCase, Depends(get_list_workspace_commits_use_case)],
+) -> dict[str, object]:
     """List recent commits for the linked repository."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-    if not workspace.github_repo:
-        raise GitHubError("Workspace is not linked to a GitHub repository")
-
-    token = await _get_github_token(current_user, identity_repo)
-    owner, repo = workspace.github_repo.split("/", 1)
-    commits = await github.list_commits(token, owner, repo, workspace.github_branch)
-
-    return {
-        "commits": [
-            {
-                "sha": c["sha"],
-                "message": c["commit"]["message"],
-                "author": c["commit"]["author"]["name"],
-                "date": c["commit"]["author"]["date"],
-                "html_url": c["html_url"],
-            }
-            for c in commits
-        ]
-    }
+    return {"commits": await use_case.execute(workspace_id, current_user)}

--- a/apps/api/app/api/routes/session.py
+++ b/apps/api/app/api/routes/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from app.application.use_cases.session_use_cases import BindWorkspaceToSessionUseCase
@@ -30,7 +30,6 @@ class SessionInfoResponse(BaseModel):
 @router.post("/workspace")
 async def bind_workspace(
     body: WorkspaceBindRequest,
-    request: Request,
     session: Annotated[Session, Depends(get_current_session)],
     use_case: Annotated[
         BindWorkspaceToSessionUseCase, Depends(get_bind_workspace_to_session_use_case)
@@ -40,6 +39,5 @@ async def bind_workspace(
 
     Validates that the workspace exists and belongs to the session user.
     """
-    _ = request
     session_info = await use_case.execute(session, body.workspace_id, body.repo_full_name)
     return SessionInfoResponse(**session_info)

--- a/apps/api/app/api/routes/session.py
+++ b/apps/api/app/api/routes/session.py
@@ -7,17 +7,12 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel
 
+from app.application.use_cases.session_use_cases import BindWorkspaceToSessionUseCase
 from app.core.dependencies import (
+    get_bind_workspace_to_session_use_case,
     get_current_session,
-    get_session_repo,
-    get_workspace_repo,
 )
-from app.core.errors import ForbiddenError, NotFoundError
 from app.domain.models.entities import Session
-from app.domain.models.repositories import (
-    SessionRepository,
-    WorkspaceRepository,
-)
 
 router = APIRouter(prefix="/session", tags=["session"])
 
@@ -37,23 +32,14 @@ async def bind_workspace(
     body: WorkspaceBindRequest,
     request: Request,
     session: Annotated[Session, Depends(get_current_session)],
-    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    use_case: Annotated[
+        BindWorkspaceToSessionUseCase, Depends(get_bind_workspace_to_session_use_case)
+    ],
 ) -> SessionInfoResponse:
     """Bind a workspace to the current session.
 
     Validates that the workspace exists and belongs to the session user.
     """
-    workspace = await workspace_repo.find_by_id(body.workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", body.workspace_id)
-    if workspace.owner_id != session.user_id:
-        raise ForbiddenError("Workspace does not belong to current user")
-
-    await session_repo.update_workspace(
-        session.id, body.workspace_id, body.repo_full_name
-    )
-    return SessionInfoResponse(
-        current_workspace_id=body.workspace_id,
-        current_repo_full_name=body.repo_full_name,
-    )
+    _ = request
+    session_info = await use_case.execute(session, body.workspace_id, body.repo_full_name)
+    return SessionInfoResponse(**session_info)

--- a/apps/api/app/api/routes/workspaces.py
+++ b/apps/api/app/api/routes/workspaces.py
@@ -10,11 +10,22 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from app.core.dependencies import get_current_user, get_workspace_repo
-from app.core.errors import ForbiddenError, NotFoundError
-from app.core.security import generate_id
+from app.application.use_cases.workspace_use_cases import (
+    CreateWorkspaceUseCase,
+    DeleteWorkspaceUseCase,
+    GetWorkspaceUseCase,
+    ListWorkspacesUseCase,
+    UpdateWorkspaceUseCase,
+)
+from app.core.dependencies import (
+    get_create_workspace_use_case,
+    get_current_user,
+    get_delete_workspace_use_case,
+    get_list_workspaces_use_case,
+    get_update_workspace_use_case,
+    get_workspace_use_case,
+)
 from app.domain.models.entities import User, Workspace
-from app.domain.models.repositories import WorkspaceRepository
 
 router = APIRouter(prefix="/workspaces", tags=["workspaces"])
 
@@ -65,10 +76,10 @@ def _workspace_to_response(ws: Workspace) -> WorkspaceResponse:
 @router.get("/")
 async def list_workspaces(
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
-) -> dict:
+    use_case: Annotated[ListWorkspacesUseCase, Depends(get_list_workspaces_use_case)],
+) -> dict[str, list[WorkspaceResponse]]:
     """List all workspaces for the current user."""
-    workspaces = await workspace_repo.find_by_owner(current_user.id)
+    workspaces = await use_case.execute(current_user)
     return {"workspaces": [_workspace_to_response(ws) for ws in workspaces]}
 
 
@@ -76,18 +87,16 @@ async def list_workspaces(
 async def create_workspace(
     body: CreateWorkspaceRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    use_case: Annotated[CreateWorkspaceUseCase, Depends(get_create_workspace_use_case)],
 ) -> WorkspaceResponse:
     """Create a new workspace."""
-    workspace = Workspace(
-        id=generate_id(),
-        owner_id=current_user.id,
-        name=body.name,
-        generator=body.generator,
-        provider=body.provider,
-        github_repo=body.github_repo,
+    workspace = await use_case.execute(
+        current_user,
+        body.name,
+        body.generator,
+        body.provider,
+        body.github_repo,
     )
-    workspace = await workspace_repo.create(workspace)
     return _workspace_to_response(workspace)
 
 
@@ -95,14 +104,10 @@ async def create_workspace(
 async def get_workspace(
     workspace_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    use_case: Annotated[GetWorkspaceUseCase, Depends(get_workspace_use_case)],
 ) -> WorkspaceResponse:
     """Get workspace by ID."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
+    workspace = await use_case.execute(workspace_id, current_user)
     return _workspace_to_response(workspace)
 
 
@@ -111,27 +116,20 @@ async def update_workspace(
     workspace_id: str,
     body: UpdateWorkspaceRequest,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    use_case: Annotated[UpdateWorkspaceUseCase, Depends(get_update_workspace_use_case)],
 ) -> WorkspaceResponse:
     """Update workspace settings."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-
-    if body.name is not None:
-        workspace.name = body.name
-    if body.generator is not None:
-        workspace.generator = body.generator
-    if body.provider is not None:
-        workspace.provider = body.provider
-    if "github_repo" in body.model_fields_set:
-        workspace.github_repo = body.github_repo
-    if "github_branch" in body.model_fields_set:
-        workspace.github_branch = body.github_branch if body.github_branch is not None else "main"
-
-    workspace = await workspace_repo.update(workspace)
+    workspace = await use_case.execute(
+        workspace_id,
+        current_user,
+        name=body.name,
+        generator=body.generator,
+        provider=body.provider,
+        github_repo=body.github_repo,
+        github_repo_provided="github_repo" in body.model_fields_set,
+        github_branch=body.github_branch,
+        github_branch_provided="github_branch" in body.model_fields_set,
+    )
     return _workspace_to_response(workspace)
 
 
@@ -139,12 +137,7 @@ async def update_workspace(
 async def delete_workspace(
     workspace_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
-    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    use_case: Annotated[DeleteWorkspaceUseCase, Depends(get_delete_workspace_use_case)],
 ) -> None:
     """Delete a workspace."""
-    workspace = await workspace_repo.find_by_id(workspace_id)
-    if not workspace:
-        raise NotFoundError("Workspace", workspace_id)
-    if workspace.owner_id != current_user.id:
-        raise ForbiddenError("You do not own this workspace")
-    await workspace_repo.delete(workspace_id)
+    _ = await use_case.execute(workspace_id, current_user)

--- a/apps/api/app/application/use_cases/ai_keys_use_cases.py
+++ b/apps/api/app/application/use_cases/ai_keys_use_cases.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import final
+
+from app.core.security import generate_id
+from app.domain.models.ai_entities import AIApiKey
+from app.domain.models.repositories import AIApiKeyRepository
+from app.infrastructure.llm.key_manager import KeyManager
+
+
+@final
+class StoreAIKeyUseCase:
+    def __init__(self, ai_api_key_repo: AIApiKeyRepository, key_manager: KeyManager) -> None:
+        self._ai_api_key_repo: AIApiKeyRepository = ai_api_key_repo
+        self._key_manager: KeyManager = key_manager
+
+    async def execute(self, user_id: str, provider: str, key: str) -> AIApiKey:
+        api_key = AIApiKey(
+            id=generate_id(),
+            user_id=user_id,
+            provider=provider,
+            encrypted_key=self._key_manager.encrypt(key),
+        )
+        return await self._ai_api_key_repo.upsert(api_key)
+
+
+@final
+class ListAIKeysUseCase:
+    def __init__(self, ai_api_key_repo: AIApiKeyRepository) -> None:
+        self._ai_api_key_repo: AIApiKeyRepository = ai_api_key_repo
+
+    async def execute(self, user_id: str) -> list[AIApiKey]:
+        return await self._ai_api_key_repo.list_by_user(user_id)
+
+
+@final
+class DeleteAIKeyUseCase:
+    def __init__(self, ai_api_key_repo: AIApiKeyRepository) -> None:
+        self._ai_api_key_repo: AIApiKeyRepository = ai_api_key_repo
+
+    async def execute(self, user_id: str, provider: str) -> bool:
+        return await self._ai_api_key_repo.delete_by_user_and_provider(user_id, provider)

--- a/apps/api/app/application/use_cases/ai_use_cases.py
+++ b/apps/api/app/application/use_cases/ai_use_cases.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+from typing import cast, final
+
+from app.core.errors import GenerationError, ValidationError
+from app.domain.models.ai_entities import (
+    AIGenerationResponse,
+    AISuggestionsResponse,
+    CostEstimate,
+)
+from app.domain.models.repositories import AIApiKeyRepository
+from app.engines.architecture_normalizer import extract_containers_and_resources
+from app.engines.prompts.architecture_prompt import build_architecture_prompt
+from app.engines.suggestions import SuggestionEngine
+from app.engines.validation import ArchitectureValidator
+from app.infrastructure.cost.infracost_client import InfracostClient, InfracostError
+from app.infrastructure.llm.client import LLMError, OpenAIClient
+from app.infrastructure.llm.key_manager import KeyManager
+
+SUBTYPE_TO_TF_RESOURCE: dict[str, str] = {
+    "ec2": "aws_instance",
+    "ecs": "aws_ecs_service",
+    "lambda": "aws_lambda_function",
+    "rds-postgres": "aws_db_instance",
+    "dynamodb": "aws_dynamodb_table",
+    "elasticache": "aws_elasticache_cluster",
+    "s3": "aws_s3_bucket",
+    "alb": "aws_lb",
+    "api-gateway": "aws_apigatewayv2_api",
+    "nat-gateway": "aws_nat_gateway",
+    "sqs": "aws_sqs_queue",
+    "sns": "aws_sns_topic",
+    "eventbridge": "aws_cloudwatch_event_bus",
+    "kinesis": "aws_kinesis_stream",
+    "redshift": "aws_redshift_cluster",
+    "iam": "aws_iam_role",
+    "cloudwatch": "aws_cloudwatch_log_group",
+    "vm": "azurerm_virtual_machine",
+    "container-instances": "azurerm_container_group",
+    "aks": "azurerm_kubernetes_cluster",
+    "sql-database": "azurerm_mssql_database",
+    "cosmos-db": "azurerm_cosmosdb_account",
+    "cache-for-redis": "azurerm_redis_cache",
+    "blob-storage": "azurerm_storage_account",
+    "application-gateway": "azurerm_application_gateway",
+    "api-management": "azurerm_api_management",
+    "firewall": "azurerm_firewall",
+    "functions": "azurerm_function_app",
+    "service-bus": "azurerm_servicebus_queue",
+    "event-grid": "azurerm_eventgrid_topic",
+    "event-hubs": "azurerm_eventhub",
+    "synapse": "azurerm_synapse_workspace",
+    "entra-id": "azurerm_user_assigned_identity",
+    "monitor": "azurerm_monitor_action_group",
+    "compute-engine": "google_compute_instance",
+    "cloud-run": "google_cloud_run_service",
+    "gke": "google_container_cluster",
+    "cloud-sql-postgres": "google_sql_database_instance",
+    "cloud-spanner": "google_spanner_instance",
+    "memorystore": "google_redis_instance",
+    "cloud-storage": "google_storage_bucket",
+    "cloud-load-balancing": "google_compute_url_map",
+    "cloud-armor": "google_compute_security_policy",
+    "cloud-functions": "google_cloudfunctions_function",
+    "pub-sub": "google_pubsub_topic",
+    "eventarc": "google_eventarc_trigger",
+    "bigquery": "google_bigquery_dataset",
+    "dataflow": "google_dataflow_job",
+    "cloud-iam": "google_project_iam_member",
+    "cloud-monitoring": "google_monitoring_alert_policy",
+}
+
+
+class _OpenAIUseCase:
+    def __init__(
+        self,
+        ai_api_key_repo: AIApiKeyRepository,
+        key_manager: KeyManager,
+        llm_base_url: str,
+        llm_model: str,
+        llm_max_tokens: int,
+        llm_timeout: int,
+    ) -> None:
+        self._ai_api_key_repo: AIApiKeyRepository = ai_api_key_repo
+        self._key_manager: KeyManager = key_manager
+        self._llm_base_url: str = llm_base_url
+        self._llm_model: str = llm_model
+        self._llm_max_tokens: int = llm_max_tokens
+        self._llm_timeout: int = llm_timeout
+
+    async def _get_client(self, user_id: str) -> OpenAIClient:
+        api_keys = await self._ai_api_key_repo.list_by_user(user_id)
+        openai_key = next((item for item in api_keys if item.provider.lower() == "openai"), None)
+        if openai_key is None:
+            raise ValidationError("No OpenAI API key stored. Please add one via /api/v1/ai/keys")
+
+        decrypted_key = self._key_manager.decrypt(openai_key.encrypted_key)
+        return OpenAIClient(
+            api_key=decrypted_key,
+            base_url=self._llm_base_url,
+            model=self._llm_model,
+            max_tokens=self._llm_max_tokens,
+            timeout=self._llm_timeout,
+        )
+
+    @staticmethod
+    def _build_system_prompt(provider: str, complexity: str) -> str:
+        prompt = build_architecture_prompt(provider)
+        return f"{prompt}\n\nComplexity target: {complexity}."
+
+
+@final
+class GenerateArchitectureUseCase(_OpenAIUseCase):
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        prompt: str,
+        provider: str,
+        complexity: str,
+    ) -> AIGenerationResponse:
+        client = await self._get_client(user_id)
+        system_prompt = self._build_system_prompt(provider, complexity)
+
+        try:
+            architecture = await client.generate(system_prompt=system_prompt, user_prompt=prompt)
+        except LLMError as exc:
+            raise GenerationError(f"AI generation failed: {exc}") from exc
+
+        return AIGenerationResponse(
+            architecture=architecture,
+            warnings=ArchitectureValidator().validate(architecture),
+        )
+
+
+@final
+class SuggestArchitectureImprovementsUseCase(_OpenAIUseCase):
+    async def execute(
+        self,
+        *,
+        user_id: str,
+        architecture: dict[str, object],
+        provider: str,
+    ) -> AISuggestionsResponse:
+        client = await self._get_client(user_id)
+        engine = SuggestionEngine(client)
+
+        try:
+            return await engine.analyze(architecture, provider)
+        except LLMError as exc:
+            raise GenerationError(f"Architecture analysis failed: {exc}") from exc
+
+
+@final
+class EstimateArchitectureCostUseCase:
+    def __init__(self, infracost_api_key: str) -> None:
+        self._infracost_api_key: str = infracost_api_key
+
+    async def execute(self, architecture: dict[str, object]) -> CostEstimate:
+        tf_json = self._architecture_to_tf_json(architecture)
+
+        temp_dir = tempfile.mkdtemp(prefix="cloudblocks_cost_")
+        tf_path = Path(temp_dir) / "main.tf.json"
+        try:
+            _ = tf_path.write_text(json.dumps(tf_json, indent=2))
+            client = InfracostClient(api_key=self._infracost_api_key)
+            return await client.estimate(temp_dir)
+        except InfracostError as exc:
+            raise GenerationError(f"Cost estimation failed: {exc}") from exc
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @staticmethod
+    def _architecture_to_tf_json(architecture: dict[str, object]) -> dict[str, object]:
+        resources: dict[str, dict[str, dict[str, object]]] = {}
+        _, blocks = extract_containers_and_resources(architecture)
+
+        for raw_block in blocks:
+            block = cast(dict[str, object], raw_block)
+            subtype = block.get("subtype")
+            name_value: object = block.get("name", "unnamed")
+            block_id_value: object = block.get("id", "unknown")
+
+            if not isinstance(subtype, str):
+                continue
+
+            tf_type = SUBTYPE_TO_TF_RESOURCE.get(subtype)
+            if tf_type is None:
+                continue
+
+            name = name_value if isinstance(name_value, str) else ""
+            block_id = block_id_value if isinstance(block_id_value, str) else str(block_id_value)
+            safe_name = block_id.replace("-", "_")
+            if tf_type not in resources:
+                resources[tf_type] = {}
+            resources[tf_type][safe_name] = {"tags": {"Name": name}}
+
+        return {"resource": resources}

--- a/apps/api/app/application/use_cases/auth_use_cases.py
+++ b/apps/api/app/application/use_cases/auth_use_cases.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import cast, final
+
+from app.core.errors import UnauthorizedError
+from app.core.security import (
+    decrypt_oauth_state,
+    encrypt_oauth_state,
+    encrypt_token,
+    generate_id,
+    generate_session_token,
+    hash_token,
+)
+from app.domain.models.entities import Identity, Session, User
+from app.domain.models.repositories import IdentityRepository, SessionRepository, UserRepository
+from app.infrastructure.github_service import GitHubService
+
+
+@dataclass
+class GitHubOAuthStartResult:
+    authorize_url: str
+    encrypted_state: str
+
+
+@dataclass
+class GitHubOAuthCallbackResult:
+    session_token: str
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+@final
+class StartGitHubOAuthUseCase:
+    def __init__(
+        self,
+        github_service: GitHubService,
+        github_redirect_uri: str,
+    ) -> None:
+        self._github_service: GitHubService = github_service
+        self._github_redirect_uri: str = github_redirect_uri
+
+    async def execute(self) -> GitHubOAuthStartResult:
+        state = generate_session_token()
+        state_data = {"state": state, "created_at": int(time.time())}
+        encrypted_state = encrypt_oauth_state(state_data)
+        authorize_url = self._github_service.get_authorize_url(self._github_redirect_uri, state)
+        return GitHubOAuthStartResult(
+            authorize_url=authorize_url,
+            encrypted_state=encrypted_state,
+        )
+
+
+@final
+class CompleteGitHubOAuthUseCase:
+    def __init__(
+        self,
+        github_service: GitHubService,
+        user_repo: UserRepository,
+        identity_repo: IdentityRepository,
+        session_repo: SessionRepository,
+        oauth_state_ttl_minutes: int,
+        session_ttl_hours: int,
+    ) -> None:
+        self._github_service: GitHubService = github_service
+        self._user_repo: UserRepository = user_repo
+        self._identity_repo: IdentityRepository = identity_repo
+        self._session_repo: SessionRepository = session_repo
+        self._oauth_state_ttl_minutes: int = oauth_state_ttl_minutes
+        self._session_ttl_hours: int = session_ttl_hours
+
+    async def execute(
+        self,
+        *,
+        code: str,
+        state: str,
+        encrypted_state: str | None,
+    ) -> GitHubOAuthCallbackResult:
+        if not encrypted_state:
+            raise UnauthorizedError("Missing OAuth state cookie")
+
+        state_data = decrypt_oauth_state(encrypted_state)
+        if not state_data or state_data.get("state") != state:
+            raise UnauthorizedError("Invalid OAuth state")
+
+        created_raw = state_data.get("created_at", 0)
+        created_at = int(created_raw)
+        if int(time.time()) - created_at > self._oauth_state_ttl_minutes * 60:
+            raise UnauthorizedError("OAuth state expired")
+
+        token_data = await self._github_service.exchange_code(code)
+        access_token = token_data["access_token"]
+
+        github_user = cast(dict[str, object], await self._github_service.get_user(access_token))
+        github_id = str(github_user.get("id", ""))
+
+        emails = cast(
+            list[dict[str, object]], await self._github_service.get_user_emails(access_token)
+        )
+        primary_email: str | None = next(
+            (
+                email_value
+                for email in emails
+                for email_value in [email.get("email")]
+                if email.get("primary") and isinstance(email_value, str)
+            ),
+            _optional_str(github_user.get("email")),
+        )
+
+        user = await self._user_repo.find_by_github_id(github_id)
+        if user:
+            user.github_username = _optional_str(github_user.get("login"))
+            user.email = primary_email
+            user.display_name = _optional_str(github_user.get("name")) or _optional_str(
+                github_user.get("login")
+            )
+            user.avatar_url = _optional_str(github_user.get("avatar_url"))
+            user = await self._user_repo.update(user)
+        else:
+            user = User(
+                id=generate_id(),
+                github_id=github_id,
+                github_username=_optional_str(github_user.get("login")),
+                email=primary_email,
+                display_name=_optional_str(github_user.get("name"))
+                or _optional_str(github_user.get("login")),
+                avatar_url=_optional_str(github_user.get("avatar_url")),
+            )
+            user = await self._user_repo.create(user)
+
+        identity = await self._identity_repo.find_by_provider("github", github_id)
+        if identity:
+            identity.access_token_hash = hash_token(access_token)
+            identity.encrypted_access_token = encrypt_token(access_token)
+            _ = await self._identity_repo.update(identity)
+        else:
+            identity = Identity(
+                id=generate_id(),
+                user_id=user.id,
+                provider="github",
+                provider_id=github_id,
+                access_token_hash=hash_token(access_token),
+                encrypted_access_token=encrypt_token(access_token),
+            )
+            _ = await self._identity_repo.create(identity)
+
+        now = int(time.time())
+        session_token = generate_session_token()
+        session = Session(
+            id=session_token,
+            user_id=user.id,
+            created_at=now,
+            expires_at=now + self._session_ttl_hours * 3600,
+        )
+        _ = await self._session_repo.create(session)
+        return GitHubOAuthCallbackResult(session_token=session_token)
+
+
+@final
+class GetSessionUserUseCase:
+    def __init__(
+        self,
+        session_repo: SessionRepository,
+        user_repo: UserRepository,
+    ) -> None:
+        self._session_repo: SessionRepository = session_repo
+        self._user_repo: UserRepository = user_repo
+
+    async def execute(self, session_token: str | None) -> User:
+        if not session_token:
+            raise UnauthorizedError("No active session")
+
+        session = await self._session_repo.get_by_id(session_token)
+        if not session:
+            raise UnauthorizedError("Invalid session")
+
+        now = int(time.time())
+        if session.expires_at < now:
+            raise UnauthorizedError("Session expired")
+        if session.revoked_at is not None:
+            raise UnauthorizedError("Session revoked")
+
+        await self._session_repo.update_last_seen(session.id, now)
+
+        user = await self._user_repo.find_by_id(session.user_id)
+        if not user:
+            raise UnauthorizedError("User not found")
+        return user
+
+
+@final
+class LogoutUseCase:
+    def __init__(self, session_repo: SessionRepository) -> None:
+        self._session_repo: SessionRepository = session_repo
+
+    async def execute(self, session_token: str | None) -> None:
+        if not session_token:
+            return
+
+        existing = await self._session_repo.get_by_id(session_token)
+        if existing and existing.revoked_at is None:
+            await self._session_repo.revoke(existing.id)

--- a/apps/api/app/application/use_cases/generation_use_cases.py
+++ b/apps/api/app/application/use_cases/generation_use_cases.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import final
+
+from app.core.errors import ForbiddenError, NotFoundError
+from app.core.security import generate_id
+from app.domain.models.entities import GenerationRun, GenerationStatus, User, Workspace
+from app.domain.models.repositories import GenerationRunRepository, WorkspaceRepository
+
+
+class _WorkspaceGenerationUseCase:
+    def __init__(self, workspace_repo: WorkspaceRepository) -> None:
+        self._workspace_repo: WorkspaceRepository = workspace_repo
+
+    async def _get_workspace(self, workspace_id: str, user: User) -> Workspace:
+        workspace = await self._workspace_repo.find_by_id(workspace_id)
+        if not workspace:
+            raise NotFoundError("Workspace", workspace_id)
+        if workspace.owner_id != user.id:
+            raise ForbiddenError("You do not own this workspace")
+        return workspace
+
+
+@final
+class TriggerGenerationUseCase(_WorkspaceGenerationUseCase):
+    def __init__(
+        self, workspace_repo: WorkspaceRepository, run_repo: GenerationRunRepository
+    ) -> None:
+        super().__init__(workspace_repo)
+        self._run_repo: GenerationRunRepository = run_repo
+
+    async def execute(self, workspace_id: str, user: User, generator: str) -> GenerationRun:
+        _ = await self._get_workspace(workspace_id, user)
+        run = GenerationRun(
+            id=generate_id(),
+            workspace_id=workspace_id,
+            status=GenerationStatus.PENDING,
+            generator=generator,
+            started_at=datetime.now(timezone.utc),
+        )
+        return await self._run_repo.create(run)
+
+
+@final
+class GetGenerationStatusUseCase(_WorkspaceGenerationUseCase):
+    def __init__(
+        self, workspace_repo: WorkspaceRepository, run_repo: GenerationRunRepository
+    ) -> None:
+        super().__init__(workspace_repo)
+        self._run_repo: GenerationRunRepository = run_repo
+
+    async def execute(self, workspace_id: str, run_id: str, user: User) -> GenerationRun:
+        _ = await self._get_workspace(workspace_id, user)
+        run = await self._run_repo.find_by_id(run_id)
+        if not run or run.workspace_id != workspace_id:
+            raise NotFoundError("GenerationRun", run_id)
+        return run
+
+
+@final
+class PreviewGenerationUseCase(_WorkspaceGenerationUseCase):
+    async def execute(self, workspace_id: str, user: User) -> dict[str, object]:
+        workspace = await self._get_workspace(workspace_id, user)
+        return {
+            "workspace_id": workspace_id,
+            "generator": workspace.generator,
+            "provider": workspace.provider,
+            "files": [],
+            "message": "Code preview will be available when the generation engine is integrated",
+        }

--- a/apps/api/app/application/use_cases/github_use_cases.py
+++ b/apps/api/app/application/use_cases/github_use_cases.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timezone
+from typing import cast, final
+
+from app.core.errors import ForbiddenError, GitHubError, NotFoundError
+from app.core.security import decrypt_token
+from app.domain.models.entities import User, Workspace
+from app.domain.models.repositories import IdentityRepository, WorkspaceRepository
+from app.infrastructure.github_service import GitHubService
+
+
+def _github_error_status_code(error: GitHubError) -> object:
+    details = cast(dict[object, object], error.details)
+    return details.get("status_code")
+
+
+class _GitHubWorkspaceUseCase:
+    def __init__(
+        self,
+        workspace_repo: WorkspaceRepository,
+        identity_repo: IdentityRepository,
+        github_service: GitHubService,
+    ) -> None:
+        self._workspace_repo: WorkspaceRepository = workspace_repo
+        self._identity_repo: IdentityRepository = identity_repo
+        self._github_service: GitHubService = github_service
+
+    async def _get_workspace(self, workspace_id: str, user: User) -> Workspace:
+        workspace = await self._workspace_repo.find_by_id(workspace_id)
+        if not workspace:
+            raise NotFoundError("Workspace", workspace_id)
+        if workspace.owner_id != user.id:
+            raise ForbiddenError("You do not own this workspace")
+        if not workspace.github_repo:
+            raise GitHubError("Workspace is not linked to a GitHub repository")
+        return workspace
+
+    async def _get_github_token(self, user: User) -> str:
+        identities = await self._identity_repo.find_by_user_id(user.id)
+        github_identity = next((item for item in identities if item.provider == "github"), None)
+        if not github_identity:
+            raise GitHubError("No GitHub identity linked. Please sign in with GitHub first.")
+        if not github_identity.encrypted_access_token:
+            raise GitHubError("GitHub token not available. Please re-authenticate with GitHub.")
+        return decrypt_token(github_identity.encrypted_access_token)
+
+    @staticmethod
+    def _split_repo(full_name: str) -> tuple[str, str]:
+        owner, repo = full_name.split("/", 1)
+        return owner, repo
+
+
+@final
+class ListGitHubReposUseCase:
+    def __init__(self, identity_repo: IdentityRepository, github_service: GitHubService) -> None:
+        self._identity_repo: IdentityRepository = identity_repo
+        self._github_service: GitHubService = github_service
+
+    async def execute(self, user: User) -> list[dict[str, object]]:
+        identities = await self._identity_repo.find_by_user_id(user.id)
+        github_identity = next((item for item in identities if item.provider == "github"), None)
+        if not github_identity:
+            raise GitHubError("No GitHub identity linked. Please sign in with GitHub first.")
+        if not github_identity.encrypted_access_token:
+            raise GitHubError("GitHub token not available. Please re-authenticate with GitHub.")
+
+        token = decrypt_token(github_identity.encrypted_access_token)
+        repos = await self._github_service.list_repos(token)
+        return [
+            {
+                "full_name": repo["full_name"],
+                "name": repo["name"],
+                "private": repo["private"],
+                "default_branch": repo.get("default_branch", "main"),
+                "html_url": repo["html_url"],
+            }
+            for repo in repos
+        ]
+
+
+@final
+class CreateGitHubRepoUseCase:
+    def __init__(self, identity_repo: IdentityRepository, github_service: GitHubService) -> None:
+        self._identity_repo: IdentityRepository = identity_repo
+        self._github_service: GitHubService = github_service
+
+    async def execute(
+        self, user: User, name: str, description: str, private: bool
+    ) -> dict[str, object]:
+        identities = await self._identity_repo.find_by_user_id(user.id)
+        github_identity = next((item for item in identities if item.provider == "github"), None)
+        if not github_identity:
+            raise GitHubError("No GitHub identity linked. Please sign in with GitHub first.")
+        if not github_identity.encrypted_access_token:
+            raise GitHubError("GitHub token not available. Please re-authenticate with GitHub.")
+
+        token = decrypt_token(github_identity.encrypted_access_token)
+        repo = await self._github_service.create_repo(token, name, description, private)
+        return {
+            "full_name": repo["full_name"],
+            "name": repo["name"],
+            "html_url": repo["html_url"],
+            "default_branch": repo.get("default_branch", "main"),
+        }
+
+
+@final
+class SyncWorkspaceToGitHubUseCase(_GitHubWorkspaceUseCase):
+    async def execute(
+        self,
+        workspace_id: str,
+        user: User,
+        architecture: dict[str, object],
+        commit_message: str,
+    ) -> dict[str, object]:
+        workspace = await self._get_workspace(workspace_id, user)
+        token = await self._get_github_token(user)
+        github_repo = workspace.github_repo
+        if github_repo is None:
+            raise GitHubError("Workspace is not linked to a GitHub repository")
+        owner, repo = self._split_repo(github_repo)
+
+        architecture_json = json.dumps(architecture, indent=2, sort_keys=True)
+        content_b64 = base64.b64encode(architecture_json.encode()).decode()
+
+        sha: str | None = None
+        try:
+            existing = await self._github_service.get_repo_contents(
+                token,
+                owner,
+                repo,
+                "cloudblocks/architecture.json",
+                workspace.github_branch,
+            )
+            if isinstance(existing, dict):
+                sha = existing.get("sha")
+        except GitHubError as exc:
+            if _github_error_status_code(exc) != 404:
+                raise
+
+        result = await self._github_service.create_or_update_file(
+            token,
+            owner,
+            repo,
+            "cloudblocks/architecture.json",
+            content_b64,
+            commit_message,
+            workspace.github_branch,
+            sha,
+        )
+
+        workspace.last_synced_at = datetime.now(timezone.utc)
+        _ = await self._workspace_repo.update(workspace)
+
+        return {
+            "message": "Architecture synced to GitHub",
+            "commit_sha": cast(dict[str, object], result.get("commit", {})).get("sha"),
+        }
+
+
+@final
+class PullWorkspaceArchitectureUseCase(_GitHubWorkspaceUseCase):
+    async def execute(self, workspace_id: str, user: User) -> dict[str, object]:
+        workspace = await self._get_workspace(workspace_id, user)
+        token = await self._get_github_token(user)
+        github_repo = workspace.github_repo
+        if github_repo is None:
+            raise GitHubError("Workspace is not linked to a GitHub repository")
+        owner, repo = self._split_repo(github_repo)
+
+        try:
+            content = await self._github_service.get_repo_contents(
+                token,
+                owner,
+                repo,
+                "cloudblocks/architecture.json",
+                workspace.github_branch,
+            )
+        except GitHubError as exc:
+            if _github_error_status_code(exc) == 404:
+                raise NotFoundError("File", "cloudblocks/architecture.json") from None
+            raise
+
+        if isinstance(content, dict) and content.get("content"):
+            encoded_content = cast(object, content.get("content"))
+            if not isinstance(encoded_content, str):
+                raise GitHubError("Unexpected response format from GitHub")
+            decoded = base64.b64decode(encoded_content).decode()
+            architecture = cast(dict[str, object], json.loads(decoded))
+            return {"architecture": architecture}
+
+        raise GitHubError("Unexpected response format from GitHub")
+
+
+@final
+class CreateWorkspacePullRequestUseCase(_GitHubWorkspaceUseCase):
+    async def execute(
+        self,
+        workspace_id: str,
+        user: User,
+        architecture: dict[str, object],
+        title: str,
+        body: str,
+        branch: str | None,
+        commit_message: str,
+    ) -> dict[str, object]:
+        workspace = await self._get_workspace(workspace_id, user)
+        token = await self._get_github_token(user)
+        github_repo = workspace.github_repo
+        if github_repo is None:
+            raise GitHubError("Workspace is not linked to a GitHub repository")
+        owner, repo = self._split_repo(github_repo)
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        branch_name = branch or f"cloudblocks/update-{timestamp}"
+
+        base_sha = await self._github_service.get_default_branch_sha(
+            token,
+            owner,
+            repo,
+            workspace.github_branch,
+        )
+        _ = await self._github_service.create_branch(token, owner, repo, branch_name, base_sha)
+
+        architecture_json = json.dumps(architecture, indent=2, sort_keys=True)
+        content_b64 = base64.b64encode(architecture_json.encode()).decode()
+
+        sha: str | None = None
+        try:
+            existing = await self._github_service.get_repo_contents(
+                token,
+                owner,
+                repo,
+                "cloudblocks/architecture.json",
+                branch_name,
+            )
+            if isinstance(existing, dict):
+                sha = existing.get("sha")
+        except GitHubError as exc:
+            if _github_error_status_code(exc) != 404:
+                raise
+
+        _ = await self._github_service.create_or_update_file(
+            token,
+            owner,
+            repo,
+            "cloudblocks/architecture.json",
+            content_b64,
+            commit_message,
+            branch_name,
+            sha,
+        )
+
+        pull_request = await self._github_service.create_pull_request(
+            token,
+            owner,
+            repo,
+            title,
+            branch_name,
+            workspace.github_branch,
+            body,
+        )
+
+        return {
+            "pull_request_url": pull_request["html_url"],
+            "number": pull_request["number"],
+            "branch": branch_name,
+        }
+
+
+@final
+class ListWorkspaceCommitsUseCase(_GitHubWorkspaceUseCase):
+    async def execute(self, workspace_id: str, user: User) -> list[dict[str, object]]:
+        workspace = await self._get_workspace(workspace_id, user)
+        token = await self._get_github_token(user)
+        github_repo = workspace.github_repo
+        if github_repo is None:
+            raise GitHubError("Workspace is not linked to a GitHub repository")
+        owner, repo = self._split_repo(github_repo)
+        commits = await self._github_service.list_commits(
+            token, owner, repo, workspace.github_branch
+        )
+        return [
+            {
+                "sha": commit["sha"],
+                "message": commit["commit"]["message"],
+                "author": commit["commit"]["author"]["name"],
+                "date": commit["commit"]["author"]["date"],
+                "html_url": commit["html_url"],
+            }
+            for commit in commits
+        ]

--- a/apps/api/app/application/use_cases/session_use_cases.py
+++ b/apps/api/app/application/use_cases/session_use_cases.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import final
+
+from app.core.errors import ForbiddenError, NotFoundError
+from app.domain.models.entities import Session
+from app.domain.models.repositories import SessionRepository, WorkspaceRepository
+
+
+@final
+class BindWorkspaceToSessionUseCase:
+    def __init__(
+        self,
+        session_repo: SessionRepository,
+        workspace_repo: WorkspaceRepository,
+    ) -> None:
+        self._session_repo: SessionRepository = session_repo
+        self._workspace_repo: WorkspaceRepository = workspace_repo
+
+    async def execute(
+        self,
+        session: Session,
+        workspace_id: str,
+        repo_full_name: str | None,
+    ) -> dict[str, str | None]:
+        workspace = await self._workspace_repo.find_by_id(workspace_id)
+        if not workspace:
+            raise NotFoundError("Workspace", workspace_id)
+        if workspace.owner_id != session.user_id:
+            raise ForbiddenError("Workspace does not belong to current user")
+
+        await self._session_repo.update_workspace(session.id, workspace_id, repo_full_name)
+        return {
+            "current_workspace_id": workspace_id,
+            "current_repo_full_name": repo_full_name,
+        }

--- a/apps/api/app/application/use_cases/workspace_use_cases.py
+++ b/apps/api/app/application/use_cases/workspace_use_cases.py
@@ -2,17 +2,20 @@
 
 from __future__ import annotations
 
+from typing import final
+
 from app.core.errors import ForbiddenError, NotFoundError
 from app.core.security import generate_id
 from app.domain.models.entities import User, Workspace
 from app.domain.models.repositories import WorkspaceRepository
 
 
+@final
 class CreateWorkspaceUseCase:
     """Create a new workspace for a user."""
 
     def __init__(self, workspace_repo: WorkspaceRepository) -> None:
-        self._repo = workspace_repo
+        self._repo: WorkspaceRepository = workspace_repo
 
     async def execute(
         self,
@@ -33,11 +36,12 @@ class CreateWorkspaceUseCase:
         return await self._repo.create(workspace)
 
 
+@final
 class GetWorkspaceUseCase:
     """Get a workspace, enforcing ownership."""
 
     def __init__(self, workspace_repo: WorkspaceRepository) -> None:
-        self._repo = workspace_repo
+        self._repo: WorkspaceRepository = workspace_repo
 
     async def execute(self, workspace_id: str, user: User) -> Workspace:
         workspace = await self._repo.find_by_id(workspace_id)
@@ -48,21 +52,23 @@ class GetWorkspaceUseCase:
         return workspace
 
 
+@final
 class ListWorkspacesUseCase:
     """List all workspaces for a user."""
 
     def __init__(self, workspace_repo: WorkspaceRepository) -> None:
-        self._repo = workspace_repo
+        self._repo: WorkspaceRepository = workspace_repo
 
     async def execute(self, user: User) -> list[Workspace]:
         return await self._repo.find_by_owner(user.id)
 
 
+@final
 class DeleteWorkspaceUseCase:
     """Delete a workspace, enforcing ownership."""
 
     def __init__(self, workspace_repo: WorkspaceRepository) -> None:
-        self._repo = workspace_repo
+        self._repo: WorkspaceRepository = workspace_repo
 
     async def execute(self, workspace_id: str, user: User) -> bool:
         workspace = await self._repo.find_by_id(workspace_id)
@@ -71,3 +77,41 @@ class DeleteWorkspaceUseCase:
         if workspace.owner_id != user.id:
             raise ForbiddenError("You do not own this workspace")
         return await self._repo.delete(workspace_id)
+
+
+@final
+class UpdateWorkspaceUseCase:
+    def __init__(self, workspace_repo: WorkspaceRepository) -> None:
+        self._repo: WorkspaceRepository = workspace_repo
+
+    async def execute(
+        self,
+        workspace_id: str,
+        user: User,
+        *,
+        name: str | None = None,
+        generator: str | None = None,
+        provider: str | None = None,
+        github_repo: str | None = None,
+        github_repo_provided: bool = False,
+        github_branch: str | None = None,
+        github_branch_provided: bool = False,
+    ) -> Workspace:
+        workspace = await self._repo.find_by_id(workspace_id)
+        if not workspace:
+            raise NotFoundError("Workspace", workspace_id)
+        if workspace.owner_id != user.id:
+            raise ForbiddenError("You do not own this workspace")
+
+        if name is not None:
+            workspace.name = name
+        if generator is not None:
+            workspace.generator = generator
+        if provider is not None:
+            workspace.provider = provider
+        if github_repo_provided:
+            workspace.github_repo = github_repo
+        if github_branch_provided:
+            workspace.github_branch = github_branch if github_branch is not None else "main"
+
+        return await self._repo.update(workspace)

--- a/apps/api/app/application/use_cases/workspace_use_cases.py
+++ b/apps/api/app/application/use_cases/workspace_use_cases.py
@@ -81,6 +81,15 @@ class DeleteWorkspaceUseCase:
 
 @final
 class UpdateWorkspaceUseCase:
+    """Update workspace fields with support for partial updates.
+
+    The workspace name, generator, provider, GitHub repository, and GitHub
+    branch can be updated. The ``github_repo_provided`` and
+    ``github_branch_provided`` flags determine whether those optional fields
+    should be changed, allowing callers to distinguish between leaving a value
+    unchanged and explicitly setting or clearing it.
+    """
+
     def __init__(self, workspace_repo: WorkspaceRepository) -> None:
         self._repo: WorkspaceRepository = workspace_repo
 

--- a/apps/api/app/core/dependencies.py
+++ b/apps/api/app/core/dependencies.py
@@ -5,12 +5,48 @@ Provides FastAPI dependencies for database, repositories, services, and auth.
 
 from __future__ import annotations
 
-import importlib
 import time
 from typing import Annotated, cast
 
 from fastapi import Depends, Request
 
+from app.application.use_cases.ai_keys_use_cases import (
+    DeleteAIKeyUseCase,
+    ListAIKeysUseCase,
+    StoreAIKeyUseCase,
+)
+from app.application.use_cases.ai_use_cases import (
+    EstimateArchitectureCostUseCase,
+    GenerateArchitectureUseCase,
+    SuggestArchitectureImprovementsUseCase,
+)
+from app.application.use_cases.auth_use_cases import (
+    CompleteGitHubOAuthUseCase,
+    GetSessionUserUseCase,
+    LogoutUseCase,
+    StartGitHubOAuthUseCase,
+)
+from app.application.use_cases.generation_use_cases import (
+    GetGenerationStatusUseCase,
+    PreviewGenerationUseCase,
+    TriggerGenerationUseCase,
+)
+from app.application.use_cases.github_use_cases import (
+    CreateGitHubRepoUseCase,
+    CreateWorkspacePullRequestUseCase,
+    ListGitHubReposUseCase,
+    ListWorkspaceCommitsUseCase,
+    PullWorkspaceArchitectureUseCase,
+    SyncWorkspaceToGitHubUseCase,
+)
+from app.application.use_cases.session_use_cases import BindWorkspaceToSessionUseCase
+from app.application.use_cases.workspace_use_cases import (
+    CreateWorkspaceUseCase,
+    DeleteWorkspaceUseCase,
+    GetWorkspaceUseCase,
+    ListWorkspacesUseCase,
+    UpdateWorkspaceUseCase,
+)
 from app.core.config import settings
 from app.core.errors import UnauthorizedError
 from app.domain.models.entities import Session, User
@@ -31,6 +67,7 @@ from app.infrastructure.db.connection import (
     create_database,
 )
 from app.infrastructure.github_service import GitHubService
+from app.infrastructure.llm.key_manager import KeyManager
 
 _github_service = GitHubService(
     client_id=settings.github_client_id,
@@ -40,9 +77,7 @@ _github_service = GitHubService(
 
 _db = create_database(settings.database_url)
 _redis_client: RedisClient | None = None
-_key_manager = importlib.import_module("app.infrastructure.llm.key_manager").KeyManager(
-    settings.ai_encryption_key
-)
+_key_manager = KeyManager(settings.ai_encryption_key)
 
 
 def get_database() -> DatabaseProtocol:
@@ -57,7 +92,7 @@ def get_github_service() -> GitHubService:
     return _github_service
 
 
-def get_key_manager():
+def get_key_manager() -> KeyManager:
     return _key_manager
 
 
@@ -142,6 +177,195 @@ def get_session_repo(db: Annotated[DatabaseProtocol, Depends(get_database)]) -> 
     from app.infrastructure.db.repositories import SQLiteSessionRepository
 
     return SQLiteSessionRepository(cast(Database, db))
+
+
+def get_list_workspaces_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> ListWorkspacesUseCase:
+    return ListWorkspacesUseCase(workspace_repo)
+
+
+def get_create_workspace_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> CreateWorkspaceUseCase:
+    return CreateWorkspaceUseCase(workspace_repo)
+
+
+def get_workspace_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> GetWorkspaceUseCase:
+    return GetWorkspaceUseCase(workspace_repo)
+
+
+def get_update_workspace_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> UpdateWorkspaceUseCase:
+    return UpdateWorkspaceUseCase(workspace_repo)
+
+
+def get_delete_workspace_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> DeleteWorkspaceUseCase:
+    return DeleteWorkspaceUseCase(workspace_repo)
+
+
+def get_start_github_oauth_use_case(
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+) -> StartGitHubOAuthUseCase:
+    return StartGitHubOAuthUseCase(github_service, settings.github_redirect_uri)
+
+
+def get_complete_github_oauth_use_case(
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+    user_repo: Annotated[UserRepository, Depends(get_user_repo)],
+    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
+    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
+) -> CompleteGitHubOAuthUseCase:
+    return CompleteGitHubOAuthUseCase(
+        github_service,
+        user_repo,
+        identity_repo,
+        session_repo,
+        settings.oauth_state_ttl_minutes,
+        settings.session_ttl_hours,
+    )
+
+
+def get_session_user_use_case(
+    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
+    user_repo: Annotated[UserRepository, Depends(get_user_repo)],
+) -> GetSessionUserUseCase:
+    return GetSessionUserUseCase(session_repo, user_repo)
+
+
+def get_logout_use_case(
+    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
+) -> LogoutUseCase:
+    return LogoutUseCase(session_repo)
+
+
+def get_list_github_repos_use_case(
+    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+) -> ListGitHubReposUseCase:
+    return ListGitHubReposUseCase(identity_repo, github_service)
+
+
+def get_create_github_repo_use_case(
+    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+) -> CreateGitHubRepoUseCase:
+    return CreateGitHubRepoUseCase(identity_repo, github_service)
+
+
+def get_sync_workspace_to_github_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+) -> SyncWorkspaceToGitHubUseCase:
+    return SyncWorkspaceToGitHubUseCase(workspace_repo, identity_repo, github_service)
+
+
+def get_pull_workspace_architecture_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+) -> PullWorkspaceArchitectureUseCase:
+    return PullWorkspaceArchitectureUseCase(workspace_repo, identity_repo, github_service)
+
+
+def get_create_workspace_pull_request_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+) -> CreateWorkspacePullRequestUseCase:
+    return CreateWorkspacePullRequestUseCase(workspace_repo, identity_repo, github_service)
+
+
+def get_list_workspace_commits_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    identity_repo: Annotated[IdentityRepository, Depends(get_identity_repo)],
+    github_service: Annotated[GitHubService, Depends(get_github_service)],
+) -> ListWorkspaceCommitsUseCase:
+    return ListWorkspaceCommitsUseCase(workspace_repo, identity_repo, github_service)
+
+
+def get_generate_architecture_use_case(
+    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
+    key_manager: Annotated[KeyManager, Depends(get_key_manager)],
+) -> GenerateArchitectureUseCase:
+    return GenerateArchitectureUseCase(
+        ai_api_key_repo,
+        key_manager,
+        settings.llm_provider_url,
+        settings.llm_model,
+        settings.llm_max_tokens,
+        settings.llm_request_timeout,
+    )
+
+
+def get_suggest_architecture_improvements_use_case(
+    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
+    key_manager: Annotated[KeyManager, Depends(get_key_manager)],
+) -> SuggestArchitectureImprovementsUseCase:
+    return SuggestArchitectureImprovementsUseCase(
+        ai_api_key_repo,
+        key_manager,
+        settings.llm_provider_url,
+        settings.llm_model,
+        settings.llm_max_tokens,
+        settings.llm_request_timeout,
+    )
+
+
+def get_estimate_architecture_cost_use_case() -> EstimateArchitectureCostUseCase:
+    return EstimateArchitectureCostUseCase(settings.infracost_api_key)
+
+
+def get_store_ai_key_use_case(
+    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
+    key_manager: Annotated[KeyManager, Depends(get_key_manager)],
+) -> StoreAIKeyUseCase:
+    return StoreAIKeyUseCase(ai_api_key_repo, key_manager)
+
+
+def get_list_ai_keys_use_case(
+    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
+) -> ListAIKeysUseCase:
+    return ListAIKeysUseCase(ai_api_key_repo)
+
+
+def get_delete_ai_key_use_case(
+    ai_api_key_repo: Annotated[AIApiKeyRepository, Depends(get_ai_api_key_repo)],
+) -> DeleteAIKeyUseCase:
+    return DeleteAIKeyUseCase(ai_api_key_repo)
+
+
+def get_trigger_generation_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    run_repo: Annotated[GenerationRunRepository, Depends(get_generation_run_repo)],
+) -> TriggerGenerationUseCase:
+    return TriggerGenerationUseCase(workspace_repo, run_repo)
+
+
+def get_generation_status_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+    run_repo: Annotated[GenerationRunRepository, Depends(get_generation_run_repo)],
+) -> GetGenerationStatusUseCase:
+    return GetGenerationStatusUseCase(workspace_repo, run_repo)
+
+
+def get_preview_generation_use_case(
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> PreviewGenerationUseCase:
+    return PreviewGenerationUseCase(workspace_repo)
+
+
+def get_bind_workspace_to_session_use_case(
+    session_repo: Annotated[SessionRepository, Depends(get_session_repo)],
+    workspace_repo: Annotated[WorkspaceRepository, Depends(get_workspace_repo)],
+) -> BindWorkspaceToSessionUseCase:
+    return BindWorkspaceToSessionUseCase(session_repo, workspace_repo)
 
 
 async def get_current_session(

--- a/apps/api/app/tests/unit/test_llm_client.py
+++ b/apps/api/app/tests/unit/test_llm_client.py
@@ -104,7 +104,7 @@ def _make_response(
 
 def _make_async_client(post_side_effect: object) -> _MockAsyncClient:
     client = _MockAsyncClient()
-    if isinstance(post_side_effect, (list, BaseException)):
+    if isinstance(post_side_effect, list | BaseException):
         client.post.side_effect = post_side_effect
     else:
         client.post.return_value = post_side_effect

--- a/apps/api/app/tests/unit/test_llm_client.py
+++ b/apps/api/app/tests/unit/test_llm_client.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from dataclasses import dataclass
+from typing import final, cast
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -8,23 +10,101 @@ import pytest
 from app.infrastructure.llm.client import LLMError, OpenAIClient
 
 
+@dataclass
+class _CallArgs:
+    args: tuple[object, ...]
+    kwargs: dict[str, object]
+
+
+@final
+class _MockResponse:
+    status_code: int
+    text: str
+    _payload: dict[str, object]
+
+    def __init__(self, status_code: int, payload: dict[str, object] | None = None, text: str = ""):
+        self.status_code = status_code
+        self.text = text
+        self._payload = payload if payload is not None else {}
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+@final
+class _AwaitableCall:
+    await_count: int
+    await_args: _CallArgs
+    side_effect: list[object] | BaseException | None
+    return_value: object | None
+
+    def __init__(self) -> None:
+        self.await_count = 0
+        self.await_args = _CallArgs(args=(), kwargs={})
+        self.side_effect = None
+        self.return_value = None
+
+    async def __call__(self, *args: object, **kwargs: object) -> object:
+        self.await_count += 1
+        self.await_args = _CallArgs(args=args, kwargs=kwargs)
+        if isinstance(self.side_effect, BaseException):
+            raise self.side_effect
+        if isinstance(self.side_effect, list):
+            if not self.side_effect:
+                raise RuntimeError("side_effect list is empty")
+            value = self.side_effect.pop(0)
+            if isinstance(value, BaseException):
+                raise value
+            return value
+        if self.side_effect is not None:
+            return self.side_effect
+        return self.return_value
+
+
+@final
+class _MockAsyncClient:
+    post: _AwaitableCall
+
+    def __init__(self) -> None:
+        self.post = _AwaitableCall()
+
+    async def __aenter__(self) -> _MockAsyncClient:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> bool:
+        return False
+
+
+@final
+class _SleepRecorder:
+    await_count: int
+    await_args: _CallArgs
+
+    def __init__(self) -> None:
+        self.await_count = 0
+        self.await_args = _CallArgs(args=(), kwargs={})
+
+    async def __call__(self, *args: object, **kwargs: object) -> None:
+        self.await_count += 1
+        self.await_args = _CallArgs(args=args, kwargs=kwargs)
+
+    def assert_awaited_once_with(self, *args: object, **kwargs: object) -> None:
+        assert self.await_count == 1
+        assert self.await_args.args == args
+        assert self.await_args.kwargs == kwargs
+
+
 def _make_response(
     status_code: int,
     payload: dict[str, object] | None = None,
     text: str = "",
-) -> MagicMock:
-    response = MagicMock()
-    response.status_code = status_code
-    response.text = text
-    response.json.return_value = payload if payload is not None else {}
-    return response
+) -> _MockResponse:
+    return _MockResponse(status_code, payload, text)
 
 
-def _make_async_client(post_side_effect: object) -> AsyncMock:
-    client = AsyncMock()
-    client.__aenter__.return_value = client
-    client.__aexit__.return_value = False
-    if isinstance(post_side_effect, list | BaseException):
+def _make_async_client(post_side_effect: object) -> _MockAsyncClient:
+    client = _MockAsyncClient()
+    if isinstance(post_side_effect, (list, BaseException)):
         client.post.side_effect = post_side_effect
     else:
         client.post.return_value = post_side_effect
@@ -64,9 +144,10 @@ async def test_generate_with_schema() -> None:
     with patch("app.infrastructure.llm.client.httpx.AsyncClient", return_value=mock_client):
         _ = await client.generate("You are helpful.", "Generate JSON.", response_schema=schema)
 
-    body = mock_client.post.await_args.kwargs["json"]
+    body = cast(dict[str, object], mock_client.post.await_args.kwargs["json"])
     assert body["response_format"] == {"type": "json_object"}
-    system_text = body["messages"][0]["content"]
+    messages = cast(list[dict[str, object]], body["messages"])
+    system_text = cast(str, messages[0]["content"])
     assert "matching this schema exactly" in system_text
     assert '"required":["ok"]' in system_text
 
@@ -77,10 +158,11 @@ async def test_retry_on_rate_limit() -> None:
     success = _make_response(200, {"choices": [{"message": {"content": '{"ok":true}'}}]})
     mock_client = _make_async_client([rate_limited, success])
     client = OpenAIClient(api_key="test-key")
+    sleep_mock = _SleepRecorder()
 
     with (
         patch("app.infrastructure.llm.client.httpx.AsyncClient", return_value=mock_client),
-        patch("app.infrastructure.llm.client.asyncio.sleep", new=AsyncMock()) as sleep_mock,
+        patch("app.infrastructure.llm.client.asyncio.sleep", new=sleep_mock),
     ):
         result = await client.generate("system", "user")
 
@@ -95,10 +177,11 @@ async def test_retry_on_server_error() -> None:
     success = _make_response(200, {"choices": [{"message": {"content": '{"ok":true}'}}]})
     mock_client = _make_async_client([server_error, success])
     client = OpenAIClient(api_key="test-key")
+    sleep_mock = _SleepRecorder()
 
     with (
         patch("app.infrastructure.llm.client.httpx.AsyncClient", return_value=mock_client),
-        patch("app.infrastructure.llm.client.asyncio.sleep", new=AsyncMock()) as sleep_mock,
+        patch("app.infrastructure.llm.client.asyncio.sleep", new=sleep_mock),
     ):
         result = await client.generate("system", "user")
 

--- a/apps/api/app/tests/unit/test_llm_client.py
+++ b/apps/api/app/tests/unit/test_llm_client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import final, cast
+from typing import cast, final
 from unittest.mock import patch
 
 import httpx

--- a/apps/api/app/tests/unit/test_llm_client.py
+++ b/apps/api/app/tests/unit/test_llm_client.py
@@ -24,7 +24,7 @@ def _make_async_client(post_side_effect: object) -> AsyncMock:
     client = AsyncMock()
     client.__aenter__.return_value = client
     client.__aexit__.return_value = False
-    if isinstance(post_side_effect, (list, BaseException)):
+    if isinstance(post_side_effect, list | BaseException):
         client.post.side_effect = post_side_effect
     else:
         client.post.return_value = post_side_effect


### PR DESCRIPTION
## Summary

- Extract business logic from all route handlers into dedicated use case classes
- Routes become thin HTTP adapters: parse request → call use case → return response
- Wire existing `workspace_use_cases.py` to actually be used by workspace routes

## Changes

| Use Case | Bounded Context |
|----------|-----------------|
| `auth_use_cases.py` | GitHub OAuth, session management |
| `github_use_cases.py` | Repo sync, PR creation, workspace push |
| `ai_use_cases.py` | Architecture generation, suggestions |
| `ai_keys_use_cases.py` | API key CRUD |
| `generation_use_cases.py` | Code generation pipeline |
| `session_use_cases.py` | Session token management |
| `workspace_use_cases.py` | Workspace CRUD (existing, now wired) |

All route files refactored to delegate to use cases. FastAPI dependency providers added in `core/dependencies.py`.

## Testing

- `ruff check .` ✅ — no lint errors
- No behavior changes — all HTTP response shapes and status codes preserved

Fixes #1686
Part of #1685