### PR TITLE
refactor(web): move AI API types to shared layer for FSD compliance

### DIFF
--- a/apps/web/src/entities/store/slices/aiSlice.ts
+++ b/apps/web/src/entities/store/slices/aiSlice.ts
@@ -1,6 +1,6 @@
 import { isApiConfigured } from '../../../shared/api/client';
-import { estimateCost, generateArchitecture, suggestImprovements } from '../../../features/ai/api';
-import type { CostResponse, GenerateResponse, SuggestResponse } from '../../../features/ai/api';
+import { estimateCost, generateArchitecture, suggestImprovements } from '../../../shared/api/ai';
+import type { CostResponse, GenerateResponse, SuggestResponse } from '../../../shared/types/ai';
 import type { ArchitectureSnapshot } from '../../../shared/types/learning';
 import { validateArchitectureShape } from './index';
 import type { ArchitectureSlice, ArchitectureState } from './types';

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -8,7 +8,7 @@ import type {
   ResourceCategory,
 } from '@cloudblocks/schema';
 import type { ValidationResult } from '@cloudblocks/domain';
-import type { CostResponse, GenerateResponse, SuggestResponse } from '../../../features/ai/api';
+import type { CostResponse, GenerateResponse, SuggestResponse } from '../../../shared/types/ai';
 import type { ArchitectureSnapshot } from '../../../shared/types/learning';
 import type { Scenario, LearningProgress } from '../../../shared/types/learning';
 import type { ArchitectureTemplate } from '../../../shared/types/template';

--- a/apps/web/src/features/ai/api.ts
+++ b/apps/web/src/features/ai/api.ts
@@ -1,77 +1,11 @@
-import { apiPost, isApiConfigured } from '../../shared/api/client';
-
-const BACKEND_REQUIRED_MESSAGE = 'AI features require the backend API - see setup guide.';
-
-function assertAiBackendConfigured(): void {
-  if (!isApiConfigured()) {
-    throw new Error(BACKEND_REQUIRED_MESSAGE);
-  }
-}
-
-// ─── Request Types ─────────────────────────────────────────
-
-export interface GenerateRequest {
-  prompt: string;
-  provider: string;
-  complexity?: string;
-}
-
-export interface SuggestRequest {
-  architecture: Record<string, unknown>;
-  provider: string;
-}
-
-export interface CostRequest {
-  architecture: Record<string, unknown>;
-  provider: string;
-}
-
-// ─── Response Types ────────────────────────────────────────
-
-export interface GenerateResponse {
-  architecture: Record<string, unknown>;
-  explanation: string;
-  warnings: string[];
-}
-
-export interface AiSuggestion {
-  category: string;
-  severity: string;
-  message: string;
-  action_description: string;
-}
-
-export interface SuggestResponse {
-  suggestions: AiSuggestion[];
-  score: Record<string, number>;
-}
-
-export interface CostResource {
-  name: string;
-  monthly_cost: number;
-  details: Record<string, unknown>;
-}
-
-export interface CostResponse {
-  monthly_cost: number;
-  hourly_cost: number;
-  currency: string;
-  resources: CostResource[];
-}
-
-// ─── API Functions ─────────────────────────────────────────
-
-export async function generateArchitecture(req: GenerateRequest): Promise<GenerateResponse> {
-  assertAiBackendConfigured();
-  return apiPost<GenerateResponse>('/api/v1/ai/generate', req);
-}
-
-export async function suggestImprovements(req: SuggestRequest): Promise<SuggestResponse> {
-  assertAiBackendConfigured();
-  return apiPost<SuggestResponse>('/api/v1/ai/suggest', req);
-}
-
-export async function estimateCost(req: CostRequest): Promise<CostResponse> {
-  assertAiBackendConfigured();
-  return apiPost<CostResponse>('/api/v1/ai/cost', req);
-}
+export { estimateCost, generateArchitecture, suggestImprovements } from '../../shared/api/ai';
+export type {
+  AiSuggestion,
+  CostRequest,
+  CostResource,
+  CostResponse,
+  GenerateRequest,
+  GenerateResponse,
+  SuggestRequest,
+  SuggestResponse,
+} from '../../shared/types/ai';

--- a/apps/web/src/shared/api/ai.ts
+++ b/apps/web/src/shared/api/ai.ts
@@ -1,0 +1,32 @@
+import { apiPost, isApiConfigured } from './client';
+import type {
+  CostRequest,
+  CostResponse,
+  GenerateRequest,
+  GenerateResponse,
+  SuggestRequest,
+  SuggestResponse,
+} from '../types/ai';
+
+const BACKEND_REQUIRED_MESSAGE = 'AI features require the backend API - see setup guide.';
+
+function assertAiBackendConfigured(): void {
+  if (!isApiConfigured()) {
+    throw new Error(BACKEND_REQUIRED_MESSAGE);
+  }
+}
+
+export async function generateArchitecture(req: GenerateRequest): Promise<GenerateResponse> {
+  assertAiBackendConfigured();
+  return apiPost<GenerateResponse>('/api/v1/ai/generate', req);
+}
+
+export async function suggestImprovements(req: SuggestRequest): Promise<SuggestResponse> {
+  assertAiBackendConfigured();
+  return apiPost<SuggestResponse>('/api/v1/ai/suggest', req);
+}
+
+export async function estimateCost(req: CostRequest): Promise<CostResponse> {
+  assertAiBackendConfigured();
+  return apiPost<CostResponse>('/api/v1/ai/cost', req);
+}

--- a/apps/web/src/shared/types/ai.ts
+++ b/apps/web/src/shared/types/ai.ts
@@ -1,0 +1,46 @@
+export interface GenerateRequest {
+  prompt: string;
+  provider: string;
+  complexity?: string;
+}
+
+export interface SuggestRequest {
+  architecture: Record<string, unknown>;
+  provider: string;
+}
+
+export interface CostRequest {
+  architecture: Record<string, unknown>;
+  provider: string;
+}
+
+export interface GenerateResponse {
+  architecture: Record<string, unknown>;
+  explanation: string;
+  warnings: string[];
+}
+
+export interface AiSuggestion {
+  category: string;
+  severity: string;
+  message: string;
+  action_description: string;
+}
+
+export interface SuggestResponse {
+  suggestions: AiSuggestion[];
+  score: Record<string, number>;
+}
+
+export interface CostResource {
+  name: string;
+  monthly_cost: number;
+  details: Record<string, unknown>;
+}
+
+export interface CostResponse {
+  monthly_cost: number;
+  hourly_cost: number;
+  currency: string;
+  resources: CostResource[];
+}


### PR DESCRIPTION
## Summary
- move AI request/response types into `apps/web/src/shared/types/ai.ts`
- move shared AI API functions into `apps/web/src/shared/api/ai.ts` and update entity-layer imports
- keep `features/ai/api.ts` as a backward-compatible re-export surface

## Validation
- `pnpm tsc -b`
- `pnpm --filter @cloudblocks/web test`
- `grep -rn \"from.*features/\" apps/web/src/entities/`

Fixes #1704
Part of #1700