### PR TITLE
feat(web): add connection packet flow animation

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -155,7 +155,7 @@ describe('BlockSprite', () => {
     vi.clearAllMocks();
     useUIStore.setState(initialUIState, true);
     useArchitectureStore.setState(initialArchitectureState, true);
-    addConnectionMock.mockReturnValue(true);
+    addConnectionMock.mockReturnValue('conn-test-id');
     interactMocks.draggableFn.mockReturnValue({ unset: interactMocks.unsetFn });
     interactMocks.interactFn.mockReturnValue({ draggable: interactMocks.draggableFn });
     useUIStore.setState({
@@ -373,7 +373,7 @@ describe('BlockSprite', () => {
 
   it('silently cancels when connect mode rejects an invalid connection', async () => {
     const user = userEvent.setup();
-    addConnectionMock.mockReturnValue(false);
+    addConnectionMock.mockReturnValue(null);
     useUIStore.setState({ toolMode: 'connect' });
 
     const sourceBlock = makeBlock('block-source', 'database');

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -286,10 +286,11 @@ export const BlockSprite = memo(function BlockSprite({
       if (!connectionSource) {
         startConnecting(resolvedBlockId);
       } else if (connectionSource !== resolvedBlockId) {
-        const success = addConnection(connectionSource, resolvedBlockId);
-        if (success) {
+        const connectionId = addConnection(connectionSource, resolvedBlockId);
+        if (connectionId) {
           triggerSnapAnimation(resolvedBlockId);
           triggerSnapAnimation(connectionSource);
+          useUIStore.getState().triggerConnectionCreationBurst(connectionId);
           const { isSoundMuted } = useUIStore.getState();
           if (!isSoundMuted) audioService.playSound('block-snap');
         }

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -35,6 +35,7 @@ import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
 import { getConnectionColorsForType } from './connectionFaceColors';
 import type { ConnectionRenderSemantic } from './connectionFaceColors';
 import { offsetScreenPoints } from './overlapOffset';
+import { PacketFlowLayer } from './PacketFlowLayer';
 
 interface ConnectionRendererProps {
   connectionId?: string;
@@ -264,6 +265,9 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const toolMode = useUIStore((s) => s.toolMode);
   const diffMode = useUIStore((s) => s.diffMode);
   const diffDelta = useUIStore((s) => s.diffDelta);
+  const creationBurstExpiry = useUIStore((state) =>
+    resolvedConnectionId ? state.connectionCreationBursts.get(resolvedConnectionId) : undefined,
+  );
   const removeConnection = useArchitectureStore((s) => s.removeConnection);
   const validationResult = useArchitectureStore((s) => s.validationResult);
   const fromEndpoint = useArchitectureStore((state) => {
@@ -335,6 +339,35 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   }, [resolvedConnectionId, validationResult]);
 
   const hasValidationError = connectionErrors.length > 0;
+  const creationBurstActive = creationBurstExpiry !== undefined;
+
+  useEffect(() => {
+    if (!resolvedConnectionId || creationBurstExpiry === undefined) {
+      return;
+    }
+
+    const remaining = creationBurstExpiry - Date.now();
+    if (remaining <= 0) {
+      useUIStore.getState().clearConnectionCreationBurst(resolvedConnectionId);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      useUIStore.getState().clearConnectionCreationBurst(resolvedConnectionId);
+    }, remaining);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [creationBurstExpiry, resolvedConnectionId]);
+
+  const packetMode = (() => {
+    if (hasValidationError) return 'static' as const;
+    if (creationBurstActive) return 'creation' as const;
+    if (isSelected) return 'selected' as const;
+    if (isHovered) return 'hover' as const;
+    return 'static' as const;
+  })();
 
   const surfaceRoute = useMemo(
     () =>
@@ -355,6 +388,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
 
     return {
       hitPath,
+      hitPoints,
       labelPos: getLabelPosition(hitPoints),
       sourcePos: hitPoints[0],
       targetPos: hitPoints[hitPoints.length - 1],
@@ -372,6 +406,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const isNeutral = connectionType === 'dataflow' || connectionType === undefined;
   const colors = getColors(renderSemantic, diffState, isHighlighted, isNeutral);
   const hitPath = surfaceRender.hitPath;
+  const hitPoints = surfaceRender.hitPoints;
   const labelPos = surfaceRender.labelPos;
   const sourcePos = surfaceRender.sourcePos;
   const targetPos = surfaceRender.targetPos;
@@ -385,6 +420,9 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     : visualStyle.strokeWidth + CASING_WIDTH_OFFSET;
   const markerId = `arrow-${resolvedConnection.id}`;
   const pinHoleStyle = CONNECTOR_THEMES[connectionType ?? 'dataflow'].pinHoleStyle;
+  const rawConnectionType = resolvedConnection.metadata?.type;
+  const resolvedConnectionType =
+    typeof rawConnectionType === 'string' ? rawConnectionType : 'dataflow';
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     e.stopPropagation();
@@ -465,6 +503,15 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
         data-layer="trace"
         markerEnd={`url(#${markerId})`}
       />
+
+      {packetMode !== 'static' && (
+        <PacketFlowLayer
+          hitPoints={hitPoints}
+          mode={packetMode}
+          connectionType={resolvedConnectionType}
+          strokeColor={colors.stroke}
+        />
+      )}
 
       {/* Provider-accent glow: hover = subtle, selection = stronger */}
       {isHighlighted && (

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { PacketFlowLayer } from './PacketFlowLayer';
+import { PACKET_SPEED_MS } from './packetFlowTokens';
+
+const useAnimationClockMock = vi.fn(() => ({ elapsed: 0, reducedMotion: false }));
+
+vi.mock('../../shared/hooks/useAnimationClock', () => ({
+  useAnimationClock: () => useAnimationClockMock(),
+}));
+
+const hitPoints = [
+  { x: 0, y: 0 },
+  { x: 200, y: 0 },
+];
+
+function renderLayer(mode: 'static' | 'hover' | 'selected' | 'creation') {
+  return render(
+    <svg aria-label="packet-flow-test">
+      <title>packet-flow-test</title>
+      <PacketFlowLayer
+        hitPoints={hitPoints}
+        mode={mode}
+        connectionType="dataflow"
+        strokeColor="#22d3ee"
+      />
+    </svg>,
+  );
+}
+
+describe('PacketFlowLayer', () => {
+  it('returns null in static mode', () => {
+    const { container } = renderLayer('static');
+
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+  });
+
+  it('returns null when reduced motion is enabled', () => {
+    useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: true });
+
+    const { container } = renderLayer('selected');
+
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+    useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
+  });
+
+  it('renders fewer packets in hover mode than selected mode', () => {
+    const hover = renderLayer('hover');
+    const hoverPackets = hover.container.querySelectorAll('[data-testid="packet-flow-packet"]');
+    expect(hoverPackets).toHaveLength(2);
+
+    hover.unmount();
+
+    const selected = renderLayer('selected');
+    const selectedPackets = selected.container.querySelectorAll(
+      '[data-testid="packet-flow-packet"]',
+    );
+    expect(selectedPackets).toHaveLength(3);
+  });
+
+  it('renders the creation packet count for the path length', () => {
+    const { container } = renderLayer('creation');
+
+    const packets = container.querySelectorAll('[data-testid="packet-flow-packet"]');
+    expect(packets).toHaveLength(4);
+  });
+
+  it('stops rendering creation packets after one pass', () => {
+    useAnimationClockMock.mockReturnValue({ elapsed: PACKET_SPEED_MS + 1, reducedMotion: false });
+
+    const { container } = renderLayer('creation');
+
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+    useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
+  });
+});

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { PacketFlowLayer } from './PacketFlowLayer';
-import { PACKET_SPEED_MS } from './packetFlowTokens';
+import { getPacketCount, getPositionAtDistance } from './packetFlowHelpers';
+import { PACKET_SPEED_MS, SHORT_PATH_THRESHOLD, MEDIUM_PATH_THRESHOLD } from './packetFlowTokens';
 
 const useAnimationClockMock = vi.fn(() => ({ elapsed: 0, reducedMotion: false }));
 
@@ -72,5 +73,179 @@ describe('PacketFlowLayer', () => {
 
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
     useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
+  });
+
+  it('returns null when hitPoints has fewer than 2 points', () => {
+    const { container } = render(
+      <svg aria-label="packet-flow-test">
+        <title>packet-flow-test</title>
+        <PacketFlowLayer
+          hitPoints={[{ x: 0, y: 0 }]}
+          mode="selected"
+          connectionType="dataflow"
+          strokeColor="#22d3ee"
+        />
+      </svg>,
+    );
+
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+  });
+
+  it('renders null for individual creation packets that exceed one pass', () => {
+    useAnimationClockMock.mockReturnValue({
+      elapsed: PACKET_SPEED_MS * 0.8,
+      reducedMotion: false,
+    });
+
+    const { container } = renderLayer('creation');
+
+    const packets = container.querySelectorAll('[data-testid="packet-flow-packet"]');
+    // With elapsed at 0.8 * PACKET_SPEED_MS and 4 packets total,
+    // some packets will have rawProgress > 1 and return null
+    expect(packets.length).toBeLessThan(4);
+
+    useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
+  });
+
+  it('handles zero-length segments in hitPoints', () => {
+    const { container } = render(
+      <svg aria-label="packet-flow-test">
+        <title>packet-flow-test</title>
+        <PacketFlowLayer
+          hitPoints={[
+            { x: 0, y: 0 },
+            { x: 0, y: 0 },
+            { x: 100, y: 0 },
+          ]}
+          mode="selected"
+          connectionType="dataflow"
+          strokeColor="#22d3ee"
+        />
+      </svg>,
+    );
+
+    // Verify that the layer renders (doesn't crash) even with zero-length segments
+    const layer = container.querySelector('[data-testid="packet-flow-layer"]');
+    expect(layer).toBeInTheDocument();
+  });
+
+  it('handles path where getPositionAtDistance falls through all segments', () => {
+    useAnimationClockMock.mockReturnValue({
+      elapsed: PACKET_SPEED_MS * 10,
+      reducedMotion: false,
+    });
+
+    const { container } = renderLayer('selected');
+
+    // Verify packets still render at the end position
+    const packets = container.querySelectorAll('[data-testid="packet-flow-packet"]');
+    expect(packets.length).toBeGreaterThan(0);
+
+    useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
+  });
+
+  it('returns null when totalLength is zero', () => {
+    const { container } = render(
+      <svg aria-label="packet-flow-test">
+        <title>packet-flow-test</title>
+        <PacketFlowLayer
+          hitPoints={[
+            { x: 5, y: 5 },
+            { x: 5, y: 5 },
+          ]}
+          mode="selected"
+          connectionType="dataflow"
+          strokeColor="#22d3ee"
+        />
+      </svg>,
+    );
+
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+  });
+
+  describe('getPacketCount', () => {
+    it('returns 0 for static mode', () => {
+      expect(getPacketCount(100, 'static')).toBe(0);
+      expect(getPacketCount(0, 'static')).toBe(0);
+    });
+
+    it('returns base count for selected mode (short path)', () => {
+      expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'selected')).toBe(1);
+    });
+
+    it('returns base count for selected mode (medium path)', () => {
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD - 1, 'selected')).toBe(2);
+    });
+
+    it('returns base count for selected mode (long path)', () => {
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'selected')).toBe(3);
+    });
+
+    it('returns fewer packets for hover mode', () => {
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'hover')).toBe(2);
+      expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'hover')).toBe(1);
+    });
+
+    it('returns more packets for creation mode', () => {
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'creation')).toBe(4);
+      expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'creation')).toBe(2);
+    });
+  });
+
+  describe('getPositionAtDistance', () => {
+    const segments = [
+      { start: { x: 0, y: 0 }, dx: 100, dy: 0, length: 100, cumulativeStart: 0 },
+      { start: { x: 100, y: 0 }, dx: 0, dy: 100, length: 100, cumulativeStart: 100 },
+    ];
+
+    it('returns null for empty segments', () => {
+      expect(getPositionAtDistance([], 0, 0)).toBeNull();
+    });
+
+    it('returns null when totalLength is zero', () => {
+      expect(getPositionAtDistance(segments, 0, 50)).toBeNull();
+    });
+
+    it('returns position at the start of the path', () => {
+      const pos = getPositionAtDistance(segments, 200, 0);
+      expect(pos).toEqual({ x: 0, y: 0, angle: 0 });
+    });
+
+    it('returns position in the middle of first segment', () => {
+      const pos = getPositionAtDistance(segments, 200, 50);
+      expect(pos).not.toBeNull();
+      expect(pos!.x).toBeCloseTo(50, 1);
+      expect(pos!.y).toBeCloseTo(0, 1);
+    });
+
+    it('returns position in the second segment', () => {
+      const pos = getPositionAtDistance(segments, 200, 150);
+      expect(pos).not.toBeNull();
+      expect(pos!.x).toBeCloseTo(100, 1);
+      expect(pos!.y).toBeCloseTo(50, 1);
+    });
+
+    it('falls back to last segment end when distance exceeds all segments', () => {
+      // Create segments where the loop won't match (distance beyond cumulativeEnd)
+      const gapSegments = [
+        { start: { x: 0, y: 0 }, dx: 10, dy: 0, length: 10, cumulativeStart: 0 },
+      ];
+      // totalLength > sum of segment lengths — forces fallthrough past the loop
+      const pos = getPositionAtDistance(gapSegments, 100, 100);
+      // Since clampedDistance=100 > segmentEnd=10, the loop exits, fallback returns last segment end
+      expect(pos).not.toBeNull();
+      expect(pos!.x).toBeCloseTo(10, 1);
+      expect(pos!.y).toBeCloseTo(0, 1);
+    });
+
+    it('handles zero-length segment by using t=0', () => {
+      const zeroSegments = [{ start: { x: 5, y: 5 }, dx: 0, dy: 0, length: 0, cumulativeStart: 0 }];
+      // totalLength must be > 0 for the function to not bail early
+      const pos = getPositionAtDistance(zeroSegments, 1, 0);
+      // clamped=0 <= segmentEnd=0, so t = length > 0 ? ... : 0 → t=0
+      expect(pos).not.toBeNull();
+      expect(pos!.x).toBe(5);
+      expect(pos!.y).toBe(5);
+    });
   });
 });

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -3,7 +3,6 @@ import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import {
   PACKET_COLOR,
-  PACKET_GLOW_COLOR,
   PACKET_LENGTH,
   PACKET_OPACITY,
   PACKET_SPEED_MS,
@@ -107,7 +106,7 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
             {/* Glow layer */}
             <path
               d={`M ${-glowHalfLen} 0 Q ${-glowHalfLen} ${-glowHalfWid} 0 ${-glowHalfWid} Q ${glowHalfLen} ${-glowHalfWid} ${glowHalfLen} 0 Q ${glowHalfLen} ${glowHalfWid} 0 ${glowHalfWid} Q ${-glowHalfLen} ${glowHalfWid} ${-glowHalfLen} 0 Z`}
-              fill={PACKET_GLOW_COLOR}
+              fill={packetColor}
               fillOpacity={opacity}
             />
             {/* Capsule body */}

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -1,0 +1,199 @@
+import { memo, useMemo } from 'react';
+import type { ScreenPoint } from '../../shared/utils/isometric';
+import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
+import {
+  MEDIUM_PATH_THRESHOLD,
+  PACKET_COLOR,
+  PACKET_GLOW_COLOR,
+  PACKET_LENGTH,
+  PACKET_OPACITY,
+  PACKET_SPEED_MS,
+  PACKET_TAIL_LENGTH,
+  PACKET_WIDTH,
+  SHORT_PATH_THRESHOLD,
+} from './packetFlowTokens';
+
+type PacketFlowMode = 'static' | 'hover' | 'selected' | 'creation';
+
+interface PacketFlowLayerProps {
+  hitPoints: ScreenPoint[];
+  mode: PacketFlowMode;
+  connectionType: string;
+  strokeColor: string;
+}
+
+interface SegmentMetric {
+  start: ScreenPoint;
+  dx: number;
+  dy: number;
+  length: number;
+  cumulativeStart: number;
+}
+
+interface PacketPosition {
+  x: number;
+  y: number;
+  angle: number;
+}
+
+function getPacketCount(totalLength: number, mode: PacketFlowMode): number {
+  if (mode === 'static') {
+    return 0;
+  }
+
+  const baseCount =
+    totalLength <= SHORT_PATH_THRESHOLD ? 1 : totalLength <= MEDIUM_PATH_THRESHOLD ? 2 : 3;
+
+  if (mode === 'hover') {
+    return Math.max(1, baseCount - 1);
+  }
+
+  if (mode === 'creation') {
+    return baseCount + 1;
+  }
+
+  return baseCount;
+}
+
+function getPositionAtDistance(
+  segments: readonly SegmentMetric[],
+  totalLength: number,
+  distance: number,
+): PacketPosition | null {
+  if (segments.length === 0 || totalLength <= 0) {
+    return null;
+  }
+
+  const clampedDistance = Math.min(Math.max(distance, 0), totalLength);
+
+  for (const segment of segments) {
+    const segmentEnd = segment.cumulativeStart + segment.length;
+    if (clampedDistance <= segmentEnd) {
+      const localDistance = clampedDistance - segment.cumulativeStart;
+      const t = segment.length > 0 ? localDistance / segment.length : 0;
+      const x = segment.start.x + segment.dx * t;
+      const y = segment.start.y + segment.dy * t;
+      const angle = (Math.atan2(segment.dy, segment.dx) * 180) / Math.PI;
+      return { x, y, angle };
+    }
+  }
+
+  const last = segments[segments.length - 1];
+  return {
+    x: last.start.x + last.dx,
+    y: last.start.y + last.dy,
+    angle: (Math.atan2(last.dy, last.dx) * 180) / Math.PI,
+  };
+}
+
+export const PacketFlowLayer = memo(function PacketFlowLayer({
+  hitPoints,
+  mode,
+  connectionType,
+  strokeColor,
+}: PacketFlowLayerProps) {
+  const { elapsed, reducedMotion } = useAnimationClock(mode !== 'static' && hitPoints.length > 1);
+
+  const { segments, totalLength } = useMemo(() => {
+    const nextSegments: SegmentMetric[] = [];
+    let cumulative = 0;
+
+    for (let index = 0; index < hitPoints.length - 1; index += 1) {
+      const start = hitPoints[index];
+      const end = hitPoints[index + 1];
+      const dx = end.x - start.x;
+      const dy = end.y - start.y;
+      const length = Math.hypot(dx, dy);
+      if (length <= 0) {
+        continue;
+      }
+
+      nextSegments.push({
+        start,
+        dx,
+        dy,
+        length,
+        cumulativeStart: cumulative,
+      });
+      cumulative += length;
+    }
+
+    return {
+      segments: nextSegments,
+      totalLength: cumulative,
+    };
+  }, [hitPoints]);
+
+  const creationCompleted = mode === 'creation' && elapsed >= PACKET_SPEED_MS;
+
+  if (
+    mode === 'static' ||
+    reducedMotion ||
+    hitPoints.length < 2 ||
+    totalLength <= 0 ||
+    (mode === 'creation' && creationCompleted)
+  ) {
+    return null;
+  }
+
+  const packetCount = getPacketCount(totalLength, mode);
+  const opacity = PACKET_OPACITY[mode];
+  const packetColor = strokeColor || PACKET_COLOR;
+
+  return (
+    <g pointerEvents="none" data-testid="packet-flow-layer" data-connection-type={connectionType}>
+      {Array.from({ length: packetCount }, (_, index) => {
+        const phaseOffset = (index / packetCount) * PACKET_SPEED_MS;
+        const rawProgress = (elapsed + phaseOffset) / PACKET_SPEED_MS;
+
+        if (mode === 'creation' && rawProgress > 1) {
+          return null;
+        }
+
+        const progress = mode === 'creation' ? rawProgress : rawProgress % 1;
+        const distance = progress * totalLength;
+        const position = getPositionAtDistance(segments, totalLength, distance);
+
+        if (!position) {
+          return null;
+        }
+
+        const halfLen = PACKET_LENGTH / 2;
+        const halfWid = PACKET_WIDTH / 2;
+        const glowHalfLen = halfLen + 1;
+        const glowHalfWid = halfWid + 1;
+
+        return (
+          <g
+            key={`packet-${phaseOffset}`}
+            transform={`translate(${position.x} ${position.y}) rotate(${position.angle})`}
+            pointerEvents="none"
+            data-testid="packet-flow-packet"
+          >
+            {/* Glow layer */}
+            <path
+              d={`M ${-glowHalfLen} 0 Q ${-glowHalfLen} ${-glowHalfWid} 0 ${-glowHalfWid} Q ${glowHalfLen} ${-glowHalfWid} ${glowHalfLen} 0 Q ${glowHalfLen} ${glowHalfWid} 0 ${glowHalfWid} Q ${-glowHalfLen} ${glowHalfWid} ${-glowHalfLen} 0 Z`}
+              fill={PACKET_GLOW_COLOR}
+              fillOpacity={opacity}
+            />
+            {/* Capsule body */}
+            <path
+              d={`M ${-halfLen} ${-halfWid} Q ${-halfLen - halfWid} 0 ${-halfLen} ${halfWid} L ${halfLen} ${halfWid} Q ${halfLen + halfWid} 0 ${halfLen} ${-halfWid} Z`}
+              fill={packetColor}
+              fillOpacity={opacity}
+            />
+            {/* Tail trail */}
+            <path
+              d={`M ${-halfLen} 0 L ${-halfLen - PACKET_TAIL_LENGTH} 0`}
+              stroke={packetColor}
+              strokeWidth={PACKET_WIDTH * 0.75}
+              strokeLinecap="round"
+              strokeOpacity={opacity * 0.55}
+              fill="none"
+            />
+          </g>
+        );
+      })}
+    </g>
+  );
+});

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -2,7 +2,6 @@ import { memo, useMemo } from 'react';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import {
-  MEDIUM_PATH_THRESHOLD,
   PACKET_COLOR,
   PACKET_GLOW_COLOR,
   PACKET_LENGTH,
@@ -10,80 +9,15 @@ import {
   PACKET_SPEED_MS,
   PACKET_TAIL_LENGTH,
   PACKET_WIDTH,
-  SHORT_PATH_THRESHOLD,
 } from './packetFlowTokens';
-
-type PacketFlowMode = 'static' | 'hover' | 'selected' | 'creation';
+import { getPacketCount, getPositionAtDistance } from './packetFlowHelpers';
+import type { PacketFlowMode, SegmentMetric } from './packetFlowHelpers';
 
 interface PacketFlowLayerProps {
   hitPoints: ScreenPoint[];
   mode: PacketFlowMode;
   connectionType: string;
   strokeColor: string;
-}
-
-interface SegmentMetric {
-  start: ScreenPoint;
-  dx: number;
-  dy: number;
-  length: number;
-  cumulativeStart: number;
-}
-
-interface PacketPosition {
-  x: number;
-  y: number;
-  angle: number;
-}
-
-function getPacketCount(totalLength: number, mode: PacketFlowMode): number {
-  if (mode === 'static') {
-    return 0;
-  }
-
-  const baseCount =
-    totalLength <= SHORT_PATH_THRESHOLD ? 1 : totalLength <= MEDIUM_PATH_THRESHOLD ? 2 : 3;
-
-  if (mode === 'hover') {
-    return Math.max(1, baseCount - 1);
-  }
-
-  if (mode === 'creation') {
-    return baseCount + 1;
-  }
-
-  return baseCount;
-}
-
-function getPositionAtDistance(
-  segments: readonly SegmentMetric[],
-  totalLength: number,
-  distance: number,
-): PacketPosition | null {
-  if (segments.length === 0 || totalLength <= 0) {
-    return null;
-  }
-
-  const clampedDistance = Math.min(Math.max(distance, 0), totalLength);
-
-  for (const segment of segments) {
-    const segmentEnd = segment.cumulativeStart + segment.length;
-    if (clampedDistance <= segmentEnd) {
-      const localDistance = clampedDistance - segment.cumulativeStart;
-      const t = segment.length > 0 ? localDistance / segment.length : 0;
-      const x = segment.start.x + segment.dx * t;
-      const y = segment.start.y + segment.dy * t;
-      const angle = (Math.atan2(segment.dy, segment.dx) * 180) / Math.PI;
-      return { x, y, angle };
-    }
-  }
-
-  const last = segments[segments.length - 1];
-  return {
-    x: last.start.x + last.dx,
-    y: last.start.y + last.dy,
-    angle: (Math.atan2(last.dy, last.dx) * 180) / Math.PI,
-  };
 }
 
 export const PacketFlowLayer = memo(function PacketFlowLayer({

--- a/apps/web/src/entities/connection/__tests__/invalidConnectionPrevention.test.tsx
+++ b/apps/web/src/entities/connection/__tests__/invalidConnectionPrevention.test.tsx
@@ -88,7 +88,7 @@ describe('Invalid connection prevention (#1253)', () => {
 
       startConnecting('block-1');
       const success = addConnection('block-1', 'block-1');
-      expect(success).toBe(false);
+      expect(success).toBeNull();
 
       // completeInteraction still works after failed addConnection
       completeInteraction();

--- a/apps/web/src/entities/connection/__tests__/overlapOffset.test.ts
+++ b/apps/web/src/entities/connection/__tests__/overlapOffset.test.ts
@@ -178,5 +178,24 @@ describe('overlapOffset', () => {
       expect(shifted[2].x).toBeCloseTo(5);
       expect(shifted[2].y).toBeCloseTo(10);
     });
+
+    it('handles coincident points (zero-length segments) in offsetScreenPoints', () => {
+      const shifted = offsetScreenPoints(
+        [
+          { x: 0, y: 0 },
+          { x: 0, y: 0 },
+          { x: 10, y: 0 },
+        ],
+        5,
+      );
+
+      // First point has zero-length backward segment, normal from forward segment only
+      // Second point: backward segment is zero-length (skipped), forward segment contributes
+      // Third point: only backward segment contributes
+      expect(shifted.length).toBe(3);
+      // The offset should still produce valid numbers
+      expect(Number.isFinite(shifted[0].x)).toBe(true);
+      expect(Number.isFinite(shifted[0].y)).toBe(true);
+    });
   });
 });

--- a/apps/web/src/entities/connection/packetFlowHelpers.ts
+++ b/apps/web/src/entities/connection/packetFlowHelpers.ts
@@ -1,0 +1,68 @@
+import type { ScreenPoint } from '../../shared/utils/isometric';
+import { MEDIUM_PATH_THRESHOLD, SHORT_PATH_THRESHOLD } from './packetFlowTokens';
+
+export type PacketFlowMode = 'static' | 'hover' | 'selected' | 'creation';
+
+export interface SegmentMetric {
+  start: ScreenPoint;
+  dx: number;
+  dy: number;
+  length: number;
+  cumulativeStart: number;
+}
+
+export interface PacketPosition {
+  x: number;
+  y: number;
+  angle: number;
+}
+
+export function getPacketCount(totalLength: number, mode: PacketFlowMode): number {
+  if (mode === 'static') {
+    return 0;
+  }
+
+  const baseCount =
+    totalLength <= SHORT_PATH_THRESHOLD ? 1 : totalLength <= MEDIUM_PATH_THRESHOLD ? 2 : 3;
+
+  if (mode === 'hover') {
+    return Math.max(1, baseCount - 1);
+  }
+
+  if (mode === 'creation') {
+    return baseCount + 1;
+  }
+
+  return baseCount;
+}
+
+export function getPositionAtDistance(
+  segments: readonly SegmentMetric[],
+  totalLength: number,
+  distance: number,
+): PacketPosition | null {
+  if (segments.length === 0 || totalLength <= 0) {
+    return null;
+  }
+
+  const clampedDistance = Math.min(Math.max(distance, 0), totalLength);
+
+  for (const segment of segments) {
+    const segmentEnd = segment.cumulativeStart + segment.length;
+    if (clampedDistance <= segmentEnd) {
+      const localDistance = clampedDistance - segment.cumulativeStart;
+      const t = segment.length > 0 ? localDistance / segment.length : 0;
+      const x = segment.start.x + segment.dx * t;
+      const y = segment.start.y + segment.dy * t;
+      const angle = (Math.atan2(segment.dy, segment.dx) * 180) / Math.PI;
+      return { x, y, angle };
+    }
+  }
+
+  const last = segments[segments.length - 1];
+  return {
+    x: last.start.x + last.dx,
+    y: last.start.y + last.dy,
+    angle: (Math.atan2(last.dy, last.dx) * 180) / Math.PI,
+  };
+}

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -1,0 +1,20 @@
+export const PACKET_SPEED_MS = 2600;
+export const PACKET_LENGTH = 10;
+export const PACKET_WIDTH = 4;
+export const PACKET_TAIL_LENGTH = 6;
+
+export const SHORT_PATH_THRESHOLD = 80;
+export const MEDIUM_PATH_THRESHOLD = 180;
+
+export const PACKET_OPACITY = {
+  hover: 0.5,
+  selected: 0.8,
+  creation: 1.0,
+} as const;
+
+export const PACKET_COLOR = '#22d3ee';
+export const PACKET_GLOW_COLOR = 'rgba(34, 211, 238, 0.3)';
+
+/** Duration of the creation burst effect in milliseconds. Matches PACKET_SPEED_MS so
+ *  the burst visual completes exactly when the timer clears the burst entry. */
+export const CREATION_BURST_DURATION_MS = PACKET_SPEED_MS;

--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -1377,7 +1377,7 @@ describe('architectureStore', () => {
       const { gatewayId, computeId } = createConnectionFixture();
       const success = getState().addConnection(gatewayId, computeId);
 
-      expect(success).toBe(true);
+      expect(success).toBeTruthy();
       const conns = getArch().connections;
       expect(conns).toHaveLength(1);
       const { sourceId, targetId, type } = resolveConnectionNodes(conns[0]);
@@ -1391,7 +1391,7 @@ describe('architectureStore', () => {
       getState().addConnection(gatewayId, computeId);
       const success = getState().addConnection(gatewayId, computeId);
 
-      expect(success).toBe(false);
+      expect(success).toBeNull();
       expect(getArch().connections).toHaveLength(1);
     });
 
@@ -1400,7 +1400,7 @@ describe('architectureStore', () => {
 
       const success = getState().addConnection(computeId, computeId);
 
-      expect(success).toBe(false);
+      expect(success).toBeNull();
       expect(getArch().connections).toHaveLength(0);
     });
 
@@ -1410,8 +1410,8 @@ describe('architectureStore', () => {
       const dbToCompute = getState().addConnection(databaseId, computeId);
       const storageToGateway = getState().addConnection(storageId, gatewayId);
 
-      expect(dbToCompute).toBe(false);
-      expect(storageToGateway).toBe(false);
+      expect(dbToCompute).toBeNull();
+      expect(storageToGateway).toBeNull();
       expect(getArch().connections).toHaveLength(0);
     });
 
@@ -1421,8 +1421,8 @@ describe('architectureStore', () => {
       const gatewayToCompute = getState().addConnection(gatewayId, computeId);
       const computeToDatabase = getState().addConnection(computeId, databaseId);
 
-      expect(gatewayToCompute).toBe(true);
-      expect(computeToDatabase).toBe(true);
+      expect(gatewayToCompute).toBeTruthy();
+      expect(computeToDatabase).toBeTruthy();
       expect(getArch().connections).toHaveLength(2);
     });
 
@@ -1431,7 +1431,7 @@ describe('architectureStore', () => {
 
       const success = getState().addConnection('missing-source', computeId);
 
-      expect(success).toBe(false);
+      expect(success).toBeNull();
       expect(getArch().connections).toHaveLength(0);
     });
 
@@ -1440,7 +1440,7 @@ describe('architectureStore', () => {
 
       const success = getState().addConnection(gatewayId, 'missing-target');
 
-      expect(success).toBe(false);
+      expect(success).toBeNull();
       expect(getArch().connections).toHaveLength(0);
     });
   });

--- a/apps/web/src/entities/store/slices/domainSlice.test.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.test.ts
@@ -440,7 +440,7 @@ describe('domainSlice – targeted branch coverage', () => {
       });
 
       const success = getState().addConnection('ext-internet', 'c1');
-      expect(success).toBe(false);
+      expect(success).toBeNull();
       expect(getArch().connections).toHaveLength(0);
     });
   });
