### PR TITLE
feat(web): add animated SVG hero illustration to landing page

### DIFF
--- a/apps/web/public/hero-illustration.svg
+++ b/apps/web/public/hero-illustration.svg
@@ -3,46 +3,13 @@
     CloudBlocks Hero Illustration
     Isometric cloud architecture scene showing container blocks,
     resource blocks, and connections in the product's visual language.
+    Uses native SVG animation elements (SMIL). CSS is limited to the
+    prefers-reduced-motion accessibility override only.
   -->
-  <style>
-    .hero-float-1 { animation: heroFloat1 4s ease-in-out infinite; }
-    .hero-float-2 { animation: heroFloat2 5s ease-in-out infinite; }
-    .hero-float-3 { animation: heroFloat3 4.5s ease-in-out infinite; }
-    .hero-float-4 { animation: heroFloat4 3.8s ease-in-out infinite; }
-    .hero-pulse { animation: heroPulse 3s ease-in-out infinite; }
-    .hero-pulse-delayed { animation: heroPulse 3s ease-in-out 1.5s infinite; }
 
-    @keyframes heroFloat1 {
-      0%, 100% { transform: translateY(0); }
-      50% { transform: translateY(-6px); }
-    }
-    @keyframes heroFloat2 {
-      0%, 100% { transform: translateY(0); }
-      50% { transform: translateY(-8px); }
-    }
-    @keyframes heroFloat3 {
-      0%, 100% { transform: translateY(0); }
-      50% { transform: translateY(-5px); }
-    }
-    @keyframes heroFloat4 {
-      0%, 100% { transform: translateY(0); }
-      50% { transform: translateY(-7px); }
-    }
-    @keyframes heroPulse {
-      0%, 100% { opacity: 0.3; }
-      50% { opacity: 0.7; }
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      .hero-float-1,
-      .hero-float-2,
-      .hero-float-3,
-      .hero-float-4 { animation: none; }
-      .hero-pulse,
-      .hero-pulse-delayed { animation: none; opacity: 0.5; }
-    }
-  </style>
-
+  <!-- Accessibility: stop SMIL animations when user prefers reduced motion.
+       CSS overrides SMIL presentation values per SVG spec §6.4. -->
+  <style>@media(prefers-reduced-motion:reduce){.hero-anim{transform:translate(0,0)!important}.hero-pulse{opacity:0.5!important}}</style>
   <defs>
     <!-- Subtle grid pattern for depth -->
     <pattern id="heroGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse" patternTransform="skewX(-30) scale(1, 0.6)">
@@ -55,7 +22,9 @@
 
   <!-- ═══ Container Block (VNet) ═══ -->
   <!-- Large isometric container representing a Virtual Network -->
-  <g class="hero-float-1">
+  <g class="hero-anim">
+    <animateTransform attributeName="transform" type="translate" values="0,0;0,-6;0,0" dur="4s" repeatCount="indefinite"/>
+
     <!-- Container shadow -->
     <path d="M400,380 L560,290 L400,200 L240,290 Z" fill="#0f172a" opacity="0.06"/>
 
@@ -72,8 +41,12 @@
     <text x="400" y="215" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af" letter-spacing="0.5">Virtual Network</text>
   </g>
 
-  <!-- ═══ Resource Block 1: Application Gateway ═══ -->
-  <g class="hero-float-2">
+  <!-- ═══ Gateway + Gateway→Compute connection group ═══ -->
+  <!-- These float together so the connection line stays aligned -->
+  <g class="hero-anim">
+    <animateTransform attributeName="transform" type="translate" values="0,0;0,-8;0,0" dur="5s" repeatCount="indefinite"/>
+
+    <!-- Resource Block 1: Application Gateway -->
     <!-- Block shadow -->
     <ellipse cx="320" cy="310" rx="32" ry="10" fill="#0f172a" opacity="0.08"/>
 
@@ -91,10 +64,23 @@
 
     <!-- Label -->
     <text x="320" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#475569">Gateway</text>
