### PR TITLE
feat(web): unify validation message templates with learning-first tone

### DIFF
--- a/apps/web/src/entities/validation/aggregation.test.ts
+++ b/apps/web/src/entities/validation/aggregation.test.ts
@@ -46,8 +46,9 @@ describe('validateAggregation', () => {
     expect(validateAggregation(block)).toEqual({
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: 'Block "ZeroCount" has invalid aggregation count: 0 (must be >= 1)',
-      suggestion: 'Set the aggregation count to 1 or greater',
+      message: '"ZeroCount" has an aggregation count of 0, which is too low.',
+      suggestion:
+        'Set the count to 1 or higher. The aggregation count represents how many instances of this resource run in your architecture.',
       targetId: 'b1',
     });
   });
@@ -62,8 +63,9 @@ describe('validateAggregation', () => {
     expect(validateAggregation(block)).toEqual({
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: 'Block "NegativeCount" has invalid aggregation count: -3 (must be >= 1)',
-      suggestion: 'Set the aggregation count to 1 or greater',
+      message: '"NegativeCount" has an aggregation count of -3, which is too low.',
+      suggestion:
+        'Set the count to 1 or higher. The aggregation count represents how many instances of this resource run in your architecture.',
       targetId: 'b2',
     });
   });
@@ -78,8 +80,9 @@ describe('validateAggregation', () => {
     expect(validateAggregation(block)).toEqual({
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: 'Block "FractionalCount" has non-integer aggregation count: 2.5',
-      suggestion: 'Set the aggregation count to a whole number',
+      message: '"FractionalCount" has a non-whole-number aggregation count: 2.5.',
+      suggestion:
+        "Use a whole number (like 1, 2, or 3). The count represents distinct resource instances, so fractions don't make sense.",
       targetId: 'b3',
     });
   });

--- a/apps/web/src/entities/validation/aggregation.ts
+++ b/apps/web/src/entities/validation/aggregation.ts
@@ -18,8 +18,9 @@ export function validateAggregation(block: ResourceBlock): ValidationError | nul
     return {
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: `Block "${block.name}" has invalid aggregation count: ${aggregation.count} (must be >= 1)`,
-      suggestion: 'Set the aggregation count to 1 or greater',
+      message: `"${block.name}" has an aggregation count of ${aggregation.count}, which is too low.`,
+      suggestion:
+        'Set the count to 1 or higher. The aggregation count represents how many instances of this resource run in your architecture.',
       targetId: block.id,
     };
   }
@@ -28,8 +29,9 @@ export function validateAggregation(block: ResourceBlock): ValidationError | nul
     return {
       ruleId: 'rule-aggregation-count',
       severity: 'error',
-      message: `Block "${block.name}" has non-integer aggregation count: ${aggregation.count}`,
-      suggestion: 'Set the aggregation count to a whole number',
+      message: `"${block.name}" has a non-whole-number aggregation count: ${aggregation.count}.`,
+      suggestion:
+        "Use a whole number (like 1, 2, or 3). The count represents distinct resource instances, so fractions don't make sense.",
       targetId: block.id,
     };
   }

--- a/apps/web/src/entities/validation/connection.test.ts
+++ b/apps/web/src/entities/validation/connection.test.ts
@@ -67,8 +67,9 @@ describe('validateConnection', () => {
     expect(validateConnection(connection, makeEndpoints(blocks), blocks)).toEqual({
       ruleId: 'rule-conn-source',
       severity: 'error',
-      message: 'Connection source "missing-source" not found',
-      suggestion: 'Remove this connection or update the source',
+      message: 'Connection source "missing-source" is missing.',
+      suggestion:
+        'The source block may have been deleted. Remove this connection or reconnect it to an existing block.',
       targetId: 'conn-source-missing',
     });
   });
@@ -84,8 +85,9 @@ describe('validateConnection', () => {
     expect(validateConnection(connection, makeEndpoints(blocks), blocks)).toEqual({
       ruleId: 'rule-conn-target',
       severity: 'error',
-      message: 'Connection target "missing-target" not found',
-      suggestion: 'Remove this connection or update the target',
+      message: 'Connection target "missing-target" is missing.',
+      suggestion:
+        'The target block may have been deleted. Remove this connection or reconnect it to an existing block.',
       targetId: 'conn-target-missing',
     });
   });
@@ -101,8 +103,9 @@ describe('validateConnection', () => {
     expect(validateConnection(connection, makeEndpoints(blocks), blocks)).toEqual({
       ruleId: 'rule-conn-self',
       severity: 'error',
-      message: 'A node cannot connect to itself',
-      suggestion: 'Connect to a different node',
+      message: "A block can't connect to itself.",
+      suggestion:
+        'Connect it to a different block. Connections represent data flow between separate components.',
       targetId: 'conn-self',
     });
   });
@@ -241,14 +244,16 @@ describe('validateConnection', () => {
 
     expect(validateConnection(dbAsSource, makeEndpoints(blocks), blocks)).toMatchObject({
       ruleId: 'rule-conn-invalid',
-      message: 'Invalid connection: data → compute',
-      suggestion: 'data cannot initiate a request to compute',
+      message: "data can't connect to compute.",
+      suggestion:
+        "This connection direction isn't supported. Check the allowed connection patterns: e.g., Edge → Compute, Compute → Data.",
       targetId: 'conn-db-source',
     });
     expect(validateConnection(storageAsSource, makeEndpoints(blocks), blocks)).toMatchObject({
       ruleId: 'rule-conn-invalid',
-      message: 'Invalid connection: data → compute',
-      suggestion: 'data cannot initiate a request to compute',
+      message: "data can't connect to compute.",
+      suggestion:
+        "This connection direction isn't supported. Check the allowed connection patterns: e.g., Edge → Compute, Compute → Data.",
       targetId: 'conn-storage-source',
     });
   });
@@ -270,7 +275,7 @@ describe('validateConnection', () => {
 
     expect(validateConnection(connection, endpoints, blocks)).toMatchObject({
       ruleId: 'rule-conn-invalid',
-      message: 'Connection endpoints must belong to existing nodes',
+      message: 'Connection endpoints are invalid.',
       targetId: 'conn-orphan-endpoint',
     });
   });