@@ -582,7 +582,7 @@ describe('domainSlice – targeted branch coverage', () => {
       });
 
       const success = getState().addConnection('ext-internet', 'gw1');
-      expect(success).toBe(true);
+      expect(success).toBeTruthy();
       expect(getArch().connections).toHaveLength(1);
       expect(getArch().connections[0].from).toContain('ext-internet');
       expect(getArch().connections[0].to).toContain('gw1');
@@ -611,7 +611,7 @@ describe('domainSlice – targeted branch coverage', () => {
       });
 
       const success = getState().addConnection('ext-internet', 'c1');
-      expect(success).toBe(false);
+      expect(success).toBeNull();
       expect(getArch().connections).toHaveLength(0);
     });
   });
@@ -633,8 +633,8 @@ describe('domainSlice – targeted branch coverage', () => {
         ],
       });
 
-      expect(getState().addConnection('c1', 'd1')).toBe(true);
-      expect(getState().addConnection('c1', 'd2')).toBe(true);
+      expect(getState().addConnection('c1', 'd1')).toBeTruthy();
+      expect(getState().addConnection('c1', 'd2')).toBeTruthy();
 
       const connections = getArch().connections;
       expect(connections).toHaveLength(2);
@@ -661,9 +661,9 @@ describe('domainSlice – targeted branch coverage', () => {
         ],
       });
 
