### PR TITLE
refactor(web): remove uiStore dependency from architectureStore

### DIFF
--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -27,6 +27,8 @@ vi.mock('uuid', () => ({
 import { useArchitectureStore } from './architectureStore';
 import { useUIStore } from './uiStore';
 
+const DEFAULT_PROVIDER = 'azure' as const;
+
 function getState() {
   return useArchitectureStore.getState();
 }
@@ -1582,7 +1584,7 @@ describe('architectureStore', () => {
       getState().addPlate('region', 'First', null);
       getState().saveToStorage();
 
-      getState().createWorkspace('Second WS');
+      getState().createWorkspace('Second WS', DEFAULT_PROVIDER);
       getState().addPlate('region', 'SecondPlate', null);
       getState().saveToStorage();
 
@@ -1705,7 +1707,7 @@ describe('architectureStore', () => {
     });
 
     it('auto-suffixes name when renaming to an existing workspace name', () => {
-      getState().createWorkspace('Other');
+      getState().createWorkspace('Other', DEFAULT_PROVIDER);
       getState().renameWorkspace('My Architecture');
       const names = getState().workspaces.map((ws) => ws.name);
       expect(names).toContain('My Architecture');
@@ -1718,7 +1720,7 @@ describe('architectureStore', () => {
   describe('createWorkspace', () => {
     it('creates a new workspace and switches to it', () => {
       const oldId = getState().workspace.id;
-      getState().createWorkspace('New Project');
+      getState().createWorkspace('New Project', DEFAULT_PROVIDER);
 
       expect(getState().workspace.name).toBe('New Project');
       expect(getState().workspace.id).not.toBe(oldId);
@@ -1729,7 +1731,7 @@ describe('architectureStore', () => {
       getState().addPlate('region', 'VNet', null);
       const oldId = getState().workspace.id;
 
-      getState().createWorkspace('New Project');
+      getState().createWorkspace('New Project', DEFAULT_PROVIDER);
 
       const saved = getState().workspaces.find((ws) => ws.id === oldId);
       expect(saved).toBeDefined();
@@ -1740,7 +1742,7 @@ describe('architectureStore', () => {
       getState().addPlate('region', 'VNet', null);
       expect(getState().canUndo).toBe(true);
 
-      getState().createWorkspace('New Project');
+      getState().createWorkspace('New Project', DEFAULT_PROVIDER);
       expect(getState().canUndo).toBe(false);
     });
 
@@ -1751,7 +1753,7 @@ describe('architectureStore', () => {
         }
       });
 
-      getState().createWorkspace('Fail Project');
+      getState().createWorkspace('Fail Project', DEFAULT_PROVIDER);
 
       expect(getState().workspace.name).toBe('Fail Project');
       const activeIdCalls = spy.mock.calls.filter(([k]) => k === 'cloudblocks:activeWorkspaceId');
@@ -1760,13 +1762,13 @@ describe('architectureStore', () => {
     });
 
     it('auto-suffixes name when a workspace with the same name exists', () => {
-      getState().createWorkspace('Alpha');
+      getState().createWorkspace('Alpha', DEFAULT_PROVIDER);
       expect(getState().workspace.name).toBe('Alpha');
 
-      getState().createWorkspace('Alpha');
+      getState().createWorkspace('Alpha', DEFAULT_PROVIDER);
       expect(getState().workspace.name).toBe('Alpha (2)');
 
-      getState().createWorkspace('Alpha');
+      getState().createWorkspace('Alpha', DEFAULT_PROVIDER);
       expect(getState().workspace.name).toBe('Alpha (3)');
     });
   });
@@ -1776,7 +1778,7 @@ describe('architectureStore', () => {
       getState().addPlate('region', 'Original', null);
       const originalId = getState().workspace.id;
 
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
 
       getState().switchWorkspace(originalId);
       expect(getState().workspace.id).toBe(originalId);
@@ -1785,7 +1787,7 @@ describe('architectureStore', () => {
     });
 
     it('no-ops when switching to current workspace', () => {
-      getState().createWorkspace('WS1');
+      getState().createWorkspace('WS1', DEFAULT_PROVIDER);
       const wsId = getState().workspace.id;
 
       getState().switchWorkspace(wsId);
@@ -1800,7 +1802,7 @@ describe('architectureStore', () => {
     });
 
     it('saves current workspace state into list before switching', () => {
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
       const secondId = getState().workspace.id;
       getState().addPlate('region', 'InSecond', null);
 
@@ -1816,7 +1818,7 @@ describe('architectureStore', () => {
     });
 
     it('skips saveActiveWorkspaceId when saveWorkspaces fails', () => {
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
       const secondId = getState().workspace.id;
       const firstId = getState().workspaces.find((ws) => ws.id !== secondId)?.id;
 
@@ -1837,7 +1839,7 @@ describe('architectureStore', () => {
 
     it('leaves diff UI state unchanged when switching workspaces', () => {
       const initialWorkspaceId = getState().workspace.id;
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
       activateDiffState();
 
       getState().switchWorkspace(initialWorkspaceId);
@@ -1852,7 +1854,7 @@ describe('architectureStore', () => {
   describe('deleteWorkspace', () => {
     it('deletes a non-current workspace', () => {
       const firstId = getState().workspace.id;
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
 
       // Add first to workspaces list if not already
       getState().deleteWorkspace(firstId);
@@ -1862,7 +1864,7 @@ describe('architectureStore', () => {
     });
 
     it('switches to first remaining when deleting current', () => {
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
       const secondId = getState().workspace.id;
 
       getState().deleteWorkspace(secondId);
@@ -1881,7 +1883,7 @@ describe('architectureStore', () => {
     });
 
     it('skips saveActiveWorkspaceId when saveWorkspaces fails on current deletion', () => {
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
       const secondId = getState().workspace.id;
 
       const spy = vi.spyOn(localStorage, 'setItem').mockImplementation((key) => {
@@ -1918,7 +1920,7 @@ describe('architectureStore', () => {
       getState().addPlate('region', 'OrigVNet', null);
       const firstId = getState().workspace.id;
 
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
 
       getState().cloneWorkspace(firstId);
 
@@ -1976,7 +1978,7 @@ describe('architectureStore', () => {
     });
 
     it('does not modify current workspace when updating a non-current workspace', () => {
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
       const secondId = getState().workspace.id;
       const firstId = getState().workspaces.find((ws) => ws.id !== secondId)!.id;
 
@@ -2008,7 +2010,7 @@ describe('architectureStore', () => {
     });
 
     it('does not modify current workspace when updating a non-current workspace', () => {
-      getState().createWorkspace('Second');
+      getState().createWorkspace('Second', DEFAULT_PROVIDER);
       const secondId = getState().workspace.id;
       const firstId = getState().workspaces.find((ws) => ws.id !== secondId)!.id;
 
@@ -2054,7 +2056,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      const result = getState().importArchitecture(JSON.stringify(arch));
+      const result = getState().importArchitecture(JSON.stringify(arch), DEFAULT_PROVIDER);
 
       expect(result).toBeNull();
       expect(getArch().name).toBe('Imported Arch');
@@ -2067,7 +2069,7 @@ describe('architectureStore', () => {
         nodes: [makeRegionNode('p1')],
       };
 
-      getState().importArchitecture(JSON.stringify(minimal));
+      getState().importArchitecture(JSON.stringify(minimal), DEFAULT_PROVIDER);
 
       expect(getArch().name).toBe('Imported Architecture');
       expect(getArch().version).toBe('1');
@@ -2081,7 +2083,7 @@ describe('architectureStore', () => {
 
     it('returns error string on invalid JSON without crashing', () => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const result = getState().importArchitecture('not-valid-json');
+      const result = getState().importArchitecture('not-valid-json', DEFAULT_PROVIDER);
       expect(result).toBeTypeOf('string');
       expect(spy).toHaveBeenCalled();
       spy.mockRestore();
@@ -2089,7 +2091,10 @@ describe('architectureStore', () => {
 
     it('returns error string when plates/blocks are missing', () => {
       const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const result = getState().importArchitecture(JSON.stringify({ name: 'No data' }));
+      const result = getState().importArchitecture(
+        JSON.stringify({ name: 'No data' }),
+        DEFAULT_PROVIDER,
+      );
       expect(result).toBeTypeOf('string');
       expect(spy).toHaveBeenCalled();
       spy.mockRestore();
@@ -2102,7 +2107,7 @@ describe('architectureStore', () => {
         externalActors: { id: 'ext-1' },
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain('externalActors must be an array');
@@ -2116,7 +2121,7 @@ describe('architectureStore', () => {
         externalActors: [{ name: 'Internet', type: 'internet' }],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain('id must be a string');
@@ -2135,7 +2140,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      getState().importArchitecture(JSON.stringify(valid));
+      getState().importArchitecture(JSON.stringify(valid), DEFAULT_PROVIDER);
 
       expect(getArch().externalActors).toHaveLength(2);
       expect((getArch().externalActors ?? []).map((actor) => actor.id)).toEqual(['ext-1', 'ext-2']);
@@ -2172,7 +2177,7 @@ describe('architectureStore', () => {
         connections: [connection],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain(message);
@@ -2192,7 +2197,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain(
@@ -2229,7 +2234,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      getState().importArchitecture(JSON.stringify(valid));
+      getState().importArchitecture(JSON.stringify(valid), DEFAULT_PROVIDER);
 
       expect(getArch().connections).toHaveLength(2);
       expect(getArch().connections.map((connection) => connection.id)).toEqual(['c1', 'c2']);
@@ -2244,7 +2249,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain(
@@ -2262,7 +2267,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain('name must be a string');
       spy.mockRestore();
     });
@@ -2278,7 +2283,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain(
         'category must be one of network, security, delivery, compute, data, messaging, identity, operations',
       );
@@ -2292,7 +2297,7 @@ describe('architectureStore', () => {
         externalActors: ['not-an-object'],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain('external actor must be an object');
@@ -2306,7 +2311,7 @@ describe('architectureStore', () => {
         connections: ['not-an-object'],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain('connection must be an object');
@@ -2326,7 +2331,7 @@ describe('architectureStore', () => {
         ],
       };
 
-      getState().importArchitecture(JSON.stringify(invalid));
+      getState().importArchitecture(JSON.stringify(invalid), DEFAULT_PROVIDER);
 
       expect(spy).toHaveBeenCalled();
       expect(String(spy.mock.calls.at(-1)?.[1])).toContain(
@@ -2347,7 +2352,7 @@ describe('architectureStore', () => {
         nodes: [makeRegionNode('p1')],
       };
 
-      const result = getState().importArchitecture(JSON.stringify(arch));
+      const result = getState().importArchitecture(JSON.stringify(arch), DEFAULT_PROVIDER);
 
       expect(result).toBeNull();
       const activeIdCalls = spy.mock.calls.filter(([k]) => k === 'cloudblocks:activeWorkspaceId');
@@ -2362,7 +2367,7 @@ describe('architectureStore', () => {
         nodes: [makeRegionNode('p1')],
       };
 
-      const result = getState().importArchitecture(JSON.stringify(arch));
+      const result = getState().importArchitecture(JSON.stringify(arch), DEFAULT_PROVIDER);
 
       expect(result).toBeNull();
       const uiState = useUIStore.getState();
@@ -2412,7 +2417,7 @@ describe('architectureStore', () => {
       };
 
       const oldId = getState().workspace.id;
-      getState().loadFromTemplate(template);
+      getState().loadFromTemplate(template, DEFAULT_PROVIDER);
 
       expect(getState().workspace.id).not.toBe(oldId);
       expect(getState().workspace.name).toBe('Test Template');
@@ -2440,7 +2445,7 @@ describe('architectureStore', () => {
         },
       };
 
-      getState().loadFromTemplate(template);
+      getState().loadFromTemplate(template, DEFAULT_PROVIDER);
       expect(getState().canUndo).toBe(false);
     });
 
@@ -2468,7 +2473,7 @@ describe('architectureStore', () => {
         },
       };
 
-      getState().loadFromTemplate(template);
+      getState().loadFromTemplate(template, DEFAULT_PROVIDER);
 
       expect(getState().workspace.name).toBe('Fail Template');
       const activeIdCalls = spy.mock.calls.filter(([k]) => k === 'cloudblocks:activeWorkspaceId');
@@ -2496,7 +2501,7 @@ describe('architectureStore', () => {
         },
       };
 
-      getState().loadFromTemplate(template);
+      getState().loadFromTemplate(template, DEFAULT_PROVIDER);
 
       const uiState = useUIStore.getState();
       expect(uiState.diffMode).toBe(true);

--- a/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
+++ b/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
@@ -629,7 +629,9 @@ describe('persistenceSlice branches', () => {
         ],
       };
 
-      const result = useArchitectureStore.getState().importArchitecture(JSON.stringify(legacy));
+      const result = useArchitectureStore
+        .getState()
+        .importArchitecture(JSON.stringify(legacy), 'azure');
       const architecture = useArchitectureStore.getState().workspace
         .architecture as ArchitectureModel;
       const container = architecture.nodes.find((node) => node.id === 'container-1');
@@ -667,7 +669,9 @@ describe('persistenceSlice branches', () => {
         externalActors: [{ id: 'ext-1', name: 'Internet', type: 'internet' }],
       };
 
-      const result = useArchitectureStore.getState().importArchitecture(JSON.stringify(model));
+      const result = useArchitectureStore
+        .getState()
+        .importArchitecture(JSON.stringify(model), 'azure');
       const architecture = useArchitectureStore.getState().workspace.architecture;
 
       expect(result).toBeNull();
@@ -756,7 +760,9 @@ describe('persistenceSlice branches', () => {
         ],
       };
 
-      const result = useArchitectureStore.getState().importArchitecture(JSON.stringify(model));
+      const result = useArchitectureStore
+        .getState()
+        .importArchitecture(JSON.stringify(model), 'azure');
       const architecture = useArchitectureStore.getState().workspace.architecture;
 
       expect(result).toBeNull();
@@ -796,7 +802,9 @@ describe('persistenceSlice branches', () => {
         connections: [],
       };
 
-      const result = useArchitectureStore.getState().importArchitecture(JSON.stringify(model));
+      const result = useArchitectureStore
+        .getState()
+        .importArchitecture(JSON.stringify(model), 'azure');
       expect(result).toBe(
         'Invalid architecture format: expected nodes[] or legacy plates[] + blocks[]',
       );
@@ -821,7 +829,9 @@ describe('persistenceSlice branches', () => {
         ],
       };
 
-      const result = useArchitectureStore.getState().importArchitecture(JSON.stringify(model));
+      const result = useArchitectureStore
+        .getState()
+        .importArchitecture(JSON.stringify(model), 'azure');
       expect(result).toBe('Invalid connection at index 0: id must be a string');
     });
 
@@ -851,7 +861,9 @@ describe('persistenceSlice branches', () => {
         ],
       };
 
-      const result = useArchitectureStore.getState().importArchitecture(JSON.stringify(legacy));
+      const result = useArchitectureStore
+        .getState()
+        .importArchitecture(JSON.stringify(legacy), 'azure');
       const architecture = useArchitectureStore.getState().workspace
         .architecture as ArchitectureModel;
       const subnetPlate = architecture.nodes.find((node) => node.id === 'container-subnet');
@@ -863,7 +875,7 @@ describe('persistenceSlice branches', () => {
     it('returns errors for invalid JSON and oversize payloads', () => {
       const invalidJsonResult = useArchitectureStore
         .getState()
-        .importArchitecture('this-is-not-json');
+        .importArchitecture('this-is-not-json', 'azure');
 
       const oversized = {
         ...makeValidNodesPayload(),
@@ -871,7 +883,7 @@ describe('persistenceSlice branches', () => {
       };
       const oversizeResult = useArchitectureStore
         .getState()
-        .importArchitecture(JSON.stringify(oversized));
+        .importArchitecture(JSON.stringify(oversized), 'azure');
 
       expect(typeof invalidJsonResult).toBe('string');
       expect(oversizeResult).toBe('Import exceeds 5MB limit');
@@ -930,7 +942,9 @@ describe('persistenceSlice branches', () => {
         endpoints: [],
       };
 
-      const result = useArchitectureStore.getState().importArchitecture(JSON.stringify(model));
+      const result = useArchitectureStore
+        .getState()
+        .importArchitecture(JSON.stringify(model), 'aws');
       const architecture = useArchitectureStore.getState().workspace.architecture;
       const defaultRegion = architecture.nodes.find(
         (node) => node.id === 'container-region-default',
@@ -1011,7 +1025,7 @@ describe('persistenceSlice branches', () => {
         },
       };
 
-      useArchitectureStore.getState().loadFromTemplate(template);
+      useArchitectureStore.getState().loadFromTemplate(template, 'gcp');
 
       const architecture = useArchitectureStore.getState().workspace.architecture;
       const defaultRegion = architecture.nodes.find(
@@ -1092,7 +1106,7 @@ describe('persistenceSlice branches', () => {
         },
       };
 
-      useArchitectureStore.getState().loadFromTemplate(template);
+      useArchitectureStore.getState().loadFromTemplate(template, 'aws');
 
       const architecture = useArchitectureStore.getState().workspace.architecture;
       const browser = architecture.nodes.find((node) => node.id === 'ext-browser');

--- a/apps/web/src/entities/store/slices/persistenceSlice.ts
+++ b/apps/web/src/entities/store/slices/persistenceSlice.ts
@@ -24,7 +24,6 @@ import {
   loadActiveWorkspaceId,
 } from '../../../shared/utils/storage';
 import { generateId } from '../../../shared/utils/id';
-import { useUIStore } from '../uiStore';
 import { remapSubtype, remapName, getContainerLabel } from '../../../shared/utils/providerMapping';
 import type { ArchitectureSlice, ArchitectureState } from './types';
 import {
@@ -456,7 +455,7 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
     });
   },
 
-  importArchitecture: (json) => {
+  importArchitecture: (json, provider) => {
     try {
       const importedRaw = JSON.parse(json) as unknown;
       validateImportData(importedRaw, json.length);
@@ -531,11 +530,10 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
       const importedExternalActors = imported.externalActors as ArchitectureModel['externalActors'];
       if (Array.isArray(importedExternalActors) && importedExternalActors.length > 0) {
         const existingNodeIds = new Set(nodes.map((n) => n.id));
-        const importProvider = useUIStore.getState().activeProvider;
         const migratedBlocks = migrateExternalActorsToBlocks(
           importedExternalActors,
           existingNodeIds,
-          importProvider,
+          provider,
         );
         nodes.push(...migratedBlocks);
       }
@@ -606,26 +604,25 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
       };
 
       // ─── Remap imported nodes to active provider ──────────────
-      const importProvider = useUIStore.getState().activeProvider;
-      if (importProvider !== 'azure') {
+      if (provider !== 'azure') {
         for (const node of normalized.nodes) {
           const azureSubtype = node.subtype ?? node.resourceType;
-          node.provider = importProvider;
+          node.provider = provider;
           if (node.kind === 'container') {
-            const containerLabel = getContainerLabel(node.layer, importProvider);
+            const containerLabel = getContainerLabel(node.layer, provider);
             if (containerLabel && node.name === getContainerLabel(node.layer, 'azure')) {
               node.name = containerLabel;
             }
             if (node.subtype) {
-              node.subtype = remapSubtype(node.subtype, importProvider);
+              node.subtype = remapSubtype(node.subtype, provider);
             }
           } else {
-            node.name = remapName(azureSubtype, node.name, importProvider);
+            node.name = remapName(azureSubtype, node.name, provider);
             if (node.subtype) {
-              node.subtype = remapSubtype(node.subtype, importProvider);
+              node.subtype = remapSubtype(node.subtype, provider);
             }
             if (node.resourceType) {
-              node.resourceType = remapSubtype(node.resourceType, importProvider);
+              node.resourceType = remapSubtype(node.resourceType, provider);
             }
           }
         }
@@ -634,7 +631,7 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
       const newWorkspace: Workspace = {
         id: generateId('ws'),
         name: normalized.name,
-        provider: useUIStore.getState().activeProvider,
+        provider,
         architecture: normalized,
         createdAt: now,
         updatedAt: now,
@@ -667,7 +664,7 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
     return JSON.stringify(state.workspace.architecture, null, 2);
   },
 
-  loadFromTemplate: (template) => {
+  loadFromTemplate: (template, provider) => {
     const now = new Date().toISOString();
     const clonedArch = JSON.parse(JSON.stringify(template.architecture));
 
@@ -675,32 +672,31 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
     clonedArch.endpoints = nodeIds.flatMap((id: string) => generateEndpointsForBlock(id));
 
     // ─── Remap nodes to active provider ──────────────────────
-    const activeProvider = useUIStore.getState().activeProvider;
-    if (activeProvider !== 'azure') {
+    if (provider !== 'azure') {
       for (const node of clonedArch.nodes ?? []) {
         const azureSubtype = node.subtype ?? node.resourceType;
-        node.provider = activeProvider;
+        node.provider = provider;
         if (node.roles?.includes('external')) {
           continue;
         }
         if (node.kind === 'container') {
           // Remap container names (VNet → VPC, etc.)
-          const containerLabel = getContainerLabel(node.layer, activeProvider);
+          const containerLabel = getContainerLabel(node.layer, provider);
           if (containerLabel && node.name === getContainerLabel(node.layer, 'azure')) {
             node.name = containerLabel;
           }
           // Remap container subtype if present
           if (node.subtype) {
-            node.subtype = remapSubtype(node.subtype, activeProvider);
+            node.subtype = remapSubtype(node.subtype, provider);
           }
         } else {
           // Remap resource block name, subtype
-          node.name = remapName(azureSubtype, node.name, activeProvider);
+          node.name = remapName(azureSubtype, node.name, provider);
           if (node.subtype) {
-            node.subtype = remapSubtype(node.subtype, activeProvider);
+            node.subtype = remapSubtype(node.subtype, provider);
           }
           if (node.resourceType) {
-            node.resourceType = remapSubtype(node.resourceType, activeProvider);
+            node.resourceType = remapSubtype(node.resourceType, provider);
           }
         }
       }
@@ -709,7 +705,7 @@ export const createPersistenceSlice: ArchitectureSlice<PersistenceSlice> = (set,
     const newWorkspace: Workspace = {
       id: generateId('ws'),
       name: template.name,
-      provider: activeProvider,
+      provider,
       architecture: {
         ...clonedArch,
         id: generateId('arch'),

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -141,13 +141,13 @@ export interface ArchitectureState {
   resetWorkspace: () => void;
   renameWorkspace: (name: string) => void;
 
-  createWorkspace: (name: string, provider?: ProviderType) => void;
+  createWorkspace: (name: string, provider: ProviderType) => void;
   switchWorkspace: (id: string) => void;
   deleteWorkspace: (id: string) => void;
   cloneWorkspace: (id: string) => void;
-  importArchitecture: (json: string) => string | null;
+  importArchitecture: (json: string, provider: ProviderType) => string | null;
   exportArchitecture: () => string;
-  loadFromTemplate: (template: ArchitectureTemplate) => void;
+  loadFromTemplate: (template: ArchitectureTemplate, provider: ProviderType) => void;
   replaceArchitecture: (snapshot: ArchitectureSnapshot) => void;
   generate: (prompt: string, provider: string) => Promise<void>;
   suggest: (provider: string) => Promise<void>;

--- a/apps/web/src/entities/store/slices/workspaceSlice.test.ts
+++ b/apps/web/src/entities/store/slices/workspaceSlice.test.ts
@@ -14,6 +14,8 @@ vi.mock('uuid', () => ({
 import { useArchitectureStore } from '../architectureStore';
 import { useUIStore } from '../uiStore';
 
+const DEFAULT_PROVIDER = 'azure' as const;
+
 function getState() {
   return useArchitectureStore.getState();
 }
@@ -82,7 +84,7 @@ describe('workspaceSlice – setLastPrResult', () => {
   });
 
   it('does not modify current workspace when workspaceId does not match', () => {
-    getState().createWorkspace('Second');
+    getState().createWorkspace('Second', DEFAULT_PROVIDER);
     const secondId = getState().workspace.id;
     const firstId = getState().workspaces.find((ws) => ws.id !== secondId)!.id;
 

--- a/apps/web/src/entities/store/slices/workspaceSlice.ts
+++ b/apps/web/src/entities/store/slices/workspaceSlice.ts
@@ -1,8 +1,8 @@
 import type { Workspace } from '../../../shared/types/index';
 import { createBlankArchitecture } from '../../../shared/types/schema';
+import type { ProviderType } from '@cloudblocks/schema';
 import { generateId } from '../../../shared/utils/id';
 import { saveWorkspaces, saveActiveWorkspaceId } from '../../../shared/utils/storage';
-import { useUIStore } from '../uiStore';
 import type { ArchitectureSlice, ArchitectureState } from './types';
 import {
   createDefaultWorkspace,
@@ -28,16 +28,15 @@ export const createWorkspaceSlice: ArchitectureSlice<WorkspaceSlice> = (set, get
   workspace: createDefaultWorkspace(),
   workspaces: [],
 
-  createWorkspace: (name, provider) => {
+  createWorkspace: (name, provider: ProviderType) => {
     const state = get();
-    const resolvedProvider = provider ?? useUIStore.getState().activeProvider;
     const allWorkspaces = upsertCurrentWorkspace(state.workspaces, state.workspace);
     const uniqueName = deduplicateWorkspaceName(name, allWorkspaces);
     const now = new Date().toISOString();
     const newWorkspace: Workspace = {
       id: generateId('ws'),
       name: uniqueName,
-      provider: resolvedProvider,
+      provider,
       architecture: createBlankArchitecture(generateId('arch'), uniqueName),
       createdAt: now,
       updatedAt: now,

--- a/apps/web/src/widgets/landing-page/LandingPage.test.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.test.tsx
@@ -28,6 +28,7 @@ describe('LandingPage', () => {
     ]);
 
     useUIStore.setState({
+      activeProvider: 'azure',
       goToBuilder: vi.fn(),
     });
 
@@ -53,7 +54,7 @@ describe('LandingPage', () => {
   it('navigates to builder when Start Learning is clicked', async () => {
     const user = userEvent.setup();
     const goToBuilder = vi.fn();
-    useUIStore.setState({ goToBuilder });
+    useUIStore.setState({ activeProvider: 'azure', goToBuilder });
 
     render(<LandingPage />);
 
@@ -67,14 +68,14 @@ describe('LandingPage', () => {
     const loadFromTemplate = vi.fn();
     const saveToStorage = vi.fn();
 
-    useUIStore.setState({ goToBuilder });
+    useUIStore.setState({ activeProvider: 'azure', goToBuilder });
     useArchitectureStore.setState({ loadFromTemplate, saveToStorage });
 
     render(<LandingPage />);
 
     await user.click(screen.getAllByRole('button', { name: 'Use This Template' })[0]);
 
-    expect(loadFromTemplate).toHaveBeenCalledWith(expect.objectContaining({ id: 't1' }));
+    expect(loadFromTemplate).toHaveBeenCalledWith(expect.objectContaining({ id: 't1' }), 'azure');
     expect(saveToStorage).toHaveBeenCalledOnce();
     expect(goToBuilder).toHaveBeenCalledOnce();
   });

--- a/apps/web/src/widgets/landing-page/LandingPage.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.tsx
@@ -7,6 +7,7 @@ import { LandingNavbar } from '../landing-navbar/LandingNavbar';
 import './LandingPage.css';
 
 export function LandingPage() {
+  const activeProvider = useUIStore((s) => s.activeProvider);
   const goToBuilder = useUIStore((s) => s.goToBuilder);
   const loadFromTemplate = useArchitectureStore((s) => s.loadFromTemplate);
   const saveToStorage = useArchitectureStore((s) => s.saveToStorage);
@@ -17,7 +18,7 @@ export function LandingPage() {
   };
 
   const handleUseTemplate = (template: ArchitectureTemplate) => {
-    loadFromTemplate(template);
+    loadFromTemplate(template, activeProvider);
     syncWorkspaceUI({ fitToContent: true });
     saveToStorage();
     goToBuilder();

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -477,7 +477,7 @@ describe('MenuBar', () => {
     }
 
     expect(readAsTextMock).toHaveBeenCalledWith(file);
-    expect(importArchitectureMock).toHaveBeenCalledWith(jsonContent);
+    expect(importArchitectureMock).toHaveBeenCalledWith(jsonContent, 'azure');
     expect(fileInput.value).toBe('');
     expect(getOverflowDropdown().className).not.toContain('show');
 

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -237,7 +237,7 @@ export function MenuBar() {
     reader.onload = (ev) => {
       const text = ev.target?.result;
       if (typeof text === 'string') {
-        const error = importArchitecture(text);
+        const error = importArchitecture(text, activeProvider);
         if (error) {
           toast.error(`Import failed: ${error}`);
         } else {

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
@@ -37,6 +37,7 @@ function setupMocks(plateCount: number, templateDrawerOpen = false) {
 
   vi.mocked(useUIStore).mockImplementation(((selector: unknown) => {
     const state = {
+      activeProvider: 'azure' as const,
       drawer: { isOpen: templateDrawerOpen, activePanel: templateDrawerOpen ? 'templates' : null },
       openDrawer: mockOpenDrawer,
     };
@@ -120,7 +121,7 @@ describe('EmptyCanvasOverlay', () => {
     fireEvent.change(fileInput, { target: { files: [file] } });
 
     await vi.waitFor(() => {
-      expect(mockImportArchitecture).toHaveBeenCalledWith(jsonContent);
+      expect(mockImportArchitecture).toHaveBeenCalledWith(jsonContent, 'azure');
     });
   });
 });

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
@@ -5,6 +5,7 @@ import { clearWorkspaceDiffUI } from '../../entities/store/uiSync';
 import './EmptyCanvasOverlay.css';
 
 export function EmptyCanvasOverlay() {
+  const activeProvider = useUIStore((s) => s.activeProvider);
   const containerCount = useArchitectureStore(
     (s) => s.workspace.architecture.nodes.filter((node) => node.kind === 'container').length,
   );
@@ -27,7 +28,7 @@ export function EmptyCanvasOverlay() {
     reader.onload = (ev) => {
       const text = ev.target?.result;
       if (typeof text === 'string') {
-        importArchitecture(text);
+        importArchitecture(text, activeProvider);
         clearWorkspaceDiffUI();
       }
     };

--- a/apps/web/src/widgets/template-gallery/TemplateGallery.tsx
+++ b/apps/web/src/widgets/template-gallery/TemplateGallery.tsx
@@ -23,6 +23,7 @@ const categoryKeys: Array<TemplateCategory | 'all'> = [
 ];
 
 export function TemplateGallery() {
+  const activeProvider = useUIStore((s) => s.activeProvider);
   const closeDrawer = useUIStore((s) => s.closeDrawer);
   const loadFromTemplate = useArchitectureStore((s) => s.loadFromTemplate);
   const saveToStorage = useArchitectureStore((s) => s.saveToStorage);
@@ -32,7 +33,7 @@ export function TemplateGallery() {
     activeCategory === 'all' ? listTemplates() : listTemplatesByCategory(activeCategory);
 
   const handleUseTemplate = (template: ArchitectureTemplate) => {
-    loadFromTemplate(template);
+    loadFromTemplate(template, activeProvider);
     syncWorkspaceUI({ fitToContent: true });
     saveToStorage();
     setActiveCategory('all');

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.test.tsx
@@ -69,7 +69,7 @@ describe('WorkspaceManager', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    useUIStore.setState({ showWorkspaceManager: false });
+    useUIStore.setState({ showWorkspaceManager: false, activeProvider: 'azure' });
     useArchitectureStore.setState({
       workspace: makeWorkspace('ws-1', 'Default Workspace', 2, 1),
       workspaces: [makeWorkspace('ws-1', 'Default Workspace', 2, 1)],
@@ -122,7 +122,7 @@ describe('WorkspaceManager', () => {
     const input = screen.getByPlaceholderText('New workspace name...');
     await user.type(input, 'My New Workspace');
     await user.click(screen.getByText('+ Create'));
-    expect(createWorkspaceMock).toHaveBeenCalledWith('My New Workspace');
+    expect(createWorkspaceMock).toHaveBeenCalledWith('My New Workspace', 'azure');
   });
 
   it('creates workspace on Enter key', async () => {
@@ -131,7 +131,7 @@ describe('WorkspaceManager', () => {
     render(<WorkspaceManager />);
     const input = screen.getByPlaceholderText('New workspace name...');
     await user.type(input, 'Enter Workspace{Enter}');
-    expect(createWorkspaceMock).toHaveBeenCalledWith('Enter Workspace');
+    expect(createWorkspaceMock).toHaveBeenCalledWith('Enter Workspace', 'azure');
   });
 
   it('does not create workspace with empty name', async () => {

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.tsx
@@ -8,6 +8,7 @@ import { promptDialog } from '../../shared/ui/PromptDialog';
 import './WorkspaceManager.css';
 
 export function WorkspaceManager() {
+  const activeProvider = useUIStore((s) => s.activeProvider);
   const show = useUIStore((s) => s.showWorkspaceManager);
   const toggleWorkspaceManager = useUIStore((s) => s.toggleWorkspaceManager);
 
@@ -32,7 +33,7 @@ export function WorkspaceManager() {
   const handleCreate = () => {
     const name = newName.trim();
     if (!name) return;
-    createWorkspace(name);
+    createWorkspace(name, activeProvider);
     syncWorkspaceUI();
     setNewName('');
   };


### PR DESCRIPTION
## Summary
- pass the active provider into architecture store actions instead of reading `useUIStore.getState()` inside architecture slices
- update template/import/workspace UI callers and tests to provide the current UI provider explicitly
- keep provider ownership in `uiStore` while preserving existing behavior and store boundary expectations

Fixes #1705
Part of #1700