@@ -288,7 +293,7 @@ describe('validateConnection', () => {
 
     expect(validateConnection(connection, makeEndpoints(blocks), blocks)).toMatchObject({
       ruleId: 'rule-conn-invalid',
-      message: 'Source endpoint must have output direction',
+      message: "The source endpoint isn't an output port.",
       targetId: 'conn-source-input',
     });
   });
@@ -306,7 +311,7 @@ describe('validateConnection', () => {
 
     expect(validateConnection(connection, makeEndpoints(blocks), blocks)).toMatchObject({
       ruleId: 'rule-conn-invalid',
-      message: 'Target endpoint must have input direction',
+      message: "The target endpoint isn't an input port.",
       targetId: 'conn-target-output',
     });
   });
@@ -324,7 +329,7 @@ describe('validateConnection', () => {
 
     expect(validateConnection(connection, makeEndpoints(blocks), blocks)).toMatchObject({
       ruleId: 'rule-conn-invalid',
-      message: 'Source and target endpoints must have matching semantics',
+      message: "Port types don't match.",
       targetId: 'conn-semantic-mismatch',
     });
   });
@@ -342,8 +347,9 @@ describe('validateConnection', () => {
 
     expect(validateConnection(connection, makeEndpoints(blocks), blocks)).toMatchObject({
       ruleId: 'rule-conn-invalid',
-      message: 'Invalid semantic for compute → data: event',
-      suggestion: 'Use a valid semantic for compute → data',
+      message: 'Wrong protocol for compute → data: "event".',
+      suggestion:
+        'This connection type doesn\'t support the "event" protocol. Use a supported protocol for this connection pair.',
       targetId: 'conn-invalid-semantic',
     });
   });
@@ -681,7 +687,7 @@ describe('canConnect', () => {
 
     expect(canConnect(fromEndpoint, toEndpoint, undefined, undefined)).toEqual({
       valid: false,
-      reason: 'Connection endpoints must belong to existing nodes',
+      reason: 'Both endpoints must belong to existing blocks.',
     });
   });
 
@@ -710,7 +716,8 @@ describe('canConnect', () => {
 
     expect(canConnect(sourceInput, semanticMismatchTarget, edge, compute)).toEqual({
       valid: false,
-      reason: 'Source endpoint must have output direction',
+      reason:
+        'Connections flow from output ports to input ports. Use an output port as the starting point.',
     });
     expect(
       canConnect(
@@ -726,7 +733,8 @@ describe('canConnect', () => {
       ),
     ).toEqual({
       valid: false,
-      reason: 'Target endpoint must have input direction',
+      reason:
+        'Connections flow from output ports to input ports. Use an input port as the destination.',
     });
     expect(
       canConnect(
@@ -742,7 +750,7 @@ describe('canConnect', () => {
       ),
     ).toEqual({
       valid: false,
-      reason: 'Source and target endpoints must have matching semantics',
+      reason: 'Both ports must use the same protocol (e.g., both HTTP or both Data).',
     });
   });
 
@@ -764,7 +772,7 @@ describe('canConnect', () => {
 
     expect(canConnect(sourceEndpoint, targetEndpoint, sourceNode, targetNode)).toEqual({
       valid: false,
-      reason: 'Invalid connection: compute → delivery',
+      reason: "compute can't connect to delivery.",
     });
 
     expect(
@@ -781,7 +789,7 @@ describe('canConnect', () => {
       ),
     ).toEqual({
       valid: false,
-      reason: 'Invalid semantic for compute → data: event',
+      reason: 'Wrong protocol for compute → data: "event".',
     });
   });
 

--- a/apps/web/src/entities/validation/connection.ts
+++ b/apps/web/src/entities/validation/connection.ts
@@ -66,8 +66,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-source',
       severity: 'error',
-      message: `Connection source "${sourceLabel}" not found`,
-      suggestion: 'Remove this connection or update the source',
+      message: `Connection source "${sourceLabel}" is missing.`,
+      suggestion:
+        'The source block may have been deleted. Remove this connection or reconnect it to an existing block.',
       targetId: connection.id,
     };
   }
@@ -79,8 +80,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-target',
       severity: 'error',
-      message: `Connection target "${targetLabel}" not found`,
-      suggestion: 'Remove this connection or update the target',
+      message: `Connection target "${targetLabel}" is missing.`,
+      suggestion:
+        'The target block may have been deleted. Remove this connection or reconnect it to an existing block.',
       targetId: connection.id,
     };
   }
@@ -89,8 +91,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-self',
       severity: 'error',
-      message: 'A node cannot connect to itself',
-      suggestion: 'Connect to a different node',
+      message: "A block can't connect to itself.",
+      suggestion:
+        'Connect it to a different block. Connections represent data flow between separate components.',
       targetId: connection.id,
     };
   }
@@ -105,8 +108,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-invalid',
       severity: 'error',
-      message: 'Connection endpoints must belong to existing nodes',
-      suggestion: 'Remove this connection or update the endpoints',
+      message: 'Connection endpoints are invalid.',
+      suggestion:
+        'Both endpoints must belong to existing blocks. Remove this connection and create a new one.',
       targetId: connection.id,
     };
   }
@@ -116,8 +120,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-invalid',
       severity: 'error',
-      message: 'Source endpoint must have output direction',
-      suggestion: 'Use an output endpoint as the connection source',
+      message: "The source endpoint isn't an output port.",
+      suggestion:
+        'Connections flow from output ports to input ports. Use an output port as the starting point.',
       targetId: connection.id,
     };
   }
@@ -126,8 +131,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-invalid',
       severity: 'error',
-      message: 'Target endpoint must have input direction',
-      suggestion: 'Use an input endpoint as the connection target',
+      message: "The target endpoint isn't an input port.",
+      suggestion:
+        'Connections flow from output ports to input ports. Use an input port as the destination.',
       targetId: connection.id,
     };
   }