-      expect(getState().addConnection('c1', 'd1')).toBe(true);
-      expect(getState().addConnection('c1', 'd2')).toBe(true);
-      expect(getState().addConnection('c1', 'd3')).toBe(false);
+      expect(getState().addConnection('c1', 'd1')).toBeTruthy();
+      expect(getState().addConnection('c1', 'd2')).toBeTruthy();
+      expect(getState().addConnection('c1', 'd3')).toBeNull();
       expect(getArch().connections).toHaveLength(2);
     });
 
@@ -684,9 +684,9 @@ describe('domainSlice – targeted branch coverage', () => {
         ],
       });
 
-      expect(getState().addConnection('c1', 'd1')).toBe(true);
-      expect(getState().addConnection('c2', 'd1')).toBe(true);
-      expect(getState().addConnection('c3', 'd1')).toBe(false);
+      expect(getState().addConnection('c1', 'd1')).toBeTruthy();
+      expect(getState().addConnection('c2', 'd1')).toBeTruthy();
+      expect(getState().addConnection('c3', 'd1')).toBeNull();
       expect(getArch().connections).toHaveLength(2);
     });
 
@@ -707,7 +707,7 @@ describe('domainSlice – targeted branch coverage', () => {
         connections: [makeLegacyConnection('legacy-conn', 'c1', 'd1', 'dataflow')],
       });
 
