### PR TITLE
chore(ci): bump bundle size budget 940→960 KB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Check bundle size budget
         run: |
-          MAX_TOTAL_KB=940
+          MAX_TOTAL_KB=960
           MAX_ENTRY_KB=350
           DIST_DIR="apps/web/dist/assets"
 


### PR DESCRIPTION
## Summary
- Bump `MAX_TOTAL_KB` from 940 to 960 KB in CI bundle size check
- Accommodates upcoming features in PR #1677 (zoom controls, autosize logic, workspace bulk delete) which add ~6 KB of real code
- The `du -sk` measurement uses 4K block boundaries, so 6 KB of real code increase translates to 12 KB in block-allocated size (944 KB vs 932 KB)

## Changes
- `.github/workflows/ci.yml`: `MAX_TOTAL_KB=940` → `MAX_TOTAL_KB=960`