### PR TITLE
feat(web): rewrite multi-cloud messaging to Azure-first framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Most diagram tools produce static images. CloudBlocks produces a **live architec
 - ✅ **Validation engine** — Real-time rule checking for placement and connections
 - 📦 **8 resource categories** — Network, Delivery, Compute, Data, Messaging, Security, Identity, Operations
 - ⚡ **Terraform starter export** — Export your design to Terraform starter code for learning and prototyping
-- 🌐 **Multi-cloud preview** — Visual preview for Azure, AWS, and GCP
+- 🌐 **Azure-first templates** — Built on Azure with mapped preview for AWS and GCP (coverage varies by template)
 - 🎨 **Dual theme system** — Workshop (light, enterprise) and Blueprint (dark, creative)
 - ⚗️ **Bicep & Pulumi** _(Experimental)_ — Additional IaC export formats
 - 🔗 **GitHub integration** _(Backend required)_ — OAuth login, repo sync, PR creation

--- a/apps/web/src/widgets/landing-page/LandingPage.css
+++ b/apps/web/src/widgets/landing-page/LandingPage.css
@@ -123,6 +123,16 @@
   padding: 2px 8px;
 }
 
+.landing-template-provider-badge {
+  font-size: 11px;
+  font-weight: 600;
+  color: #1e40af;
+  background: #dbeafe;
+  border-radius: 4px;
+  padding: 2px 8px;
+  letter-spacing: 0.3px;
+}
+
 .landing-template-card-btn {
   width: 100%;
   border: 0;

--- a/apps/web/src/widgets/landing-page/LandingPage.test.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.test.tsx
@@ -96,4 +96,12 @@ describe('LandingPage', () => {
 
     expect(screen.getByText('Best experienced on desktop')).toBeInTheDocument();
   });
+
+  it('shows Azure-first badges in hero and template cards', () => {
+    render(<LandingPage />);
+
+    expect(screen.getByText('Azure-first templates')).toBeInTheDocument();
+    const providerBadges = screen.getAllByText('Azure');
+    expect(providerBadges.length).toBe(4);
+  });
 });

--- a/apps/web/src/widgets/landing-page/LandingPage.test.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.test.tsx
@@ -101,7 +101,8 @@ describe('LandingPage', () => {
     render(<LandingPage />);
 
     expect(screen.getByText('Azure-first templates')).toBeInTheDocument();
+    const templateCards = screen.getAllByText('Use This Template');
     const providerBadges = screen.getAllByText('Azure');
-    expect(providerBadges.length).toBe(4);
+    expect(providerBadges).toHaveLength(templateCards.length);
   });
 });

--- a/apps/web/src/widgets/landing-page/LandingPage.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.tsx
@@ -48,7 +48,7 @@ export function LandingPage() {
             <span className="landing-hero-badge">Azure-first templates</span>
             <span className="landing-hero-badge">Guided learning scenarios</span>
             <span className="landing-hero-badge">
-              Terraform export &middot; Azure &middot; AWS &middot; GCP
+              Terraform export &middot; Azure-native &middot; AWS &amp; GCP preview
             </span>
           </div>
           <button type="button" className="landing-hero-cta" onClick={handleStartBuilding}>

--- a/apps/web/src/widgets/landing-page/LandingPage.tsx
+++ b/apps/web/src/widgets/landing-page/LandingPage.tsx
@@ -33,8 +33,9 @@ export function LandingPage() {
             Start from guided templates. Learn by editing. Export Terraform starter code.
           </h1>
           <p className="landing-hero-subtitle">
-            CloudBlocks is a visual cloud learning tool for beginners — pick a template, understand
-            the architecture pattern, and export Terraform starter code. No cloud account required.
+            CloudBlocks is a visual cloud learning tool for beginners — start with Azure-first
+            templates, learn architecture patterns, and export Terraform starter code. No cloud
+            account required.
           </p>
           <img
             src={`${import.meta.env.BASE_URL}hero-illustration.svg`}
@@ -44,9 +45,11 @@ export function LandingPage() {
             height="360"
           />
           <div className="landing-hero-badges">
-            <span className="landing-hero-badge">Guided templates</span>
+            <span className="landing-hero-badge">Azure-first templates</span>
             <span className="landing-hero-badge">Guided learning scenarios</span>
-            <span className="landing-hero-badge">Terraform starter export</span>
+            <span className="landing-hero-badge">
+              Terraform export &middot; Azure &middot; AWS &middot; GCP
+            </span>
           </div>
           <button type="button" className="landing-hero-cta" onClick={handleStartBuilding}>
             Get Started
@@ -93,6 +96,7 @@ export function LandingPage() {
                   <h3 className="landing-template-card-name">{template.name}</h3>
                   <p className="landing-template-card-desc">{template.description}</p>
                   <div className="landing-template-card-tags">
+                    <span className="landing-template-provider-badge">Azure</span>
                     {template.tags.slice(0, 3).map((tag) => (
                       <span key={tag} className="landing-template-tag">
                         {tag}


### PR DESCRIPTION
## Summary

Rewrites the landing page messaging from generic "multi-cloud" framing to an Azure-first positioning that reflects the actual template coverage.

Fixes #1757

## Changes

- **Hero subtitle**: Updated to "Azure-first visual cloud learning tool for beginners"
- **Hero badges**: Changed to "Azure-first templates" and "Terraform export · Azure · AWS · GCP"
- **Template cards**: Added "Azure" provider badge to each template card
- **README.md**: Changed feature bullet from "Multi-cloud preview" to "Azure-first templates with mapped preview for AWS and GCP"
- **Tests**: Added assertion for Azure provider badges on template cards

## Verification

- All 3344 tests pass
- Build succeeds
- Lint clean