-      expect(getState().addConnection('c1', 'd2')).toBe(true);
+      expect(getState().addConnection('c1', 'd2')).toBeTruthy();
 
       const newConnection = getArch().connections.find(
         (connection) => connection.id !== 'legacy-conn',
@@ -1010,9 +1010,9 @@ describe('domainSlice – targeted branch coverage', () => {
         connections: [makeLegacyConnection('conn-existing', edge.id, compute.id)],
       });
 
-      expect(getState().addConnection('compute-1', 'ext-internet')).toBe(false);
+      expect(getState().addConnection('compute-1', 'ext-internet')).toBeNull();
 
-      expect(getState().addConnection('ext-internet', 'delivery-1')).toBe(true);
+      expect(getState().addConnection('ext-internet', 'delivery-1')).toBeTruthy();
     });
 
     it('uses parseEndpointId fallback for capacity counting when endpoints are missing', () => {
@@ -1055,7 +1055,7 @@ describe('domainSlice – targeted branch coverage', () => {
         ],
       });
 
-      expect(getState().addConnection('delivery-1', 'compute-1')).toBe(true);
+      expect(getState().addConnection('delivery-1', 'compute-1')).toBeTruthy();
 
       const createdConnection = getArch().connections.at(-1);
       expect(createdConnection?.metadata?.sourcePort).toBe(1);
@@ -1072,7 +1072,7 @@ describe('domainSlice – targeted branch coverage', () => {
         externalActors: [],
       });
 
-      expect(getState().addConnection('delivery-1', 'compute-1')).toBe(false);
+      expect(getState().addConnection('delivery-1', 'compute-1')).toBeNull();
     });
 
     it('returns false when target has no stored endpoint and is not an actor', () => {
@@ -1095,7 +1095,7 @@ describe('domainSlice – targeted branch coverage', () => {
       });
 
       // Source (delivery-1) has endpoints, target (compute-1) does not
-      expect(getState().addConnection('delivery-1', 'compute-1')).toBe(false);
+      expect(getState().addConnection('delivery-1', 'compute-1')).toBeNull();
     });
 
     it('no-ops updateConnectionType when endpoints for existing connection are missing', () => {
@@ -1112,6 +1112,108 @@ describe('domainSlice – targeted branch coverage', () => {
       const before = getArch();
       getState().updateConnectionType('conn-1', 'async');
       expect(getArch()).toBe(before);
+    });
+  });
+
+  describe('removeConnection – burst cleanup', () => {
+    it('clears connectionCreationBursts entry when a connection is removed', () => {
+      seedState({
+        nodes: [
+          makeContainerNode('r1'),
+          makeContainerNode('s1', {
+            layer: 'subnet',
+            parentId: 'r1',
+            position: { x: 0, y: 0.7, z: 0 },
+            frame: { width: 6, height: 0.3, depth: 8 },
+          }),
+          makeLeafNode('c1', 's1', 'compute'),
+          makeLeafNode('d1', 's1', 'data'),
+        ],
+      });
+
+      const connectionId = getState().addConnection('c1', 'd1');
+      expect(connectionId).toBeTruthy();
+
+      useUIStore.getState().triggerConnectionCreationBurst(connectionId!);
+      expect(useUIStore.getState().connectionCreationBursts.has(connectionId!)).toBe(true);
+
+      getState().removeConnection(connectionId!);
+      expect(useUIStore.getState().connectionCreationBursts.has(connectionId!)).toBe(false);
+    });
+
+    it('does not throw when removing a connection without an active burst', () => {
+      seedState({
+        nodes: [
+          makeContainerNode('r1'),
+          makeContainerNode('s1', {
+            layer: 'subnet',
+            parentId: 'r1',
+            position: { x: 0, y: 0.7, z: 0 },
+            frame: { width: 6, height: 0.3, depth: 8 },
+          }),
+          makeLeafNode('c1', 's1', 'compute'),
+          makeLeafNode('d1', 's1', 'data'),
+        ],
+      });
+
+      const connectionId = getState().addConnection('c1', 'd1');
+      expect(connectionId).toBeTruthy();
+
+      expect(() => getState().removeConnection(connectionId!)).not.toThrow();
+    });
+  });
+
+  describe('removeBlock – cascade burst cleanup', () => {
+    it('clears bursts for connections attached to a removed block', () => {
+      seedState({
+        nodes: [
+          makeContainerNode('r1'),
+          makeContainerNode('s1', {
+            layer: 'subnet',
+            parentId: 'r1',
+            position: { x: 0, y: 0.7, z: 0 },
+            frame: { width: 6, height: 0.3, depth: 8 },
+          }),
+          makeLeafNode('c1', 's1', 'compute'),
+          makeLeafNode('d1', 's1', 'data'),
+        ],
+      });
+
+      const connectionId = getState().addConnection('c1', 'd1');
+      expect(connectionId).toBeTruthy();
+
+      useUIStore.getState().triggerConnectionCreationBurst(connectionId!);
+      expect(useUIStore.getState().connectionCreationBursts.has(connectionId!)).toBe(true);
+
+      getState().removeBlock('c1');
+      expect(useUIStore.getState().connectionCreationBursts.has(connectionId!)).toBe(false);
+    });
+  });
+
+  describe('removePlate – cascade burst cleanup', () => {
+    it('clears bursts for all connections when a container is removed', () => {
+      seedState({
+        nodes: [
+          makeContainerNode('r1'),
+          makeContainerNode('s1', {
+            layer: 'subnet',
+            parentId: 'r1',
+            position: { x: 0, y: 0.7, z: 0 },
+            frame: { width: 6, height: 0.3, depth: 8 },
+          }),
+          makeLeafNode('c1', 's1', 'compute'),
+          makeLeafNode('d1', 's1', 'data'),
+        ],
+      });
+
+      const connectionId = getState().addConnection('c1', 'd1');
+      expect(connectionId).toBeTruthy();
+
+      useUIStore.getState().triggerConnectionCreationBurst(connectionId!);
+      expect(useUIStore.getState().connectionCreationBursts.has(connectionId!)).toBe(true);
+
+      getState().removePlate('s1');
+      expect(useUIStore.getState().connectionCreationBursts.has(connectionId!)).toBe(false);
     });
   });
 });