@@ -137,8 +143,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-invalid',
       severity: 'error',
-      message: 'Source and target endpoints must have matching semantics',
-      suggestion: 'Use endpoints with the same semantic type',
+      message: "Port types don't match.",
+      suggestion:
+        'Both ports must use the same protocol (e.g., both HTTP or both Data). Match the port types to create a valid connection.',
       targetId: connection.id,
     };
   }
@@ -151,8 +158,9 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-invalid',
       severity: 'error',
-      message: `Invalid connection: ${fromType} \u2192 ${toType}`,
-      suggestion: `${fromType} cannot initiate a request to ${toType}`,
+      message: `${fromType} can't connect to ${toType}.`,
+      suggestion:
+        "This connection direction isn't supported. Check the allowed connection patterns: e.g., Edge → Compute, Compute → Data.",
       targetId: connection.id,
     };
   }
@@ -161,8 +169,8 @@ export function validateConnection(
     return {
       ruleId: 'rule-conn-invalid',
       severity: 'error',
-      message: `Invalid semantic for ${fromType} \u2192 ${toType}: ${fromEndpoint.semantic}`,
-      suggestion: `Use a valid semantic for ${fromType} \u2192 ${toType}`,
+      message: `Wrong protocol for ${fromType} → ${toType}: "${fromEndpoint.semantic}".`,
+      suggestion: `This connection type doesn't support the "${fromEndpoint.semantic}" protocol. Use a supported protocol for this connection pair.`,
       targetId: connection.id,
     };
   }
@@ -191,8 +199,8 @@ export function validatePortIndices(
         return {
           ruleId: 'rule-conn-endpoint-source',
           severity: 'error',
-          message: `Source endpoint index ${semanticIndex} exceeds outbound capacity ${fromPorts.outbound} for ${fromType}`,
-          suggestion: 'Use a semantic that fits the source category port capacity',
+          message: `Source port exceeds ${fromType}'s outbound capacity.`,
+          suggestion: `${fromType} blocks support up to ${fromPorts.outbound} outbound connection types. Use a different protocol or connection path.`,
           targetId: connection.id,
         };
       }
@@ -208,8 +216,8 @@ export function validatePortIndices(
         return {
           ruleId: 'rule-conn-endpoint-target',
           severity: 'error',
-          message: `Target endpoint index ${semanticIndex} exceeds inbound capacity ${toPorts.inbound} for ${toType}`,
-          suggestion: 'Use a semantic that fits the target category port capacity',
+          message: `Target port exceeds ${toType}'s inbound capacity.`,
+          suggestion: `${toType} blocks support up to ${toPorts.inbound} inbound connection types. Use a different protocol or connection path.`,
           targetId: connection.id,
         };
       }
@@ -248,19 +256,30 @@ export function canConnect(
   const fromEndpoint = source;
   const toEndpoint = target;
   if (!fromNode || !toNode) {
-    return { valid: false, reason: 'Connection endpoints must belong to existing nodes' };
+    return { valid: false, reason: 'Both endpoints must belong to existing blocks.' };
   }
 
   if (fromEndpoint.direction !== 'output') {
-    return { valid: false, reason: 'Source endpoint must have output direction' };
+    return {
+      valid: false,
+      reason:
+        'Connections flow from output ports to input ports. Use an output port as the starting point.',
+    };
   }
 
   if (toEndpoint.direction !== 'input') {
-    return { valid: false, reason: 'Target endpoint must have input direction' };
+    return {
+      valid: false,
+      reason:
+        'Connections flow from output ports to input ports. Use an input port as the destination.',
+    };
   }
 
   if (fromEndpoint.semantic !== toEndpoint.semantic) {
-    return { valid: false, reason: 'Source and target endpoints must have matching semantics' };
+    return {
+      valid: false,
+      reason: 'Both ports must use the same protocol (e.g., both HTTP or both Data).',
+    };
   }
 
   const fromType = getEffectiveEndpointType(fromNode);
@@ -269,13 +288,13 @@ export function canConnect(
   const allowedSemantics = ALLOWED_CONNECTIONS[ruleKey];
 
   if (!allowedSemantics) {
-    return { valid: false, reason: `Invalid connection: ${fromType} \u2192 ${toType}` };
+    return { valid: false, reason: `${fromType} can't connect to ${toType}.` };
   }
 
   if (!allowedSemantics.includes(fromEndpoint.semantic)) {
     return {
       valid: false,
-      reason: `Invalid semantic for ${fromType} \u2192 ${toType}: ${fromEndpoint.semantic}`,
+      reason: `Wrong protocol for ${fromType} → ${toType}: "${fromEndpoint.semantic}".`,
     };
   }
 

--- a/apps/web/src/entities/validation/placement.test.ts
+++ b/apps/web/src/entities/validation/placement.test.ts
@@ -67,8 +67,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, undefined)).toEqual({
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: 'Resource "Compute A" is not placed on any container',
-      suggestion: 'Place the resource on a valid subnet container',
+      message: '"Compute A" needs a container.',
+      suggestion:
+        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
       targetId: 'compute-1',
     });
   });
@@ -80,8 +81,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-compute-parent',
       severity: 'error',
-      message: 'Compute resource "Compute B" must be placed on a Subnet',
-      suggestion: 'Move the Compute resource to a Subnet',
+      message: '"Compute B" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'compute-2',
     });
   });
@@ -100,8 +102,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-data-parent',
       severity: 'error',
-      message: 'Data resource "Database A" must be placed on a Subnet',
-      suggestion: 'Move the Data resource to a Subnet',
+      message: '"Database A" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'db-1',
     });
   });
@@ -120,8 +123,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-delivery-parent',
       severity: 'error',
-      message: 'Delivery resource "Gateway A" must be placed on a Subnet',
-      suggestion: 'Move the Delivery resource to a Subnet',
+      message: '"Gateway A" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'gw-1',
     });
   });
@@ -140,8 +144,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-data-parent',
       severity: 'error',
