### PR TITLE
feat(web): align first-screen CTA labels and destinations

### DIFF
--- a/apps/web/e2e/learning/scenarios.spec.ts
+++ b/apps/web/e2e/learning/scenarios.spec.ts
@@ -52,8 +52,8 @@ const SCENARIOS = [
 
 async function goToBuilder(page: Page) {
   await page.goto('/');
-  // Click "Start Learning" on landing page to enter the builder
-  const startBtn = page.getByRole('button', { name: 'Start Learning' });
+  // Click "Get Started" on landing page to enter the builder
+  const startBtn = page.getByRole('button', { name: 'Get Started' });
   if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
     await startBtn.click();
   }

--- a/apps/web/e2e/learning/templates.spec.ts
+++ b/apps/web/e2e/learning/templates.spec.ts
@@ -21,7 +21,7 @@ const TEMPLATES = [
 
 async function goToBuilder(page: Page) {
   await page.goto('/');
-  const startBtn = page.getByRole('button', { name: 'Start Learning' });
+  const startBtn = page.getByRole('button', { name: 'Get Started' });
   if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
     await startBtn.click();
   }

--- a/apps/web/e2e/screenshots/capture-all.spec.ts
+++ b/apps/web/e2e/screenshots/capture-all.spec.ts
@@ -47,7 +47,7 @@ function toKebabCase(value: string): string {
 
 async function goToBuilder(page: Page) {
   await page.goto('/');
-  const startBtn = page.getByRole('button', { name: 'Start Learning' });
+  const startBtn = page.getByRole('button', { name: 'Get Started' });
   if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
     await startBtn.click();
   }

--- a/apps/web/e2e/unification/external-block.spec.ts
+++ b/apps/web/e2e/unification/external-block.spec.ts
@@ -22,7 +22,7 @@ const TEMPLATES = [
 
 async function goToBuilder(page: Page) {
   await page.goto('/');
-  const startBtn = page.getByRole('button', { name: 'Start Learning' });
+  const startBtn = page.getByRole('button', { name: 'Get Started' });
   if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
     await startBtn.click();
   }

--- a/apps/web/src/widgets/landing-navbar/LandingNavbar.test.tsx
+++ b/apps/web/src/widgets/landing-navbar/LandingNavbar.test.tsx
@@ -19,7 +19,7 @@ describe('LandingNavbar', () => {
     render(<LandingNavbar />);
 
     expect(screen.getByText('CloudBlocks')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', { name: 'Start Learning' }));
+    await user.click(screen.getByRole('button', { name: 'Get Started' }));
     expect(goToBuilder).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/widgets/landing-navbar/LandingNavbar.tsx
+++ b/apps/web/src/widgets/landing-navbar/LandingNavbar.tsx
@@ -24,7 +24,7 @@ export function LandingNavbar() {
         </a>
       </nav>
       <button type="button" className="landing-navbar-cta" onClick={goToBuilder}>
-        Start Learning
+        Get Started
       </button>
     </header>
   );

--- a/apps/web/src/widgets/landing-page/LandingPage.test.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.test.tsx
@@ -51,14 +51,14 @@ describe('LandingPage', () => {
     expect(screen.queryByText('d')).not.toBeInTheDocument();
   });
 
-  it('navigates to builder when Start Learning is clicked', async () => {
+  it('navigates to builder when Get Started is clicked', async () => {
     const user = userEvent.setup();
     const goToBuilder = vi.fn();
     useUIStore.setState({ activeProvider: 'azure', goToBuilder });
 
     render(<LandingPage />);
 
-    await user.click(screen.getAllByRole('button', { name: 'Start Learning' })[0]);
+    await user.click(screen.getAllByRole('button', { name: 'Get Started' })[0]);
     expect(goToBuilder).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/widgets/landing-page/LandingPage.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.tsx
@@ -42,7 +42,7 @@ export function LandingPage() {
             <span className="landing-hero-badge">Terraform starter export</span>
           </div>
           <button type="button" className="landing-hero-cta" onClick={handleStartBuilding}>
-            Start Learning
+            Get Started
           </button>
         </section>
 

--- a/docs/user-guide/first-architecture.md
+++ b/docs/user-guide/first-architecture.md
@@ -11,7 +11,7 @@ Learn your first cloud architecture in 5 minutes using a built-in template with 
 - **Live Demo**: Visit [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/)
 - **Local**: Clone and run (see [Quick Start](quick-start.md))
 
-When CloudBlocks opens, click **Start Learning** to enter the builder.
+When CloudBlocks opens, click **Get Started** to enter the builder.
 
 ---
 

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -22,7 +22,7 @@ pnpm dev
 
 Open [http://localhost:5173](http://localhost:5173) in your browser.
 
-When CloudBlocks opens, you will see a landing page. Click **Start Learning** to enter the builder.
+When CloudBlocks opens, you will see a landing page. Click **Get Started** to enter the builder.
 
 ---
 


### PR DESCRIPTION
## Summary

- Landing hero and navbar CTA labels changed from "Start Learning" to "Get Started" since they only navigate to the builder
- EmptyCanvasCTA retains "Start Learning" since it actually opens the scenario gallery
- Each CTA label now accurately describes its action, eliminating user confusion

## Changes

| File | Change |
|------|--------|
| `LandingPage.tsx` | Hero button: "Start Learning" → "Get Started" |
| `LandingNavbar.tsx` | Navbar CTA: "Start Learning" → "Get Started" |
| `LandingPage.test.tsx` | Updated test assertion to match new label |
| `LandingNavbar.test.tsx` | Updated test assertion to match new label |

## User Flow (after fix)

1. Landing page → **"Get Started"** → navigates to builder
2. Builder (empty canvas) → **"Start Learning"** → opens scenario gallery
3. Each label accurately describes its destination

Fixes #1749