+
+    <!-- Gateway → Compute connection (inside Gateway group for drift-free animation) -->
+    <line x1="345" y1="285" x2="375" y2="275" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4" class="hero-pulse">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3s" repeatCount="indefinite"/>
+    </line>
+
+    <!-- Data packet dot between Gateway and Compute -->
+    <circle cx="360" cy="279" r="2.5" fill="#2563eb" class="hero-pulse">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- ═══ Resource Block 2: Virtual Machine ═══ -->
-  <g class="hero-float-3">
+  <!-- ═══ Compute + Compute→Database connection group ═══ -->
+  <g class="hero-anim">
+    <animateTransform attributeName="transform" type="translate" values="0,0;0,-5;0,0" dur="4.5s" repeatCount="indefinite"/>
+
+    <!-- Resource Block 2: Virtual Machine -->
     <!-- Block shadow -->
     <ellipse cx="400" cy="300" rx="32" ry="10" fill="#0f172a" opacity="0.08"/>
 
@@ -113,10 +99,22 @@
 
     <!-- Label -->
     <text x="400" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#475569">Compute</text>
+
+    <!-- Compute → Database connection (inside Compute group for drift-free animation) -->
+    <line x1="425" y1="275" x2="455" y2="285" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4" class="hero-pulse">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3s" begin="1.5s" repeatCount="indefinite"/>
+    </line>
+
+    <!-- Data packet dot between Compute and Database -->
+    <circle cx="440" cy="279" r="2.5" fill="#2563eb" class="hero-pulse">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
   <!-- ═══ Resource Block 3: Database ═══ -->
-  <g class="hero-float-4">
+  <g class="hero-anim">
+    <animateTransform attributeName="transform" type="translate" values="0,0;0,-7;0,0" dur="3.8s" repeatCount="indefinite"/>
+
     <!-- Block shadow -->
     <ellipse cx="480" cy="310" rx="32" ry="10" fill="#0f172a" opacity="0.08"/>
 
@@ -138,36 +136,32 @@
     <text x="480" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#475569">Database</text>
   </g>
 
-  <!-- ═══ Connection Lines ═══ -->
-  <!-- Gateway → Compute -->
-  <line x1="345" y1="285" x2="375" y2="275" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4" class="hero-pulse"/>
+  <!-- ═══ External actor: Internet globe + connection to Gateway ═══ -->
+  <g class="hero-anim">
+    <animateTransform attributeName="transform" type="translate" values="0,0;0,-8;0,0" dur="5s" repeatCount="indefinite"/>
 
-  <!-- Compute → Database -->
-  <line x1="425" y1="275" x2="455" y2="285" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4" class="hero-pulse-delayed"/>
+    <!-- Internet globe -->
+    <circle cx="200" cy="170" r="14" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+    <ellipse cx="200" cy="170" rx="14" ry="6" fill="none" stroke="#94a3b8" stroke-width="0.8"/>
+    <line x1="200" y1="156" x2="200" y2="184" stroke="#94a3b8" stroke-width="0.8"/>
+    <text x="200" y="196" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Internet</text>
 
-  <!-- ═══ Decorative Elements ═══ -->
-  <!-- Small floating dots suggesting data packets -->
-  <circle cx="360" cy="279" r="2.5" fill="#2563eb" class="hero-pulse"/>
-  <circle cx="440" cy="279" r="2.5" fill="#2563eb" class="hero-pulse-delayed"/>
-
-  <!-- External actor: Internet globe (top-left) -->
-  <g class="hero-float-2" transform="translate(200, 170)">
-    <circle cx="0" cy="0" r="14" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
-    <ellipse cx="0" cy="0" rx="14" ry="6" fill="none" stroke="#94a3b8" stroke-width="0.8"/>
-    <line x1="0" y1="-14" x2="0" y2="14" stroke="#94a3b8" stroke-width="0.8"/>
-    <text x="0" y="26" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Internet</text>
+    <!-- Connection from Internet to Gateway -->
+    <line x1="215" y1="185" x2="295" y2="265" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,4" class="hero-pulse">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3s" repeatCount="indefinite"/>
+    </line>
   </g>
 