-      message: 'Data resource "Storage A" must be placed on a Subnet',
-      suggestion: 'Move the Data resource to a Subnet',
+      message: '"Storage A" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'storage-1',
     });
   });
@@ -167,8 +172,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-compute-parent',
       severity: 'error',
-      message: 'Compute resource "Block" must be placed on a Subnet',
-      suggestion: 'Move the Compute resource to a Subnet',
+      message: '"Block" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'block-1',
     });
   });
@@ -185,8 +191,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-messaging-parent',
       severity: 'error',
-      message: 'Messaging resource "QueueA" must be placed on a Region container',
-      suggestion: 'Move the Messaging resource to a Region container',
+      message: '"QueueA" is on the wrong container type.',
+      suggestion:
+        'Move it to a Region container. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'queue-1',
     });
   });
@@ -210,8 +217,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-messaging-parent',
       severity: 'error',
-      message: 'Messaging resource "EventA" must be placed on a Region container',
-      suggestion: 'Move the Messaging resource to a Region container',
+      message: '"EventA" is on the wrong container type.',
+      suggestion:
+        'Move it to a Region container. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'event-1',
     });
   });
@@ -230,8 +238,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-operations-parent',
       severity: 'error',
-      message: 'Operations resource "AnalyticsA" must be placed on a Subnet',
-      suggestion: 'Move the Operations resource to a Subnet',
+      message: '"AnalyticsA" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'analytics-1',
     });
   });
@@ -243,8 +252,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-security-parent',
       severity: 'error',
-      message: 'Security resource "IdentityA" must be placed on a Subnet',
-      suggestion: 'Move the Security resource to a Subnet',
+      message: '"IdentityA" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'identity-1',
     });
   });
@@ -260,8 +270,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-operations-parent',
       severity: 'error',
-      message: 'Operations resource "ObservabilityA" must be placed on a Subnet',
-      suggestion: 'Move the Operations resource to a Subnet',
+      message: '"ObservabilityA" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'observability-1',
     });
   });
@@ -303,8 +314,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(computeBlock, region)).toEqual({
       ruleId: 'rule-compute-parent',
       severity: 'error',
-      message: 'Compute resource "VM" must be placed on a Subnet',
-      suggestion: 'Move the Compute resource to a Subnet',
+      message: '"VM" is on the wrong container type.',
+      suggestion:
+        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'vm-1',
     });
 
@@ -312,8 +324,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(msgBlock, subnet)).toEqual({
       ruleId: 'rule-messaging-parent',
       severity: 'error',
-      message: 'Messaging resource "Queue" must be placed on a Region container',
-      suggestion: 'Move the Messaging resource to a Region container',
+      message: '"Queue" is on the wrong container type.',
+      suggestion:
+        'Move it to a Region container. Each resource type has specific container requirements based on its cloud infrastructure role.',
       targetId: 'mq-1',
     });
   });
@@ -370,8 +383,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, undefined)).toEqual({
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: 'Resource "VM" is not placed on any container',
-      suggestion: 'Place the resource on a valid subnet container',
+      message: '"VM" needs a container.',
+      suggestion:
+        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
       targetId: 'vm-1',
     });
   });
@@ -386,8 +400,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, undefined)).toEqual({
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: 'Resource "SQL DB" is not placed on any container',
-      suggestion: 'Place the resource on a valid subnet container',
+      message: '"SQL DB" needs a container.',
+      suggestion:
+        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
       targetId: 'sql-1',
     });
   });
@@ -407,8 +422,8 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-delivery-parent',
       severity: 'error',
-      message: expect.stringContaining('must be placed'),
-      suggestion: expect.stringContaining('Move'),
+      message: expect.stringContaining('wrong container type'),
+      suggestion: expect.stringContaining('Move it to'),
       targetId: 'dns-1',
     });
   });
@@ -425,8 +440,8 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-network-parent',
       severity: 'error',
-      message: expect.stringContaining('must be placed'),
-      suggestion: expect.stringContaining('Move'),
+      message: expect.stringContaining('wrong container type'),
+      suggestion: expect.stringContaining('Move it to'),
       targetId: 'pip-1',
     });
   });
@@ -443,8 +458,8 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-data-parent',
       severity: 'error',
-      message: expect.stringContaining('must be placed'),
-      suggestion: expect.stringContaining('Move'),
+      message: expect.stringContaining('wrong container type'),
+      suggestion: expect.stringContaining('Move it to'),
       targetId: 'blob-1',
     });
   });
@@ -461,8 +476,8 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-identity-parent',
       severity: 'error',
-      message: expect.stringContaining('must be placed'),
-      suggestion: expect.stringContaining('Move'),
+      message: expect.stringContaining('wrong container type'),
+      suggestion: expect.stringContaining('Move it to'),
       targetId: 'mi-1',
     });
   });
@@ -479,8 +494,8 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-identity-parent',
       severity: 'error',
-      message: expect.stringContaining('must be placed'),
-      suggestion: expect.stringContaining('Move'),
+      message: expect.stringContaining('wrong container type'),
+      suggestion: expect.stringContaining('Move it to'),
       targetId: 'sa-1',
     });
   });
@@ -672,9 +687,9 @@ describe('validateLayerPlacement', () => {
     expect(validateLayerPlacement(block, invalidContainer)).toEqual({
       ruleId: 'rule-layer-hierarchy',
       severity: 'error',
-      message:
-        'Resource "InvalidLayerBlock" cannot be placed on a "resource" container (invalid layer hierarchy)',
-      suggestion: 'Valid parent layers for resources: subnet, zone, region, edge, global',
+      message: '"InvalidLayerBlock" can\'t go inside a "resource" container.',
+      suggestion:
+        'Resources can be placed on: subnet, zone, region, edge, global. This hierarchy mirrors how cloud providers organize infrastructure layers.',
       targetId: 'b-invalid',
     });
   });
