### PR TITLE
fix(web): add idle packet flow mode for always-on connection animation

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -123,6 +123,62 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
   });
 
+  it('suppresses packet flow layer when reducedMotion prop is true', () => {
+    const { container } = render(
+      <svg aria-label="Test SVG">
+        <title>Test SVG</title>
+        <ConnectionRenderer
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          originX={100}
+          originY={200}
+          elapsed={1000}
+          reducedMotion={true}
+        />
+      </svg>,
+    );
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+  });
+
+  it('uses elapsed prop to determine packet position', () => {
+    const { container: container1 } = render(
+      <svg aria-label="Test SVG">
+        <title>Test SVG</title>
+        <ConnectionRenderer
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          originX={100}
+          originY={200}
+          elapsed={500}
+          reducedMotion={false}
+        />
+      </svg>,
+    );
+    const packet1 = container1.querySelector('[data-testid="packet-flow-packet"]');
+    const transform1 = packet1?.getAttribute('transform');
+
+    const { container: container2 } = render(
+      <svg aria-label="Test SVG">
+        <title>Test SVG</title>
+        <ConnectionRenderer
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          originX={100}
+          originY={200}
+          elapsed={2000}
+          reducedMotion={false}
+        />
+      </svg>,
+    );
+    const packet2 = container2.querySelector('[data-testid="packet-flow-packet"]');
+    const transform2 = packet2?.getAttribute('transform');
+
+    expect(transform1).not.toBe(transform2);
+  });
+
   it('does not render packet flow layer when connection has validation errors', () => {
     useArchitectureStore.setState({
       validationResult: {
@@ -164,6 +220,31 @@ describe('ConnectionRenderer', () => {
     const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
     expect(packetLayer).toBeInTheDocument();
     expect(packetGlow?.getAttribute('fill-opacity')).toBe('0.8');
+  });
+
+  it('selected mode takes precedence over hover when both are active', () => {
+    useUIStore.setState({ selectedId: connection.id, selectedIds: new Set([connection.id]) });
+    const { container } = renderConnector();
+
+    fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
+
+    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
+    expect(packetGlow?.getAttribute('fill-opacity')).toBe('0.8');
+  });
+
+  it('creation mode takes precedence over selected and hover', () => {
+    useUIStore.setState({
+      selectedId: connection.id,
+      selectedIds: new Set([connection.id]),
+      connectionCreationBursts: new Map([[connection.id, Date.now() + 10000]]),
+    });
+
+    const { container } = renderConnector();
+
+    fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
+
+    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
+    expect(packetGlow?.getAttribute('fill-opacity')).toBe('1');
   });
 
   it('click in select mode sets selectedId to connection id', () => {
@@ -573,6 +654,30 @@ describe('ConnectionRenderer', () => {
       useArchitectureStore.setState({ validationResult: null });
       const { container } = renderConnector();
       expect(container.querySelector('[data-testid="connection-invalid"]')).not.toBeInTheDocument();
+    });
+
+    it('renders idle packet flow even when connection has only validation warnings', () => {
+      useArchitectureStore.setState({
+        validationResult: {
+          valid: true,
+          errors: [],
+          warnings: [
+            {
+              ruleId: 'suboptimal-connection',
+              message: 'This connection pattern is suboptimal',
+              targetId: connection.id,
+              severity: 'warning',
+            },
+          ],
+        },
+      });
+
+      const { container } = renderConnector();
+      expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-testid="connection-invalid"]')).not.toBeInTheDocument();
+      expect(
+        container.querySelector('[data-testid="connection-error-label"]'),
+      ).not.toBeInTheDocument();
     });
 
     it('shows error label on hover when connection is invalid', () => {

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -118,6 +118,11 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-testid="connection-hit-area"]')).toBeInTheDocument();
   });
 
+  it('renders packet flow layer in default idle mode', () => {
+    const { container } = renderConnector();
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
+  });
+
   it('click in select mode sets selectedId to connection id', () => {
     const { container } = renderConnector();
     fireEvent.click(

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -123,6 +123,49 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
   });
 
+  it('does not render packet flow layer when connection has validation errors', () => {
+    useArchitectureStore.setState({
+      validationResult: {
+        valid: false,
+        errors: [
+          {
+            ruleId: 'invalid-connection',
+            message: 'Connection has validation errors',
+            targetId: connection.id,
+            severity: 'error',
+          },
+        ],
+        warnings: [],
+      },
+    });
+
+    const { container } = renderConnector();
+
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+  });
+
+  it('renders hover packet visuals when connection is hovered', () => {
+    const { container } = renderConnector();
+
+    fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
+
+    const packetLayer = container.querySelector('[data-testid="packet-flow-layer"]');
+    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
+    expect(packetLayer).toBeInTheDocument();
+    expect(packetGlow?.getAttribute('fill-opacity')).toBe('0.5');
+  });
+
+  it('renders selected packet visuals when connection is selected', () => {
+    useUIStore.setState({ selectedId: connection.id, selectedIds: new Set([connection.id]) });
+
+    const { container } = renderConnector();
+
+    const packetLayer = container.querySelector('[data-testid="packet-flow-layer"]');
+    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
+    expect(packetLayer).toBeInTheDocument();
+    expect(packetGlow?.getAttribute('fill-opacity')).toBe('0.8');
+  });
+
   it('click in select mode sets selectedId to connection id', () => {
     const { container } = renderConnector();
     fireEvent.click(

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -247,6 +247,91 @@ describe('ConnectionRenderer', () => {
     expect(packetGlow?.getAttribute('fill-opacity')).toBe('1');
   });
 
+  it('creation mode renders packets even when external elapsed exceeds PACKET_SPEED_MS', () => {
+    const burstExpiry = Date.now() + 2000;
+    useUIStore.setState({
+      connectionCreationBursts: new Map([[connection.id, burstExpiry]]),
+    });
+
+    // External elapsed is far beyond PACKET_SPEED_MS (2600ms), simulating a canvas
+    // that has been open for a long time. Without the fix, this would cause the
+    // creation burst to render as already completed.
+    const { container } = render(
+      <svg aria-label="Test SVG">
+        <title>Test SVG</title>
+        <ConnectionRenderer
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          originX={100}
+          originY={200}
+          elapsed={999999}
+          reducedMotion={false}
+        />
+      </svg>,
+    );
+
+    // Packet flow layer should still render because creation elapsed is derived
+    // from creationBurstExpiry, not the shared clock.
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
+    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
+    expect(packetGlow?.getAttribute('fill-opacity')).toBe('1');
+  });
+
+  it('creation mode uses burst-local elapsed instead of shared clock elapsed', () => {
+    vi.useFakeTimers();
+    const now = Date.now();
+    const burstExpiry = now + 2600; // CREATION_BURST_DURATION_MS = PACKET_SPEED_MS = 2600
+    useUIStore.setState({
+      connectionCreationBursts: new Map([[connection.id, burstExpiry]]),
+    });
+
+    // Render with two different external elapsed values — both very large.
+    // If creation mode correctly uses burst-local elapsed, both should produce
+    // the same packet position (because burst-local elapsed is ~0 in both cases).
+    const { container: container1 } = render(
+      <svg aria-label="Test SVG">
+        <title>Test SVG</title>
+        <ConnectionRenderer
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          originX={100}
+          originY={200}
+          elapsed={50000}
+          reducedMotion={false}
+        />
+      </svg>,
+    );
+    const packet1 = container1.querySelector('[data-testid="packet-flow-packet"]');
+    const transform1 = packet1?.getAttribute('transform');
+
+    const { container: container2 } = render(
+      <svg aria-label="Test SVG">
+        <title>Test SVG</title>
+        <ConnectionRenderer
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          originX={100}
+          originY={200}
+          elapsed={100000}
+          reducedMotion={false}
+        />
+      </svg>,
+    );
+    const packet2 = container2.querySelector('[data-testid="packet-flow-packet"]');
+    const transform2 = packet2?.getAttribute('transform');
+
+    // Both should render packets (not null) and at the same position
+    // because burst-local elapsed is the same (~0) regardless of external elapsed.
+    expect(packet1).toBeInTheDocument();
+    expect(packet2).toBeInTheDocument();
+    expect(transform1).toBe(transform2);
+
+    vi.useRealTimers();
+  });
+
   it('click in select mode sets selectedId to connection id', () => {
     const { container } = renderConnector();
     fireEvent.click(

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -332,6 +332,32 @@ describe('ConnectionRenderer', () => {
     vi.useRealTimers();
   });
 
+  it('creation mode works without elapsed prop (standalone fallback clock)', () => {
+    const burstExpiry = Date.now() + 2000;
+    useUIStore.setState({
+      connectionCreationBursts: new Map([[connection.id, burstExpiry]]),
+    });
+
+    // Render without elapsed prop — PacketFlowLayer should use its internal clock
+    const { container } = render(
+      <svg aria-label="Test SVG">
+        <title>Test SVG</title>
+        <ConnectionRenderer
+          connection={connection}
+          blocks={[]}
+          plates={[]}
+          originX={100}
+          originY={200}
+        />
+      </svg>,
+    );
+
+    // Creation burst should still render — PacketFlowLayer falls back to internal clock
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
+    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
+    expect(packetGlow?.getAttribute('fill-opacity')).toBe('1');
+  });
+
   it('click in select mode sets selectedId to connection id', () => {
     const { container } = renderConnector();
     fireEvent.click(

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -388,7 +388,9 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   // a long-running canvas (elapsed > PACKET_SPEED_MS) would cause new bursts
   // to render as already completed on first frame.
   const packetElapsed =
-    packetMode === 'creation' ? Math.max(0, (elapsed ?? 0) - creationStartElapsed) : elapsed;
+    packetMode === 'creation' && elapsed !== undefined
+      ? Math.max(0, elapsed - creationStartElapsed)
+      : elapsed;
 
   const surfaceRoute = useMemo(
     () =>

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -336,10 +336,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
 
   const connectionErrors = useMemo(() => {
     if (!validationResult || !resolvedConnectionId) return [];
-    return [
-      ...validationResult.errors.filter((e) => e.targetId === resolvedConnectionId),
-      ...validationResult.warnings.filter((w) => w.targetId === resolvedConnectionId),
-    ];
+    return validationResult.errors.filter((e) => e.targetId === resolvedConnectionId);
   }, [resolvedConnectionId, validationResult]);
 
   const hasValidationError = connectionErrors.length > 0;

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -366,7 +366,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     if (creationBurstActive) return 'creation' as const;
     if (isSelected) return 'selected' as const;
     if (isHovered) return 'hover' as const;
-    return 'static' as const;
+    return 'idle' as const;
   })();
 
   const surfaceRoute = useMemo(

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -45,6 +45,8 @@ interface ConnectionRendererProps {
   originX: number;
   originY: number;
   overlapOffset?: number;
+  elapsed?: number;
+  reducedMotion?: boolean;
 }
 
 /** Resolved colors for the 2-layer trace rendering. */
@@ -229,6 +231,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   originX,
   originY,
   overlapOffset = 0,
+  elapsed,
+  reducedMotion,
 }: ConnectionRendererProps) {
   const resolvedConnectionId = connectionId ?? connection?.id ?? null;
   const storeConnection = useArchitectureStore((state) => {
@@ -510,6 +514,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
           mode={packetMode}
           connectionType={resolvedConnectionType}
           strokeColor={colors.stroke}
+          elapsed={elapsed}
+          reducedMotion={reducedMotion}
         />
       )}
 

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -242,6 +242,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const resolvedConnection = storeConnection ?? connection ?? null;
   const [isHovered, setIsHovered] = useState(false);
   const drawInRef = useRef<SVGPathElement>(null);
+  const [creationStartElapsed, setCreationStartElapsed] = useState(0);
+  const [prevBurstExpiry, setPrevBurstExpiry] = useState<number | undefined>(undefined);
 
   useEffect(() => {
     const el = drawInRef.current;
@@ -342,6 +344,17 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const hasValidationError = connectionErrors.length > 0;
   const creationBurstActive = creationBurstExpiry !== undefined;
 
+  // Capture the shared elapsed when a new creation burst starts, so the
+  // PacketFlowLayer receives a local elapsed starting from 0.
+  // Uses the React "adjust state during render" pattern so the value
+  // is available on the first frame (unlike useEffect which runs after).
+  if (creationBurstExpiry !== prevBurstExpiry) {
+    setPrevBurstExpiry(creationBurstExpiry);
+    if (creationBurstExpiry !== undefined) {
+      setCreationStartElapsed(elapsed ?? 0);
+    }
+  }
+
   useEffect(() => {
     if (!resolvedConnectionId || creationBurstExpiry === undefined) {
       return;
@@ -369,6 +382,13 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     if (isHovered) return 'hover' as const;
     return 'idle' as const;
   })();
+
+  // Creation bursts use a connection-local elapsed derived from the shared clock
+  // value at burst start, not the current shared elapsed. Without this,
+  // a long-running canvas (elapsed > PACKET_SPEED_MS) would cause new bursts
+  // to render as already completed on first frame.
+  const packetElapsed =
+    packetMode === 'creation' ? Math.max(0, (elapsed ?? 0) - creationStartElapsed) : elapsed;
 
   const surfaceRoute = useMemo(
     () =>
@@ -511,7 +531,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
           mode={packetMode}
           connectionType={resolvedConnectionType}
           strokeColor={colors.stroke}
-          elapsed={elapsed}
+          elapsed={packetElapsed}
           reducedMotion={reducedMotion}
         />
       )}

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -15,7 +15,7 @@ const hitPoints = [
   { x: 200, y: 0 },
 ];
 
-function renderLayer(mode: 'static' | 'hover' | 'selected' | 'creation') {
+function renderLayer(mode: 'static' | 'idle' | 'hover' | 'selected' | 'creation') {
   return render(
     <svg aria-label="packet-flow-test">
       <title>packet-flow-test</title>
@@ -27,6 +27,14 @@ function renderLayer(mode: 'static' | 'hover' | 'selected' | 'creation') {
       />
     </svg>,
   );
+}
+
+function extractTranslateX(transform: string): number {
+  const match = /translate\(([-\d.]+)\s+([-\d.]+)\)/.exec(transform);
+  if (!match) {
+    throw new Error(`Unexpected transform: ${transform}`);
+  }
+  return Number(match[1]);
 }
 
 describe('PacketFlowLayer', () => {
@@ -57,6 +65,39 @@ describe('PacketFlowLayer', () => {
       '[data-testid="packet-flow-packet"]',
     );
     expect(selectedPackets).toHaveLength(3);
+  });
+
+  it('renders packets in idle mode', () => {
+    const { container } = renderLayer('idle');
+
+    const packets = container.querySelectorAll('[data-testid="packet-flow-packet"]');
+    expect(packets).toHaveLength(2);
+
+    const firstPacketGlow = packets[0]?.querySelector('path');
+    expect(firstPacketGlow).toHaveAttribute('fill-opacity', '0.25');
+  });
+
+  it('idle mode uses slower speed', () => {
+    useAnimationClockMock.mockReturnValue({ elapsed: PACKET_SPEED_MS / 2, reducedMotion: false });
+
+    const idle = renderLayer('idle');
+    const idlePacket = idle.container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(idlePacket).toBeInTheDocument();
+    const idleTransform = idlePacket?.getAttribute('transform');
+    expect(idleTransform).toBeTruthy();
+    const idleX = extractTranslateX(idleTransform ?? '');
+
+    idle.unmount();
+
+    const hover = renderLayer('hover');
+    const hoverPacket = hover.container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(hoverPacket).toBeInTheDocument();
+    const hoverTransform = hoverPacket?.getAttribute('transform');
+    expect(hoverTransform).toBeTruthy();
+    const hoverX = extractTranslateX(hoverTransform ?? '');
+
+    expect(idleX).toBeLessThan(hoverX);
+    useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
   });
 
   it('renders the creation packet count for the path length', () => {
@@ -184,6 +225,11 @@ describe('PacketFlowLayer', () => {
     it('returns fewer packets for hover mode', () => {
       expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'hover')).toBe(2);
       expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'hover')).toBe(1);
+    });
+
+    it('returns fewer packets for idle mode', () => {
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'idle')).toBe(2);
+      expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'idle')).toBe(1);
     });
 
     it('returns more packets for creation mode', () => {

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -2,7 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import { PacketFlowLayer } from './PacketFlowLayer';
 import { getPacketCount, getPositionAtDistance } from './packetFlowHelpers';
-import { PACKET_SPEED_MS, SHORT_PATH_THRESHOLD, MEDIUM_PATH_THRESHOLD } from './packetFlowTokens';
+import {
+  IDLE_CYCLE_MS,
+  MEDIUM_PATH_THRESHOLD,
+  PACKET_SPEED_MS,
+  SHORT_PATH_THRESHOLD,
+} from './packetFlowTokens';
 
 const useAnimationClockMock = vi.fn(() => ({ elapsed: 0, reducedMotion: false }));
 
@@ -95,8 +100,11 @@ describe('PacketFlowLayer', () => {
     const hoverTransform = hoverPacket?.getAttribute('transform');
     expect(hoverTransform).toBeTruthy();
     const hoverX = extractTranslateX(hoverTransform ?? '');
+    const expectedIdleProgress = PACKET_SPEED_MS / 2 / IDLE_CYCLE_MS;
+    const expectedIdleX = expectedIdleProgress * 200;
 
     expect(idleX).toBeLessThan(hoverX);
+    expect(idleX).toBeCloseTo(expectedIdleX, 1);
     useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
   });
 
@@ -228,6 +236,8 @@ describe('PacketFlowLayer', () => {
     });
 
     it('returns fewer packets for idle mode', () => {
+      expect(getPacketCount(SHORT_PATH_THRESHOLD, 'idle')).toBe(1);
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD, 'idle')).toBe(1);
       expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'idle')).toBe(2);
       expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'idle')).toBe(1);
     });

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from 'react';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import {
-  IDLE_SPEED_MULTIPLIER,
+  IDLE_CYCLE_MS,
   PACKET_COLOR,
   PACKET_LENGTH,
   PACKET_OPACITY,
@@ -18,6 +18,8 @@ interface PacketFlowLayerProps {
   mode: PacketFlowMode;
   connectionType: string;
   strokeColor: string;
+  elapsed?: number;
+  reducedMotion?: boolean;
 }
 
 export const PacketFlowLayer = memo(function PacketFlowLayer({
@@ -25,8 +27,14 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
   mode,
   connectionType,
   strokeColor,
+  elapsed: externalElapsed,
+  reducedMotion: externalReducedMotion,
 }: PacketFlowLayerProps) {
-  const { elapsed, reducedMotion } = useAnimationClock(mode !== 'static' && hitPoints.length > 1);
+  const fallbackClock = useAnimationClock(
+    externalElapsed === undefined && mode !== 'static' && hitPoints.length > 1,
+  );
+  const elapsed = externalElapsed ?? fallbackClock.elapsed;
+  const reducedMotion = externalReducedMotion ?? fallbackClock.reducedMotion;
 
   const { segments, totalLength } = useMemo(() => {
     const nextSegments: SegmentMetric[] = [];
@@ -73,8 +81,7 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
   const packetCount = getPacketCount(totalLength, mode);
   const opacity = PACKET_OPACITY[mode];
   const packetColor = strokeColor || PACKET_COLOR;
-  const effectiveSpeed =
-    mode === 'idle' ? PACKET_SPEED_MS / IDLE_SPEED_MULTIPLIER : PACKET_SPEED_MS;
+  const effectiveSpeed = mode === 'idle' ? IDLE_CYCLE_MS : PACKET_SPEED_MS;
 
   return (
     <g pointerEvents="none" data-testid="packet-flow-layer" data-connection-type={connectionType}>

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -2,6 +2,7 @@ import { memo, useMemo } from 'react';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import {
+  IDLE_SPEED_MULTIPLIER,
   PACKET_COLOR,
   PACKET_LENGTH,
   PACKET_OPACITY,
@@ -72,12 +73,14 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
   const packetCount = getPacketCount(totalLength, mode);
   const opacity = PACKET_OPACITY[mode];
   const packetColor = strokeColor || PACKET_COLOR;
+  const effectiveSpeed =
+    mode === 'idle' ? PACKET_SPEED_MS / IDLE_SPEED_MULTIPLIER : PACKET_SPEED_MS;
 
   return (
     <g pointerEvents="none" data-testid="packet-flow-layer" data-connection-type={connectionType}>
       {Array.from({ length: packetCount }, (_, index) => {
-        const phaseOffset = (index / packetCount) * PACKET_SPEED_MS;
-        const rawProgress = (elapsed + phaseOffset) / PACKET_SPEED_MS;
+        const phaseOffset = (index / packetCount) * effectiveSpeed;
+        const rawProgress = (elapsed + phaseOffset) / effectiveSpeed;
 
         if (mode === 'creation' && rawProgress > 1) {
           return null;

--- a/apps/web/src/entities/connection/packetFlowHelpers.ts
+++ b/apps/web/src/entities/connection/packetFlowHelpers.ts
@@ -1,7 +1,7 @@
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { MEDIUM_PATH_THRESHOLD, SHORT_PATH_THRESHOLD } from './packetFlowTokens';
 
-export type PacketFlowMode = 'static' | 'hover' | 'selected' | 'creation';
+export type PacketFlowMode = 'static' | 'idle' | 'hover' | 'selected' | 'creation';
 
 export interface SegmentMetric {
   start: ScreenPoint;
@@ -25,7 +25,7 @@ export function getPacketCount(totalLength: number, mode: PacketFlowMode): numbe
   const baseCount =
     totalLength <= SHORT_PATH_THRESHOLD ? 1 : totalLength <= MEDIUM_PATH_THRESHOLD ? 2 : 3;
 
-  if (mode === 'hover') {
+  if (mode === 'idle' || mode === 'hover') {
     return Math.max(1, baseCount - 1);
   }
 

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -7,10 +7,13 @@ export const SHORT_PATH_THRESHOLD = 80;
 export const MEDIUM_PATH_THRESHOLD = 180;
 
 export const PACKET_OPACITY = {
+  idle: 0.25,
   hover: 0.5,
   selected: 0.8,
   creation: 1.0,
 } as const;
+
+export const IDLE_SPEED_MULTIPLIER = 0.4;
 
 export const PACKET_COLOR = '#22d3ee';
 export const PACKET_GLOW_COLOR = 'rgba(34, 211, 238, 0.3)';

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -13,7 +13,7 @@ export const PACKET_OPACITY = {
   creation: 1.0,
 } as const;
 
-export const IDLE_SPEED_MULTIPLIER = 0.4;
+export const IDLE_CYCLE_MS = 6500;
 
 export const PACKET_COLOR = '#22d3ee';
 export const PACKET_GLOW_COLOR = 'rgba(34, 211, 238, 0.3)';

--- a/apps/web/src/widgets/scene-canvas/ConnectionAnimationLayer.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionAnimationLayer.tsx
@@ -1,0 +1,39 @@
+import { memo } from 'react';
+import type { Connection } from '@cloudblocks/schema';
+import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
+import { ConnectionRenderer } from '../../entities/connection/ConnectionRenderer';
+
+interface ConnectionAnimationLayerProps {
+  connections: readonly Connection[];
+  originX: number;
+  originY: number;
+  overlapOffsets: ReadonlyMap<string, number>;
+}
+
+export const ConnectionAnimationLayer = memo(function ConnectionAnimationLayer({
+  connections,
+  originX,
+  originY,
+  overlapOffsets,
+}: ConnectionAnimationLayerProps) {
+  const hasAnyActiveConnection = connections.length > 0;
+  const { elapsed, reducedMotion } = useAnimationClock(hasAnyActiveConnection);
+
+  return (
+    <svg className="connection-layer" style={{ width: 1, height: 1 }}>
+      <title>Connections</title>
+      {connections.map((conn) => (
+        <ConnectionRenderer
+          key={conn.id}
+          connectionId={conn.id}
+          connection={conn}
+          originX={originX}
+          originY={originY}
+          overlapOffset={overlapOffsets.get(conn.id) ?? 0}
+          elapsed={elapsed}
+          reducedMotion={reducedMotion}
+        />
+      ))}
+    </svg>
+  );
+});

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -10,8 +10,8 @@ import type { SoundName } from '../../shared/utils/audioService';
 
 import { ContainerBlockSprite } from '../../entities/container-block/ContainerBlockSprite';
 import { BlockSprite } from '../../entities/block/BlockSprite';
-import { ConnectionRenderer } from '../../entities/connection/ConnectionRenderer';
 import { computeOverlapOffsets } from '../../entities/connection/overlapOffset';
+import { ConnectionAnimationLayer } from './ConnectionAnimationLayer';
 import { DragGhost } from './DragGhost';
 import { ConnectionPreview } from './ConnectionPreview';
 import type { ContainerBlock, ResourceBlock } from '@cloudblocks/schema';
@@ -26,7 +26,6 @@ import {
   computeWheelViewportTransform,
 } from './utils/viewportUtils';
 import { ZoomControls } from './ZoomControls';
-import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import './SceneCanvas.css';
 
 const EMPTY_OCCUPIED_CELLS = new Set<string>();
@@ -42,8 +41,6 @@ export function SceneCanvas() {
   );
   const nodes = architecture.nodes;
   const connections = architecture.connections;
-  const hasAnyActiveConnection = connections.length > 0;
-  const { elapsed: sharedElapsed, reducedMotion } = useAnimationClock(hasAnyActiveConnection);
   const indexedNodeById = useMemo(
     () => nodeById ?? new Map(nodes.map((node) => [node.id, node])),
     [nodeById, nodes],
@@ -535,21 +532,12 @@ export function SceneCanvas() {
           })}
         </div>
 
-        <svg className="connection-layer" style={{ width: 1, height: 1 }}>
-          <title>Connections</title>
-          {connections.map((conn) => (
-            <ConnectionRenderer
-              key={conn.id}
-              connectionId={conn.id}
-              connection={conn}
-              originX={origin.x}
-              originY={origin.y}
-              overlapOffset={overlapOffsets.get(conn.id) ?? 0}
-              elapsed={sharedElapsed}
-              reducedMotion={reducedMotion}
-            />
-          ))}
-        </svg>
+        <ConnectionAnimationLayer
+          connections={connections}
+          originX={origin.x}
+          originY={origin.y}
+          overlapOffsets={overlapOffsets}
+        />
 
         <svg className="interaction-overlay" style={{ width: 1, height: 1 }}>
           <title>Interaction Overlay</title>

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -26,6 +26,7 @@ import {
   computeWheelViewportTransform,
 } from './utils/viewportUtils';
 import { ZoomControls } from './ZoomControls';
+import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import './SceneCanvas.css';
 
 const EMPTY_OCCUPIED_CELLS = new Set<string>();
@@ -41,6 +42,8 @@ export function SceneCanvas() {
   );
   const nodes = architecture.nodes;
   const connections = architecture.connections;
+  const hasAnyActiveConnection = connections.length > 0;
+  const { elapsed: sharedElapsed, reducedMotion } = useAnimationClock(hasAnyActiveConnection);
   const indexedNodeById = useMemo(
     () => nodeById ?? new Map(nodes.map((node) => [node.id, node])),
     [nodeById, nodes],
@@ -542,6 +545,8 @@ export function SceneCanvas() {
               originX={origin.x}
               originY={origin.y}
               overlapOffset={overlapOffsets.get(conn.id) ?? 0}
+              elapsed={sharedElapsed}
+              reducedMotion={reducedMotion}
             />
           ))}
         </svg>


### PR DESCRIPTION
## Summary

- Add `'idle'` mode to `PacketFlowMode` so all connections show a subtle always-on animation without requiring hover or selection
- Default `packetMode` changed from `'static'` to `'idle'`
- Idle mode uses lower opacity (0.25), slower speed (40% of normal), and fewer packets per connection

## Problem

After implementing the packet flow animation in M40 (#1742), the default mode was `'static'` which rendered no animation. Users reported not seeing any animation — connections appeared completely static unless explicitly hovered or selected.

## Changes

| File | Change |
|------|--------|
| `packetFlowHelpers.ts` | Add `'idle'` to `PacketFlowMode` union; `getPacketCount` returns `Math.max(1, baseCount - 1)` for idle |
| `packetFlowTokens.ts` | Add `PACKET_OPACITY.idle = 0.25` and `IDLE_SPEED_MULTIPLIER = 0.4` |
| `ConnectionRenderer.tsx` | Default mode changed from `'static'` to `'idle'` |
| `PacketFlowLayer.tsx` | Compute `effectiveSpeed` for idle mode (6500ms cycle vs 2600ms normal) |
| `PacketFlowLayer.test.tsx` | Add idle mode render, speed, and packet count tests |
| `ConnectionRenderer.test.tsx` | Add default idle mode coverage test |

## Verification

- ✅ `pnpm lint` — clean
- ✅ `pnpm build` — clean
- ✅ `vitest run --coverage` — 3313 tests passed, 90.97% branch coverage
- ✅ Browser verification: 5 connections → 10 packets rendered, opacity 0.25, `isMoving: true`
- ✅ `prefers-reduced-motion` respected (existing behavior preserved)