### PR TITLE
fix(web): restore visible focus indicators across interactive controls

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -15,6 +15,11 @@
   appearance: none;
 }
 
+.block-button:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: 2px;
+}
+
 .block-img {
   width: 100%;
   height: 100%;

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.css
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.css
@@ -16,6 +16,11 @@
   appearance: none;
 }
 
+.container-button:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: 2px;
+}
+
 .container-img {
   width: 100%;
   height: 100%;

--- a/apps/web/src/features/ai/components/AiPromptBar.css
+++ b/apps/web/src/features/ai/components/AiPromptBar.css
@@ -51,6 +51,11 @@
   min-width: 150px;
 }
 
+.ai-prompt-input:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .ai-prompt-input::placeholder {
   color: #998c40;
   font-weight: 500;
@@ -73,6 +78,11 @@
   cursor: pointer;
   padding: 2px 4px;
   border-radius: 4px;
+}
+
+.ai-provider-select:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
 }
 
 .ai-provider-select:hover:not(:disabled) {
@@ -118,6 +128,11 @@
   color: #999;
   cursor: not-allowed;
   box-shadow: none;
+}
+
+.ai-submit-btn:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
 }
 
 .ai-loading-spinner {

--- a/apps/web/src/shared/ui/PromptDialog.css
+++ b/apps/web/src/shared/ui/PromptDialog.css
@@ -16,3 +16,8 @@
   border-color: color-mix(in srgb, var(--accent-primary) 50%, transparent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-primary) 18%, transparent);
 }
+
+.prompt-dialog-input:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}

--- a/apps/web/src/widgets/code-preview/CodePreview.css
+++ b/apps/web/src/widgets/code-preview/CodePreview.css
@@ -105,6 +105,19 @@
   border-color: var(--accent-primary);
 }
 
+.code-preview-input:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.code-preview-close:focus-visible,
+.code-preview-generate-btn:focus-visible,
+.code-preview-action-btn:focus-visible,
+.code-preview-tab:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .code-preview-generate-btn {
   padding: 5px 14px;
   background: color-mix(in srgb, var(--accent-primary) 30%, transparent);

--- a/apps/web/src/widgets/github-pr/GitHubPR.css
+++ b/apps/web/src/widgets/github-pr/GitHubPR.css
@@ -74,6 +74,19 @@
   border-color: var(--accent-primary);
 }
 
+.github-pr-input:focus-visible,
+.github-pr-textarea:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.github-pr-close:focus-visible,
+.github-pr-submit:focus-visible,
+.github-pr-compare-btn:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .github-pr-submit {
   padding: 6px 10px;
   background: color-mix(in srgb, var(--accent-primary) 28%, transparent);

--- a/apps/web/src/widgets/github-repos/GitHubRepos.css
+++ b/apps/web/src/widgets/github-repos/GitHubRepos.css
@@ -97,6 +97,18 @@
   border-color: var(--accent-primary);
 }
 
+.github-repos-input:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.github-repos-close:focus-visible,
+.github-repos-create-btn:focus-visible,
+.github-repos-link-created-btn:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .github-repos-checkbox-row {
   display: flex;
   align-items: center;

--- a/apps/web/src/widgets/github-sync/GitHubSync.css
+++ b/apps/web/src/widgets/github-sync/GitHubSync.css
@@ -92,6 +92,20 @@
   border-color: var(--accent-primary);
 }
 
+.github-sync-input:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.github-sync-close:focus-visible,
+.github-sync-primary-btn:focus-visible,
+.github-sync-secondary-btn:focus-visible,
+.github-sync-open-repos:focus-visible,
+.github-sync-unlink-btn:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .github-sync-open-repos,
 .github-sync-primary-btn,
 .github-sync-secondary-btn {

--- a/apps/web/src/widgets/right-drawer/panels/PropertiesDrawerPanel.css
+++ b/apps/web/src/widgets/right-drawer/panels/PropertiesDrawerPanel.css
@@ -97,6 +97,19 @@
   border-color: var(--accent-primary);
 }
 
