### PR TITLE
fix(web): show import failure toast from empty-canvas drop handler

### DIFF
--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
@@ -3,9 +3,19 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { EmptyCanvasOverlay } from './EmptyCanvasOverlay';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
+import { toast } from 'react-hot-toast';
 
 vi.mock('../../entities/store/architectureStore');
 vi.mock('../../entities/store/uiStore');
+vi.mock('react-hot-toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+vi.mock('../../entities/store/uiSync', () => ({
+  clearWorkspaceDiffUI: vi.fn(),
+}));
 
 const mockAddNode = vi.fn();
 const mockOpenDrawer = vi.fn();
@@ -111,8 +121,9 @@ describe('EmptyCanvasOverlay', () => {
     expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('importing a JSON file calls importArchitecture with file content', async () => {
+  it('importing a valid JSON file shows success toast', async () => {
     setupMocks(0);
+    mockImportArchitecture.mockReturnValue(null);
     render(<EmptyCanvasOverlay />);
     const fileInput = screen.getByTestId('import-file-input') as HTMLInputElement;
     const jsonContent = '{"nodes":[],"connections":[]}';
@@ -122,6 +133,24 @@ describe('EmptyCanvasOverlay', () => {
 
     await vi.waitFor(() => {
       expect(mockImportArchitecture).toHaveBeenCalledWith(jsonContent, 'azure');
+      expect(toast.success).toHaveBeenCalledWith('Architecture imported successfully!');
+      expect(toast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  it('importing an invalid JSON file shows error toast', async () => {
+    setupMocks(0);
+    mockImportArchitecture.mockReturnValue('Invalid schema version');
+    render(<EmptyCanvasOverlay />);
+    const fileInput = screen.getByTestId('import-file-input') as HTMLInputElement;
+    const jsonContent = '{"bad":true}';
+    const file = new File([jsonContent], 'bad.json', { type: 'application/json' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Import failed: Invalid schema version');
+      expect(toast.success).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.test.tsx
@@ -4,6 +4,7 @@ import { EmptyCanvasOverlay } from './EmptyCanvasOverlay';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { toast } from 'react-hot-toast';
+import { clearWorkspaceDiffUI } from '../../entities/store/uiSync';
 
 vi.mock('../../entities/store/architectureStore');
 vi.mock('../../entities/store/uiStore');
@@ -133,6 +134,7 @@ describe('EmptyCanvasOverlay', () => {
 
     await vi.waitFor(() => {
       expect(mockImportArchitecture).toHaveBeenCalledWith(jsonContent, 'azure');
+      expect(clearWorkspaceDiffUI).toHaveBeenCalled();
       expect(toast.success).toHaveBeenCalledWith('Architecture imported successfully!');
       expect(toast.error).not.toHaveBeenCalled();
     });
@@ -152,5 +154,28 @@ describe('EmptyCanvasOverlay', () => {
       expect(toast.error).toHaveBeenCalledWith('Import failed: Invalid schema version');
       expect(toast.success).not.toHaveBeenCalled();
     });
+  });
+
+  it('shows error toast when FileReader fails', () => {
+    setupMocks(0);
+
+    // Patch FileReader.readAsText to call onerror synchronously
+    const originalReadAsText = FileReader.prototype.readAsText;
+    FileReader.prototype.readAsText = function () {
+      // onerror is already assigned before readAsText is called
+      if (this.onerror) {
+        (this.onerror as () => void)();
+      }
+    };
+
+    render(<EmptyCanvasOverlay />);
+    const fileInput = screen.getByTestId('import-file-input') as HTMLInputElement;
+    const file = new File(['content'], 'arch.json', { type: 'application/json' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(toast.error).toHaveBeenCalledWith('Failed to read file.');
+
+    FileReader.prototype.readAsText = originalReadAsText;
   });
 });

--- a/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
+++ b/apps/web/src/widgets/scene-canvas/EmptyCanvasOverlay.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { useArchitectureStore } from '../../entities/store/architectureStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { clearWorkspaceDiffUI } from '../../entities/store/uiSync';
+import { toast } from 'react-hot-toast';
 import './EmptyCanvasOverlay.css';
 
 export function EmptyCanvasOverlay() {
@@ -28,9 +29,17 @@ export function EmptyCanvasOverlay() {
     reader.onload = (ev) => {
       const text = ev.target?.result;
       if (typeof text === 'string') {
-        importArchitecture(text, activeProvider);
-        clearWorkspaceDiffUI();
+        const error = importArchitecture(text, activeProvider);
+        if (error) {
+          toast.error(`Import failed: ${error}`);
+        } else {
+          clearWorkspaceDiffUI();
+          toast.success('Architecture imported successfully!');
+        }
       }
+    };
+    reader.onerror = () => {
+      toast.error('Failed to read file.');
     };
     reader.readAsText(file);
     e.target.value = '';


### PR DESCRIPTION
## Summary

- Add toast feedback (success/error) when importing architecture JSON via the EmptyCanvasOverlay file picker
- Add `reader.onerror` handler with error toast for file read failures
- Matches existing MenuBar import handler pattern exactly

## Changes

- **EmptyCanvasOverlay.tsx**: Check `importArchitecture` return value, show `toast.error` on failure or `toast.success` on success. Add `reader.onerror` handler.
- **EmptyCanvasOverlay.test.tsx**: Add toast mock, tests for success toast and error toast paths.

## Testing

- All 3327 tests pass
- Lint, type check clean

Fixes #1746