@@ -702,8 +717,9 @@ describe('validateGridAlignment', () => {
     expect(validateGridAlignment(block)).toEqual({
       ruleId: 'rule-grid-alignment',
       severity: 'error',
-      message: 'Resource "BadX" position (1.5, 0) is not CU-aligned',
-      suggestion: 'Snap the resource to integer grid positions',
+      message: '"BadX" is off the grid.',
+      suggestion:
+        'Snap it to a grid position. All blocks align to a uniform grid to keep architectures tidy and readable.',
       targetId: 'b1',
     });
   });
@@ -714,8 +730,9 @@ describe('validateGridAlignment', () => {
     expect(validateGridAlignment(block)).toEqual({
       ruleId: 'rule-grid-alignment',
       severity: 'error',
-      message: 'Resource "BadZ" position (0, 2.7) is not CU-aligned',
-      suggestion: 'Snap the resource to integer grid positions',
+      message: '"BadZ" is off the grid.',
+      suggestion:
+        'Snap it to a grid position. All blocks align to a uniform grid to keep architectures tidy and readable.',
       targetId: 'b2',
     });
   });
@@ -726,8 +743,9 @@ describe('validateGridAlignment', () => {
     expect(validateGridAlignment(block)).toEqual({
       ruleId: 'rule-grid-alignment',
       severity: 'error',
-      message: 'Resource "BadBoth" position (0.1, 0.9) is not CU-aligned',
-      suggestion: 'Snap the resource to integer grid positions',
+      message: '"BadBoth" is off the grid.',
+      suggestion:
+        'Snap it to a grid position. All blocks align to a uniform grid to keep architectures tidy and readable.',
       targetId: 'b3',
     });
   });
@@ -775,8 +793,9 @@ describe('validateNoOverlap', () => {
     expect(validateNoOverlap(block, [sibling], getSize)).toEqual({
       ruleId: 'rule-no-overlap',
       severity: 'error',
-      message: 'Resource "A" overlaps with "B"',
-      suggestion: 'Move the resource to a non-overlapping position',
+      message: '"A" overlaps with "B".',
+      suggestion:
+        "Move one of them so they don't overlap. Each resource needs its own space on the container.",
       targetId: 'a',
     });
   });
@@ -788,8 +807,9 @@ describe('validateNoOverlap', () => {
     expect(validateNoOverlap(block, [sibling], getSize)).toEqual({
       ruleId: 'rule-no-overlap',
       severity: 'error',
-      message: 'Resource "A" overlaps with "B"',
-      suggestion: 'Move the resource to a non-overlapping position',
+      message: '"A" overlaps with "B".',
+      suggestion:
+        "Move one of them so they don't overlap. Each resource needs its own space on the container.",
       targetId: 'a',
     });
   });

--- a/apps/web/src/entities/validation/placement.test.ts
+++ b/apps/web/src/entities/validation/placement.test.ts
@@ -67,9 +67,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, undefined)).toEqual({
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: '"Compute A" needs a container.',
+      message: '"Compute A" needs a container \u2014 place it on a Subnet or Region container.',
       suggestion:
-        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
+        'Most resources need a parent container to define their network scope. Drag this block onto a container on the canvas.',
       targetId: 'compute-1',
     });
   });
@@ -81,9 +81,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-compute-parent',
       severity: 'error',
-      message: '"Compute B" is on the wrong container type.',
+      message: '"Compute B" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'compute-2',
     });
   });
@@ -102,9 +102,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-data-parent',
       severity: 'error',
-      message: '"Database A" is on the wrong container type.',
+      message: '"Database A" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'db-1',
     });
   });
@@ -123,9 +123,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-delivery-parent',
       severity: 'error',
-      message: '"Gateway A" is on the wrong container type.',
+      message: '"Gateway A" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'gw-1',
     });
   });
@@ -144,9 +144,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-data-parent',
       severity: 'error',
-      message: '"Storage A" is on the wrong container type.',
+      message: '"Storage A" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'storage-1',
     });
   });
@@ -172,9 +172,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-compute-parent',
       severity: 'error',
-      message: '"Block" is on the wrong container type.',
+      message: '"Block" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'block-1',
     });
   });
@@ -191,9 +191,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-messaging-parent',
       severity: 'error',
-      message: '"QueueA" is on the wrong container type.',
+      message: '"QueueA" is on the wrong container type \u2014 it needs a Region container.',
       suggestion:
-        'Move it to a Region container. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'queue-1',
     });
   });
@@ -217,9 +217,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-messaging-parent',
       severity: 'error',
-      message: '"EventA" is on the wrong container type.',
+      message: '"EventA" is on the wrong container type \u2014 it needs a Region container.',
       suggestion:
-        'Move it to a Region container. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'event-1',
     });
   });
@@ -238,9 +238,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-operations-parent',
       severity: 'error',
-      message: '"AnalyticsA" is on the wrong container type.',
+      message: '"AnalyticsA" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'analytics-1',
     });
   });
@@ -252,9 +252,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-security-parent',
       severity: 'error',
-      message: '"IdentityA" is on the wrong container type.',
+      message: '"IdentityA" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'identity-1',
     });
   });
@@ -270,9 +270,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, container)).toEqual({
       ruleId: 'rule-operations-parent',
       severity: 'error',
-      message: '"ObservabilityA" is on the wrong container type.',
+      message: '"ObservabilityA" is on the wrong container type \u2014 it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'observability-1',
     });
   });
@@ -314,9 +314,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(computeBlock, region)).toEqual({
       ruleId: 'rule-compute-parent',
       severity: 'error',
-      message: '"VM" is on the wrong container type.',
+      message: '"VM" is on the wrong container type — it needs a Subnet.',
       suggestion:
-        'Move it to a Subnet. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'vm-1',
     });
 
@@ -324,9 +324,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(msgBlock, subnet)).toEqual({
       ruleId: 'rule-messaging-parent',
       severity: 'error',
-      message: '"Queue" is on the wrong container type.',
+      message: '"Queue" is on the wrong container type — it needs a Region container.',
       suggestion:
-        'Move it to a Region container. Each resource type has specific container requirements based on its cloud infrastructure role.',
+        'Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.',
       targetId: 'mq-1',
     });
   });
