### PR TITLE
fix(web): restore builder view on page refresh when workspace data exists

### DIFF
--- a/apps/web/src/entities/store/uiStore.test.ts
+++ b/apps/web/src/entities/store/uiStore.test.ts
@@ -126,11 +126,26 @@ describe('useUIStore', () => {
   });
 
   describe('appView', () => {
-    it("defaults to 'landing' when no workspaces in localStorage", () => {
-      expect(useUIStore.getState().appView).toBe('landing');
+    it("defaults to 'landing' when no workspaces in localStorage", async () => {
+      vi.resetModules();
+      const { useUIStore: reloadedUIStore } = await import('./uiStore');
+      expect(reloadedUIStore.getState().appView).toBe('landing');
     });
     it("defaults to 'builder' when workspaces exist in localStorage", async () => {
-      localStorage.setItem('cloudblocks:workspaces', '[{"id":"test"}]');
+      localStorage.setItem(
+        'cloudblocks:workspaces',
+        JSON.stringify({
+          schemaVersion: '4.1.0',
+          workspaces: [
+            {
+              id: 'test',
+              name: 'Test',
+              provider: 'azure',
+              architecture: { nodes: [], edges: [], endpoints: [] },
+            },
+          ],
+        }),
+      );
       vi.resetModules();
       const { useUIStore: reloadedUIStore } = await import('./uiStore');
       expect(reloadedUIStore.getState().appView).toBe('builder');

--- a/apps/web/src/entities/store/uiStore.test.ts
+++ b/apps/web/src/entities/store/uiStore.test.ts
@@ -5,6 +5,7 @@ describe('useUIStore', () => {
   beforeEach(() => {
     localStorage.removeItem('cloudblocks:theme-variant');
     localStorage.removeItem('cloudblocks:app-view');
+    localStorage.removeItem('cloudblocks:workspaces');
 
     // Reset store to initial state before each test
     useUIStore.setState({
@@ -125,8 +126,14 @@ describe('useUIStore', () => {
   });
 
   describe('appView', () => {
-    it("defaults to 'landing'", () => {
+    it("defaults to 'landing' when no workspaces in localStorage", () => {
       expect(useUIStore.getState().appView).toBe('landing');
+    });
+    it("defaults to 'builder' when workspaces exist in localStorage", async () => {
+      localStorage.setItem('cloudblocks:workspaces', '[{"id":"test"}]');
+      vi.resetModules();
+      const { useUIStore: reloadedUIStore } = await import('./uiStore');
+      expect(reloadedUIStore.getState().appView).toBe('builder');
     });
 
     it('setAppView updates app view', () => {

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -12,6 +12,7 @@ import type {
   DeploymentVersion,
 } from '../../shared/types/ops';
 import type { DrawerPanelId } from '../../shared/types/drawer';
+import { loadWorkspaces } from '../../shared/utils/storage';
 
 export type ToolMode = 'select' | 'connect' | 'delete';
 export type InteractionState = 'idle' | 'selecting' | 'dragging' | 'placing' | 'connecting';
@@ -389,7 +390,7 @@ export const useUIStore = create<UIState>((set, get) => {
   };
 
   return {
-    appView: (localStorage.getItem('cloudblocks:workspaces') ? 'builder' : 'landing') as AppView,
+    appView: (loadWorkspaces().length > 0 ? 'builder' : 'landing') as AppView,
     setAppView: (view) => {
       set({ appView: view });
     },

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -389,7 +389,7 @@ export const useUIStore = create<UIState>((set, get) => {
   };
 
   return {
-    appView: 'landing' as AppView,
+    appView: (localStorage.getItem('cloudblocks:workspaces') ? 'builder' : 'landing') as AppView,
     setAppView: (view) => {
       set({ appView: view });
     },


### PR DESCRIPTION
## Summary

- Fixes the bug where refreshing the page while in the editor would return the user to the landing page, losing their working context
- The `appView` state in `uiStore` now checks `localStorage` for existing workspace data on initialization — if workspaces exist, starts as `'builder'` instead of `'landing'`

## Changes

- `apps/web/src/entities/store/uiStore.ts`: Changed `appView` initial value from hardcoded `'landing'` to a conditional check: `localStorage.getItem('cloudblocks:workspaces') ? 'builder' : 'landing'`
- `apps/web/src/entities/store/uiStore.test.ts`: Added `localStorage.removeItem` cleanup in `beforeEach`, added new test case verifying builder restoration when workspace data exists

## Testing

- All 3186 tests pass (1 pre-existing `client.test.ts` failure unrelated)
- Build passes
- Browser-verified via Playwright:
  - Fresh load (no workspaces) → landing page ✅
  - Template selected → editor ✅ 
  - Page refresh → stays in editor ✅
  - Theme confirmed as `'workshop'` (white) ✅