--- a/apps/web/src/entities/store/slices/domainSlice.ts
+++ b/apps/web/src/entities/store/slices/domainSlice.ts
@@ -23,6 +23,7 @@ import {
 } from '@cloudblocks/schema';
 import { generateId } from '../../../shared/utils/id';
 import { metricsService } from '../../../shared/utils/metricsService';
+import { useUIStore } from '../uiStore';
 import type {
   AddNodeInput,
   ArchitectureSlice,
@@ -274,37 +275,52 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
   },
 
   removePlate: (id) => {
+    // Collect IDs to remove and clear bursts for cascade-deleted connections
+    const currentArch = get().workspace.architecture;
+    const containers = currentArch.nodes.filter(isContainer);
+    const resources = currentArch.nodes.filter(isResource);
+    const container = containers.find((candidate) => candidate.id === id);
+
+    if (!container) {
+      return;
+    }
+
+    const idsToRemove = new Set<string>();
+    const collectChildren = (plateId: string) => {
+      idsToRemove.add(plateId);
+      for (const candidate of containers) {
+        if (candidate.parentId === plateId && !idsToRemove.has(candidate.id)) {
+          collectChildren(candidate.id);
+        }
+      }
+    };
+    collectChildren(id);
+
+    const removedResourceIds = new Set(
+      resources
+        .filter((resource) => {
+          const parentId = resource.parentId;
+          return (parentId !== null && idsToRemove.has(parentId)) || idsToRemove.has(resource.id);
+        })
+        .map((resource) => resource.id),
+    );
+    const removedNodeIds = new Set<string>([...idsToRemove, ...removedResourceIds]);
+
+    const removedEndpointIds = new Set(
+      currentArch.endpoints
+        .filter((endpoint) => removedNodeIds.has(endpoint.blockId))
+        .map((endpoint) => endpoint.id),
+    );
+
+    // Clear bursts for connections that reference removed endpoints
+    for (const connection of currentArch.connections) {
+      if (removedEndpointIds.has(connection.from) || removedEndpointIds.has(connection.to)) {
+        useUIStore.getState().clearConnectionCreationBurst(connection.id);
+      }
+    }
+
     set((state) => {
       const arch = state.workspace.architecture;
-      const containers = arch.nodes.filter(isContainer);
-      const resources = arch.nodes.filter(isResource);
-      const container = containers.find((candidate) => candidate.id === id);
-
-      if (!container) {
-        return state;
-      }
-
-      const idsToRemove = new Set<string>();
-      const collectChildren = (plateId: string) => {
-        idsToRemove.add(plateId);
-        for (const candidate of containers) {
-          if (candidate.parentId === plateId && !idsToRemove.has(candidate.id)) {
-            collectChildren(candidate.id);
-          }
-        }
-      };
-
-      collectChildren(id);
-
-      const removedResourceIds = new Set(
-        resources
-          .filter((resource) => {
-            const parentId = resource.parentId;
-            return (parentId !== null && idsToRemove.has(parentId)) || idsToRemove.has(resource.id);
-          })
-          .map((resource) => resource.id),
-      );
-      const removedNodeIds = new Set<string>([...idsToRemove, ...removedResourceIds]);
 
       const nodes = arch.nodes.filter((node) => {
         if (idsToRemove.has(node.id)) {
@@ -315,12 +331,6 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
         }
         return true;
       });
-
-      const removedEndpointIds = new Set(
-        arch.endpoints
-          .filter((endpoint) => removedNodeIds.has(endpoint.blockId))
-          .map((endpoint) => endpoint.id),
-      );
 
       const endpoints = arch.endpoints.filter((endpoint) => !removedNodeIds.has(endpoint.blockId));
 
@@ -497,6 +507,15 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
   },
 
   removeBlock: (id) => {
+    // Clear bursts for connections that will be cascade-deleted
+    const arch = get().workspace.architecture;
+    const prefix = endpointIdPrefix(id);
+    for (const connection of arch.connections) {
+      if (connection.from.startsWith(prefix) || connection.to.startsWith(prefix)) {
+        useUIStore.getState().clearConnectionCreationBurst(connection.id);
+      }
+    }
+
     set((state) => {
       const arch = state.workspace.architecture;
       const block = arch.nodes.filter(isResource).find((candidate) => candidate.id === id);
@@ -1113,17 +1132,17 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
       : null;
 
     if (!sourceType || !targetType) {
-      return false;
+      return null;
     }
 
     // Self-connection check
     if (from === to) {
-      return false;
+      return null;
     }
 
     // Category pair check
     if (!canConnect(sourceType, targetType)) {
-      return false;
+      return null;
     }
 
     // Resolve endpoint IDs using default 'data' semantic
@@ -1137,7 +1156,7 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
     );
 
     if (exists) {
-      return false;
+      return null;
     }
 
     // Verify endpoints exist
@@ -1145,10 +1164,10 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
     const targetEndpoint = arch.endpoints.find((endpoint) => endpoint.id === toEndpointId);
 
     if (!sourceEndpoint) {
-      return false;
+      return null;
     }
     if (!targetEndpoint) {
-      return false;
+      return null;
     }
 
     // Port capacity check
@@ -1176,13 +1195,15 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
     }).length;
 
     if (usedOutbound >= sourcePorts.outbound || usedInbound >= targetPorts.inbound) {
-      return false;
+      return null;
     }
+
+    const connectionId = generateId('conn');
 
     set((state) => {
       const nextArch = state.workspace.architecture;
       const connection: Connection = {
-        id: generateId('conn'),
+        id: connectionId,
         from: fromEndpointId,
         to: toEndpointId,
         metadata: {
@@ -1200,10 +1221,11 @@ export const createDomainSlice: ArchitectureSlice<DomainSlice> = (set, get) => (
       });
     });
     metricsService.trackEvent('first_connection_created');
-    return true;
+    return connectionId;
   },
 
   removeConnection: (id) => {
+    useUIStore.getState().clearConnectionCreationBurst(id);
     set((state) => {
       const arch = state.workspace.architecture;
 

--- a/apps/web/src/entities/store/slices/types.ts
+++ b/apps/web/src/entities/store/slices/types.ts
@@ -130,7 +130,7 @@ export interface ArchitectureState {
     position?: { x: number; y: number; z: number },
   ) => void;
 
-  addConnection: (from: string, to: string) => boolean;
+  addConnection: (from: string, to: string) => string | null;
   removeConnection: (id: string) => void;
   updateConnectionType: (connectionId: string, type: ConnectionType) => void;
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../shared/types/ops';
 import type { DrawerPanelId } from '../../shared/types/drawer';
 import { loadWorkspaces } from '../../shared/utils/storage';
+import { CREATION_BURST_DURATION_MS } from '../connection/packetFlowTokens';
 
 export type ToolMode = 'select' | 'connect' | 'delete';
 export type InteractionState = 'idle' | 'selecting' | 'dragging' | 'placing' | 'connecting';
@@ -305,6 +306,9 @@ interface UIState {
   // ── Connection snap animation ──
   snapTargetBlockIds: Set<string>;
   triggerSnapAnimation: (blockId: string) => void;
+  connectionCreationBursts: Map<string, number>;
+  triggerConnectionCreationBurst: (connectionId: string) => void;
+  clearConnectionCreationBurst: (connectionId: string) => void;
 
   // ── Magnetic snap (connection preview proximity) ──
   magneticSnapTargetId: string | null;
@@ -784,6 +788,26 @@ export const useUIStore = create<UIState>((set, get) => {
           return { snapTargetBlockIds: next };
         });
       }, 500);
+    },
+
+    connectionCreationBursts: new Map<string, number>(),
+    triggerConnectionCreationBurst: (connectionId) => {
+      set((s) => {
+        const next = new Map(s.connectionCreationBursts);
+        next.set(connectionId, Date.now() + CREATION_BURST_DURATION_MS);
+        return { connectionCreationBursts: next };
+      });
+    },
+    clearConnectionCreationBurst: (connectionId) => {
+      set((s) => {
+        if (!s.connectionCreationBursts.has(connectionId)) {
+          return s;
+        }
+
+        const next = new Map(s.connectionCreationBursts);
+        next.delete(connectionId);
+        return { connectionCreationBursts: next };
+      });
     },
 
     magneticSnapTargetId: null,

--- a/apps/web/src/shared/hooks/useAnimationClock.test.ts
+++ b/apps/web/src/shared/hooks/useAnimationClock.test.ts
@@ -153,4 +153,21 @@ describe('useAnimationClock', () => {
     });
     expect(result.current.elapsed).toBe(100);
   });
+
+  it('cancels pending frame when transitioning from active to inactive', () => {
+    const { runFrame, cancelAnimationFrameMock } = installRafMocks();
+
+    const { rerender } = renderHook(({ enabled }) => useAnimationClock(enabled), {
+      initialProps: { enabled: true },
+    });
+
+    // Run a frame so frameRef.current is set
+    act(() => {
+      runFrame(100);
+    });
+
+    // Transition to inactive — should cancel the pending frame
+    rerender({ enabled: false });
+    expect(cancelAnimationFrameMock).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/shared/hooks/useAnimationClock.test.ts
+++ b/apps/web/src/shared/hooks/useAnimationClock.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAnimationClock } from './useAnimationClock';
+
+const useReducedMotionMock = vi.fn(() => false);
+
+vi.mock('./useReducedMotion', () => ({
+  useReducedMotion: () => useReducedMotionMock(),
+}));
+
+interface RafController {
+  runFrame: (timestamp?: number) => void;
+  requestAnimationFrameMock: ReturnType<typeof vi.fn>;
+  cancelAnimationFrameMock: ReturnType<typeof vi.fn>;
+}
+
+function installRafMocks(): RafController {
+  let frameId = 0;
+  const frameQueue = new Map<number, FrameRequestCallback>();
+
+  const requestAnimationFrameMock = vi.fn((callback: FrameRequestCallback) => {
+    frameId += 1;
+    frameQueue.set(frameId, callback);
+    return frameId;
+  });
+
+  const cancelAnimationFrameMock = vi.fn((id: number) => {
+    frameQueue.delete(id);
+  });
+
+  vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
+  vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock);
+
+  const runFrame = (timestamp = 16) => {
+    const queuedFrames = [...frameQueue.entries()];
+    frameQueue.clear();
+    queuedFrames.forEach(([, callback]) => {
+      callback(timestamp);
+    });
+  };
+
+  return {
+    runFrame,
+    requestAnimationFrameMock,
+    cancelAnimationFrameMock,
+  };
+}
+
+describe('useAnimationClock', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useReducedMotionMock.mockReset();
+    useReducedMotionMock.mockReturnValue(false);
+  });
+
+  it('returns elapsed 0 and does not schedule frames when disabled', () => {
+    const { requestAnimationFrameMock } = installRafMocks();
+
+    const { result } = renderHook(() => useAnimationClock(false));
+
+    expect(result.current.elapsed).toBe(0);
+    expect(result.current.reducedMotion).toBe(false);
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled();
+  });
+
+  it('returns elapsed 0 and reducedMotion true when reduced motion is enabled', () => {
+    const { requestAnimationFrameMock } = installRafMocks();
+    useReducedMotionMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useAnimationClock(true));
+
+    expect(result.current.elapsed).toBe(0);
+    expect(result.current.reducedMotion).toBe(true);
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled();
+  });
+
+  it('increments elapsed time while enabled', () => {
+    const { runFrame } = installRafMocks();
+
+    const { result } = renderHook(() => useAnimationClock(true));
+
+    act(() => {
+      runFrame(100);
+    });
+    expect(result.current.elapsed).toBe(0);
+
+    act(() => {
+      runFrame(160);
+    });
+    expect(result.current.elapsed).toBe(60);
+  });
+
+  it('cancels pending animation frame on unmount', () => {
+    const { cancelAnimationFrameMock } = installRafMocks();
+
+    const { unmount } = renderHook(() => useAnimationClock(true));
+    unmount();
+
+    expect(cancelAnimationFrameMock).toHaveBeenCalledOnce();
+  });
+
+  it('resets elapsed to 0 when disabled after being active', () => {
+    const { runFrame } = installRafMocks();
+
+    const { result, rerender } = renderHook(({ enabled }) => useAnimationClock(enabled), {
+      initialProps: { enabled: true },
+    });
+
+    act(() => {
+      runFrame(100);
+    });
+    act(() => {
+      runFrame(200);
+    });
+    expect(result.current.elapsed).toBe(100);
+
+    rerender({ enabled: false });
+    expect(result.current.elapsed).toBe(0);
+  });
+
+  it('returns elapsed 0 on first frame after re-enable (no stale value)', () => {
+    const { runFrame } = installRafMocks();
+
+    const { result, rerender } = renderHook(({ enabled }) => useAnimationClock(enabled), {
+      initialProps: { enabled: true },
+    });
+
+    // Run a few frames to accumulate elapsed time
+    act(() => {
+      runFrame(100);
+    });
+    act(() => {
+      runFrame(200);
+    });
+    expect(result.current.elapsed).toBe(100);
+
+    // Disable
+    rerender({ enabled: false });
+    expect(result.current.elapsed).toBe(0);
+
+    // Re-enable — before RAF fires, elapsed must still be 0 (not stale 100)
+    rerender({ enabled: true });
+    expect(result.current.elapsed).toBe(0);
+
+    // After first RAF fires on re-enable, elapsed resets from new start
+    act(() => {
+      runFrame(500);
+    });
+    expect(result.current.elapsed).toBe(0); // first frame sets startRef
+
+    act(() => {
+      runFrame(600);
+    });
+    expect(result.current.elapsed).toBe(100);
+  });
+});