@@ -383,9 +383,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, undefined)).toEqual({
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: '"VM" needs a container.',
+      message: '"VM" needs a container — place it on a Subnet or Region container.',
       suggestion:
-        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
+        'Most resources need a parent container to define their network scope. Drag this block onto a container on the canvas.',
       targetId: 'vm-1',
     });
   });
@@ -400,9 +400,9 @@ describe('validatePlacement', () => {
     expect(validatePlacement(block, undefined)).toEqual({
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: '"SQL DB" needs a container.',
+      message: '"SQL DB" needs a container — place it on a Subnet or Region container.',
       suggestion:
-        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
+        'Most resources need a parent container to define their network scope. Drag this block onto a container on the canvas.',
       targetId: 'sql-1',
     });
   });
@@ -423,7 +423,7 @@ describe('validatePlacement', () => {
       ruleId: 'rule-delivery-parent',
       severity: 'error',
       message: expect.stringContaining('wrong container type'),
-      suggestion: expect.stringContaining('Move it to'),
+      suggestion: expect.stringContaining('Move this block'),
       targetId: 'dns-1',
     });
   });
@@ -441,7 +441,7 @@ describe('validatePlacement', () => {
       ruleId: 'rule-network-parent',
       severity: 'error',
       message: expect.stringContaining('wrong container type'),
-      suggestion: expect.stringContaining('Move it to'),
+      suggestion: expect.stringContaining('Move this block'),
       targetId: 'pip-1',
     });
   });
@@ -459,7 +459,7 @@ describe('validatePlacement', () => {
       ruleId: 'rule-data-parent',
       severity: 'error',
       message: expect.stringContaining('wrong container type'),
-      suggestion: expect.stringContaining('Move it to'),
+      suggestion: expect.stringContaining('Move this block'),
       targetId: 'blob-1',
     });
   });
@@ -477,7 +477,7 @@ describe('validatePlacement', () => {
       ruleId: 'rule-identity-parent',
       severity: 'error',
       message: expect.stringContaining('wrong container type'),
-      suggestion: expect.stringContaining('Move it to'),
+      suggestion: expect.stringContaining('Move this block'),
       targetId: 'mi-1',
     });
   });
@@ -495,7 +495,7 @@ describe('validatePlacement', () => {
       ruleId: 'rule-identity-parent',
       severity: 'error',
       message: expect.stringContaining('wrong container type'),
-      suggestion: expect.stringContaining('Move it to'),
+      suggestion: expect.stringContaining('Move this block'),
       targetId: 'sa-1',
     });
   });

--- a/apps/web/src/entities/validation/placement.ts
+++ b/apps/web/src/entities/validation/placement.ts
@@ -67,8 +67,9 @@ export function validatePlacement(
     return {
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: `Resource "${resource.name}" is not placed on any container`,
-      suggestion: 'Place the resource on a valid subnet container',
+      message: `"${resource.name}" needs a container.`,
+      suggestion:
+        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
       targetId: resource.id,
     };
   }
@@ -80,12 +81,11 @@ export function validatePlacement(
     const parentTypes = allowed?.filter((p): p is string => p !== null) ?? [];
     const labels = parentTypes.map((t) => PARENT_LABEL[t] ?? t);
     const destination = labels.length > 0 ? labels.join(' or ') : 'a valid container';
-    const cat = resource.category.charAt(0).toUpperCase() + resource.category.slice(1);
     return {
       ruleId: `rule-${resource.category}-parent`,
       severity: 'error',
-      message: `${cat} resource "${resource.name}" must be placed on a ${destination}`,
-      suggestion: `Move the ${cat} resource to a ${destination}`,
+      message: `"${resource.name}" is on the wrong container type.`,
+      suggestion: `Move it to a ${destination}. Each resource type has specific container requirements based on its cloud infrastructure role.`,
       targetId: resource.id,
     };
   }
@@ -153,8 +153,8 @@ export function validateLayerPlacement(
     return {
       ruleId: 'rule-layer-hierarchy',
       severity: 'error',
-      message: `Resource "${resource.name}" cannot be placed on a "${container.layer}" container (invalid layer hierarchy)`,
-      suggestion: `Valid parent layers for resources: ${validParents.join(', ')}`,
+      message: `"${resource.name}" can't go inside a "${container.layer}" container.`,
+      suggestion: `Resources can be placed on: ${validParents.join(', ')}. This hierarchy mirrors how cloud providers organize infrastructure layers.`,
       targetId: resource.id,
     };
   }
@@ -174,8 +174,9 @@ export function validateGridAlignment(resource: ResourceBlock): ValidationError 
     return {
       ruleId: 'rule-grid-alignment',
       severity: 'error',
-      message: `Resource "${resource.name}" position (${x}, ${z}) is not CU-aligned`,
-      suggestion: 'Snap the resource to integer grid positions',
+      message: `"${resource.name}" is off the grid.`,
+      suggestion:
+        'Snap it to a grid position. All blocks align to a uniform grid to keep architectures tidy and readable.',
       targetId: resource.id,
     };
   }
@@ -219,8 +220,9 @@ export function validateNoOverlap(
       return {
         ruleId: 'rule-no-overlap',
         severity: 'error',
-        message: `Resource "${resource.name}" overlaps with "${sibling.name}"`,
-        suggestion: 'Move the resource to a non-overlapping position',
+        message: `"${resource.name}" overlaps with "${sibling.name}".`,
+        suggestion:
+          "Move one of them so they don't overlap. Each resource needs its own space on the container.",
         targetId: resource.id,
       };
     }

--- a/apps/web/src/entities/validation/placement.ts
+++ b/apps/web/src/entities/validation/placement.ts
@@ -67,9 +67,9 @@ export function validatePlacement(
     return {
       ruleId: 'rule-container-exists',
       severity: 'error',
-      message: `"${resource.name}" needs a container.`,
+      message: `"${resource.name}" needs a container — place it on a Subnet or Region container.`,
       suggestion:
-        'Drag it onto a Subnet or Region container. Most resources need a parent container to define their network scope.',
+        'Most resources need a parent container to define their network scope. Drag this block onto a container on the canvas.',
       targetId: resource.id,
     };
   }
