### PR TITLE
revert: undo v1.0.0-beta.1 release and add process guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,38 @@ zundo        — Zustand undo/redo middleware
   - When creating a new milestone, consult `docs/concept/ROADMAP.md` first — verify the milestone fits within the current dependency chain, does not duplicate existing scope, and has a clear placement in the evolution summary.
   - When all issues in a milestone are closed, update `docs/concept/ROADMAP.md`: mark exit criteria as checked (`[x]`), add a ✅ marker to the heading, update the Summary chain and Dependency Graph, and add or revise the Success Metrics entry.
 
+### Process Guardrails (INVIOLABLE)
+
+These rules exist to prevent recurring process failures (duplicate milestones, orphaned PRs, wrong version tags, batch releases). Every rule includes a verification step — compliance is not optional.
+
+#### Meta-Rule
+
+- **Preflight before mutating (MANDATORY)**: Before any state-changing GitHub operation — creating/renaming milestones, assigning PR milestones, bumping versions, creating tags, or publishing releases — MUST reconcile live GitHub state with current policy files (`AGENTS.md`, `CONTRIBUTING.md`, `docs/design/VERSION_POLICY.md`). If live state and policy conflict, STOP the operation and fix the documentation conflict first. Never proceed with ambiguity.
+
+#### Milestone Management
+
+- **Uniqueness check**: Before creating a milestone, MUST query `gh api 'repos/{owner}/{repo}/milestones?state=all&per_page=100'` and confirm no milestone with the same number exists. If it exists, MUST reuse or update — NEVER create a duplicate.
+- **Sequential numbering**: A new milestone number MUST be exactly `max(existing milestone numbers) + 1`. NEVER choose numbers for semantics, marketing, or round-number preference. Verify: the proposed number is one greater than the highest existing `Milestone N`.
+- **Title format**: Milestone titles MUST use the exact format `Milestone N — Name`. Verify: title matches the pattern `Milestone [0-9]+ — .+`.
+- **Universal milestone assignment**: Every issue and every PR MUST belong to a milestone — including dependency bumps, docs, maintenance, and CI changes. If no fitting open milestone exists, create or reuse the next sequential maintenance milestone before opening the issue/PR.
+
+#### PR/Issue Hygiene
+
+- **Issue milestone first**: Every issue MUST have a milestone assigned before branch creation. Verify: `gh issue view <number> --json milestone` returns non-null.
+- **PR inherits milestone**: Every PR MUST reference exactly one closing issue and MUST use the same milestone as that issue. Verify: compare `gh pr view <number> --json milestone` with `gh issue view <issue> --json milestone`.
+- **No exceptions**: Automation PRs, dependency bumps, docs PRs, and chore PRs are NOT exempt from milestone assignment. They go to the active maintenance milestone.
+
+#### Release Integrity
+
+- **One release = one milestone**: Each release MUST correspond to exactly one completed milestone. NEVER combine multiple milestone numbers or unreleased work into a single version bump, release commit, tag, or GitHub Release. Verify: all issues closed by the release PR belong to one milestone only.
+- **Version scheme is sacred**: Release versions MUST be `v0.N.0` (milestone releases) or `v0.N.P` (hotfixes). NEVER create `v1.x`, `-beta`, `-rc`, or any other version scheme without explicit user approval in the current conversation. Verify: version strings, tags, changelog headings, and release titles all match `v0.N.P`.
+- **Single bump at release time**: Version bump happens exactly once per milestone, at release time only. Verify: the release PR changes version files from the previous release to exactly one new `v0.N.0`.
+- **Run version check**: After updating version sources, MUST run `./scripts/check-versions.sh` and confirm exit code 0 before creating the release commit, tag, or GitHub Release.
+
+#### Anti-Precedent Rule
+
+- Historical commits, tags, releases, and previously accepted exceptions MUST NOT be treated as precedent when they conflict with current policy files. If a past batch release, non-standard tag, or skipped version exists in git history, that does NOT authorize repeating the pattern. Current `AGENTS.md`, `CONTRIBUTING.md`, and `docs/design/VERSION_POLICY.md` always win.
+
 ## Release Workflow
 
 When all issues in a milestone are closed, perform the following release steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,107 +2,9 @@
 
 All notable changes to CloudBlocks are documented in this file.
 
