### PR TITLE
fix(web): prevent external actor blocks from disappearing in saved workspaces

### DIFF
--- a/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
+++ b/apps/web/src/entities/store/slices/__tests__/persistenceSlice.test.ts
@@ -686,8 +686,8 @@ describe('persistenceSlice branches', () => {
         parentId: null,
         roles: ['external'],
       });
-      // Position fallback: actor had no position, so defaults to { x: 4, y: 0, z: 10 }
-      expect(architecture.nodes[0].position).toEqual({ x: 4, y: 0, z: 10 });
+      // Position fallback: actor had no position, so defaults to { x: 7, y: 0, z: 10 }
+      expect(architecture.nodes[0].position).toEqual({ x: 7, y: 0, z: 10 });
       expect(architecture.externalActors).toEqual([
         { id: 'ext-1', name: 'Internet', type: 'internet', position: { x: 4, y: 0, z: 10 } },
       ]);

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -982,15 +982,13 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         return candidate;
       });
 
+      // Sync externalActors[] from the computed node position (single source of truth)
+      const updatedNode = nodes.find((n) => n.id === id);
       const externalActors = arch.externalActors?.map((actor) => {
-        if (actor.id === id) {
+        if (actor.id === id && updatedNode) {
           return {
             ...actor,
-            position: {
-              x: (actor.position?.x ?? 0) + deltaX,
-              y: actor.position?.y ?? 0,
-              z: (actor.position?.z ?? 0) + deltaZ,
-            },
+            position: { ...updatedNode.position },
           };
         }
         return actor;

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -982,7 +982,21 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         return candidate;
       });
 
-      return withHistory(state, { ...arch, nodes });
+      const externalActors = arch.externalActors?.map((actor) => {
+        if (actor.id === id) {
+          return {
+            ...actor,
+            position: {
+              x: (actor.position?.x ?? 0) + deltaX,
+              y: actor.position?.y ?? 0,
+              z: (actor.position?.z ?? 0) + deltaZ,
+            },
+          };
+        }
+        return actor;
+      });
+
+      return withHistory(state, { ...arch, nodes, ...(externalActors ? { externalActors } : {}) });
     });
   },
 

--- a/apps/web/src/shared/types/schema.additional.test.ts
+++ b/apps/web/src/shared/types/schema.additional.test.ts
@@ -64,7 +64,7 @@ describe('schema deserialize additional branch coverage', () => {
         entry.kind === 'container',
     );
 
-    expect(actor?.position).toEqual({ x: 4, y: 0, z: 10 });
+    expect(actor?.position).toEqual({ x: 7, y: 0, z: 10 });
     expect(container?.profileId).toBeDefined();
   });
 