--- a/apps/web/src/shared/hooks/useAnimationClock.ts
+++ b/apps/web/src/shared/hooks/useAnimationClock.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+import { useReducedMotion } from './useReducedMotion';
+
+export interface AnimationClockResult {
+  elapsed: number;
+  reducedMotion: boolean;
+}
+
+export function useAnimationClock(enabled: boolean): AnimationClockResult {
+  const reducedMotion = useReducedMotion();
+  const active = enabled && !reducedMotion;
+  const [elapsed, setElapsed] = useState(0);
+  const startRef = useRef<number | null>(null);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      startRef.current = null;
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+      return;
+    }
+
+    const tick = (now: number) => {
+      if (startRef.current === null) {
+        startRef.current = now;
+      }
+
+      setElapsed(now - startRef.current);
+      frameRef.current = requestAnimationFrame(tick);
+    };
+
+    frameRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+  }, [active]);
+
+  // Reset stale elapsed when transitioning to inactive.
+  // This is a "adjust state during render" pattern (React-safe),
+  // avoiding synchronous setState inside effects.
+  if (!active && elapsed !== 0) {
+    setElapsed(0);
+  }
+
+  return { elapsed: active ? elapsed : 0, reducedMotion };
+}

--- a/apps/web/src/shared/hooks/useReducedMotion.test.ts
+++ b/apps/web/src/shared/hooks/useReducedMotion.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useReducedMotion } from './useReducedMotion';
+
+interface MotionQueryMock {
+  mql: MediaQueryList & { dispatchChange: (matches: boolean) => void };
+}
+
+function createMotionQueryMock(matches: boolean): MotionQueryMock {
+  const listeners: Array<(event: MediaQueryListEvent) => void> = [];
+  let currentMatches = matches;
+
+  const mql = {
+    get matches() {
+      return currentMatches;
+    },
+    media: '(prefers-reduced-motion: reduce)',
+    onchange: null,
+    addEventListener: vi.fn((_event: string, handler: (event: MediaQueryListEvent) => void) => {
+      listeners.push(handler);
+    }),
+    removeEventListener: vi.fn((_event: string, handler: (event: MediaQueryListEvent) => void) => {
+      const index = listeners.indexOf(handler);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    }),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+    dispatchChange(nextMatches: boolean) {
+      currentMatches = nextMatches;
+      for (const listener of listeners) {
+        listener({ matches: nextMatches } as MediaQueryListEvent);
+      }
+    },
+  } as unknown as MediaQueryList & { dispatchChange: (matches: boolean) => void };
+
+  return { mql };
+}
+
+describe('useReducedMotion', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('uses the current reduced motion preference as initial value', () => {
+    const { mql } = createMotionQueryMock(true);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { result } = renderHook(() => useReducedMotion());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when the media query changes', () => {
+    const { mql } = createMotionQueryMock(false);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { result } = renderHook(() => useReducedMotion());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mql.dispatchChange(true);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('removes the change listener on unmount', () => {
+    const { mql } = createMotionQueryMock(false);
+    window.matchMedia = vi.fn().mockReturnValue(mql);
+
+    const { unmount } = renderHook(() => useReducedMotion());
+
+    expect(mql.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    unmount();
+    expect(mql.removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+  });
+});

--- a/apps/web/src/shared/hooks/useReducedMotion.ts
+++ b/apps/web/src/shared/hooks/useReducedMotion.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(
+    () => typeof window !== 'undefined' && window.matchMedia(QUERY).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(QUERY);
+    const handler = (event: MediaQueryListEvent) => setReduced(event.matches);
+    mql.addEventListener('change', handler);
+
+    return () => {
+      mql.removeEventListener('change', handler);
+    };
+  }, []);
+
+  return reduced;
+}


### PR DESCRIPTION
## Summary

- Add animated capsule-shaped packets that travel along SVG connection polyline paths to visualize data flow direction between resources
- Implement RAF-driven animation clock with `prefers-reduced-motion` support and creation burst effect for newly created connections
- Add cascade burst cleanup in `removeBlock`/`removePlate` to prevent orphan UI state on block/container deletion

## Changes

### New Files
- `PacketFlowLayer.tsx` — SVG capsule-shaped packet animation component
- `packetFlowTokens.ts` — Design tokens (speed, colors, sizes, burst duration)
- `useAnimationClock.ts` — RAF-driven animation clock with reduced-motion support
- `useReducedMotion.ts` — `prefers-reduced-motion` media query hook
- Tests for all new modules

### Modified Files
- `ConnectionRenderer.tsx` — Integrates PacketFlowLayer into connection rendering
- `uiStore.ts` — Creation burst state management (`triggerConnectionCreationBurst`, `clearConnectionCreationBurst`)
- `domainSlice.ts` — `addConnection` returns `string | null`; `removeBlock`/`removePlate` clear burst state for cascade-deleted connections
- `BlockSprite.tsx` — Triggers creation burst on successful connection

## Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm test` — 3203/3204 pass (1 pre-existing `client.test.ts` failure unrelated)
- Oracle review: **100/100** (3 rounds)
- Visual browser verification ✅

Fixes #1738, fixes #1739, fixes #1740

Part of #1737