### PR TITLE
perf(web): add indexed lookup maps to canvas selectors

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -8,7 +8,7 @@ import type {
   ResourceBlock,
   ResourceCategory,
 } from '@cloudblocks/schema';
-import { isExternalResourceType, parseEndpointId } from '@cloudblocks/schema';
+import { generateEndpointsForBlock, isExternalResourceType } from '@cloudblocks/schema';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 import type { DiffDelta } from '../../shared/types/diff';
@@ -64,9 +64,7 @@ export const BlockSprite = memo(function BlockSprite({
   const resolvedBlockId = blockId ?? block?.id ?? null;
   const storeBlock = useArchitectureStore((state) => {
     if (!resolvedBlockId) return null;
-    const node = state.workspace.architecture.nodes.find(
-      (candidate) => candidate.id === resolvedBlockId,
-    );
+    const node = state.nodeById.get(resolvedBlockId);
     return node?.kind === 'resource' ? node : null;
   });
   const resolvedBlock = storeBlock ?? block ?? null;
@@ -74,9 +72,7 @@ export const BlockSprite = memo(function BlockSprite({
     parentContainerId ?? resolvedBlock?.parentId ?? parentContainer?.id ?? null;
   const storeParentContainer = useArchitectureStore((state) => {
     if (!resolvedParentContainerId) return null;
-    const node = state.workspace.architecture.nodes.find(
-      (candidate) => candidate.id === resolvedParentContainerId,
-    );
+    const node = state.nodeById.get(resolvedParentContainerId);
     return node?.kind === 'container' ? node : null;
   });
   const resolvedParentContainer = storeParentContainer ?? parentContainer ?? undefined;
@@ -96,24 +92,19 @@ export const BlockSprite = memo(function BlockSprite({
   const moveNodePosition = useArchitectureStore((s) => s.moveNodePosition);
   const sourceNode = useArchitectureStore((state) => {
     if (!connectionSource) return null;
-    const node = state.workspace.architecture.nodes.find(
-      (candidate) => candidate.id === connectionSource,
-    );
+    const node = state.nodeById.get(connectionSource);
     return node?.kind === 'resource' ? node : null;
   });
   const relevantConnectionIds = useArchitectureStore(
     useShallow((state) => {
       if (!resolvedBlockId) return [] as string[];
-      const endpoints = state.workspace.architecture.endpoints;
-      return state.workspace.architecture.connections
-        .filter((connection) => {
-          const fromEndpoint = endpoints.find((endpoint) => endpoint.id === connection.from);
-          const toEndpoint = endpoints.find((endpoint) => endpoint.id === connection.to);
-          const fromBlockId = fromEndpoint?.blockId ?? parseEndpointId(connection.from)?.blockId;
-          const toBlockId = toEndpoint?.blockId ?? parseEndpointId(connection.to)?.blockId;
-          return fromBlockId === resolvedBlockId || toBlockId === resolvedBlockId;
-        })
-        .map((connection) => connection.id);
+      const relevantConnectionIds = new Set<string>();
+      for (const endpoint of generateEndpointsForBlock(resolvedBlockId)) {
+        for (const connection of state.connectionsByEndpoint.get(endpoint.id) ?? []) {
+          relevantConnectionIds.add(connection.id);
+        }
+      }
+      return [...relevantConnectionIds];
     }),
   );
 
@@ -237,12 +228,8 @@ export const BlockSprite = memo(function BlockSprite({
           }
 
           if (isDragging.current) {
-            const currentBlock = useArchitectureStore
-              .getState()
-              .workspace.architecture.nodes.filter(
-                (node): node is ResourceBlock => node.kind === 'resource',
-              )
-              .find((candidate) => candidate.id === resolvedBlockId);
+            const currentNode = useArchitectureStore.getState().nodeById.get(resolvedBlockId);
+            const currentBlock = currentNode?.kind === 'resource' ? currentNode : null;
 
             if (currentBlock) {
               const snappedPosition = snapToGrid(currentBlock.position.x, currentBlock.position.z);

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -56,25 +56,20 @@ interface TraceColors {
 const HIT_AREA_WIDTH = 20;
 
 function collectRelevantContainers(
-  nodes: readonly (ContainerBlock | ResourceBlock)[],
+  nodeById: ReadonlyMap<string, ContainerBlock | ResourceBlock>,
   ...parentIds: Array<string | null | undefined>
 ): ContainerBlock[] {
-  const containers = new Map(
-    nodes
-      .filter((node): node is ContainerBlock => node.kind === 'container')
-      .map((container) => [container.id, container]),
-  );
   const relevantContainers: ContainerBlock[] = [];
   const seen = new Set<string>();
 
   for (const parentId of parentIds) {
     let currentId = parentId;
     while (currentId && !seen.has(currentId)) {
-      const container = containers.get(currentId);
-      if (!container) break;
+      const node = nodeById.get(currentId);
+      if (node?.kind !== 'container') break;
       seen.add(currentId);
-      relevantContainers.push(container);
-      currentId = container.parentId;
+      relevantContainers.push(node);
+      currentId = node.parentId;
     }
   }
 
@@ -237,11 +232,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const resolvedConnectionId = connectionId ?? connection?.id ?? null;
   const storeConnection = useArchitectureStore((state) => {
     if (!resolvedConnectionId) return null;
-    return (
-      state.workspace.architecture.connections.find(
-        (candidate) => candidate.id === resolvedConnectionId,
-      ) ?? null
-    );
+    return state.connectionById.get(resolvedConnectionId) ?? null;
   });
   const resolvedConnection = storeConnection ?? connection ?? null;
   const [isHovered, setIsHovered] = useState(false);
@@ -277,19 +268,11 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const validationResult = useArchitectureStore((s) => s.validationResult);
   const fromEndpoint = useArchitectureStore((state) => {
     if (!resolvedConnection) return null;
-    return (
-      state.workspace.architecture.endpoints.find(
-        (endpoint) => endpoint.id === resolvedConnection.from,
-      ) ?? null
-    );
+    return state.endpointById.get(resolvedConnection.from) ?? null;
   });
   const toEndpoint = useArchitectureStore((state) => {
     if (!resolvedConnection) return null;
-    return (
-      state.workspace.architecture.endpoints.find(
-        (endpoint) => endpoint.id === resolvedConnection.to,
-      ) ?? null
-    );
+    return state.endpointById.get(resolvedConnection.to) ?? null;
   });
   const sourceBlockId =
     fromEndpoint?.blockId ??
@@ -301,16 +284,12 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     null;
   const sourceBlock = useArchitectureStore((state) => {
     if (!sourceBlockId) return null;
-    const node = state.workspace.architecture.nodes.find(
-      (candidate) => candidate.id === sourceBlockId,
-    );
+    const node = state.nodeById.get(sourceBlockId);
     return node?.kind === 'resource' ? node : null;
   });
   const targetBlock = useArchitectureStore((state) => {
     if (!targetBlockId) return null;
-    const node = state.workspace.architecture.nodes.find(
-      (candidate) => candidate.id === targetBlockId,
-    );
+    const node = state.nodeById.get(targetBlockId);
     return node?.kind === 'resource' ? node : null;
   });
   const relevantPlates = useArchitectureStore(
@@ -319,7 +298,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
         return plates;
       }
       return collectRelevantContainers(
-        state.workspace.architecture.nodes,
+        state.nodeById,
         sourceBlock?.parentId,
         targetBlock?.parentId,
       );

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.tsx
@@ -42,9 +42,7 @@ export const ContainerBlockSprite = memo(function PlateSprite({
   const resolvedContainerId = containerId ?? container?.id ?? null;
   const storeContainer = useArchitectureStore((state) => {
     if (!resolvedContainerId) return null;
-    const node = state.workspace.architecture.nodes.find(
-      (candidate) => candidate.id === resolvedContainerId,
-    );
+    const node = state.nodeById.get(resolvedContainerId);
     return node?.kind === 'container' ? node : null;
   });
   const resolvedContainer = storeContainer ?? container ?? null;
@@ -137,12 +135,8 @@ export const ContainerBlockSprite = memo(function PlateSprite({
           }
 
           if (isDragging.current) {
-            const currentPlate = useArchitectureStore
-              .getState()
-              .workspace.architecture.nodes.filter(
-                (node): node is ContainerBlock => node.kind === 'container',
-              )
-              .find((candidate) => candidate.id === resolvedContainerId);
+            const currentNode = useArchitectureStore.getState().nodeById.get(resolvedContainerId);
+            const currentPlate = currentNode?.kind === 'container' ? currentNode : null;
 
             if (currentPlate) {
               const snappedPosition = snapToGrid(currentPlate.position.x, currentPlate.position.z);

--- a/apps/web/src/entities/store/architectureStore.ts
+++ b/apps/web/src/entities/store/architectureStore.ts
@@ -1,4 +1,11 @@
 import { create } from 'zustand';
+import type {
+  ArchitectureModel,
+  Connection,
+  ContainerBlock,
+  Endpoint,
+  ResourceBlock,
+} from '@cloudblocks/schema';
 import { createAiSlice } from './slices/aiSlice';
 import { createDomainSlice } from './slices/domainSlice';
 import { createHistorySlice } from './slices/historySlice';
@@ -10,21 +17,135 @@ import type { ArchitectureState } from './slices/types';
 
 export type { ArchitectureState } from './slices/types';
 
-export const useArchitectureStore = create<ArchitectureState>()((...a) => ({
-  ...createWorkspaceSlice(...a),
-  ...createValidationSlice(...a),
-  ...createHistorySlice(...a),
-  ...createDomainSlice(...a),
-  ...createPersistenceSlice(...a),
-  ...createLearningSlice(...a),
-  ...createAiSlice(...a),
-}));
+function buildArchitectureIndexes(
+  architecture: ArchitectureModel,
+): Pick<
+  ArchitectureState,
+  'nodeById' | 'connectionById' | 'endpointById' | 'connectionsByEndpoint'
+> {
+  const nodeById = new Map<string, ResourceBlock | ContainerBlock>();
+  for (const node of architecture.nodes) {
+    nodeById.set(node.id, node);
+  }
+
+  const connectionById = new Map<string, Connection>();
+  const connectionsByEndpoint = new Map<string, Connection[]>();
+  for (const connection of architecture.connections) {
+    connectionById.set(connection.id, connection);
+
+    const fromConnections = connectionsByEndpoint.get(connection.from) ?? [];
+    fromConnections.push(connection);
+    connectionsByEndpoint.set(connection.from, fromConnections);
+
+    const toConnections = connectionsByEndpoint.get(connection.to) ?? [];
+    toConnections.push(connection);
+    connectionsByEndpoint.set(connection.to, toConnections);
+  }
+
+  const endpointById = new Map<string, Endpoint>();
+  for (const endpoint of architecture.endpoints) {
+    endpointById.set(endpoint.id, endpoint);
+  }
+
+  return {
+    nodeById,
+    connectionById,
+    endpointById,
+    connectionsByEndpoint,
+  };
+}
+
+function withArchitectureIndexes(
+  partialState: Partial<ArchitectureState> | ArchitectureState,
+): Partial<ArchitectureState> | ArchitectureState {
+  const architecture = partialState.workspace?.architecture;
+  if (!architecture) {
+    return partialState;
+  }
+
+  return {
+    ...partialState,
+    ...buildArchitectureIndexes(architecture),
+  };
+}
+
+function indexesMatchArchitecture(state: ArchitectureState): boolean {
+  const architecture = state.workspace.architecture;
+
+  if (
+    state.nodeById.size !== architecture.nodes.length ||
+    state.connectionById.size !== architecture.connections.length ||
+    state.endpointById.size !== architecture.endpoints.length
+  ) {
+    return false;
+  }
+
+  for (const node of architecture.nodes) {
+    if (state.nodeById.get(node.id) !== node) {
+      return false;
+    }
+  }
+
+  for (const connection of architecture.connections) {
+    if (state.connectionById.get(connection.id) !== connection) {
+      return false;
+    }
+  }
+
+  for (const endpoint of architecture.endpoints) {
+    if (state.endpointById.get(endpoint.id) !== endpoint) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export const useArchitectureStore = create<ArchitectureState>()((set, get, api) => {
+  const setWithIndexes: typeof set = (partial, replace) => {
+    if (typeof partial === 'function') {
+      if (replace) {
+        return set((state) => withArchitectureIndexes(partial(state)) as ArchitectureState, true);
+      }
+
+      return set(
+        (state) => withArchitectureIndexes(partial(state)) as Partial<ArchitectureState>,
+        false,
+      );
+    }
+
+    if (replace) {
+      return set(withArchitectureIndexes(partial) as ArchitectureState, true);
+    }
+
+    return set(withArchitectureIndexes(partial) as Partial<ArchitectureState>, false);
+  };
+
+  const baseState = {
+    ...createWorkspaceSlice(setWithIndexes, get, api),
+    ...createValidationSlice(setWithIndexes, get, api),
+    ...createHistorySlice(setWithIndexes, get, api),
+    ...createDomainSlice(setWithIndexes, get, api),
+    ...createPersistenceSlice(setWithIndexes, get, api),
+    ...createLearningSlice(setWithIndexes, get, api),
+    ...createAiSlice(setWithIndexes, get, api),
+  };
+
+  return {
+    ...baseState,
+    ...buildArchitectureIndexes(baseState.workspace.architecture),
+  };
+});
 
 let autoValidateTimer: ReturnType<typeof setTimeout> | null = null;
 const AUTO_VALIDATE_DELAY_MS = 300;
 
 useArchitectureStore.subscribe((state, prevState) => {
   const archChanged = state.workspace.architecture !== prevState.workspace.architecture;
+
+  if (archChanged && !indexesMatchArchitecture(state)) {
+    useArchitectureStore.setState(buildArchitectureIndexes(state.workspace.architecture));
+  }
 
   if (archChanged && state.validationResult === null) {
     if (autoValidateTimer) {

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -2,9 +2,13 @@ import type { StateCreator } from 'zustand';
 import type { LastPrResult, ContainerBlockProfileId, Workspace } from '../../../shared/types/index';
 import type {
   ArchitectureModel,
+  Connection,
   ConnectionType,
+  ContainerBlock,
+  Endpoint,
   LayerType,
   ProviderType,
+  ResourceBlock,
   ResourceCategory,
 } from '@cloudblocks/schema';
 import type { ValidationResult } from '@cloudblocks/domain';
@@ -46,6 +50,10 @@ export interface ArchitectureState {
   workspace: Workspace;
   workspaces: Workspace[];
   validationResult: ValidationResult | null;
+  nodeById: Map<string, ResourceBlock | ContainerBlock>;
+  connectionById: Map<string, Connection>;
+  endpointById: Map<string, Endpoint>;
+  connectionsByEndpoint: Map<string, Connection[]>;
 
   activeScenario: Scenario | null;
   progress: LearningProgress | null;

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -27,16 +27,23 @@ import {
 } from './utils/viewportUtils';
 import './SceneCanvas.css';
 
+const EMPTY_OCCUPIED_CELLS = new Set<string>();
+
 export function SceneCanvas() {
-  const { nodes, connections, addNode, moveExternalBlockPosition } = useArchitectureStore(
+  const { architecture, nodeById, addNode, moveExternalBlockPosition } = useArchitectureStore(
     useShallow((state) => ({
-      nodes: state.workspace.architecture.nodes,
-      connections: state.workspace.architecture.connections,
+      architecture: state.workspace.architecture,
+      nodeById: state.nodeById,
       addNode: state.addNode,
       moveExternalBlockPosition: state.moveExternalBlockPosition,
     })),
   );
-  const nodeById = useMemo(() => new Map(nodes.map((node) => [node.id, node])), [nodes]);
+  const nodes = architecture.nodes;
+  const connections = architecture.connections;
+  const indexedNodeById = useMemo(
+    () => nodeById ?? new Map(nodes.map((node) => [node.id, node])),
+    [nodeById, nodes],
+  );
   const containerIds = useMemo(
     () =>
       nodes
@@ -48,11 +55,11 @@ export function SceneCanvas() {
     () =>
       new Map(
         containerIds
-          .map((containerId) => nodeById.get(containerId))
+          .map((containerId) => indexedNodeById.get(containerId))
           .filter((node): node is ContainerBlock => node?.kind === 'container')
           .map((container) => [container.id, container]),
       ),
-    [containerIds, nodeById],
+    [containerIds, indexedNodeById],
   );
   const blockIds = useMemo(
     () =>
@@ -64,28 +71,31 @@ export function SceneCanvas() {
   const containerBlockIds = useMemo(
     () =>
       blockIds.filter((blockId) => {
-        const block = nodeById.get(blockId);
+        const block = indexedNodeById.get(blockId);
         return block?.kind === 'resource' && block.parentId !== null;
       }),
-    [blockIds, nodeById],
+    [blockIds, indexedNodeById],
   );
   const rootExternalBlockIds = useMemo(
     () =>
       blockIds.filter((blockId) => {
-        const block = nodeById.get(blockId);
+        const block = indexedNodeById.get(blockId);
         return (
           block?.kind === 'resource' &&
           block.parentId === null &&
           (Boolean(block.roles?.includes('external')) || isExternalResourceType(block.resourceType))
         );
       }),
-    [blockIds, nodeById],
+    [blockIds, indexedNodeById],
   );
   const overlapOffsets = useMemo(
     () => computeOverlapOffsets(connections, OVERLAP_OFFSET_PX),
     [connections],
   );
-  const occupiedCellsByContainer = useMemo(() => computeOccupiedCellsByContainer(nodes), [nodes]);
+  const occupiedCellsByContainer = useMemo(
+    () => computeOccupiedCellsByContainer(architecture.nodes),
+    [architecture],
+  );
   const {
     clearSelection,
     setSelectedIds,
@@ -156,10 +166,10 @@ export function SceneCanvas() {
 
   const externalLaneBounds = useMemo(() => {
     const externalBlocks = rootExternalBlockIds
-      .map((blockId) => nodeById.get(blockId))
+      .map((blockId) => indexedNodeById.get(blockId))
       .filter((node): node is ResourceBlock => node?.kind === 'resource');
     return computeExternalLaneBounds(externalBlocks, origin);
-  }, [nodeById, origin, rootExternalBlockIds]);
+  }, [indexedNodeById, origin, rootExternalBlockIds]);
 
   const isDragging = useRef(false);
   const lastMouse = useRef({ x: 0, y: 0 });
@@ -450,7 +460,7 @@ export function SceneCanvas() {
                 screenX={screenPos.x}
                 screenY={screenPos.y}
                 zIndex={zIndex}
-                occupiedCells={occupiedCellsByContainer.get(container.id)}
+                occupiedCells={occupiedCellsByContainer.get(container.id) ?? EMPTY_OCCUPIED_CELLS}
               />
             );
           })}
@@ -462,6 +472,7 @@ export function SceneCanvas() {
             <ConnectionRenderer
               key={conn.id}
               connectionId={conn.id}
+              connection={conn}
               originX={origin.x}
               originY={origin.y}
               overlapOffset={overlapOffsets.get(conn.id) ?? 0}
@@ -514,7 +525,7 @@ export function SceneCanvas() {
 
         <div className="block-layer">
           {containerBlockIds.map((blockId) => {
-            const block = nodeById.get(blockId);
+            const block = indexedNodeById.get(blockId);
             if (block?.kind !== 'resource') return null;
             const parentContainer = block.parentId ? containerById.get(block.parentId) : null;
             if (!parentContainer?.frame) return null;
@@ -534,7 +545,7 @@ export function SceneCanvas() {
             );
           })}
           {rootExternalBlockIds.map((blockId) => {
-            const block = nodeById.get(blockId);
+            const block = indexedNodeById.get(blockId);
             if (block?.kind !== 'resource') return null;
             const screenPos = worldToScreen(
               block.position.x,


### PR DESCRIPTION
Fixes #1701
Part of #1700

## Summary
- add derived architecture lookup maps for nodes, endpoints, connections, and endpoint adjacency so canvas selectors avoid repeated hot-path array scans
- switch block, container, connection, and scene canvas rendering paths to indexed lookups while keeping fallback behavior intact for tests and direct store state injection
- memoize occupied-cell computation off the architecture reference and reuse a stable empty set to avoid drag-time recalculation churn

## Verification
- pnpm tsc -b
- pnpm --filter @cloudblocks/web test