--- a/apps/web/src/shared/types/schema.test.ts
+++ b/apps/web/src/shared/types/schema.test.ts
@@ -373,7 +373,7 @@ describe('schema utilities', () => {
 
     const result = deserialize(JSON.stringify(legacyData));
 
-    expect(result[0].architecture.externalActors?.[0]?.position).toEqual({ x: 4, y: 0, z: 10 });
+    expect(result[0].architecture.externalActors?.[0]?.position).toEqual({ x: 7, y: 0, z: 10 });
   });
 
   it('rejects legacy 0.1.0 schema (clean start — no migration)', () => {
@@ -594,7 +594,7 @@ describe('schema utilities', () => {
           provider: 'azure',
           parentId: null,
           roles: ['external'],
-          position: { x: 4, y: 0, z: 10 },
+          position: { x: 1, y: 0, z: 10 },
           metadata: {},
         },
         {
@@ -694,7 +694,7 @@ describe('schema utilities', () => {
         },
       ],
       externalActors: [
-        { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
+        { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 1, y: 0, z: 10 } },
         {
           id: 'ext-internet',
           name: 'Internet',
@@ -754,6 +754,9 @@ it('roundtrips createBlankArchitecture through serialize and deserialize', () =>
   expect(internetNode?.resourceType).toBe('internet');
   expect(browserNode?.roles).toEqual(['external']);
   expect(internetNode?.roles).toEqual(['external']);
+  expect(browserNode?.position).toEqual({ x: 1, y: 0, z: 10 });
+  expect(internetNode?.position).toEqual({ x: 7, y: 0, z: 10 });
+  expect(browserNode?.position).not.toEqual(internetNode?.position);
 
   // Endpoints should include both blocks (6 each = 12 total)
   const browserEps = loaded.architecture.endpoints.filter((ep) => ep.id.includes('ext-browser'));
@@ -765,6 +768,25 @@ it('roundtrips createBlankArchitecture through serialize and deserialize', () =>
   expect(loaded.architecture.connections).toHaveLength(1);
   expect(loaded.architecture.connections[0].from).toContain('ext-browser');
   expect(loaded.architecture.connections[0].to).toContain('ext-internet');
+});
+
+it('roundtrip keeps browser and internet at distinct default positions', () => {
+  const workspace: Workspace = {
+    id: 'ws-distinct',
+    name: 'Distinct External Positions',
+    provider: 'azure',
+    architecture: createBlankArchitecture('arch-distinct', 'Distinct External Positions'),
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  const [loaded] = deserialize(serialize([workspace]));
+  const browserNode = loaded.architecture.nodes.find((n) => n.id === 'ext-browser');
+  const internetNode = loaded.architecture.nodes.find((n) => n.id === 'ext-internet');
+
+  expect(browserNode?.position).toEqual({ x: 1, y: 0, z: 10 });
+  expect(internetNode?.position).toEqual({ x: 7, y: 0, z: 10 });
+  expect(browserNode?.position).not.toEqual(internetNode?.position);
 });
 
 it('remaps legacy 10-category names to 7-category names during plates+blocks migration', () => {
@@ -1128,7 +1150,7 @@ describe('migrateExternalActorsToBlocks', () => {
     expect(result).toHaveLength(0);
   });
 
-  it('uses default position when actor position is missing', () => {
+  it('uses per-type default positions when actor position is missing', () => {
     const actors = [
       {
         id: 'ext-internet',
@@ -1136,11 +1158,20 @@ describe('migrateExternalActorsToBlocks', () => {
         type: 'internet' as const,
         position: undefined as unknown as { x: number; y: number; z: number },
       },
+      {
+        id: 'ext-browser',
+        name: 'Client',
+        type: 'browser' as const,
+        position: undefined as unknown as { x: number; y: number; z: number },
+      },
     ];
     const result = migrateExternalActorsToBlocks(actors, new Set(), 'gcp');
 
-    expect(result).toHaveLength(1);
-    expect(result[0].position).toEqual({ x: 4, y: 0, z: 10 });
+    expect(result).toHaveLength(2);
+    const internet = result.find((node) => node.id === 'ext-internet');
+    const browser = result.find((node) => node.id === 'ext-browser');
+    expect(internet?.position).toEqual({ x: 7, y: 0, z: 10 });
+    expect(browser?.position).toEqual({ x: 1, y: 0, z: 10 });
   });
 });
 
@@ -1261,6 +1292,65 @@ describe('deserialize — externalActors migration', () => {
     // Should NOT duplicate — still just 1 node
     expect(ws.architecture.nodes).toHaveLength(1);
     expect(ws.architecture.nodes[0].id).toBe('ext-internet');
+  });
+
+  it('self-heals external blocks when browser and internet overlap', () => {
+    const data = {
+      schemaVersion: SCHEMA_VERSION,
+      workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Test',
+          provider: 'azure',
+          architecture: {
+            id: 'arch-1',
+            name: 'Arch',
+            version: '1',
+            nodes: [
+              {
+                id: 'ext-browser',
+                name: 'Client',
+                kind: 'resource',
+                layer: 'resource',
+                resourceType: 'browser',
+                category: 'delivery',
+                provider: 'azure',
+                parentId: null,
+                position: { x: 4, y: 0, z: 10 },
+                metadata: {},
+                roles: ['external'],
+              },
+              {
+                id: 'ext-internet',
+                name: 'Internet',
+                kind: 'resource',
+                layer: 'resource',
+                resourceType: 'internet',
+                category: 'delivery',
+                provider: 'azure',
+                parentId: null,
+                position: { x: 4, y: 0, z: 10 },
+                metadata: {},
+                roles: ['external'],
+              },
+            ],
+            endpoints: [],
+            connections: [],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    const [ws] = deserialize(JSON.stringify(data));
+    const browserNode = ws.architecture.nodes.find((n) => n.id === 'ext-browser');
+    const internetNode = ws.architecture.nodes.find((n) => n.id === 'ext-internet');
+
+    expect(browserNode?.position).toEqual({ x: 1, y: 0, z: 10 });
+    expect(internetNode?.position).toEqual({ x: 7, y: 0, z: 10 });
   });
 
   it('loads new block-only data without externalActors field', () => {

--- a/apps/web/src/shared/types/schema.test.ts
+++ b/apps/web/src/shared/types/schema.test.ts
@@ -1353,6 +1353,153 @@ describe('deserialize — externalActors migration', () => {
     expect(internetNode?.position).toEqual({ x: 7, y: 0, z: 10 });
   });
 
+  it('does NOT self-heal when external blocks overlap at a non-default position', () => {
+    // Users may intentionally place browser and internet at the same spot.
+    // Self-heal should only fire at the old shared default {x:4, y:0, z:10}.
+    const data = {
+      schemaVersion: SCHEMA_VERSION,
+      workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Test',
+          provider: 'azure',
+          architecture: {
+            id: 'arch-1',
+            name: 'Arch',
+            version: '1',
+            nodes: [
+              {
+                id: 'ext-browser',
+                name: 'Client',
+                kind: 'resource',
+                layer: 'resource',
+                resourceType: 'browser',
+                category: 'delivery',
+                provider: 'azure',
+                parentId: null,
+                position: { x: 2, y: 0, z: 8 },
+                metadata: {},
+                roles: ['external'],
+              },
+              {
+                id: 'ext-internet',
+                name: 'Internet',
+                kind: 'resource',
+                layer: 'resource',
+                resourceType: 'internet',
+                category: 'delivery',
+                provider: 'azure',
+                parentId: null,
+                position: { x: 2, y: 0, z: 8 },
+                metadata: {},
+                roles: ['external'],
+              },
+            ],
+            endpoints: [],
+            connections: [],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    const [ws] = deserialize(JSON.stringify(data));
+    const browserNode = ws.architecture.nodes.find((n) => n.id === 'ext-browser');
+    const internetNode = ws.architecture.nodes.find((n) => n.id === 'ext-internet');
+
+    // Positions should remain unchanged — intentional overlap preserved
+    expect(browserNode?.position).toEqual({ x: 2, y: 0, z: 8 });
+    expect(internetNode?.position).toEqual({ x: 2, y: 0, z: 8 });
+  });
+
+  it('keeps nodes[] and externalActors[] positions in sync after self-heal roundtrip', () => {
+    // After self-heal in deserialize(), externalActors[] should mirror repaired node positions.
+    const data = {
+      schemaVersion: SCHEMA_VERSION,
+      workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Test',
+          provider: 'azure',
+          architecture: {
+            id: 'arch-1',
+            name: 'Arch',
+            version: '1',
+            nodes: [
+              {
+                id: 'ext-browser',
+                name: 'Client',
+                kind: 'resource',
+                layer: 'resource',
+                resourceType: 'browser',
+                category: 'delivery',
+                provider: 'azure',
+                parentId: null,
+                position: { x: 4, y: 0, z: 10 },
+                metadata: {},
+                roles: ['external'],
+              },
+              {
+                id: 'ext-internet',
+                name: 'Internet',
+                kind: 'resource',
+                layer: 'resource',
+                resourceType: 'internet',
+                category: 'delivery',
+                provider: 'azure',
+                parentId: null,
+                position: { x: 4, y: 0, z: 10 },
+                metadata: {},
+                roles: ['external'],
+              },
+            ],
+            endpoints: [],
+            connections: [],
+            externalActors: [
+              {
+                id: 'ext-browser',
+                name: 'Client',
+                type: 'browser',
+                position: { x: 4, y: 0, z: 10 },
+              },
+              {
+                id: 'ext-internet',
+                name: 'Internet',
+                type: 'internet',
+                position: { x: 4, y: 0, z: 10 },
+              },
+            ],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    const [ws] = deserialize(JSON.stringify(data));
+    const browserNode = ws.architecture.nodes.find((n) => n.id === 'ext-browser');
+    const internetNode = ws.architecture.nodes.find((n) => n.id === 'ext-internet');
+    const browserActor = ws.architecture.externalActors?.find((a) => a.id === 'ext-browser');
+    const internetActor = ws.architecture.externalActors?.find((a) => a.id === 'ext-internet');
+
+    // nodes[] should have repaired positions
+    expect(browserNode?.position).toEqual({ x: 1, y: 0, z: 10 });
+    expect(internetNode?.position).toEqual({ x: 7, y: 0, z: 10 });
+
+    // externalActors[] should mirror the repaired node positions exactly
+    expect(browserActor?.position).toEqual({ x: 1, y: 0, z: 10 });
+    expect(internetActor?.position).toEqual({ x: 7, y: 0, z: 10 });
+
+    // Parity: node and actor positions must be identical
+    expect(browserNode?.position).toEqual(browserActor?.position);
+    expect(internetNode?.position).toEqual(internetActor?.position);
+  });
+
   it('loads new block-only data without externalActors field', () => {
     const data = {
       schemaVersion: SCHEMA_VERSION,

--- a/apps/web/src/shared/types/schema.ts
+++ b/apps/web/src/shared/types/schema.ts
@@ -24,6 +24,11 @@ import {
   SCHEMA_VERSION,
 } from '@cloudblocks/schema';
 
+const EXTERNAL_ACTOR_DEFAULT_POSITIONS: Record<string, Position> = {
+  browser: { x: 1, y: 0, z: 10 },
+  internet: { x: 7, y: 0, z: 10 },
+};
+
 const DEFAULT_EXTERNAL_ACTOR_POSITION = { x: 4, y: 0, z: 10 };
 
 /**
@@ -53,7 +58,9 @@ export function migrateExternalActorsToBlocks(
         category: 'delivery',
         provider,
         parentId: null,
-        position: actor.position ?? { ...DEFAULT_EXTERNAL_ACTOR_POSITION },
+        position: actor.position ?? {
+          ...(EXTERNAL_ACTOR_DEFAULT_POSITIONS[actor.type] ?? DEFAULT_EXTERNAL_ACTOR_POSITION),
+        },
         metadata: {},
         roles: ['external'],
       }),
@@ -452,6 +459,29 @@ export function deserialize(json: string): Workspace[] {
         }
       }
 
+      if (Array.isArray(architectureUnknown.nodes)) {
+        const extBrowser = (architectureUnknown.nodes as ResourceBlock[]).find(
+          (n) => n.id === 'ext-browser' || (n.kind === 'resource' && n.resourceType === 'browser'),
+        );
+        const extInternet = (architectureUnknown.nodes as ResourceBlock[]).find(
+          (n) =>
+            n.id === 'ext-internet' || (n.kind === 'resource' && n.resourceType === 'internet'),
+        );
+        if (
+          extBrowser &&
+          extInternet &&
+          extBrowser.position.x === extInternet.position.x &&
+          extBrowser.position.z === extInternet.position.z
+        ) {
+          extBrowser.position = {
+            ...(EXTERNAL_ACTOR_DEFAULT_POSITIONS.browser ?? DEFAULT_EXTERNAL_ACTOR_POSITION),
+          };
+          extInternet.position = {
+            ...(EXTERNAL_ACTOR_DEFAULT_POSITIONS.internet ?? DEFAULT_EXTERNAL_ACTOR_POSITION),
+          };
+        }
+      }
+
       const nodeIds = architectureUnknown.nodes
         .filter(isRecord)
         .map((node) => node.id)
@@ -487,7 +517,10 @@ export function deserialize(json: string): Workspace[] {
         }
         const legacyActor = actor as typeof actor & { position?: Position };
         if (!legacyActor.position) {
-          legacyActor.position = { ...DEFAULT_EXTERNAL_ACTOR_POSITION };
+          legacyActor.position = {
+            ...(EXTERNAL_ACTOR_DEFAULT_POSITIONS[legacyActor.type as string] ??
+              DEFAULT_EXTERNAL_ACTOR_POSITION),
+          };
         }
       }
     }
@@ -516,7 +549,7 @@ export function createBlankArchitecture(id: string, name: string): ArchitectureM
         provider: 'azure',
         parentId: null,
         roles: ['external'],
-        position: { x: 4, y: 0, z: 10 },
+        position: { x: 1, y: 0, z: 10 },
         metadata: {},
       },
       {
@@ -546,7 +579,7 @@ export function createBlankArchitecture(id: string, name: string): ArchitectureM
       },
     ],
     externalActors: [
-      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 4, y: 0, z: 10 } },
+      { id: 'ext-browser', name: 'Client', type: 'browser', position: { x: 1, y: 0, z: 10 } },
       { id: 'ext-internet', name: 'Internet', type: 'internet', position: { x: 7, y: 0, z: 10 } },
     ],
     createdAt: now,

--- a/apps/web/src/shared/types/schema.ts
+++ b/apps/web/src/shared/types/schema.ts
@@ -459,7 +459,13 @@ export function deserialize(json: string): Workspace[] {
         }
       }
 
+      // ── Self-heal: fix external blocks stuck at the old shared default ──────
+      // Before M38 all external actors fell back to a single shared position
+      // {x:4, y:0, z:10}. If BOTH browser and internet still sit at exactly
+      // that old default, spread them to per-type defaults. Any other overlap
+      // (including intentional user stacking) is left untouched.
       if (Array.isArray(architectureUnknown.nodes)) {
+        const OLD_SHARED_DEFAULT: Position = { x: 4, y: 0, z: 10 };
         const extBrowser = (architectureUnknown.nodes as ResourceBlock[]).find(
           (n) => n.id === 'ext-browser' || (n.kind === 'resource' && n.resourceType === 'browser'),
         );
@@ -470,8 +476,10 @@ export function deserialize(json: string): Workspace[] {
         if (
           extBrowser &&
           extInternet &&
-          extBrowser.position.x === extInternet.position.x &&
-          extBrowser.position.z === extInternet.position.z
+          extBrowser.position.x === OLD_SHARED_DEFAULT.x &&
+          extBrowser.position.z === OLD_SHARED_DEFAULT.z &&
+          extInternet.position.x === OLD_SHARED_DEFAULT.x &&
+          extInternet.position.z === OLD_SHARED_DEFAULT.z
         ) {
           extBrowser.position = {
             ...(EXTERNAL_ACTOR_DEFAULT_POSITIONS.browser ?? DEFAULT_EXTERNAL_ACTOR_POSITION),
@@ -479,6 +487,23 @@ export function deserialize(json: string): Workspace[] {
           extInternet.position = {
             ...(EXTERNAL_ACTOR_DEFAULT_POSITIONS.internet ?? DEFAULT_EXTERNAL_ACTOR_POSITION),
           };
+
+          // Sync repaired positions into externalActors[] if present
+          if (Array.isArray(architectureUnknown.externalActors)) {
+            for (const actor of architectureUnknown.externalActors as Array<
+              Record<string, unknown>
+            >) {
+              if (!isRecord(actor)) continue;
+              if (actor.id === extBrowser.id || (actor as { type?: string }).type === 'browser') {
+                (actor as { position?: Position }).position = { ...extBrowser.position };
+              } else if (
+                actor.id === extInternet.id ||
+                (actor as { type?: string }).type === 'internet'
+              ) {
+                (actor as { position?: Position }).position = { ...extInternet.position };
+              }
+            }
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

- Fix browser/internet external actor blocks disappearing when loading saved workspaces from localStorage
- Replace shared DEFAULT_EXTERNAL_ACTOR_POSITION with per-type defaults (browser at x:1, internet at x:7) so migration never collapses both actors to the same coordinate
- Add self-healing repair in deserialize() that nudges overlapping ext-browser/ext-internet to their type-specific positions
- Sync moveExternalBlockPosition to update externalActors[] alongside nodes[] for legacy parity

Fixes #1725
Part of #1724

## Testing

- 32 schema tests pass (including 6 new regression tests)
- 3154 total tests pass (1 pre-existing failure in client.test.ts unrelated)
- Build and lint pass
- Zero LSP diagnostics on changed files