### PR TITLE
refactor(web): fix FSD upward imports and restore dependency direction

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -10,12 +10,12 @@ import type {
 import { isExternalResourceType, parseEndpointId } from '@cloudblocks/schema';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
-import { getDiffState } from '../../features/diff/engine';
 import type { DiffDelta } from '../../shared/types/diff';
+import { getDiffState } from '../../shared/utils/diff';
 import { screenDeltaToWorld, snapToGrid } from '../../shared/utils/isometric';
 import { audioService } from '../../shared/utils/audioService';
 import { canConnect } from '../validation/connection';
-import type { EndpointType } from '../validation/connection';
+import type { EndpointType } from '../../shared/types/endpoint';
 import { validatePlacement } from '../validation/placement';
 import { getBlockDimensions } from '../../shared/types/visualProfile';
 import { cuToSilhouetteDimensions } from './silhouettes';

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -4,7 +4,7 @@ import { endpointId } from '@cloudblocks/schema';
 import type { Connection, ConnectionType } from '@cloudblocks/schema';
 import type { DiffDelta } from '../../shared/types/diff';
 import { ConnectionRenderer } from './ConnectionRenderer';
-import { getDiffState } from '../../features/diff/engine';
+import { getDiffState } from '../../shared/utils/diff';
 import { getConnectionSurfaceRoute } from './surfaceRouting';
 import type { SurfaceRoute } from './surfaceRouting';
 import { useUIStore } from '../store/uiStore';
@@ -28,7 +28,7 @@ vi.mock('../../shared/tokens/designTokens', () => ({
   PORT_DOT_STROKE_WIDTH: 1.5,
 }));
 
-vi.mock('../../features/diff/engine', () => ({
+vi.mock('../../shared/utils/diff', () => ({
   getDiffState: vi.fn(),
 }));
 

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -7,7 +7,7 @@ import type {
   EndpointSemantic,
   ResourceBlock,
 } from '@cloudblocks/schema';
-import { getDiffState } from '../../features/diff/engine';
+import { getDiffState } from '../../shared/utils/diff';
 import { worldToScreen } from '../../shared/utils/isometric';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useUIStore } from '../store/uiStore';

--- a/apps/web/src/entities/connection/endpointResolver.ts
+++ b/apps/web/src/entities/connection/endpointResolver.ts
@@ -1,7 +1,8 @@
 import type { ResourceBlock, ResourceCategory } from '@cloudblocks/schema';
 import { isExternalResourceType } from '@cloudblocks/schema';
+import type { EndpointType as SharedEndpointType } from '../../shared/types/endpoint';
 
-export type EndpointType = ResourceCategory | 'internet' | 'browser';
+export type EndpointType = SharedEndpointType;
 
 export interface EndpointSource {
   id: string;

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
@@ -8,7 +8,7 @@ import {
 import type { ContainerBlock, LayerType } from '@cloudblocks/schema';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
-import { getDiffState } from '../../features/diff/engine';
+import { getDiffState } from '../../shared/utils/diff';
 import type { DiffDelta } from '../../shared/types/diff';
 import { getContainerBlockIconUrl } from '../../shared/utils/iconResolver';
 import { getContainerLabel } from '../../shared/utils/providerMapping';

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -11,6 +11,7 @@ import type {
   RollbackRecord,
   DeploymentVersion,
 } from '../../shared/types/ops';
+import type { DrawerPanelId } from '../../shared/types/drawer';
 
 export type ToolMode = 'select' | 'connect' | 'delete';
 export type InteractionState = 'idle' | 'selecting' | 'dragging' | 'placing' | 'connecting';
@@ -26,15 +27,6 @@ export type RightOverlayId =
   | 'githubPR'
   | 'diff'
   | null;
-export type DrawerPanelId =
-  | 'properties'
-  | 'validation'
-  | 'connections'
-  | 'scenarios'
-  | 'learning'
-  | 'code'
-  | 'templates';
-
 export interface ActivityLogEntry {
   id: string;
   ts: string;
@@ -43,6 +35,7 @@ export interface ActivityLogEntry {
 }
 export type { EditorMode } from '../../shared/types/learning';
 export type { ComplexityLevel } from '../../shared/types';
+export type { DrawerPanelId } from '../../shared/types/drawer';
 
 /** Runtime health/status for a block — not persisted in architecture model. */
 export type BlockHealthStatus = 'ok' | 'warn' | 'error';

--- a/apps/web/src/features/diff/engine.ts
+++ b/apps/web/src/features/diff/engine.ts
@@ -4,7 +4,10 @@ import type {
   ContainerBlock,
   ResourceBlock,
 } from '@cloudblocks/schema';
-import type { DiffDelta, DiffState, EntityDiff, PropertyChange } from '../../shared/types/diff';
+import type { DiffDelta, EntityDiff, PropertyChange } from '../../shared/types/diff';
+import { getDiffState } from '../../shared/utils/diff';
+
+export { getDiffState };
 
 const ROOT_VOLATILE_PATHS = new Set(['createdAt', 'updatedAt']);
 const ROOT_ENTITY_PATHS = new Set(['nodes', 'endpoints', 'connections', 'createdAt', 'updatedAt']);
@@ -220,22 +223,4 @@ export function computeArchitectureDiff(
     ...deltaWithoutSummary,
     summary: computeSummary(deltaWithoutSummary),
   };
-}
-
-export function getDiffState(entityId: string, delta: DiffDelta): DiffState {
-  const entityDiffs = [delta.plates, delta.blocks, delta.connections];
-
-  if (entityDiffs.some((diff) => diff.added.some((entity) => entity.id === entityId))) {
-    return 'added';
-  }
-
-  if (entityDiffs.some((diff) => diff.removed.some((entity) => entity.id === entityId))) {
-    return 'removed';
-  }
-
-  if (entityDiffs.some((diff) => diff.modified.some((entity) => entity.id === entityId))) {
-    return 'modified';
-  }
-
-  return 'unchanged';
 }

--- a/apps/web/src/features/generate/types.ts
+++ b/apps/web/src/features/generate/types.ts
@@ -5,6 +5,9 @@ import type {
   ResourceBlock,
   ResourceCategory,
 } from '@cloudblocks/schema';
+import type { GeneratorId as SharedGeneratorId } from '../../shared/types/generator';
+
+export type GeneratorId = SharedGeneratorId;
 
 type PlateLayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
 
@@ -23,7 +26,6 @@ type PlateLayerType = 'global' | 'edge' | 'region' | 'zone' | 'subnet';
 
 // ─── Generator Identity ─────────────────────────────────────
 
-export type GeneratorId = 'terraform' | 'bicep' | 'pulumi';
 export type KnownLanguage = 'hcl' | 'json' | 'bicep' | 'typescript';
 export type FileLanguage = KnownLanguage | (string & {});
 

--- a/apps/web/src/shared/hooks/useTechTree.test.ts
+++ b/apps/web/src/shared/hooks/useTechTree.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useArchitectureStore } from '../../entities/store/architectureStore';
 import type { ArchitectureModel, ContainerBlock, ResourceCategory } from '@cloudblocks/schema';
 import { makeTestBlock, makeTestPlate } from '../../__tests__/legacyModelTestUtils';
 import {
@@ -8,6 +7,8 @@ import {
   ACTION_GRID,
   ALL_RESOURCES,
   RESOURCE_DEFINITIONS,
+  getResourceLabel,
+  getResourceShortLabel,
   getCreationGroupId,
   getCreationGroupMeta,
   useTechTree,
@@ -95,14 +96,6 @@ function buildArchitecture(plates: ContainerBlock[], blockCount = 0): Architectu
     ...BASE_ARCHITECTURE,
     nodes: [...plates, ...blocks],
   };
-}
-
-function setArchitectureState(architecture: ArchitectureModel): void {
-  const workspace = useArchitectureStore.getState().workspace;
-  useArchitectureStore.setState({
-    workspace: { ...workspace, architecture },
-    validationResult: null,
-  });
 }
 
 describe('useTechTree constants', () => {
@@ -467,13 +460,8 @@ describe('useTechTree constants', () => {
 });
 
 describe('useTechTree hook', () => {
-  beforeEach(() => {
-    useArchitectureStore.getState().resetWorkspace();
-    setArchitectureState(buildArchitecture([], 0));
-  });
-
   it('returns expected state when no plates exist', () => {
-    const { result } = renderHook(() => useTechTree());
+    const { result } = renderHook(() => useTechTree(buildArchitecture([], 0)));
     const techTreeState: TechTreeState = result.current;
 
     expect(techTreeState.hasVNet).toBe(false);
@@ -483,15 +471,16 @@ describe('useTechTree hook', () => {
   });
 
   it('enables network always, and gates subnet/vm/storage on vnet availability', () => {
-    const { result: emptyResult } = renderHook(() => useTechTree());
+    const { result: emptyResult } = renderHook(() => useTechTree(buildArchitecture([], 0)));
 
     expect(emptyResult.current.isEnabled('network')).toBe(true);
     expect(emptyResult.current.isEnabled('subnet')).toBe(false);
     expect(emptyResult.current.isEnabled('vm')).toBe(false);
     expect(emptyResult.current.isEnabled('storage')).toBe(false);
 
-    setArchitectureState(buildArchitecture([NETWORK_PLATE], 2));
-    const { result: vnetResult } = renderHook(() => useTechTree());
+    const { result: vnetResult } = renderHook(() =>
+      useTechTree(buildArchitecture([NETWORK_PLATE], 2)),
+    );
 
     expect(vnetResult.current.hasVNet).toBe(true);
     expect(vnetResult.current.hasSubnet).toBe(false);
@@ -503,14 +492,15 @@ describe('useTechTree hook', () => {
   });
 
   it('returns null disabled reason for enabled resources and custom reason for disabled ones', () => {
-    const { result: emptyResult } = renderHook(() => useTechTree());
+    const { result: emptyResult } = renderHook(() => useTechTree(buildArchitecture([], 0)));
 
     expect(emptyResult.current.getDisabledReason('vm')).toBe(
       'Create a Network first. Virtual Machines need a network to connect to.',
     );
 
-    setArchitectureState(buildArchitecture([NETWORK_PLATE], 0));
-    const { result: enabledResult } = renderHook(() => useTechTree());
+    const { result: enabledResult } = renderHook(() =>
+      useTechTree(buildArchitecture([NETWORK_PLATE], 0)),
+    );
 
     expect(enabledResult.current.getDisabledReason('vm')).toBeNull();
     expect(enabledResult.current.getDisabledReason('network')).toBeNull();
@@ -527,7 +517,7 @@ describe('useTechTree hook', () => {
     Reflect.set(RESOURCE_DEFINITIONS, 'network', mutatedNetwork);
 
     try {
-      const { result } = renderHook(() => useTechTree());
+      const { result } = renderHook(() => useTechTree(buildArchitecture([], 0)));
 
       expect(result.current.isEnabled('network')).toBe(false);
       expect(result.current.getDisabledReason('network')).toBe(
@@ -539,7 +529,7 @@ describe('useTechTree hook', () => {
   });
 
   it('returns all creation resources from RESOURCE_DEFINITIONS', () => {
-    const { result } = renderHook(() => useTechTree());
+    const { result } = renderHook(() => useTechTree(buildArchitecture([], 0)));
 
     const expectedResourceTypes = ALL_RESOURCES;
     const creationResources = result.current.getCreationResources();
@@ -556,27 +546,28 @@ describe('useTechTree hook', () => {
   });
 
   it('selects target container for vm: subnet first, then network, otherwise null', () => {
-    const { result: emptyResult } = renderHook(() => useTechTree());
+    const { result: emptyResult } = renderHook(() => useTechTree(buildArchitecture([], 0)));
     expect(emptyResult.current.getTargetPlateId('vm')).toBeNull();
 
-    setArchitectureState(buildArchitecture([NETWORK_PLATE], 0));
-    const { result: networkOnlyResult } = renderHook(() => useTechTree());
+    const { result: networkOnlyResult } = renderHook(() =>
+      useTechTree(buildArchitecture([NETWORK_PLATE], 0)),
+    );
     expect(networkOnlyResult.current.getTargetPlateId('vm')).toBe('net-1');
 
-    setArchitectureState(buildArchitecture([NETWORK_PLATE, SUBNET_PLATE], 0));
-    const { result: withSubnetResult } = renderHook(() => useTechTree());
+    const { result: withSubnetResult } = renderHook(() =>
+      useTechTree(buildArchitecture([NETWORK_PLATE, SUBNET_PLATE], 0)),
+    );
     expect(withSubnetResult.current.getTargetPlateId('vm')).toBe('sub-1');
   });
 
   it('selects network container for non-vnet-required resources like storage', () => {
-    setArchitectureState(buildArchitecture([NETWORK_PLATE], 0));
-    const { result } = renderHook(() => useTechTree());
+    const { result } = renderHook(() => useTechTree(buildArchitecture([NETWORK_PLATE], 0)));
 
     expect(result.current.getTargetPlateId('storage')).toBe('net-1');
   });
 
   it('returns null target container for non-vnet-required resources when no network exists', () => {
-    const { result } = renderHook(() => useTechTree());
+    const { result } = renderHook(() => useTechTree(buildArchitecture([], 0)));
 
     expect(result.current.getTargetPlateId('storage')).toBeNull();
   });
@@ -617,6 +608,18 @@ describe('getCreationGroupId', () => {
 
   it('maps monitor to operations group', () => {
     expect(getCreationGroupId('monitor')).toBe('operations');
+  });
+});
+
+describe('provider-aware resource labels', () => {
+  it('returns provider-specific labels when defined', () => {
+    expect(getResourceLabel('vm', 'aws')).toBe('EC2');
+    expect(getResourceShortLabel('vm', 'aws')).toBe('EC2');
+  });
+
+  it('falls back to default labels when a provider override is missing', () => {
+    expect(getResourceLabel('subnet', 'gcp')).toBe('Subnet');
+    expect(getResourceShortLabel('subnet', 'gcp')).toBe('Subnet');
   });
 });
 

--- a/apps/web/src/shared/hooks/useTechTree.ts
+++ b/apps/web/src/shared/hooks/useTechTree.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { useArchitectureStore } from '../../entities/store/architectureStore';
 import type {
+  ArchitectureModel,
   ProviderType,
   ResourceCategory,
   ResourceType as SchemaResourceType,
@@ -604,93 +604,79 @@ export interface TechTreeState {
   getTargetPlateId: (type: ResourceType) => string | null;
 }
 
-export function useTechTree(): TechTreeState {
-  const architecture = useArchitectureStore((s) => s.workspace.architecture);
+export function buildTechTreeState(architecture: ArchitectureModel): TechTreeState {
+  const containers = architecture.nodes.filter((node) => node.kind === 'container');
+  const resources = architecture.nodes.filter((node) => node.kind === 'resource');
+  const networkPlates = containers.filter((p) => p.layer === 'region');
+  const subnetPlates = containers.filter((p) => p.layer === 'subnet');
+  const hasVNet = networkPlates.length > 0;
+  const hasSubnet = subnetPlates.length > 0;
 
-  return useMemo(() => {
-    const containers = architecture.nodes.filter((node) => node.kind === 'container');
-    const resources = architecture.nodes.filter((node) => node.kind === 'resource');
-    const networkPlates = containers.filter((p) => p.layer === 'region');
-    const subnetPlates = containers.filter((p) => p.layer === 'subnet');
-    const hasVNet = networkPlates.length > 0;
-    const hasSubnet = subnetPlates.length > 0;
+  const isEnabled = (type: ResourceType): boolean => {
+    const def = RESOURCE_DEFINITIONS[type];
 
-    const isEnabled = (type: ResourceType): boolean => {
-      const def = RESOURCE_DEFINITIONS[type];
+    switch (def.category) {
+      case 'foundation':
+        if (type === 'network') return true;
+        return hasVNet;
+      case 'always':
+      case 'vnet-optional':
+      case 'vnet-required':
+        return hasVNet;
+      default:
+        return false;
+    }
+  };
 
-      switch (def.category) {
-        case 'foundation':
-          // Network is always enabled
-          if (type === 'network') return true;
-          // Subnets require VNet
-          return hasVNet;
+  const getDisabledReason = (type: ResourceType): string | null => {
+    if (isEnabled(type)) return null;
 
-        case 'always':
-          // Always enabled (but needs a container to place on)
-          return hasVNet;
+    const def = RESOURCE_DEFINITIONS[type];
+    if (def.disabledReason) return def.disabledReason;
 
-        case 'vnet-optional':
-          // VNet optional — enabled if we have a network container
-          return hasVNet;
+    if (def.category === 'vnet-required' || def.category === 'vnet-optional') {
+      return 'Create a Network first to unlock this resource.';
+    }
+    if (def.category === 'always') {
+      return 'Create a Network first to place resources.';
+    }
 
-        case 'vnet-required':
-          // Requires VNet to exist
-          return hasVNet;
+    return 'This resource is not available yet.';
+  };
 
-        default:
-          return false;
-      }
-    };
+  const getCreationResources = () => {
+    return ALL_RESOURCES.map((type) => ({
+      resource: RESOURCE_DEFINITIONS[type],
+      enabled: isEnabled(type),
+      disabledReason: getDisabledReason(type),
+    }));
+  };
 
-    const getDisabledReason = (type: ResourceType): string | null => {
-      if (isEnabled(type)) return null;
+  const getTargetPlateId = (type: ResourceType): string | null => {
+    const def = RESOURCE_DEFINITIONS[type];
 
-      const def = RESOURCE_DEFINITIONS[type];
-      if (def.disabledReason) return def.disabledReason;
-
-      // Default reason
-      if (def.category === 'vnet-required' || def.category === 'vnet-optional') {
-        return 'Create a Network first to unlock this resource.';
-      }
-      if (def.category === 'always') {
-        return 'Create a Network first to place resources.';
-      }
-
-      return 'This resource is not available yet.';
-    };
-
-    const getCreationResources = () => {
-      return ALL_RESOURCES.map((type) => ({
-        resource: RESOURCE_DEFINITIONS[type],
-        enabled: isEnabled(type),
-        disabledReason: getDisabledReason(type),
-      }));
-    };
-
-    const getTargetPlateId = (type: ResourceType): string | null => {
-      const def = RESOURCE_DEFINITIONS[type];
-
-      // For VNet-required resources, prefer subnet if available
-      if (def.category === 'vnet-required') {
-        if (subnetPlates.length > 0) return subnetPlates[0].id;
-        if (networkPlates.length > 0) return networkPlates[0].id;
-        return null;
-      }
-
-      // For other blocks, use network container
+    if (def.category === 'vnet-required') {
+      if (subnetPlates.length > 0) return subnetPlates[0].id;
       if (networkPlates.length > 0) return networkPlates[0].id;
       return null;
-    };
+    }
 
-    return {
-      hasVNet,
-      hasSubnet,
-      blockCount: resources.length,
-      plateCount: containers.length,
-      isEnabled,
-      getDisabledReason,
-      getCreationResources,
-      getTargetPlateId,
-    };
-  }, [architecture.nodes]);
+    if (networkPlates.length > 0) return networkPlates[0].id;
+    return null;
+  };
+
+  return {
+    hasVNet,
+    hasSubnet,
+    blockCount: resources.length,
+    plateCount: containers.length,
+    isEnabled,
+    getDisabledReason,
+    getCreationResources,
+    getTargetPlateId,
+  };
+}
+
+export function useTechTree(architecture: ArchitectureModel): TechTreeState {
+  return useMemo(() => buildTechTreeState(architecture), [architecture]);
 }

--- a/apps/web/src/shared/types/drawer.ts
+++ b/apps/web/src/shared/types/drawer.ts
@@ -1,0 +1,8 @@
+export type DrawerPanelId =
+  | 'properties'
+  | 'validation'
+  | 'connections'
+  | 'scenarios'
+  | 'learning'
+  | 'code'
+  | 'templates';

--- a/apps/web/src/shared/types/endpoint.ts
+++ b/apps/web/src/shared/types/endpoint.ts
@@ -1,0 +1,3 @@
+import type { ResourceCategory } from '@cloudblocks/schema';
+
+export type EndpointType = ResourceCategory | 'internet' | 'browser';

--- a/apps/web/src/shared/types/generator.ts
+++ b/apps/web/src/shared/types/generator.ts
@@ -1,0 +1,1 @@
+export type GeneratorId = 'terraform' | 'bicep' | 'pulumi';

--- a/apps/web/src/shared/types/learning.ts
+++ b/apps/web/src/shared/types/learning.ts
@@ -1,5 +1,5 @@
 import type { ArchitectureModel, ResourceCategory, ContainerLayer } from './index';
-import type { EndpointType } from '../../entities/validation/connection';
+import type { EndpointType } from './endpoint';
 import type { TemplateCategory } from './template';
 
 // ─── Editor Mode ───────────────────────────────────────────

--- a/apps/web/src/shared/types/template.ts
+++ b/apps/web/src/shared/types/template.ts
@@ -1,5 +1,5 @@
 import type { ArchitectureModel } from './index';
-import type { GeneratorId } from '../../features/generate/types';
+import type { GeneratorId } from './generator';
 
 // ─── Template Types (extracted from features/templates for FSD compliance) ──
 

--- a/apps/web/src/shared/utils/diff.ts
+++ b/apps/web/src/shared/utils/diff.ts
@@ -1,0 +1,19 @@
+import type { DiffDelta, DiffState } from '../types/diff';
+
+export function getDiffState(entityId: string, delta: DiffDelta): DiffState {
+  const entityDiffs = [delta.plates, delta.blocks, delta.connections];
+
+  if (entityDiffs.some((diff) => diff.added.some((entity) => entity.id === entityId))) {
+    return 'added';
+  }
+
+  if (entityDiffs.some((diff) => diff.removed.some((entity) => entity.id === entityId))) {
+    return 'removed';
+  }
+
+  if (entityDiffs.some((diff) => diff.modified.some((entity) => entity.id === entityId))) {
+    return 'modified';
+  }
+
+  return 'unchanged';
+}

--- a/apps/web/src/widgets/right-drawer/panelRegistry.ts
+++ b/apps/web/src/widgets/right-drawer/panelRegistry.ts
@@ -16,15 +16,9 @@ import {
   Code,
   LayoutTemplate,
 } from 'lucide-react';
+import type { DrawerPanelId as SharedDrawerPanelId } from '../../shared/types/drawer';
 
-export type DrawerPanelId =
-  | 'properties'
-  | 'validation'
-  | 'connections'
-  | 'scenarios'
-  | 'learning'
-  | 'code'
-  | 'templates';
+export type DrawerPanelId = SharedDrawerPanelId;
 
 export interface PanelRegistryEntry {
   id: DrawerPanelId;

--- a/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
@@ -10,7 +10,7 @@ import { CATEGORY_PORTS, isExternalResourceType } from '@cloudblocks/schema';
 import type { ResourceBlock, ContainerBlock } from '@cloudblocks/schema';
 import { PORT_OUT_PX } from '../../shared/tokens/designTokens';
 import { canConnect } from '../../entities/validation/connection';
-import type { EndpointType } from '../../entities/validation/connection';
+import type { EndpointType } from '../../shared/types/endpoint';
 
 interface ConnectionPreviewProps {
   originX: number;

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.tsx
@@ -276,7 +276,8 @@ function PaletteExternalGroup({
 }
 
 export function SidebarPalette() {
-  const techTree = useTechTree();
+  const architecture = useArchitectureStore((s) => s.workspace.architecture);
+  const techTree = useTechTree(architecture);
   const addNode = useArchitectureStore((s) => s.addNode);
   const addExternalBlock = useArchitectureStore((s) => s.addExternalBlock);
   const activeProvider = useUIStore((s) => s.activeProvider);


### PR DESCRIPTION
## Summary
- Eliminates all FSD upward import violations in `shared/` and `entities/`
- Extracts shared primitives: `EndpointType`, `GeneratorId`, `DrawerPanelId`, `getDiffState`
- Decouples `useTechTree` hook from direct store import (now accepts architecture as parameter)
- All existing tests pass with 90.19% branch coverage

Fixes #1687
Part of #1685