-This project uses [Semantic Versioning](https://semver.org/). Starting from v1.0.0-beta.1, the version follows standard semver. For the 0.x development history, each milestone mapped to a minor version (`v0.{milestone}.{patch}`).
+This project uses [Semantic Versioning](https://semver.org/). Version numbers follow the convention `v0.{milestone}.{patch}` — each milestone maps directly to a minor version.
 
 ---
-
-## [v1.0.0-beta.1] — 2026-04-13
-
-**First Public Beta — Visual Cloud Learning Tool for Beginners**
-
-This release marks the transition from `v0.x` development milestones to `v1.0.0-beta.1` — the first public beta of CloudBlocks as a visual cloud learning tool for beginners. It consolidates 55 commits and 10+ milestones of work since v0.35.0, covering visual hierarchy, accessibility, learning content, landing page, and connection animation.
-
-### Highlights
-
-- **Visual hierarchy enforcement** — Container blocks and resource blocks now follow a strict size hierarchy (VPC/VNet > Subnet > Resources), preventing overlap and ensuring correct nesting in all 6 built-in templates
-- **Connection packet flow animation** — Animated packets travel along connection lines with semantic colors per connection type, providing visual feedback on data flow direction
-- **Accessible by default** — Full keyboard navigation with ARIA semantics for MenuBar, focus-visible indicators on all interactive controls, wheel zoom guard to prevent scroll trapping
-- **Azure-first landing page** — Redesigned hero with animated SVG illustration, difficulty badges on template cards, social sharing metadata (OG image, Twitter card), and aligned CTA labels
-- **Beginner-appropriate learning content** — All 6 learning scenarios rewritten with plain-language explanations, progressive terminology introduction, and encouraging tone
-
-### Features
-
-- Animated SVG hero illustration on landing page (#1760)
-- Difficulty badge and estimated time on landing template cards (#1762)
-- Azure-first multi-cloud messaging on landing page (#1761)
-- Social sharing metadata — OG image, Twitter card, canonical URL (#1763)
-- Aligned first-screen CTA labels and destinations (#1754)
-- Keyboard navigation and ARIA semantics for MenuBar (#1752)
-- Connection packet flow animation with 5 typed visual styles (#1742)
-- Idle packet flow mode — always-on connection animation (#1744)
-- Validation error count badge on Validate button (#1722)
-- GitHub button demoted to icon-only with tooltip (#1721)
-- Unified validation message templates with learning-first tone (#1723)
-- Differentiated resource block sizes by category hierarchy (#1730)
-- Increased container heights and workspace bulk delete (#1677)
-- Block state system with disabled, error, health, and unconnected overlays (#1598)
-- Zoom-dependent information density (#1592, #1597)
-
-### Bug Fixes
-
-- Improved packet flow visibility with semantic colors and flow-priority layering (#1765)
-- Focus-visible indicators added to all interactive controls (#1753)
-- Import failure toast from empty-canvas drop handler (#1751)
-- Canvas wheel zoom no longer traps page scroll (#1750)
-- External actor blocks no longer disappear in saved workspaces (#1728)
-- Resource block overlap prevented during drag-and-drop (#1729)
-- Visual hierarchy enforced in all 6 built-in templates (#1734)
-- Page refresh now restores builder view when workspace data exists (#1735)
-- Template subnet layouts aligned with Azure/AWS/GCP best practices (#1676)
-- GitHub unlink, error parsing, and PR guard bugs resolved (#1656)
-- External block positions corrected to render outside VNet (#1644, #1668)
-- Template architecture accuracy corrected for AWS, Azure, and GCP (#1625)
-- Empty initial architectures, endpointId format, screenshot coverage (#1643)
-- External role badge hidden; GCP short labels fixed on block face (#1618)
-- Container block visual hierarchy improved (#1617)
-- External block Browser renamed to Client with descriptions (#1615)
-- Uniform rect silhouettes and external actor placement fixed (#1611)
-- Sync backend status on logout failure (#1712)
-- OAuth state parsing hardened against malformed payloads (#1711)
-- CodePreview panel mounted in app layout (#1694)
-- AI suggestion errors propagated instead of masked (#1693)
-
-### Performance
-
-- Canvas rendering optimized to avoid full-scene rerender on drag (#1695)
-- Indexed lookup maps added to canvas selectors (#1710)
-
-### Refactoring
-
-- Store boundaries consolidated to documented 3-store model (#1698)
-- uiStore dependency removed from architectureStore (#1708)
-- Panel visibility state deduplicated in uiStore (#1709)
-- AI API types moved to shared layer for FSD compliance (#1707)
-- FSD upward imports fixed — dependency direction restored (#1699)
-- Route orchestration moved into application use cases (#1696)
-- SceneCanvas included in coverage gate with testable logic extracted (#1697)
-
-### Learning Content
-
-- All 6 scenario scripts rewritten for beginner-appropriate language (#1736)
-
-### Infrastructure
-
-- Bundle size budget bumped 940→960 KB (#1743)
-- Schema versioning unified and VERSION_POLICY.md extended (#1612)
-- Documentation audit — split, consolidate, delete stale docs (#1613)
-- Screenshot capture script and 3 new learning scenarios (#1642)
-
-### Dependencies
-
-- `actions/checkout` bumped from 4 to 6 (#1678)
-- `dorny/paths-filter` bumped from 3 to 4 (#1679)
-- `typescript-eslint` bumped to 8.58.0 (#1680)
-- `@playwright/test` bumped to 1.59.1 (#1681)
-- `@types/node` bumped to 25.5.2 (#1684)
-- `eslint` bumped to 10.2.0 (#1682)
-
-### Statistics
-
-- 55 commits since v0.35.0
-- 3,362 tests passing
-- Coverage: 96.36% statements, 90.56% branches, 98.01% functions, 96.92% lines
-- 10+ milestones consolidated (M37–M50+)
 
 ---
 
@@ -1173,7 +1075,6 @@ Milestone 4 (Workspace Management):
 
 ---
 
-[v1.0.0-beta.1]: https://github.com/yeongseon/cloudblocks/compare/v0.35.0...v1.0.0-beta.1
 [v0.35.0]: https://github.com/yeongseon/cloudblocks/compare/v0.34.0...v0.35.0
 [v0.34.0]: https://github.com/yeongseon/cloudblocks/compare/v0.33.0...v0.34.0
 [v0.33.0]: https://github.com/yeongseon/cloudblocks/compare/v0.32.0...v0.33.0

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudblocks/web",
   "private": true,
-  "version": "1.0.0-beta.1",
+  "version": "0.35.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -65,18 +65,11 @@ CloudBlocks evolves through four stages — from visual cloud learning tool to e
 | M33       | Learning Content Validation                  | ✅ Done |
 | M34       | ExternalActor-to-Block Unification           | ✅ Done |
 | M35       | Visual Hierarchy & Presentation Consistency  | ✅ Done |
-| M37       | Beginner UX & Validation Tone                | ✅ Done |
-| M38       | Visual Hierarchy & Block Sizing               | ✅ Done |
-| M39       | Template Architecture Accuracy                | ✅ Done |
-| M40       | Connection Packet Flow Animation              | ✅ Done |
-| M50       | Landing Page & External Communication         | ✅ Done |
-| —         | Accessibility & Keyboard Navigation           | ✅ Done |
-| —         | Performance & Store Refactoring               | ✅ Done |
 
 ### Version Transition
 
 ```
-v0.35.0 → v1.0.0-beta.1 (current — first public beta) → v1.0.0 (baseline)
+v0.35.0 (current) → v1.0.0-beta.1 (first public release) → v1.0.0 (baseline)
 ```
 
 After v1.0.0, development continues with backward-compatible minor releases (v1.1.0, v1.2.0, ...).
@@ -125,11 +118,9 @@ After v1.0.0, development continues with backward-compatible minor releases (v1.
 
 | Metric                   | Value                                                                                                     |
 | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| Current version          | v1.0.0-beta.1                                                                                             |
 | 0.x milestones completed | 35 (M0–M35, all closed)                                                                                   |
-| Post-M35 work            | 10+ milestone batches (M37–M50+, accessibility, landing page, packet flow)                                 |
-| Tests passing            | 3,362                                                                                                     |
-| Branch coverage          | ≥ 90% (90.56% branches, 96.36% statements)                                                                |
+| Tests passing            | 2,783                                                                                                     |
+| Branch coverage          | ≥ 90%                                                                                                     |
 | Codebase                 | TypeScript (React 19) + Python (FastAPI) monorepo                                                         |
 | Architecture             | Block-based composition with `kind` + `traits` type system ([ADR-0013](../adr/0013-block-unification.md)) |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "1.0.0-beta.1",
+  "version": "0.35.0",
   "description": "Visual cloud learning tool for beginners — learn cloud architecture patterns with guided templates and export Terraform starter code",
   "type": "module",
   "repository": {

--- a/packages/cloudblocks-domain/package.json
+++ b/packages/cloudblocks-domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/domain",
-  "version": "1.0.0-beta.1",
+  "version": "0.35.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/schema",
-  "version": "1.0.0-beta.1",
+  "version": "0.35.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- **Revert** the incorrect v1.0.0-beta.1 release commit (PR #1766), restoring all package versions to 0.35.0
- **Add process guardrails** to AGENTS.md to prevent future milestone/release failures

## Why

The v1.0.0-beta.1 release violated the project's versioning convention (`v0.N.0` per milestone) and batch-released 8 milestones into a single version.

## What Changed

### Revert (commit 1)
- All package.json versions: 1.0.0-beta.1 → 0.35.0
- CHANGELOG.md: Remove incorrect v1.0.0-beta.1 section
- ROADMAP.md: Remove incorrect post-M35 entries

### Process Guardrails (commit 2)
- Milestone Management: Uniqueness check, sequential numbering, title format, universal assignment
- PR/Issue Hygiene: Issue milestone first, PR inherits milestone, no exceptions
- Release Integrity: One release per milestone, version scheme sacred, single bump
- Anti-Precedent Rule: Historical exceptions don't override current policy

## Next Steps

Sequential releases v0.36.0 through v0.43.0 will follow (one per milestone).