### PR TITLE
feat(web): show validation error count badge on Validate button

### DIFF
--- a/apps/web/src/widgets/menu-bar/MenuBar.css
+++ b/apps/web/src/widgets/menu-bar/MenuBar.css
@@ -340,6 +340,12 @@
   border: 1px solid var(--bg-surface);
   pointer-events: none;
 }
+.core-btn .panel-btn-badge {
+  min-width: 14px;
+  width: auto;
+  padding: 0 3px;
+  box-sizing: border-box;
+}
 
 .core-actions {
   display: flex;

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -204,7 +204,7 @@ describe('MenuBar', () => {
     expect(useUIStore.getState().drawer.isOpen).toBe(true);
     expect(useUIStore.getState().drawer.activePanel).toBe('templates');
 
-    await user.click(screen.getByRole('button', { name: 'Validate' }));
+    await user.click(screen.getByRole('button', { name: /Validate architecture/ }));
     expect(useUIStore.getState().drawer.isOpen).toBe(true);
     expect(useUIStore.getState().drawer.activePanel).toBe('validation');
   });
@@ -655,7 +655,7 @@ describe('MenuBar', () => {
     useUIStore.setState({ showValidation: true });
     render(<MenuBar />);
 
-    await user.click(screen.getByRole('button', { name: 'Validate' }));
+    await user.click(screen.getByRole('button', { name: /Validate architecture/ }));
     expect(useUIStore.getState().drawer.isOpen).toBe(true);
     expect(useUIStore.getState().drawer.activePanel).toBe('validation');
   });
@@ -1057,7 +1057,8 @@ describe('MenuBar', () => {
     const validationBtn = screen.getByTitle('Validate Architecture');
     const badge = validationBtn.querySelector('.panel-btn-badge');
     expect(badge).toBeInTheDocument();
-    expect(badge?.textContent).toBe('!');
+    expect(badge?.textContent).toBe('1');
+    expect(validationBtn).toHaveAttribute('aria-label', 'Validate architecture (1 error)');
   });
 
   it('does not show validation badge when validation passes', () => {
@@ -1069,5 +1070,25 @@ describe('MenuBar', () => {
     const validationBtn = screen.getByTitle('Validate Architecture');
     const badge = validationBtn.querySelector('.panel-btn-badge');
     expect(badge).not.toBeInTheDocument();
+    expect(validationBtn).toHaveAttribute('aria-label', 'Validate architecture');
+  });
+
+  it('caps the validation badge at 9+ for more than 9 errors', () => {
+    const errors = Array.from({ length: 12 }, (_, i) => ({
+      ruleId: `r${i}`,
+      message: `err ${i}`,
+      severity: 'error' as const,
+      targetId: `block-${i}`,
+    }));
+    useArchitectureStore.setState({
+      validationResult: { valid: false, errors, warnings: [] },
+    });
+    render(<MenuBar />);
+
+    const validationBtn = screen.getByTitle('Validate Architecture');
+    const badge = validationBtn.querySelector('.panel-btn-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge?.textContent).toBe('9+');
+    expect(validationBtn).toHaveAttribute('aria-label', 'Validate architecture (9 or more errors)');
   });
 });

--- a/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.test.tsx
@@ -1061,6 +1061,26 @@ describe('MenuBar', () => {
     expect(validationBtn).toHaveAttribute('aria-label', 'Validate architecture (1 error)');
   });
 
+  it('shows plural error count in badge and aria-label for 2 errors', () => {
+    useArchitectureStore.setState({
+      validationResult: {
+        valid: false,
+        errors: [
+          { ruleId: 'r1', message: 'err 1', severity: 'error', targetId: 'block-1' },
+          { ruleId: 'r2', message: 'err 2', severity: 'error', targetId: 'block-2' },
+        ],
+        warnings: [],
+      },
+    });
+    render(<MenuBar />);
+
+    const validationBtn = screen.getByTitle('Validate Architecture');
+    const badge = validationBtn.querySelector('.panel-btn-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge?.textContent).toBe('2');
+    expect(validationBtn).toHaveAttribute('aria-label', 'Validate architecture (2 errors)');
+  });
+
   it('does not show validation badge when validation passes', () => {
     useArchitectureStore.setState({
       validationResult: { valid: true, errors: [], warnings: [] },

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -624,11 +624,18 @@ export function MenuBar() {
           className="core-btn"
           onClick={handleValidate}
           title="Validate Architecture"
+          aria-label={
+            validationResult && !validationResult.valid && validationResult.errors.length > 0
+              ? `Validate architecture (${validationResult.errors.length > 9 ? '9 or more' : validationResult.errors.length} error${validationResult.errors.length === 1 ? '' : 's'})`
+              : 'Validate architecture'
+          }
         >
           <CheckCircle size={14} />
           <span className="core-btn-label">Validate</span>
-          {validationResult && !validationResult.valid && (
-            <span className="panel-btn-badge">!</span>
+          {validationResult && !validationResult.valid && validationResult.errors.length > 0 && (
+            <span className="panel-btn-badge" aria-hidden="true">
+              {validationResult.errors.length > 9 ? '9+' : validationResult.errors.length}
+            </span>
           )}
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Replace static `!` badge on Validate button with dynamic error count (1–9 or "9+")
- Show badge only when validation has run and there are actual errors
- No badge when validation hasn't run (validationResult is null)
- No badge when architecture is valid (0 errors)
- Uses existing `.panel-btn-badge` styling with minor width override for multi-char counts (e.g., "9+")

## Changes
- **MenuBar.tsx**: Updated badge condition to check `validationResult.errors.length > 0` and display error count instead of static `!`
- **MenuBar.css**: Added `.core-btn .panel-btn-badge` rule to allow badge to expand width for counts > 1 digit

## Testing
- ✅ `pnpm build` passes
- ✅ `pnpm lint` passes
- Error count updates dynamically as validation engine runs (300ms debounce)

Fixes #1719