### PR TITLE
feat(web): packet flow UX improvements

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -940,6 +940,14 @@ describe('ConnectionRenderer', () => {
     it('uses white text for dark label backgrounds', () => {
       expect(contrastTextColor('#1E293B')).toBe('#ffffff');
     });
+
+    it('extracts fallback hex from CSS var() strings', () => {
+      expect(contrastTextColor('var(--connection-http-stroke, #667894)')).toBe('#ffffff');
+    });
+
+    it('returns white for unparseable values', () => {
+      expect(contrastTextColor('rgb(100, 120, 148)')).toBe('#ffffff');
+    });
   });
 
   describe('validation overlay', () => {

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -9,6 +9,7 @@ import { getConnectionSurfaceRoute } from './surfaceRouting';
 import type { SurfaceRoute } from './surfaceRouting';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
+import { contrastTextColor } from './contrastTextColor';
 
 vi.mock('./surfaceRouting', () => ({
   getConnectionSurfaceRoute: vi.fn(),
@@ -928,6 +929,16 @@ describe('ConnectionRenderer', () => {
       expect(selectionOutline).toBeInTheDocument();
       // http: selected=highlighted, casing = 4+2.5+1 = 7.5, selection = 7.5+4 = 11.5
       expect(selectionOutline?.getAttribute('stroke-width')).toBe('11.5');
+    });
+  });
+
+  describe('connection type label contrast text color', () => {
+    it('uses dark text for light label backgrounds', () => {
+      expect(contrastTextColor('#FCD34D')).toBe('#1e293b');
+    });
+
+    it('uses white text for dark label backgrounds', () => {
+      expect(contrastTextColor('#1E293B')).toBe('#ffffff');
     });
   });
 

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -36,6 +36,7 @@ import { getConnectionColorsForType } from './connectionFaceColors';
 import type { ConnectionRenderSemantic } from './connectionFaceColors';
 import { offsetScreenPoints } from './overlapOffset';
 import { PacketFlowLayer } from './PacketFlowLayer';
+import { contrastTextColor } from './contrastTextColor';
 
 interface ConnectionRendererProps {
   connectionId?: string;
@@ -458,7 +459,11 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: SVG <g> must stay interactive for connector hit testing.
-    <g opacity={colors.opacity} data-connector-type={connectionType ?? 'dataflow'}>
+    <g
+      opacity={colors.opacity}
+      data-connector-type={connectionType ?? 'dataflow'}
+      data-selected={isSelected ? 'true' : undefined}
+    >
       {/* Arrow marker definition — one per connection for semantic color */}
       <defs>
         <marker
@@ -656,7 +661,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
                 y={labelPos.y - rectHeight / 2 - 4 + 1}
                 textAnchor="middle"
                 dominantBaseline="central"
-                fill="#ffffff"
+                fill={contrastTextColor(colors.stroke)}
                 fontSize={10}
                 fontFamily="var(--font-ui, system-ui)"
                 style={{ pointerEvents: 'none' }}

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -270,6 +270,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   );
   const setSelectedId = useUIStore((s) => s.setSelectedId);
   const toolMode = useUIStore((s) => s.toolMode);
+  const canvasZoom = useUIStore((s) => s.canvasZoom);
   const diffMode = useUIStore((s) => s.diffMode);
   const diffDelta = useUIStore((s) => s.diffDelta);
   const creationBurstExpiry = useUIStore((state) =>
@@ -536,6 +537,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
           connectionType={connectionType ?? 'dataflow'}
           elapsed={packetElapsed}
           reducedMotion={reducedMotion}
+          canvasZoom={canvasZoom}
         />
       )}
 
@@ -580,6 +582,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
 
       {hasValidationError && (
         <path
+          className="connection-error-pulse"
           d={hitPath}
           stroke="var(--accent-error, #ef4444)"
           strokeWidth={3}
@@ -624,6 +627,41 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
                 style={{ pointerEvents: 'none' }}
               >
                 {msg.length > 35 ? msg.slice(0, 32) + '\u2026' : msg}
+              </text>
+            </g>
+          );
+        })()}
+
+      {isHighlighted &&
+        !hasValidationError &&
+        labelPos &&
+        (() => {
+          const typeLabel = connectionType ?? 'dataflow';
+          const rectWidth = typeLabel.length * 6.5 + 12;
+          const rectHeight = 18;
+
+          return (
+            <g data-testid="connection-type-label" pointerEvents="none">
+              <rect
+                x={labelPos.x - rectWidth / 2}
+                y={labelPos.y - rectHeight - 4}
+                width={rectWidth}
+                height={rectHeight}
+                rx={8}
+                fill={colors.stroke}
+                fillOpacity={0.85}
+              />
+              <text
+                x={labelPos.x}
+                y={labelPos.y - rectHeight / 2 - 4 + 1}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fill="#ffffff"
+                fontSize={10}
+                fontFamily="var(--font-ui, system-ui)"
+                style={{ pointerEvents: 'none' }}
+              >
+                {typeLabel}
               </text>
             </g>
           );

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -5,9 +5,11 @@ import { getPacketCount, getPositionAtDistance } from './packetFlowHelpers';
 import {
   IDLE_CYCLE_MS,
   MEDIUM_PATH_THRESHOLD,
+  PACKET_SELECTED_SCALE,
   PACKET_SPEED_MS,
   SHORT_PATH_THRESHOLD,
 } from './packetFlowTokens';
+import type { ScreenPoint } from '../../shared/utils/isometric';
 
 const useAnimationClockMock = vi.fn(() => ({ elapsed: 0, reducedMotion: false }));
 
@@ -16,6 +18,11 @@ vi.mock('../../shared/hooks/useAnimationClock', () => ({
 }));
 
 const hitPoints = [
+  { x: 0, y: 0 },
+  { x: 200, y: 0 },
+];
+
+const straightLine: ScreenPoint[] = [
   { x: 0, y: 0 },
   { x: 200, y: 0 },
 ];
@@ -38,6 +45,103 @@ function extractTranslateX(transform: string): number {
 }
 
 describe('PacketFlowLayer', () => {
+  describe('packet flow oracle findings coverage', () => {
+    it('renders packet-flow-layer with data-connection-type in active mode', () => {
+      const { container } = render(
+        <svg aria-label="packet-flow-test">
+          <title>packet-flow-test</title>
+          <PacketFlowLayer hitPoints={straightLine} mode="idle" connectionType="http" />
+        </svg>,
+      );
+
+      const layer = container.querySelector('[data-testid="packet-flow-layer"]');
+      expect(layer).toBeInTheDocument();
+      expect(layer?.getAttribute('data-connection-type')).toBe('http');
+    });
+
+    it('scales static chevron count by path length in reduced motion mode', () => {
+      const shortPath: ScreenPoint[] = [
+        { x: 0, y: 0 },
+        { x: 120, y: 0 },
+      ];
+      const longPath: ScreenPoint[] = [
+        { x: 0, y: 0 },
+        { x: 400, y: 0 },
+      ];
+
+      const shortRender = render(
+        <svg aria-label="packet-flow-test">
+          <title>packet-flow-test</title>
+          <PacketFlowLayer
+            hitPoints={shortPath}
+            mode="selected"
+            connectionType="dataflow"
+            reducedMotion={true}
+          />
+        </svg>,
+      );
+      const shortCount = shortRender.container.querySelectorAll(
+        '[data-testid="packet-direction-chevron"]',
+      ).length;
+      shortRender.unmount();
+
+      const longRender = render(
+        <svg aria-label="packet-flow-test">
+          <title>packet-flow-test</title>
+          <PacketFlowLayer
+            hitPoints={longPath}
+            mode="selected"
+            connectionType="dataflow"
+            reducedMotion={true}
+          />
+        </svg>,
+      );
+      const longCount = longRender.container.querySelectorAll(
+        '[data-testid="packet-direction-chevron"]',
+      ).length;
+
+      expect(shortCount).toBe(1);
+      expect(longCount).toBeGreaterThan(shortCount);
+    });
+
+    it('applies inverse zoom compensation scale when canvasZoom is below 1', () => {
+      const { container } = render(
+        <svg aria-label="packet-flow-test">
+          <title>packet-flow-test</title>
+          <PacketFlowLayer
+            hitPoints={straightLine}
+            mode="hover"
+            connectionType="dataflow"
+            elapsed={100}
+            canvasZoom={0.5}
+          />
+        </svg>,
+      );
+
+      const packet = container.querySelector('[data-testid="packet-flow-packet"]');
+      expect(packet).toBeInTheDocument();
+      expect(packet?.getAttribute('transform')).toContain('scale(2)');
+    });
+
+    it('applies PACKET_SELECTED_SCALE when mode is selected', () => {
+      const { container } = render(
+        <svg aria-label="packet-flow-test">
+          <title>packet-flow-test</title>
+          <PacketFlowLayer
+            hitPoints={straightLine}
+            mode="selected"
+            connectionType="dataflow"
+            elapsed={100}
+          />
+        </svg>,
+      );
+
+      const packet = container.querySelector('[data-testid="packet-flow-packet"]');
+      expect(packet).toBeInTheDocument();
+      expect(packet?.getAttribute('transform')).toContain(`scale(${PACKET_SELECTED_SCALE})`);
+    });
+  });
+
   it('returns null in static mode', () => {
     const { container } = renderLayer('static');
 

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -7,6 +7,7 @@ import {
   PACKET_COLOR,
   PACKET_LENGTH,
   PACKET_OPACITY,
+  PACKET_SELECTED_SCALE,
   PACKET_SPEED_MS,
   PACKET_TAIL_LENGTH,
   PACKET_WIDTH,
@@ -22,6 +23,7 @@ interface PacketFlowLayerProps {
   connectionType: string;
   elapsed?: number;
   reducedMotion?: boolean;
+  canvasZoom?: number;
 }
 
 /** Resolve semantic two-layer colors for a connection type. */
@@ -79,6 +81,7 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
   connectionType,
   elapsed: externalElapsed,
   reducedMotion: externalReducedMotion,
+  canvasZoom,
 }: PacketFlowLayerProps) {
   const fallbackClock = useAnimationClock(
     externalElapsed === undefined && mode !== 'static' && hitPoints.length > 1,
@@ -148,9 +151,15 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
   const halfWid = PACKET_WIDTH / 2;
   const glowHalfLen = halfLen + 2;
   const glowHalfWid = halfWid + 1.5;
+  const selectedScale = mode === 'selected' ? PACKET_SELECTED_SCALE : 1;
+  const zoomCompensationScale =
+    canvasZoom !== undefined && canvasZoom < 1 ? 1 / Math.max(canvasZoom, 0.1) : 1;
+  const packetScale = selectedScale * zoomCompensationScale;
 
   return (
     <g pointerEvents="none" data-testid="packet-flow-layer" data-connection-type={connectionType}>
+      {(mode === 'selected' || mode === 'hover') &&
+        renderStaticDirectionGlyphs(segments, totalLength, packetColors)}
       {Array.from({ length: packetCount }, (_, index) => {
         const phaseOffset = (index / packetCount) * effectiveSpeed;
         const rawProgress = (elapsed + phaseOffset) / effectiveSpeed;
@@ -170,7 +179,7 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
         return (
           <g
             key={`packet-${phaseOffset}`}
-            transform={`translate(${position.x} ${position.y}) rotate(${position.angle})`}
+            transform={`translate(${position.x} ${position.y}) rotate(${position.angle})${packetScale !== 1 ? ` scale(${packetScale})` : ''}`}
             pointerEvents="none"
             data-testid="packet-flow-packet"
           >

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -42,8 +42,9 @@ function renderStaticDirectionGlyphs(
 ): React.ReactElement | null {
   if (segments.length === 0 || totalLength <= 0) return null;
 
-  // Place 1 chevron at 60% for short paths, 2 at 33%/66% for longer paths
-  const positions = totalLength <= 120 ? [0.6] : [0.33, 0.66];
+  const CHEVRON_SPACING = 80;
+  const count = Math.max(1, Math.floor(totalLength / CHEVRON_SPACING));
+  const positions = Array.from({ length: count }, (_, i) => (i + 1) / (count + 1));
 
   return (
     <>

--- a/apps/web/src/entities/connection/contrastTextColor.ts
+++ b/apps/web/src/entities/connection/contrastTextColor.ts
@@ -1,5 +1,13 @@
-export function contrastTextColor(hexColor: string): string {
-  const hex = hexColor.replace('#', '');
+/**
+ * Return '#1e293b' (dark) or '#ffffff' (white) depending on the background
+ * luminance. Accepts raw hex ('#667894') or CSS var strings
+ * ('var(--token, #667894)') — the fallback hex is extracted automatically.
+ */
+export function contrastTextColor(cssOrHex: string): string {
+  // Extract the fallback hex from a CSS var() if present
+  const hexMatch = cssOrHex.match(/#[0-9A-Fa-f]{6}/);
+  if (!hexMatch) return '#ffffff'; // default to white for unparseable values
+  const hex = hexMatch[0].replace('#', '');
   const r = parseInt(hex.substring(0, 2), 16) / 255;
   const g = parseInt(hex.substring(2, 4), 16) / 255;
   const b = parseInt(hex.substring(4, 6), 16) / 255;

--- a/apps/web/src/entities/connection/contrastTextColor.ts
+++ b/apps/web/src/entities/connection/contrastTextColor.ts
@@ -1,0 +1,8 @@
+export function contrastTextColor(hexColor: string): string {
+  const hex = hexColor.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luminance > 0.5 ? '#1e293b' : '#ffffff';
+}

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -16,6 +16,7 @@ export const PACKET_OPACITY = {
 } as const;
 
 export const IDLE_CYCLE_MS = 3600;
+export const PACKET_SELECTED_SCALE = 1.35;
 
 export const PACKET_COLOR = '#22d3ee';
 

--- a/apps/web/src/entities/store/uiStore.ts
+++ b/apps/web/src/entities/store/uiStore.ts
@@ -283,6 +283,9 @@ interface UIState {
   /** Zoom level reported by SceneCanvas, used for auto label density */
   canvasZoom: number;
   setCanvasZoom: (zoom: number) => void;
+  flowFocusMode: boolean;
+  toggleFlowFocusMode: () => void;
+  setFlowFocusMode: (on: boolean) => void;
   fitToContentRequested: boolean;
   requestFitToContent: () => void;
   clearFitToContentRequest: () => void;
@@ -843,6 +846,9 @@ export const useUIStore = create<UIState>((set, get) => {
           labelMode: effectiveLabelMode,
         };
       }),
+    flowFocusMode: false,
+    toggleFlowFocusMode: () => set((s) => ({ flowFocusMode: !s.flowFocusMode })),
+    setFlowFocusMode: (on) => set({ flowFocusMode: on }),
     fitToContentRequested: false,
     requestFitToContent: () => set({ fitToContentRequested: true }),
     clearFitToContentRequest: () => set({ fitToContentRequested: false }),

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -33,6 +33,7 @@ import {
   PanelLeft,
   BookMarked,
   Search,
+  Focus,
   Volume2,
   VolumeX,
   Moon,
@@ -416,6 +417,8 @@ export function MenuBar() {
   const toggleGitHubPR = useUIStore((s) => s.toggleGitHubPR);
   const setBackendStatus = useUIStore((s) => s.setBackendStatus);
   const diffMode = useUIStore((s) => s.diffMode);
+  const flowFocusMode = useUIStore((s) => s.flowFocusMode);
+  const toggleFlowFocusMode = useUIStore((s) => s.toggleFlowFocusMode);
   const drawer = useUIStore((s) => s.drawer);
   const isLearningOpen = drawer.isOpen && drawer.activePanel === 'learning';
   const activeScenario = useArchitectureStore((s) => s.activeScenario);
@@ -948,6 +951,18 @@ export function MenuBar() {
             <span className="menu-item-left">
               {diffMode ? <span aria-hidden="true">✓ </span> : ''}
               <GitCompare size={14} /> Diff View
+            </span>
+          </button>
+          <button
+            type="button"
+            className="menu-item"
+            role="menuitemcheckbox"
+            aria-checked={flowFocusMode}
+            onClick={() => handleAction(toggleFlowFocusMode)}
+          >
+            <span className="menu-item-left">
+              {flowFocusMode ? <span aria-hidden="true">✓ </span> : '  '}
+              <Focus size={14} /> Flow Focus
             </span>
           </button>
 

--- a/apps/web/src/widgets/scene-canvas/ConnectionAnimationLayer.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionAnimationLayer.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import type { Connection } from '@cloudblocks/schema';
 import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import { ConnectionRenderer } from '../../entities/connection/ConnectionRenderer';
+import { useUIStore } from '../../entities/store/uiStore';
 
 interface ConnectionAnimationLayerProps {
   connections: readonly Connection[];
@@ -18,9 +19,13 @@ export const ConnectionAnimationLayer = memo(function ConnectionAnimationLayer({
 }: ConnectionAnimationLayerProps) {
   const hasAnyActiveConnection = connections.length > 0;
   const { elapsed, reducedMotion } = useAnimationClock(hasAnyActiveConnection);
+  const flowFocusMode = useUIStore((s) => s.flowFocusMode);
 
   return (
-    <svg className="connection-layer" style={{ width: 1, height: 1 }}>
+    <svg
+      className={`connection-layer${flowFocusMode ? ' flow-focus-active' : ''}`}
+      style={{ width: 1, height: 1 }}
+    >
       <title>Connections</title>
       {connections.map((conn) => (
         <ConnectionRenderer

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -127,7 +127,7 @@
   transition: opacity 150ms ease-out;
 }
 
-.flow-focus-active > g:is(:hover, :focus-within) {
+.flow-focus-active > g:is(:hover, :focus-within, [data-selected='true']) {
   opacity: 1;
   transition: opacity 80ms ease-out;
 }
@@ -145,7 +145,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .flow-focus-active > g,
-  .flow-focus-active > g:is(:hover, :focus-within),
+  .flow-focus-active > g:is(:hover, :focus-within, [data-selected='true']),
   .connection-layer:has(a:is(:hover, :focus-visible)) > g,
   .connection-layer:has(a:is(:hover, :focus-visible)) > g:is(:hover, :focus-within) {
     transition: none;

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -122,6 +122,16 @@
   z-index: 1;
 }
 
+.flow-focus-active > g {
+  opacity: 0.18;
+  transition: opacity 150ms ease-out;
+}
+
+.flow-focus-active > g:is(:hover, :focus-within) {
+  opacity: 1;
+  transition: opacity 80ms ease-out;
+}
+
 /* P4: Flow-priority layering — dim neighbors when a connection is hovered */
 .connection-layer:has(a:is(:hover, :focus-visible)) > g {
   opacity: 0.18;
@@ -134,6 +144,8 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .flow-focus-active > g,
+  .flow-focus-active > g:is(:hover, :focus-within),
   .connection-layer:has(a:is(:hover, :focus-visible)) > g,
   .connection-layer:has(a:is(:hover, :focus-visible)) > g:is(:hover, :focus-within) {
     transition: none;
@@ -173,6 +185,22 @@
   }
 }
 
+@keyframes connection-error-pulse {
+  0%,
+  100% {
+    stroke-opacity: 1;
+    stroke-width: 3;
+  }
+  50% {
+    stroke-opacity: 0.5;
+    stroke-width: 4;
+  }
+}
+
+.connection-error-pulse {
+  animation: connection-error-pulse 1.2s ease-in-out infinite;
+}
+
 /* ── Accessibility ──────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   @keyframes connector-draw-in {
@@ -190,6 +218,10 @@
     to {
       stroke-opacity: 0;
     }
+  }
+
+  .connection-error-pulse {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## Summary

- **Screen-space minimum packet size**: Packets maintain minimum visual size when zooming out via inverse scale compensation (`canvasZoom` passed from `useUIStore`)
- **Larger selected-state packets**: Selected connections render packets at 1.35x scale (`PACKET_SELECTED_SCALE`)
- **Chevrons on hover/selected**: Static direction chevrons render alongside animated packets for hover and selected connections
- **Connection type pill label**: Highlighted connections show a type pill label (e.g., "http", "dataflow") at the midpoint
- **Error pulse animation**: Validation error paths pulse with CSS animation (`connection-error-pulse` keyframes), respects `prefers-reduced-motion`
- **Flow Focus mode**: New `flowFocusMode` state in `uiStore` dims all connections except hovered/focused when active, with CSS dimming class on connection layer

Fixes #1773

## Files Changed

- `apps/web/src/entities/connection/PacketFlowLayer.tsx` — zoom compensation, selected scale, chevrons on hover/selected
- `apps/web/src/entities/connection/packetFlowTokens.ts` — added `PACKET_SELECTED_SCALE`
- `apps/web/src/entities/connection/ConnectionRenderer.tsx` — pass `canvasZoom`, type label pill, error pulse class
- `apps/web/src/entities/store/uiStore.ts` — `flowFocusMode` state + actions
- `apps/web/src/widgets/scene-canvas/ConnectionAnimationLayer.tsx` — apply `flow-focus-active` class
- `apps/web/src/widgets/scene-canvas/SceneCanvas.css` — flow focus dimming CSS, error pulse keyframes, reduced-motion overrides

## Validation

- `pnpm build` ✅ (730 KB, within 960 KB budget)
- `pnpm lint` ✅
- `lsp_diagnostics` clean on all changed files
- No `as any`, `@ts-ignore`, or `@ts-expect-error`
- `prefers-reduced-motion` respected for all new animations