+.props-field-input:focus-visible,
+.props-field-textarea:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.props-connection-item:focus-visible,
+.props-action-btn:focus-visible,
+.props-danger-btn:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .props-field-textarea {
   resize: vertical;
   min-height: 48px;

--- a/apps/web/src/widgets/rollback-dialog/RollbackDialog.css
+++ b/apps/web/src/widgets/rollback-dialog/RollbackDialog.css
@@ -190,6 +190,21 @@
   border-color: color-mix(in srgb, var(--accent-primary) 50%, transparent);
 }
 
+.rollback-reason-textarea:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.rollback-dialog-close:focus-visible,
+.rollback-btn-primary:focus-visible,
+.rollback-btn-secondary:focus-visible,
+.rollback-btn-confirm:focus-visible,
+.rollback-btn-cancel-confirm:focus-visible,
+.rollback-version-item:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .rollback-reason-textarea::placeholder {
   color: var(--text-muted);
 }

--- a/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
+++ b/apps/web/src/widgets/sidebar-palette/SidebarPalette.css
@@ -46,6 +46,11 @@
   font: 600 var(--text-sm) / 1.2 var(--font-ui);
 }
 
+.sidebar-palette-search input:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .sidebar-palette-search input::placeholder {
   color: var(--text-muted);
 }
@@ -98,6 +103,11 @@
 
 .sidebar-palette-group-toggle:hover {
   background: color-mix(in srgb, var(--category-color) 26%, var(--bg-surface-raised));
+}
+
+.sidebar-palette-group-toggle:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
 }
 
 .sidebar-palette-group-title {
@@ -168,6 +178,11 @@
 .sidebar-palette-resource-btn:active:not(.disabled):not(:disabled) {
   cursor: grabbing;
   transform: translateY(0);
+}
+
+.sidebar-palette-resource-btn:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
 }
 
 .sidebar-palette-resource-btn.is-dragging {

--- a/apps/web/src/widgets/workspace-manager/WorkspaceManager.css
+++ b/apps/web/src/widgets/workspace-manager/WorkspaceManager.css
@@ -67,6 +67,19 @@
   border-color: var(--accent-primary);
 }
 
+.workspace-manager-input:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
+.workspace-manager-close:focus-visible,
+.workspace-manager-create-btn:focus-visible,
+.workspace-manager-action:focus-visible,
+.workspace-manager-delete-selected:focus-visible {
+  outline: 2px solid var(--accent-primary, #3b82f6);
+  outline-offset: -2px;
+}
+
 .workspace-manager-input::placeholder {
   color: var(--text-muted);
 }


### PR DESCRIPTION
## Summary
- Audit 12 CSS files with `outline: none` / `outline: 0` that lacked compensating `:focus-visible` styles (WCAG 2.4.7 violation risk)
- Add consistent `:focus-visible` focus indicators using `outline: 2px solid var(--accent-primary, #3b82f6)` for keyboard navigation
- Covers inputs, buttons, selects, canvas sprite buttons, and panel controls across the entire app

## Files Changed (12)
| File | Elements |
|------|----------|
| `AiPromptBar.css` | `.ai-prompt-input`, `.ai-provider-select`, `.ai-submit-btn` |
| `PromptDialog.css` | `.prompt-dialog-input` |
| `ContainerBlockSprite.css` | `.container-button` |
| `BlockSprite.css` | `.block-button` |
| `SidebarPalette.css` | search input, group toggle, resource button |
| `GitHubSync.css` | input + 5 button selectors |
| `CodePreview.css` | input + 4 button selectors |
| `GitHubRepos.css` | input + 3 button selectors |
| `PropertiesDrawerPanel.css` | input/textarea + 3 button selectors |
| `WorkspaceManager.css` | input + 4 button selectors |
| `GitHubPR.css` | input/textarea + 3 button selectors |
| `RollbackDialog.css` | textarea + 6 button selectors |

## Design Decisions
- **Preserved all existing `outline: none`** — prevents focus rings on mouse click
- **`:focus-visible` only** — shows focus ring only during keyboard navigation
- **`outline-offset: -2px`** for inline/panel elements (matches `ValidationDrawerPanel.css`)
- **`outline-offset: 2px`** for canvas sprite buttons (`BlockSprite`, `ContainerBlockSprite`) to avoid clipping

## Verification
- ✅ Build passes (238 KB main bundle)
- ✅ All 3343 tests pass
- ✅ Prettier formatted

Fixes #1748