@@ -80,12 +80,12 @@ export function validatePlacement(
     const allowed = getAllowedParents(resource.resourceType);
     const parentTypes = allowed?.filter((p): p is string => p !== null) ?? [];
     const labels = parentTypes.map((t) => PARENT_LABEL[t] ?? t);
-    const destination = labels.length > 0 ? labels.join(' or ') : 'a valid container';
+    const destination = labels.length > 0 ? labels.join(' or ') : 'valid container';
     return {
       ruleId: `rule-${resource.category}-parent`,
       severity: 'error',
-      message: `"${resource.name}" is on the wrong container type.`,
-      suggestion: `Move it to a ${destination}. Each resource type has specific container requirements based on its cloud infrastructure role.`,
+      message: `"${resource.name}" is on the wrong container type — it needs a ${destination}.`,
+      suggestion: `Each resource type has specific container requirements based on its cloud infrastructure role. Move this block to the correct container.`,
       targetId: resource.id,
     };
   }

--- a/apps/web/src/entities/validation/providerValidation.test.ts
+++ b/apps/web/src/entities/validation/providerValidation.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { validateProviderRules } from './providerValidation';
+import {
+  makeTestBlock,
+  makeTestPlate,
+  makeTestArchitecture,
+} from '../../__tests__/legacyModelTestUtils';
+
+describe('validateProviderRules', () => {
+  it('returns empty array when no resource blocks exist', () => {
+    const model = makeTestArchitecture({ nodes: [] });
+    expect(validateProviderRules(model)).toEqual([]);
+  });
+
+  it('returns empty array for a block with no provider-specific warnings', () => {
+    const block = makeTestBlock({
+      provider: 'azure',
+      category: 'compute',
+      resourceType: 'web_compute',
+    });
+    const container = makeTestPlate({ id: 'container-1' });
+    const model = makeTestArchitecture({ plates: [container], blocks: [block] });
+    expect(validateProviderRules(model)).toEqual([]);
+  });
+
+  it('warns when AWS Lambda is inside a subnet', () => {
+    const container = makeTestPlate({ id: 'subnet-1' });
+    const block = makeTestBlock({
+      id: 'lambda-1',
+      name: 'MyLambda',
+      provider: 'aws',
+      category: 'compute',
+      resourceType: 'web_compute',
+      subtype: 'lambda',
+      placementId: 'subnet-1',
+    });
+    const model = makeTestArchitecture({ plates: [container], blocks: [block] });
+
+    const result = validateProviderRules(model);
+    expect(result).toHaveLength(1);
+    expect(result[0].ruleId).toBe('rule-provider-aws-lambda-subnet');
+    expect(result[0].severity).toBe('warning');
+    expect(result[0].targetId).toBe('lambda-1');
+    expect(result[0].message).toBe('AWS Lambda "MyLambda" is inside a subnet.');
+    expect(result[0].suggestion).toBe(
+      "Lambda is serverless — it usually doesn't need VPC placement. If you need private resource access, keep it here; otherwise, consider placing it outside the subnet.",
+    );
+  });
+
+  it('warns when GCP Cloud SQL is on a subnet without explicit security', () => {
+    const container = makeTestPlate({ id: 'subnet-1' });
+    const block = makeTestBlock({
+      id: 'sql-1',
+      name: 'MyCloudSQL',
+      provider: 'gcp',
+      category: 'data',
+      resourceType: 'database',
+      subtype: 'cloud-sql-postgres',
+      placementId: 'subnet-1',
+    });
+    const model = makeTestArchitecture({ plates: [container], blocks: [block] });
+
+    const result = validateProviderRules(model);
+    expect(result).toHaveLength(1);
+    expect(result[0].ruleId).toBe('rule-provider-gcp-sql-public');
+    expect(result[0].severity).toBe('warning');
+    expect(result[0].targetId).toBe('sql-1');
+    expect(result[0].message).toBe(
+      'GCP Cloud SQL "MyCloudSQL" is on a subnet without explicit security.',
+    );
+    expect(result[0].suggestion).toBe(
+      'Database instances should be protected with VPC firewall rules or private service access. This is a reminder to configure network security for your database.',
+    );
+  });
+
+  it('warns for unrecognized subtype', () => {
+    const container = makeTestPlate({ id: 'subnet-1' });
+    const block = makeTestBlock({
+      id: 'block-x',
+      name: 'WeirdService',
+      provider: 'aws',
+      category: 'compute',
+      resourceType: 'web_compute',
+      subtype: 'nonexistent-service',
+      placementId: 'subnet-1',
+    });
+    const model = makeTestArchitecture({ plates: [container], blocks: [block] });
+
+    const result = validateProviderRules(model);
+    expect(result).toHaveLength(1);
+    expect(result[0].ruleId).toBe('rule-provider-unknown-subtype');
+    expect(result[0].severity).toBe('warning');
+    expect(result[0].targetId).toBe('block-x');
+    expect(result[0].message).toBe(
+      '"WeirdService" uses an unrecognized subtype "nonexistent-service" for aws compute.',
+    );
+    expect(result[0].suggestion).toBe(
+      'This subtype may not be a standard aws service. Check available subtypes for aws compute resources, or verify the spelling.',
+    );
+  });
+
+  it('does not warn for recognized AWS Lambda subtype outside subnet', () => {
+    const container = makeTestPlate({ id: 'region-1', type: 'region' });
+    const block = makeTestBlock({
+      provider: 'aws',
+      category: 'compute',
+      resourceType: 'web_compute',
+      subtype: 'lambda',
+      placementId: 'region-1',
+    });
+    const model = makeTestArchitecture({ plates: [container], blocks: [block] });
+
+    expect(validateProviderRules(model)).toEqual([]);
+  });
+
+  it('does not warn for recognized subtype', () => {
+    const container = makeTestPlate({ id: 'subnet-1' });
+    const block = makeTestBlock({
+      provider: 'aws',
+      category: 'compute',
+      resourceType: 'web_compute',
+      subtype: 'ec2',
+      placementId: 'subnet-1',
+    });
+    const model = makeTestArchitecture({ plates: [container], blocks: [block] });
+
+    expect(validateProviderRules(model)).toEqual([]);
+  });
+});