-  <!-- Connection from Internet to Gateway -->
-  <line x1="215" y1="185" x2="295" y2="265" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,4" class="hero-pulse"/>
-
-  <!-- Terraform export hint (bottom-right) -->
+  <!-- ═══ Decorative Elements ═══ -->
+  <!-- Terraform export hint (bottom-right, static) -->
   <g transform="translate(580, 340)">
     <rect x="-40" y="-14" width="80" height="28" rx="6" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"/>
     <text x="0" y="0" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b" dominant-baseline="middle">{ } Terraform</text>
   </g>
 
   <!-- Export arrow -->
-  <path d="M520,310 C540,315 550,325 560,330" fill="none" stroke="#94a3b8" stroke-width="1.2" stroke-dasharray="3,3" class="hero-pulse-delayed"/>
+  <path d="M520,310 C540,315 550,325 560,330" fill="none" stroke="#94a3b8" stroke-width="1.2" stroke-dasharray="3,3" class="hero-pulse">
+    <animate attributeName="opacity" values="0.3;0.7;0.3" dur="3s" begin="1.5s" repeatCount="indefinite"/>
+  </path>
   <polygon points="560,326 564,334 556,332" fill="#94a3b8"/>
 </svg>

--- a/apps/web/public/hero-illustration.svg
+++ b/apps/web/public/hero-illustration.svg
@@ -1,0 +1,173 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" fill="none">
+  <!--
+    CloudBlocks Hero Illustration
+    Isometric cloud architecture scene showing container blocks,
+    resource blocks, and connections in the product's visual language.
+  -->
+  <style>
+    .hero-float-1 { animation: heroFloat1 4s ease-in-out infinite; }
+    .hero-float-2 { animation: heroFloat2 5s ease-in-out infinite; }
+    .hero-float-3 { animation: heroFloat3 4.5s ease-in-out infinite; }
+    .hero-float-4 { animation: heroFloat4 3.8s ease-in-out infinite; }
+    .hero-pulse { animation: heroPulse 3s ease-in-out infinite; }
+    .hero-pulse-delayed { animation: heroPulse 3s ease-in-out 1.5s infinite; }
+
+    @keyframes heroFloat1 {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
+    }
+    @keyframes heroFloat2 {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-8px); }
+    }
+    @keyframes heroFloat3 {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-5px); }
+    }
+    @keyframes heroFloat4 {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-7px); }
+    }
+    @keyframes heroPulse {
+      0%, 100% { opacity: 0.3; }
+      50% { opacity: 0.7; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .hero-float-1,
+      .hero-float-2,
+      .hero-float-3,
+      .hero-float-4 { animation: none; }
+      .hero-pulse,
+      .hero-pulse-delayed { animation: none; opacity: 0.5; }
+    }
+  </style>
+
+  <defs>
+    <!-- Subtle grid pattern for depth -->
+    <pattern id="heroGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse" patternTransform="skewX(-30) scale(1, 0.6)">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#e2e8f0" stroke-width="0.5" opacity="0.5"/>
+    </pattern>
+  </defs>
+
+  <!-- Background grid for isometric feel -->
+  <rect x="100" y="120" width="600" height="280" fill="url(#heroGrid)" opacity="0.4"/>
+
+  <!-- ═══ Container Block (VNet) ═══ -->
+  <!-- Large isometric container representing a Virtual Network -->
+  <g class="hero-float-1">
+    <!-- Container shadow -->
+    <path d="M400,380 L560,290 L400,200 L240,290 Z" fill="#0f172a" opacity="0.06"/>
+
+    <!-- Container top face -->
+    <path d="M400,370 L560,280 L400,190 L240,280 Z" fill="#eff6ff" stroke="#bfdbfe" stroke-width="1.5"/>
+
+    <!-- Container left face -->
+    <path d="M240,280 L240,330 L400,420 L400,370 Z" fill="#dbeafe" stroke="#bfdbfe" stroke-width="1"/>
+
+    <!-- Container right face -->
+    <path d="M560,280 L560,330 L400,420 L400,370 Z" fill="#bfdbfe" stroke="#93c5fd" stroke-width="1"/>
+
+    <!-- Container label -->
+    <text x="400" y="215" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="600" fill="#1e40af" letter-spacing="0.5">Virtual Network</text>
+  </g>
+
+  <!-- ═══ Resource Block 1: Application Gateway ═══ -->
+  <g class="hero-float-2">
+    <!-- Block shadow -->
+    <ellipse cx="320" cy="310" rx="32" ry="10" fill="#0f172a" opacity="0.08"/>
+
+    <!-- Top face -->
+    <path d="M320,258 L358,278 L320,298 L282,278 Z" fill="#60a5fa"/>
+    <!-- Left face -->
+    <path d="M282,278 L282,300 L320,320 L320,298 Z" fill="#3b82f6"/>
+    <!-- Right face -->
+    <path d="M358,278 L358,300 L320,320 L320,298 Z" fill="#2563eb"/>
+
+    <!-- Icon circle on top -->
+    <circle cx="320" cy="274" r="10" fill="#ffffff" opacity="0.9"/>
+    <!-- Gateway icon (simplified shield) -->
+    <path d="M316,270 L320,268 L324,270 L324,276 C324,278 320,280 320,280 C320,280 316,278 316,276 Z" fill="#2563eb" stroke="none"/>
+
+    <!-- Label -->
+    <text x="320" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#475569">Gateway</text>
+  </g>
+
+  <!-- ═══ Resource Block 2: Virtual Machine ═══ -->
+  <g class="hero-float-3">
+    <!-- Block shadow -->
+    <ellipse cx="400" cy="300" rx="32" ry="10" fill="#0f172a" opacity="0.08"/>
+
+    <!-- Top face -->
+    <path d="M400,248 L438,268 L400,288 L362,268 Z" fill="#60a5fa"/>
+    <!-- Left face -->
+    <path d="M362,268 L362,290 L400,310 L400,288 Z" fill="#3b82f6"/>
+    <!-- Right face -->
+    <path d="M438,268 L438,290 L400,310 L400,288 Z" fill="#2563eb"/>
+
+    <!-- Icon circle on top -->
+    <circle cx="400" cy="264" r="10" fill="#ffffff" opacity="0.9"/>
+    <!-- VM icon (simplified monitor) -->
+    <rect x="394" y="259" width="12" height="8" rx="1" fill="#2563eb"/>
+    <rect x="398" y="268" width="4" height="2" fill="#2563eb"/>
+
+    <!-- Label -->
+    <text x="400" y="330" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#475569">Compute</text>
+  </g>
+
+  <!-- ═══ Resource Block 3: Database ═══ -->
+  <g class="hero-float-4">
+    <!-- Block shadow -->
+    <ellipse cx="480" cy="310" rx="32" ry="10" fill="#0f172a" opacity="0.08"/>
+
+    <!-- Top face -->
+    <path d="M480,258 L518,278 L480,298 L442,278 Z" fill="#60a5fa"/>
+    <!-- Left face -->
+    <path d="M442,278 L442,300 L480,320 L480,298 Z" fill="#3b82f6"/>
+    <!-- Right face -->
+    <path d="M518,278 L518,300 L480,320 L480,298 Z" fill="#2563eb"/>
+
+    <!-- Icon circle on top -->
+    <circle cx="480" cy="274" r="10" fill="#ffffff" opacity="0.9"/>
+    <!-- DB icon (cylinder) -->
+    <ellipse cx="480" cy="270" rx="6" ry="3" fill="#2563eb"/>
+    <rect x="474" y="270" width="12" height="7" fill="#2563eb"/>
+    <ellipse cx="480" cy="277" rx="6" ry="3" fill="#3b82f6"/>
+
+    <!-- Label -->
+    <text x="480" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#475569">Database</text>
+  </g>
+
+  <!-- ═══ Connection Lines ═══ -->
+  <!-- Gateway → Compute -->
+  <line x1="345" y1="285" x2="375" y2="275" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4" class="hero-pulse"/>
+
+  <!-- Compute → Database -->
+  <line x1="425" y1="275" x2="455" y2="285" stroke="#2563eb" stroke-width="2" stroke-dasharray="6,4" class="hero-pulse-delayed"/>
+
+  <!-- ═══ Decorative Elements ═══ -->
+  <!-- Small floating dots suggesting data packets -->
+  <circle cx="360" cy="279" r="2.5" fill="#2563eb" class="hero-pulse"/>
+  <circle cx="440" cy="279" r="2.5" fill="#2563eb" class="hero-pulse-delayed"/>
+
+  <!-- External actor: Internet globe (top-left) -->
+  <g class="hero-float-2" transform="translate(200, 170)">
+    <circle cx="0" cy="0" r="14" fill="#f1f5f9" stroke="#cbd5e1" stroke-width="1"/>
+    <ellipse cx="0" cy="0" rx="14" ry="6" fill="none" stroke="#94a3b8" stroke-width="0.8"/>
+    <line x1="0" y1="-14" x2="0" y2="14" stroke="#94a3b8" stroke-width="0.8"/>
+    <text x="0" y="26" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Internet</text>
+  </g>
+
+  <!-- Connection from Internet to Gateway -->
+  <line x1="215" y1="185" x2="295" y2="265" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,4" class="hero-pulse"/>
+
+  <!-- Terraform export hint (bottom-right) -->
+  <g transform="translate(580, 340)">
+    <rect x="-40" y="-14" width="80" height="28" rx="6" fill="#f1f5f9" stroke="#e2e8f0" stroke-width="1"/>
+    <text x="0" y="0" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b" dominant-baseline="middle">{ } Terraform</text>
+  </g>
+
+  <!-- Export arrow -->
+  <path d="M520,310 C540,315 550,325 560,330" fill="none" stroke="#94a3b8" stroke-width="1.2" stroke-dasharray="3,3" class="hero-pulse-delayed"/>
+  <polygon points="560,326 564,334 556,332" fill="#94a3b8"/>
+</svg>

--- a/apps/web/src/widgets/landing-page/LandingPage.baseurl.test.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.baseurl.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Regression tests for non-root BASE_URL (GitHub Pages subpath deployment).
+ *
+ * When Vite builds with --base /cloudblocks/, import.meta.env.BASE_URL is
+ * inlined as "/cloudblocks/".  The hero illustration <img> must use that
+ * base so the browser fetches the correct path.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useArchitectureStore } from '../../entities/store/architectureStore';
+import { useUIStore } from '../../entities/store/uiStore';
+import { LandingPage } from './LandingPage';
+
+const listTemplatesMock = vi.fn();
+
+vi.mock('./LandingPage.css', () => ({}));
+vi.mock('../../features/templates/registry', () => ({
+  listTemplates: () => listTemplatesMock(),
+}));
+
+const SUBPATH_BASE = '/cloudblocks/';
+
+describe('LandingPage with non-root BASE_URL', () => {
+  beforeEach(() => {
+    vi.stubEnv('BASE_URL', SUBPATH_BASE);
+
+    listTemplatesMock.mockReturnValue([
+      { id: 't1', name: 'Template 1', description: 'Desc 1', tags: ['a'], model: {} },
+    ]);
+
+    useUIStore.setState({
+      activeProvider: 'azure',
+      goToBuilder: vi.fn(),
+    });
+
+    useArchitectureStore.setState({
+      loadFromTemplate: vi.fn(),
+      saveToStorage: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefixes hero illustration src with subpath base URL', () => {
+    render(<LandingPage />);
+
+    const illustration = screen.getByAltText(
+      'Isometric cloud architecture diagram showing container blocks, resource blocks, and connections',
+    );
+    expect(illustration).toHaveAttribute('src', '/cloudblocks/hero-illustration.svg');
+  });
+
+  it('does not produce double slashes in hero illustration src', () => {
+    render(<LandingPage />);
+
+    const illustration = screen.getByAltText(
+      'Isometric cloud architecture diagram showing container blocks, resource blocks, and connections',
+    );
+    const src = illustration.getAttribute('src') ?? '';
+    expect(src).not.toMatch(/\/\//);
+  });
+});

--- a/apps/web/src/widgets/landing-page/LandingPage.css
+++ b/apps/web/src/widgets/landing-page/LandingPage.css
@@ -210,7 +210,7 @@
 .landing-hero-hint {
   margin: 12px 0 0;
   font-size: 13px;
-  color: #94a3b8;
+  color: #64748b;
 }
 
 .landing-how-it-works {

--- a/apps/web/src/widgets/landing-page/LandingPage.css
+++ b/apps/web/src/widgets/landing-page/LandingPage.css
@@ -199,6 +199,19 @@
   padding: 6px 14px;
   font-weight: 500;
 }
+.landing-hero-illustration {
+  display: block;
+  margin: 32px auto 0;
+  max-width: 640px;
+  width: 100%;
+  height: auto;
+}
+
+.landing-hero-hint {
+  margin: 12px 0 0;
+  font-size: 13px;
+  color: #94a3b8;
+}
 
 .landing-how-it-works {
   padding: 48px 24px;
@@ -272,5 +285,9 @@
 
   .landing-how-steps {
     grid-template-columns: 1fr;
+  }
+
+  .landing-hero-illustration {
+    max-width: 100%;
   }
 }

--- a/apps/web/src/widgets/landing-page/LandingPage.test.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.test.tsx
@@ -79,4 +79,21 @@ describe('LandingPage', () => {
     expect(saveToStorage).toHaveBeenCalledOnce();
     expect(goToBuilder).toHaveBeenCalledOnce();
   });
+
+  it('renders hero illustration with alt text', () => {
+    render(<LandingPage />);
+
+    const illustration = screen.getByAltText(
+      'Isometric cloud architecture diagram showing container blocks, resource blocks, and connections',
+    );
+    expect(illustration).toBeInTheDocument();
+    expect(illustration.tagName.toLowerCase()).toBe('img');
+    expect(illustration).toHaveAttribute('src', '/hero-illustration.svg');
+  });
+
+  it('shows desktop hint text', () => {
+    render(<LandingPage />);
+
+    expect(screen.getByText('Best experienced on desktop')).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/widgets/landing-page/LandingPage.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.tsx
@@ -37,7 +37,7 @@ export function LandingPage() {
             the architecture pattern, and export Terraform starter code. No cloud account required.
           </p>
           <img
-            src="/hero-illustration.svg"
+            src={`${import.meta.env.BASE_URL}hero-illustration.svg`}
             alt="Isometric cloud architecture diagram showing container blocks, resource blocks, and connections"
             className="landing-hero-illustration"
             width="640"

--- a/apps/web/src/widgets/landing-page/LandingPage.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.tsx
@@ -36,6 +36,13 @@ export function LandingPage() {
             CloudBlocks is a visual cloud learning tool for beginners — pick a template, understand
             the architecture pattern, and export Terraform starter code. No cloud account required.
           </p>
+          <img
+            src="/hero-illustration.svg"
+            alt="Isometric cloud architecture diagram showing container blocks, resource blocks, and connections"
+            className="landing-hero-illustration"
+            width="640"
+            height="360"
+          />
           <div className="landing-hero-badges">
             <span className="landing-hero-badge">Guided templates</span>
             <span className="landing-hero-badge">Guided learning scenarios</span>
@@ -44,6 +51,7 @@ export function LandingPage() {
           <button type="button" className="landing-hero-cta" onClick={handleStartBuilding}>
             Get Started
           </button>
+          <p className="landing-hero-hint">Best experienced on desktop</p>
         </section>
 
         <section className="landing-how-it-works">


### PR DESCRIPTION
## Summary

- Add animated SVG hero illustration to the landing page showcasing an isometric cloud architecture scene
- The illustration uses the product's visual language: VNet container block, 3 resource blocks (Gateway, Compute, Database), connection lines, Internet actor, and Terraform export hint
- Include `prefers-reduced-motion` media query that stops all SVG animations for accessibility
- Add "Best experienced on desktop" hint below the CTA button

## Changes

### New Files
- `apps/web/public/hero-illustration.svg` — Self-contained animated SVG illustration (<15KB)

### Modified Files
- `apps/web/src/widgets/landing-page/LandingPage.tsx` — Add `<img>` hero illustration between subtitle and badges; add desktop hint
- `apps/web/src/widgets/landing-page/LandingPage.css` — Add `.landing-hero-illustration` and `.landing-hero-hint` styles with responsive rules
- `apps/web/src/widgets/landing-page/LandingPage.test.tsx` — Add 2 new tests for hero illustration alt text and desktop hint

## Verification
- All 3345 tests pass
- Bundle size: 727 KB (within 960 KB budget)
- Lint passes
- No LSP diagnostics errors

Fixes #1756