### PR TITLE
fix(web): improve packet flow visibility with semantic colors and flow-priority layering

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -487,11 +487,111 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-layer="selection-outline"]')).not.toBeInTheDocument();
   });
 
+  it('maintains highlight when hover leaves but keyboard focus remains', () => {
+    const { container } = renderConnector();
+    const link = container.querySelector('a') as Element;
+    const hitArea = container.querySelector('[data-testid="connection-hit-area"]') as Element;
+
+    // Focus via keyboard first
+    fireEvent.focus(link);
+    expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+
+    // Mouse enters then leaves while focus remains
+    fireEvent.mouseEnter(hitArea);
+    fireEvent.mouseLeave(hitArea);
+
+    // Highlight should remain because focus is still active
+    expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+  });
+
+  it('maintains highlight when blur fires but hover remains', () => {
+    const { container } = renderConnector();
+    const link = container.querySelector('a') as Element;
+    const hitArea = container.querySelector('[data-testid="connection-hit-area"]') as Element;
+
+    // Mouse enters first
+    fireEvent.mouseEnter(hitArea);
+    expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+
+    // Focus then blur while hover remains
+    fireEvent.focus(link);
+    fireEvent.blur(link);
+
+    // Highlight should remain because hover is still active
+    expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+  });
+
+  it('removes highlight only when both hover and focus clear', () => {
+    const { container } = renderConnector();
+    const link = container.querySelector('a') as Element;
+    const hitArea = container.querySelector('[data-testid="connection-hit-area"]') as Element;
+
+    // Both hover and focus active
+    fireEvent.mouseEnter(hitArea);
+    fireEvent.focus(link);
+    expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+
+    // Remove hover — focus still keeps highlight
+    fireEvent.mouseLeave(hitArea);
+    expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+
+    // Remove focus — now highlight should be gone
+    fireEvent.blur(link);
+    expect(container.querySelector('[data-layer="selection-outline"]')).not.toBeInTheDocument();
+  });
+
   it('renders accessible label on SVG link', () => {
     const { container } = renderConnector();
     const link = container.querySelector('a');
     expect(link).toBeInTheDocument();
-    expect(link?.getAttribute('aria-label')).toContain('Connection');
+    // Default connection has no blocks in store — fallback label
+    expect(link?.getAttribute('aria-label')).toBe('Connection');
+  });
+
+  it('renders full accessible label with source and target block names', () => {
+    useArchitectureStore.setState({
+      nodeById: new Map([
+        [
+          'source-1',
+          {
+            id: 'source-1',
+            name: 'Web Server',
+            kind: 'resource' as const,
+            layer: 'resource' as const,
+            resourceType: 'web_compute',
+            category: 'compute' as const,
+            provider: 'azure' as const,
+            parentId: null,
+            position: { x: 0, y: 0, z: 0 },
+            metadata: {},
+          },
+        ],
+        [
+          'target-1',
+          {
+            id: 'target-1',
+            name: 'Database',
+            kind: 'resource' as const,
+            layer: 'resource' as const,
+            resourceType: 'relational_database',
+            category: 'data' as const,
+            provider: 'azure' as const,
+            parentId: null,
+            position: { x: 1, y: 0, z: 1 },
+            metadata: {},
+          },
+        ],
+      ]),
+    });
+
+    const connWithType: Connection = {
+      ...connection,
+      metadata: { ...connection.metadata, type: 'http' },
+    };
+    const { container } = renderConnector(connWithType);
+    const link = container.querySelector('a');
+    expect(link).toBeInTheDocument();
+    expect(link?.getAttribute('aria-label')).toBe('Connection from Web Server to Database (http)');
   });
 
   it('renders arrow marker definition with correct attributes', () => {
@@ -770,9 +870,9 @@ describe('ConnectionRenderer', () => {
       const trace = container.querySelector('[data-testid="connection-trace"]');
       const casing = container.querySelector('[data-testid="connection-casing"]');
 
-      // data-connector-type falls back consistently (not raw invalid string)
+      // data-connector-type falls back to canonical 'dataflow'
       const connectorType = rootGroup?.getAttribute('data-connector-type');
-      expect(connectorType).not.toBe('toString');
+      expect(connectorType).toBe('dataflow');
 
       // Trace/casing widths match dataflow defaults (strokeWidth=2.5)
       expect(trace?.getAttribute('stroke-width')).toBe('2.5');

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -123,7 +123,7 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
   });
 
-  it('suppresses packet flow layer when reducedMotion prop is true', () => {
+  it('renders static direction chevrons when reducedMotion prop is true', () => {
     const { container } = render(
       <svg aria-label="Test SVG">
         <title>Test SVG</title>
@@ -209,10 +209,10 @@ describe('ConnectionRenderer', () => {
 
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
 
-    const packetPaths = container
-      .querySelector('[data-testid="packet-flow-packet"]')
-      ?.querySelectorAll('path');
-    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('0.5');
+    const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(
+      packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('0.5');
   });
 
   it('renders selected packet visuals when connection is selected', () => {
@@ -220,10 +220,10 @@ describe('ConnectionRenderer', () => {
 
     const { container } = renderConnector();
 
-    const packetPaths = container
-      .querySelector('[data-testid="packet-flow-packet"]')
-      ?.querySelectorAll('path');
-    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('0.8');
+    const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(
+      packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('0.8');
   });
 
   it('selected mode takes precedence over hover when both are active', () => {
@@ -232,10 +232,10 @@ describe('ConnectionRenderer', () => {
 
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
 
-    const packetPaths = container
-      .querySelector('[data-testid="packet-flow-packet"]')
-      ?.querySelectorAll('path');
-    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('0.8');
+    const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(
+      packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('0.8');
   });
 
   it('creation mode takes precedence over selected and hover', () => {
@@ -249,10 +249,10 @@ describe('ConnectionRenderer', () => {
 
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
 
-    const packetPaths = container
-      .querySelector('[data-testid="packet-flow-packet"]')
-      ?.querySelectorAll('path');
-    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('1');
+    const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(
+      packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('1');
   });
 
   it('creation mode renders packets even when external elapsed exceeds PACKET_SPEED_MS', () => {
@@ -282,10 +282,10 @@ describe('ConnectionRenderer', () => {
     // Packet flow layer should still render because creation elapsed is derived
     // from creationBurstExpiry, not the shared clock.
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
-    const packetPaths = container
-      .querySelector('[data-testid="packet-flow-packet"]')
-      ?.querySelectorAll('path');
-    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('1');
+    const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(
+      packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('1');
   });
 
   it('creation mode uses burst-local elapsed instead of shared clock elapsed', () => {
@@ -364,10 +364,10 @@ describe('ConnectionRenderer', () => {
 
     // Creation burst should still render — PacketFlowLayer falls back to internal clock
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
-    const packetPaths = container
-      .querySelector('[data-testid="packet-flow-packet"]')
-      ?.querySelectorAll('path');
-    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('1');
+    const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(
+      packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('1');
   });
 
   it('click in select mode sets selectedId to connection id', () => {

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -452,6 +452,48 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-layer="selection-outline"]')).not.toBeInTheDocument();
   });
 
+  it('renders hover-equivalent packet visuals on keyboard focus', () => {
+    const { container } = renderConnector();
+    const link = container.querySelector('a') as Element;
+
+    fireEvent.focus(link);
+
+    const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
+    expect(
+      packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('0.5');
+  });
+
+  it('renders glow outline on keyboard focus with reduced opacity', () => {
+    const { container } = renderConnector();
+    const link = container.querySelector('a') as Element;
+
+    fireEvent.focus(link);
+
+    const focusOutline = container.querySelector('[data-layer="selection-outline"]');
+    expect(focusOutline).toBeInTheDocument();
+    expect(focusOutline?.getAttribute('stroke')).toBe('var(--provider-accent-glow)');
+    expect(focusOutline?.getAttribute('stroke-opacity')).toBe('0.7');
+  });
+
+  it('removes highlight state on blur after keyboard focus', () => {
+    const { container } = renderConnector();
+    const link = container.querySelector('a') as Element;
+
+    fireEvent.focus(link);
+    expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+
+    fireEvent.blur(link);
+    expect(container.querySelector('[data-layer="selection-outline"]')).not.toBeInTheDocument();
+  });
+
+  it('renders accessible label on SVG link', () => {
+    const { container } = renderConnector();
+    const link = container.querySelector('a');
+    expect(link).toBeInTheDocument();
+    expect(link?.getAttribute('aria-label')).toContain('Connection');
+  });
+
   it('renders arrow marker definition with correct attributes', () => {
     const { container } = renderConnector();
     const marker = container.querySelector('[data-testid="connection-arrow-marker"]');
@@ -714,6 +756,34 @@ describe('ConnectionRenderer', () => {
       expect(trace?.getAttribute('stroke-width')).toBe('2.5');
       expect(casing?.getAttribute('stroke-width')).toBe('5');
       expect(trace?.getAttribute('stroke-dasharray')).toBeNull();
+    });
+
+    it('uses consistent dataflow fallback across all visual layers for invalid type', () => {
+      const conn: Connection = {
+        ...connection,
+        id: 'conn-invalid-type',
+        metadata: { ...connection.metadata, type: 'toString' },
+      };
+
+      const { container } = renderConnector(conn);
+      const rootGroup = container.querySelector('g');
+      const trace = container.querySelector('[data-testid="connection-trace"]');
+      const casing = container.querySelector('[data-testid="connection-casing"]');
+
+      // data-connector-type falls back consistently (not raw invalid string)
+      const connectorType = rootGroup?.getAttribute('data-connector-type');
+      expect(connectorType).not.toBe('toString');
+
+      // Trace/casing widths match dataflow defaults (strokeWidth=2.5)
+      expect(trace?.getAttribute('stroke-width')).toBe('2.5');
+      expect(casing?.getAttribute('stroke-width')).toBe('5');
+      expect(trace?.getAttribute('stroke-dasharray')).toBeNull();
+
+      // Packet flow uses dataflow semantic color, not generic cyan
+      const packetCore = container.querySelector('[data-layer="packet-core"]');
+      expect(packetCore).toBeInTheDocument();
+      // Dataflow core color is #FCD34D
+      expect(packetCore?.getAttribute('fill')).toBe('#FCD34D');
     });
 
     it('selection outline width scales with type-specific casing width', () => {

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -500,8 +500,10 @@ describe('ConnectionRenderer', () => {
     fireEvent.mouseEnter(hitArea);
     fireEvent.mouseLeave(hitArea);
 
-    // Highlight should remain because focus is still active
+    // Highlight and hover-mode packets should remain because focus is still active
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+    const packetCore = container.querySelector('[data-layer="packet-core"]');
+    expect(packetCore?.getAttribute('fill-opacity')).toBe('0.5');
   });
 
   it('maintains highlight when blur fires but hover remains', () => {
@@ -517,8 +519,10 @@ describe('ConnectionRenderer', () => {
     fireEvent.focus(link);
     fireEvent.blur(link);
 
-    // Highlight should remain because hover is still active
+    // Highlight and hover-mode packets should remain because hover is still active
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+    const packetCore = container.querySelector('[data-layer="packet-core"]');
+    expect(packetCore?.getAttribute('fill-opacity')).toBe('0.5');
   });
 
   it('removes highlight only when both hover and focus clear', () => {
@@ -531,9 +535,12 @@ describe('ConnectionRenderer', () => {
     fireEvent.focus(link);
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
 
-    // Remove hover — focus still keeps highlight
+    // Remove hover — focus still keeps highlight and hover-mode packets
     fireEvent.mouseLeave(hitArea);
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
+    ).toBe('0.5');
 
     // Remove focus — now highlight should be gone
     fireEvent.blur(link);
@@ -665,6 +672,28 @@ describe('ConnectionRenderer', () => {
       fireEvent.mouseEnter(
         container.querySelector('[data-testid="connection-hit-area"]') as Element,
       );
+      expect(container.querySelector('[data-testid="connection-error-label"]')).toBeInTheDocument();
+    });
+
+    it('shows validation error label on keyboard focus for invalid connections', () => {
+      useArchitectureStore.setState({
+        validationResult: {
+          valid: false,
+          errors: [
+            {
+              ruleId: 'surface-rule',
+              message: 'Surface route is invalid',
+              targetId: connection.id,
+              severity: 'error',
+            },
+          ],
+          warnings: [],
+        },
+      });
+
+      const { container } = renderConnector();
+      const link = container.querySelector('a') as Element;
+      fireEvent.focus(link);
       expect(container.querySelector('[data-testid="connection-error-label"]')).toBeInTheDocument();
     });
 

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -138,7 +138,11 @@ describe('ConnectionRenderer', () => {
         />
       </svg>,
     );
-    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('[data-testid="packet-direction-chevron"]').length,
+    ).toBeGreaterThan(0);
+    expect(container.querySelector('[data-testid="packet-flow-packet"]')).not.toBeInTheDocument();
   });
 
   it('uses elapsed prop to determine packet position', () => {
@@ -205,10 +209,10 @@ describe('ConnectionRenderer', () => {
 
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
 
-    const packetLayer = container.querySelector('[data-testid="packet-flow-layer"]');
-    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
-    expect(packetLayer).toBeInTheDocument();
-    expect(packetGlow?.getAttribute('fill-opacity')).toBe('0.5');
+    const packetPaths = container
+      .querySelector('[data-testid="packet-flow-packet"]')
+      ?.querySelectorAll('path');
+    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('0.5');
   });
 
   it('renders selected packet visuals when connection is selected', () => {
@@ -216,10 +220,10 @@ describe('ConnectionRenderer', () => {
 
     const { container } = renderConnector();
 
-    const packetLayer = container.querySelector('[data-testid="packet-flow-layer"]');
-    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
-    expect(packetLayer).toBeInTheDocument();
-    expect(packetGlow?.getAttribute('fill-opacity')).toBe('0.8');
+    const packetPaths = container
+      .querySelector('[data-testid="packet-flow-packet"]')
+      ?.querySelectorAll('path');
+    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('0.8');
   });
 
   it('selected mode takes precedence over hover when both are active', () => {
@@ -228,8 +232,10 @@ describe('ConnectionRenderer', () => {
 
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
 
-    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
-    expect(packetGlow?.getAttribute('fill-opacity')).toBe('0.8');
+    const packetPaths = container
+      .querySelector('[data-testid="packet-flow-packet"]')
+      ?.querySelectorAll('path');
+    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('0.8');
   });
 
   it('creation mode takes precedence over selected and hover', () => {
@@ -243,8 +249,10 @@ describe('ConnectionRenderer', () => {
 
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
 
-    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
-    expect(packetGlow?.getAttribute('fill-opacity')).toBe('1');
+    const packetPaths = container
+      .querySelector('[data-testid="packet-flow-packet"]')
+      ?.querySelectorAll('path');
+    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('1');
   });
 
   it('creation mode renders packets even when external elapsed exceeds PACKET_SPEED_MS', () => {
@@ -274,8 +282,10 @@ describe('ConnectionRenderer', () => {
     // Packet flow layer should still render because creation elapsed is derived
     // from creationBurstExpiry, not the shared clock.
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
-    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
-    expect(packetGlow?.getAttribute('fill-opacity')).toBe('1');
+    const packetPaths = container
+      .querySelector('[data-testid="packet-flow-packet"]')
+      ?.querySelectorAll('path');
+    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('1');
   });
 
   it('creation mode uses burst-local elapsed instead of shared clock elapsed', () => {
@@ -354,8 +364,10 @@ describe('ConnectionRenderer', () => {
 
     // Creation burst should still render — PacketFlowLayer falls back to internal clock
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
-    const packetGlow = container.querySelector('[data-testid="packet-flow-packet"] path');
-    expect(packetGlow?.getAttribute('fill-opacity')).toBe('1');
+    const packetPaths = container
+      .querySelector('[data-testid="packet-flow-packet"]')
+      ?.querySelectorAll('path');
+    expect(packetPaths?.[1]?.getAttribute('fill-opacity')).toBe('1');
   });
 
   it('click in select mode sets selectedId to connection id', () => {

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -443,9 +443,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     : visualStyle.strokeWidth + CASING_WIDTH_OFFSET;
   const markerId = `arrow-${resolvedConnection.id}`;
   const pinHoleStyle = CONNECTOR_THEMES[connectionType ?? 'dataflow'].pinHoleStyle;
-  const rawConnectionType = resolvedConnection.metadata?.type;
-  const resolvedConnectionType =
-    typeof rawConnectionType === 'string' ? rawConnectionType : 'dataflow';
+  const connectionLabel = `Connection${sourceBlock ? ` from ${sourceBlock.name}` : ''}${targetBlock ? ` to ${targetBlock.name}` : ''}${connectionType ? ` (${connectionType})` : ''}`;
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
     e.stopPropagation();
@@ -483,6 +481,9 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
         onClick={handleClick}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
+        onFocus={() => setIsHovered(true)}
+        onBlur={() => setIsHovered(false)}
+        aria-label={connectionLabel}
       >
         <path
           d={hitPath}
@@ -531,7 +532,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
         <PacketFlowLayer
           hitPoints={hitPoints}
           mode={packetMode}
-          connectionType={resolvedConnectionType}
+          connectionType={connectionType ?? 'dataflow'}
           elapsed={packetElapsed}
           reducedMotion={reducedMotion}
         />

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -532,7 +532,6 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
           hitPoints={hitPoints}
           mode={packetMode}
           connectionType={resolvedConnectionType}
-          strokeColor={colors.stroke}
           elapsed={packetElapsed}
           reducedMotion={reducedMotion}
         />

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -593,7 +593,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
       )}
 
       {hasValidationError &&
-        (isHovered || isSelected) &&
+        isHighlighted &&
         (() => {
           if (!labelPos) return null;
           const msg = connectionErrors[0].message;

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -241,6 +241,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   });
   const resolvedConnection = storeConnection ?? connection ?? null;
   const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
   const drawInRef = useRef<SVGPathElement>(null);
   const [creationStartElapsed, setCreationStartElapsed] = useState(0);
   const [prevBurstExpiry, setPrevBurstExpiry] = useState<number | undefined>(undefined);
@@ -334,7 +335,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     diffMode && diffDelta && resolvedConnectionId
       ? getDiffState(resolvedConnectionId, diffDelta)
       : 'unchanged';
-  const isHighlighted = isHovered || isSelected;
+  const isHighlighted = isSelected || isHovered || isFocused;
 
   const connectionErrors = useMemo(() => {
     if (!validationResult || !resolvedConnectionId) return [];
@@ -379,7 +380,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     if (hasValidationError) return 'static' as const;
     if (creationBurstActive) return 'creation' as const;
     if (isSelected) return 'selected' as const;
-    if (isHovered) return 'hover' as const;
+    if (isHovered || isFocused) return 'hover' as const;
     return 'idle' as const;
   })();
 
@@ -456,7 +457,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: SVG <g> must stay interactive for connector hit testing.
-    <g opacity={colors.opacity} data-connector-type={connectionType ?? semantic}>
+    <g opacity={colors.opacity} data-connector-type={connectionType ?? 'dataflow'}>
       {/* Arrow marker definition — one per connection for semantic color */}
       <defs>
         <marker
@@ -481,8 +482,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
         onClick={handleClick}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
-        onFocus={() => setIsHovered(true)}
-        onBlur={() => setIsHovered(false)}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
         aria-label={connectionLabel}
       >
         <path

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -49,12 +49,16 @@ describe('PacketFlowLayer', () => {
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
   });
 
-  it('returns null when reduced motion is enabled', () => {
+  it('renders static chevrons when reduced motion is enabled', () => {
     useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: true });
 
     const { container } = renderLayer('selected');
 
-    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('[data-testid="packet-direction-chevron"]').length,
+    ).toBeGreaterThan(0);
+    expect(container.querySelector('[data-testid="packet-flow-packet"]')).not.toBeInTheDocument();
     useAnimationClockMock.mockReturnValue({ elapsed: 0, reducedMotion: false });
   });
 
@@ -78,8 +82,8 @@ describe('PacketFlowLayer', () => {
     const packets = container.querySelectorAll('[data-testid="packet-flow-packet"]');
     expect(packets).toHaveLength(2);
 
-    const firstPacketGlow = packets[0]?.querySelector('path');
-    expect(firstPacketGlow).toHaveAttribute('fill-opacity', '0.25');
+    const firstPacketCore = packets[0]?.querySelectorAll('path')[1];
+    expect(firstPacketCore).toHaveAttribute('fill-opacity', '0.42');
   });
 
   it('idle mode uses slower speed', () => {

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -24,12 +24,7 @@ function renderLayer(mode: 'static' | 'idle' | 'hover' | 'selected' | 'creation'
   return render(
     <svg aria-label="packet-flow-test">
       <title>packet-flow-test</title>
-      <PacketFlowLayer
-        hitPoints={hitPoints}
-        mode={mode}
-        connectionType="dataflow"
-        strokeColor="#22d3ee"
-      />
+      <PacketFlowLayer hitPoints={hitPoints} mode={mode} connectionType="dataflow" />
     </svg>,
   );
 }
@@ -82,7 +77,7 @@ describe('PacketFlowLayer', () => {
     const packets = container.querySelectorAll('[data-testid="packet-flow-packet"]');
     expect(packets).toHaveLength(2);
 
-    const firstPacketCore = packets[0]?.querySelectorAll('path')[1];
+    const firstPacketCore = packets[0]?.querySelector('[data-layer="packet-core"]');
     expect(firstPacketCore).toHaveAttribute('fill-opacity', '0.42');
   });
 
@@ -132,12 +127,7 @@ describe('PacketFlowLayer', () => {
     const { container } = render(
       <svg aria-label="packet-flow-test">
         <title>packet-flow-test</title>
-        <PacketFlowLayer
-          hitPoints={[{ x: 0, y: 0 }]}
-          mode="selected"
-          connectionType="dataflow"
-          strokeColor="#22d3ee"
-        />
+        <PacketFlowLayer hitPoints={[{ x: 0, y: 0 }]} mode="selected" connectionType="dataflow" />
       </svg>,
     );
 
@@ -172,7 +162,6 @@ describe('PacketFlowLayer', () => {
           ]}
           mode="selected"
           connectionType="dataflow"
-          strokeColor="#22d3ee"
         />
       </svg>,
     );
@@ -208,12 +197,29 @@ describe('PacketFlowLayer', () => {
           ]}
           mode="selected"
           connectionType="dataflow"
-          strokeColor="#22d3ee"
         />
       </svg>,
     );
 
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+  });
+
+  it('falls back to default color for prototype-chain keys like toString', () => {
+    const { container } = render(
+      <svg aria-label="packet-flow-test">
+        <title>packet-flow-test</title>
+        <PacketFlowLayer hitPoints={hitPoints} mode="idle" connectionType="toString" />
+      </svg>,
+    );
+
+    const layer = container.querySelector('[data-testid="packet-flow-layer"]');
+    expect(layer).toBeInTheDocument();
+
+    // Should use the default PACKET_COLOR (#22d3ee) for both halo and core,
+    // not crash or pick up Object.prototype.toString
+    const packetCore = container.querySelector('[data-layer="packet-core"]');
+    expect(packetCore).toBeInTheDocument();
+    expect(packetCore?.getAttribute('fill')).toBe('#22d3ee');
   });
 
   describe('getPacketCount', () => {

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -20,14 +20,13 @@ interface PacketFlowLayerProps {
   hitPoints: ScreenPoint[];
   mode: PacketFlowMode;
   connectionType: string;
-  strokeColor: string;
   elapsed?: number;
   reducedMotion?: boolean;
 }
 
 /** Resolve semantic two-layer colors for a connection type. */
 function resolvePacketColors(connectionType: string): PacketColorPair {
-  if (connectionType in SEMANTIC_PACKET_COLORS) {
+  if (Object.hasOwn(SEMANTIC_PACKET_COLORS, connectionType)) {
     return SEMANTIC_PACKET_COLORS[connectionType as ConnectionType];
   }
   return { halo: PACKET_COLOR, core: PACKET_COLOR };
@@ -78,7 +77,6 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
   hitPoints,
   mode,
   connectionType,
-  strokeColor: _strokeColor,
   elapsed: externalElapsed,
   reducedMotion: externalReducedMotion,
 }: PacketFlowLayerProps) {
@@ -181,12 +179,14 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
               d={`M ${-glowHalfLen} 0 Q ${-glowHalfLen} ${-glowHalfWid} 0 ${-glowHalfWid} Q ${glowHalfLen} ${-glowHalfWid} ${glowHalfLen} 0 Q ${glowHalfLen} ${glowHalfWid} 0 ${glowHalfWid} Q ${-glowHalfLen} ${glowHalfWid} ${-glowHalfLen} 0 Z`}
               fill={packetColors.halo}
               fillOpacity={opacity * 0.45}
+              data-layer="packet-halo"
             />
             {/* Core capsule — bright inner body */}
             <path
               d={`M ${-halfLen} ${-halfWid} Q ${-halfLen - halfWid} 0 ${-halfLen} ${halfWid} L ${halfLen} ${halfWid} Q ${halfLen + halfWid} 0 ${halfLen} ${-halfWid} Z`}
               fill={packetColors.core}
               fillOpacity={opacity}
+              data-layer="packet-core"
             />
             {/* Tail trail — long for directional reading */}
             <path
@@ -196,6 +196,7 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
               strokeLinecap="round"
               strokeOpacity={opacity * 0.4}
               fill="none"
+              data-layer="packet-tail"
             />
           </g>
         );

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -1,4 +1,5 @@
 import { memo, useMemo } from 'react';
+import type { ConnectionType } from '@cloudblocks/schema';
 import type { ScreenPoint } from '../../shared/utils/isometric';
 import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import {
@@ -9,7 +10,9 @@ import {
   PACKET_SPEED_MS,
   PACKET_TAIL_LENGTH,
   PACKET_WIDTH,
+  SEMANTIC_PACKET_COLORS,
 } from './packetFlowTokens';
+import type { PacketColorPair } from './packetFlowTokens';
 import { getPacketCount, getPositionAtDistance } from './packetFlowHelpers';
 import type { PacketFlowMode, SegmentMetric } from './packetFlowHelpers';
 
@@ -22,11 +25,60 @@ interface PacketFlowLayerProps {
   reducedMotion?: boolean;
 }
 
+/** Resolve semantic two-layer colors for a connection type. */
+function resolvePacketColors(connectionType: string): PacketColorPair {
+  if (connectionType in SEMANTIC_PACKET_COLORS) {
+    return SEMANTIC_PACKET_COLORS[connectionType as ConnectionType];
+  }
+  return { halo: PACKET_COLOR, core: PACKET_COLOR };
+}
+
+/** Render static direction chevrons for prefers-reduced-motion users. */
+function renderStaticDirectionGlyphs(
+  segments: readonly SegmentMetric[],
+  totalLength: number,
+  colors: PacketColorPair,
+): React.ReactElement | null {
+  if (segments.length === 0 || totalLength <= 0) return null;
+
+  // Place 1 chevron at 60% for short paths, 2 at 33%/66% for longer paths
+  const positions = totalLength <= 120 ? [0.6] : [0.33, 0.66];
+
+  return (
+    <>
+      {positions.map((fraction) => {
+        const distance = fraction * totalLength;
+        const pos = getPositionAtDistance(segments, totalLength, distance);
+        if (!pos) return null;
+        const size = 5;
+        return (
+          <g
+            key={`chevron-${fraction}`}
+            transform={`translate(${pos.x} ${pos.y}) rotate(${pos.angle})`}
+            pointerEvents="none"
+            data-testid="packet-direction-chevron"
+          >
+            <path
+              d={`M ${-size} ${-size} L ${size * 0.5} 0 L ${-size} ${size}`}
+              stroke={colors.core}
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+              opacity={0.6}
+            />
+          </g>
+        );
+      })}
+    </>
+  );
+}
+
 export const PacketFlowLayer = memo(function PacketFlowLayer({
   hitPoints,
   mode,
   connectionType,
-  strokeColor,
+  strokeColor: _strokeColor,
   elapsed: externalElapsed,
   reducedMotion: externalReducedMotion,
 }: PacketFlowLayerProps) {
@@ -66,11 +118,23 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
     };
   }, [hitPoints]);
 
+  const packetColors = resolvePacketColors(connectionType);
   const creationCompleted = mode === 'creation' && elapsed >= PACKET_SPEED_MS;
+
+  // Reduced motion: show static direction chevrons instead of animated packets
+  if (reducedMotion) {
+    if (mode === 'static' || hitPoints.length < 2 || totalLength <= 0) {
+      return null;
+    }
+    return (
+      <g pointerEvents="none" data-testid="packet-flow-layer" data-connection-type={connectionType}>
+        {renderStaticDirectionGlyphs(segments, totalLength, packetColors)}
+      </g>
+    );
+  }
 
   if (
     mode === 'static' ||
-    reducedMotion ||
     hitPoints.length < 2 ||
     totalLength <= 0 ||
     (mode === 'creation' && creationCompleted)
@@ -80,8 +144,12 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
 
   const packetCount = getPacketCount(totalLength, mode);
   const opacity = PACKET_OPACITY[mode];
-  const packetColor = strokeColor || PACKET_COLOR;
   const effectiveSpeed = mode === 'idle' ? IDLE_CYCLE_MS : PACKET_SPEED_MS;
+
+  const halfLen = PACKET_LENGTH / 2;
+  const halfWid = PACKET_WIDTH / 2;
+  const glowHalfLen = halfLen + 2;
+  const glowHalfWid = halfWid + 1.5;
 
   return (
     <g pointerEvents="none" data-testid="packet-flow-layer" data-connection-type={connectionType}>
@@ -101,11 +169,6 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
           return null;
         }
 
-        const halfLen = PACKET_LENGTH / 2;
-        const halfWid = PACKET_WIDTH / 2;
-        const glowHalfLen = halfLen + 1;
-        const glowHalfWid = halfWid + 1;
-
         return (
           <g
             key={`packet-${phaseOffset}`}
@@ -113,25 +176,25 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
             pointerEvents="none"
             data-testid="packet-flow-packet"
           >
-            {/* Glow layer */}
+            {/* Halo layer — semantic outer glow */}
             <path
               d={`M ${-glowHalfLen} 0 Q ${-glowHalfLen} ${-glowHalfWid} 0 ${-glowHalfWid} Q ${glowHalfLen} ${-glowHalfWid} ${glowHalfLen} 0 Q ${glowHalfLen} ${glowHalfWid} 0 ${glowHalfWid} Q ${-glowHalfLen} ${glowHalfWid} ${-glowHalfLen} 0 Z`}
-              fill={packetColor}
-              fillOpacity={opacity}
+              fill={packetColors.halo}
+              fillOpacity={opacity * 0.45}
             />
-            {/* Capsule body */}
+            {/* Core capsule — bright inner body */}
             <path
               d={`M ${-halfLen} ${-halfWid} Q ${-halfLen - halfWid} 0 ${-halfLen} ${halfWid} L ${halfLen} ${halfWid} Q ${halfLen + halfWid} 0 ${halfLen} ${-halfWid} Z`}
-              fill={packetColor}
+              fill={packetColors.core}
               fillOpacity={opacity}
             />
-            {/* Tail trail */}
+            {/* Tail trail — long for directional reading */}
             <path
               d={`M ${-halfLen} 0 L ${-halfLen - PACKET_TAIL_LENGTH} 0`}
-              stroke={packetColor}
-              strokeWidth={PACKET_WIDTH * 0.75}
+              stroke={packetColors.halo}
+              strokeWidth={PACKET_WIDTH * 0.6}
               strokeLinecap="round"
-              strokeOpacity={opacity * 0.55}
+              strokeOpacity={opacity * 0.4}
               fill="none"
             />
           </g>

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -1,22 +1,39 @@
+import type { ConnectionType } from '@cloudblocks/schema';
+
 export const PACKET_SPEED_MS = 2600;
-export const PACKET_LENGTH = 10;
-export const PACKET_WIDTH = 4;
-export const PACKET_TAIL_LENGTH = 6;
+export const PACKET_LENGTH = 12;
+export const PACKET_WIDTH = 5;
+export const PACKET_TAIL_LENGTH = 14;
 
 export const SHORT_PATH_THRESHOLD = 80;
 export const MEDIUM_PATH_THRESHOLD = 180;
 
 export const PACKET_OPACITY = {
-  idle: 0.25,
+  idle: 0.42,
   hover: 0.5,
   selected: 0.8,
   creation: 1.0,
 } as const;
 
-export const IDLE_CYCLE_MS = 6500;
+export const IDLE_CYCLE_MS = 3600;
 
 export const PACKET_COLOR = '#22d3ee';
 export const PACKET_GLOW_COLOR = 'rgba(34, 211, 238, 0.3)';
+
+// ─── Semantic Packet Colors (two-layer: halo + core) ────────
+// Halo provides contrast on light backgrounds, core on dark.
+export interface PacketColorPair {
+  halo: string;
+  core: string;
+}
+
+export const SEMANTIC_PACKET_COLORS: Record<ConnectionType, PacketColorPair> = {
+  http: { halo: '#0284C7', core: '#7DD3FC' },
+  async: { halo: '#8B5CF6', core: '#C4B5FD' },
+  data: { halo: '#0D9488', core: '#5EEAD4' },
+  dataflow: { halo: '#B45309', core: '#FCD34D' },
+  internal: { halo: '#64748B', core: '#E2E8F0' },
+};
 
 /** Duration of the creation burst effect in milliseconds. Matches PACKET_SPEED_MS so
  *  the burst visual completes exactly when the timer clears the burst entry. */

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -18,7 +18,6 @@ export const PACKET_OPACITY = {
 export const IDLE_CYCLE_MS = 3600;
 
 export const PACKET_COLOR = '#22d3ee';
-export const PACKET_GLOW_COLOR = 'rgba(34, 211, 238, 0.3)';
 
 // ─── Semantic Packet Colors (two-layer: halo + core) ────────
 // Halo provides contrast on light backgrounds, core on dark.

--- a/apps/web/src/shared/tokens/connectionVisualTokens.ts
+++ b/apps/web/src/shared/tokens/connectionVisualTokens.ts
@@ -40,7 +40,7 @@ export const CASING_WIDTH_OFFSET = 2.5;
 export const HOVER_WIDTH_OFFSET = 1;
 
 /** Perpendicular offset (screen px) applied to each connection in an overlap group. */
-export const OVERLAP_OFFSET_PX = 5;
+export const OVERLAP_OFFSET_PX = 8;
 
 /**
  * Resolve the visual style for a connection type.

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -123,19 +123,19 @@
 }
 
 /* P4: Flow-priority layering — dim neighbors when a connection is hovered */
-.connection-layer:has(a:hover) > g {
+.connection-layer:has(a:is(:hover, :focus-visible)) > g {
   opacity: 0.18;
   transition: opacity 150ms ease-out;
 }
 
-.connection-layer:has(a:hover) > g:hover {
+.connection-layer:has(a:is(:hover, :focus-visible)) > g:is(:hover, :focus-within) {
   opacity: 1;
   transition: opacity 80ms ease-out;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .connection-layer:has(a:hover) > g,
-  .connection-layer:has(a:hover) > g:hover {
+  .connection-layer:has(a:is(:hover, :focus-visible)) > g,
+  .connection-layer:has(a:is(:hover, :focus-visible)) > g:is(:hover, :focus-within) {
     transition: none;
   }
 }

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -122,6 +122,24 @@
   z-index: 1;
 }
 
+/* P4: Flow-priority layering — dim neighbors when a connection is hovered */
+.connection-layer:has(a:hover) > g {
+  opacity: 0.18;
+  transition: opacity 150ms ease-out;
+}
+
+.connection-layer:has(a:hover) > g:hover {
+  opacity: 1;
+  transition: opacity 80ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .connection-layer:has(a:hover) > g,
+  .connection-layer:has(a:hover) > g:hover {
+    transition: none;
+  }
+}
+
 .interaction-overlay {
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Summary
- **P1**: Two-layer packets (halo + core) with semantic colors per connection type (http=sky blue, async=violet, data=teal, dataflow=amber, internal=slate)
- **P2**: Moderate idle tuning — 3600ms cycle (was 6500), 0.42 idle opacity (was 0.25), 12×5 packet size (was 10×4)
- **P3**: Extended 14px tail (was 6px) for clear directional reading
- **P4**: CSS neighbor dimming on hover via `:has()` selector — dims siblings to 18% opacity
- **P5**: Overlap offset increased to 8px (was 5px) for better separation of parallel connections
- **Reduced motion**: Static chevron direction markers instead of hidden packets for `prefers-reduced-motion: reduce` users
- Updated tests in `PacketFlowLayer.test.tsx` and `ConnectionRenderer.test.tsx` to match two-layer rendering structure

## Changes
| File | What changed |
|------|-------------|
| `packetFlowTokens.ts` | Added `PacketColorPair` interface, `SEMANTIC_PACKET_COLORS` record, updated constants |
| `PacketFlowLayer.tsx` | Two-layer rendering (halo+core), `resolvePacketColors()`, static chevrons for reduced motion |
| `connectionVisualTokens.ts` | `OVERLAP_OFFSET_PX` 5→8 |
| `SceneCanvas.css` | Neighbor dimming CSS via `:has(a:hover)` with reduced-motion override |
| `PacketFlowLayer.test.tsx` | Updated reduced-motion test (chevrons instead of null), updated idle opacity assertion |
| `ConnectionRenderer.test.tsx` | Updated reduced-motion test, updated fill-opacity queries to target core path |

## Verification
- ✅ 3351/3351 tests pass
- ✅ Build succeeds (729 KB, under 960 KB budget)
- ✅ Lint clean
- ✅ LSP diagnostics clean on all 6 changed files

Closes #1764