--- a/apps/web/src/entities/validation/providerValidation.ts
+++ b/apps/web/src/entities/validation/providerValidation.ts
@@ -62,8 +62,9 @@ function validateBlockProviderRules(
     warnings.push({
       ruleId: 'rule-provider-aws-lambda-subnet',
       severity: 'warning',
-      message: `AWS Lambda "${block.name}" is placed on a subnet. Lambda functions are serverless and typically don't require VPC placement unless accessing private resources.`,
-      suggestion: 'Consider whether VPC placement is intentional for private resource access.',
+      message: `AWS Lambda "${block.name}" is inside a subnet.`,
+      suggestion:
+        "Lambda is serverless — it usually doesn't need VPC placement. If you need private resource access, keep it here; otherwise, consider placing it outside the subnet.",
       targetId: block.id,
     });
   }
@@ -76,9 +77,9 @@ function validateBlockProviderRules(
     warnings.push({
       ruleId: 'rule-provider-gcp-sql-public',
       severity: 'warning',
-      message: `GCP Cloud SQL "${block.name}" is on a subnet. Database instances should typically be secured with appropriate VPC firewall rules or private service access.`,
+      message: `GCP Cloud SQL "${block.name}" is on a subnet without explicit security.`,
       suggestion:
-        'Ensure proper VPC firewall rules or private service access are configured for this subnet.',
+        'Database instances should be protected with VPC firewall rules or private service access. This is a reminder to configure network security for your database.',
       targetId: block.id,
     });
   }
@@ -91,8 +92,8 @@ function validateBlockProviderRules(
       warnings.push({
         ruleId: 'rule-provider-unknown-subtype',
         severity: 'warning',
-        message: `Block "${block.name}" has unknown subtype "${block.subtype}" for ${block.provider} ${block.category}.`,
-        suggestion: `Check available subtypes for ${block.provider} ${block.category} resources.`,
+        message: `"${block.name}" uses an unrecognized subtype "${block.subtype}" for ${block.provider} ${block.category}.`,
+        suggestion: `This subtype may not be a standard ${block.provider} service. Check available subtypes for ${block.provider} ${block.category} resources, or verify the spelling.`,
         targetId: block.id,
       });
     }

--- a/apps/web/src/entities/validation/role.test.ts
+++ b/apps/web/src/entities/validation/role.test.ts
@@ -53,7 +53,7 @@ describe('validateRoles', () => {
     expect(result).not.toBeNull();
     expect(result!.ruleId).toBe('rule-role-invalid');
     expect(result!.severity).toBe('error');
-    expect(result!.message).toContain('invalid-role');
+    expect(result!.message).toBe('"BadRole" has unrecognized role(s): invalid-role.');
     expect(result!.targetId).toBe('b1');
   });
 
@@ -67,8 +67,7 @@ describe('validateRoles', () => {
     const result = validateRoles(block);
     expect(result).not.toBeNull();
     expect(result!.ruleId).toBe('rule-role-invalid');
-    expect(result!.message).toContain('bogus');
-    expect(result!.message).toContain('fake');
+    expect(result!.message).toBe('"MultiInvalid" has unrecognized role(s): bogus, fake.');
   });
 
   it('returns warning for duplicate roles', () => {
@@ -82,7 +81,7 @@ describe('validateRoles', () => {
     expect(result).not.toBeNull();
     expect(result!.ruleId).toBe('rule-role-duplicate');
     expect(result!.severity).toBe('warning');
-    expect(result!.message).toContain('public');
+    expect(result!.message).toBe('"DupeRole" has duplicate role(s): public.');
     expect(result!.targetId).toBe('b3');
   });
 
@@ -96,8 +95,7 @@ describe('validateRoles', () => {
     const result = validateRoles(block);
     expect(result).not.toBeNull();
     expect(result!.ruleId).toBe('rule-role-duplicate');
-    expect(result!.message).toContain('reader');
-    expect(result!.message).toContain('writer');
+    expect(result!.message).toBe('"MultiDupe" has duplicate role(s): reader, writer.');
   });
 
   it('invalid role takes precedence over duplicates', () => {

--- a/apps/web/src/entities/validation/role.ts
+++ b/apps/web/src/entities/validation/role.ts
@@ -22,8 +22,8 @@ export function validateRoles(block: ResourceBlock): ValidationError | null {
     return {
       ruleId: 'rule-role-invalid',
       severity: 'error',
-      message: `Block "${block.name}" has invalid role(s): ${invalidRoles.join(', ')}`,
-      suggestion: `Valid roles: ${BLOCK_ROLES.join(', ')}`,
+      message: `"${block.name}" has unrecognized role(s): ${invalidRoles.join(', ')}.`,
+      suggestion: `Valid roles are: ${BLOCK_ROLES.join(', ')}. Roles are visual tags that help communicate a block's purpose in your architecture.`,
       targetId: block.id,
     };
   }
@@ -35,8 +35,8 @@ export function validateRoles(block: ResourceBlock): ValidationError | null {
     return {
       ruleId: 'rule-role-duplicate',
       severity: 'warning',
-      message: `Block "${block.name}" has duplicate role(s): ${[...new Set(duplicates)].join(', ')}`,
-      suggestion: 'Remove duplicate roles',
+      message: `"${block.name}" has duplicate role(s): ${[...new Set(duplicates)].join(', ')}.`,
+      suggestion: 'Remove the duplicate - each role only needs to be assigned once.',
       targetId: block.id,
     };
   }


### PR DESCRIPTION
## Summary
- Rewrite all validation error/warning messages across 5 validation files
- Consistent format: clear "What's wrong" message + actionable "How to fix it" suggestion
- Learning-first tone: assumes beginner, explains cloud concepts inline
- Add 💡 icon prefix to suggestion text in ValidationDrawerPanel
- Update all test assertions to match new message text

Fixes #1720