### PR TITLE
chore: release v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 ---
 
+## [v0.44.0] — 2026-04-13
+
+**Milestone 44 — Maintenance & Polish**
+
+Documentation quality pass (version refs, provider claims, nav cleanup, onboarding screenshots) and packet flow UX improvements (screen-space sizing, chevron direction indicators, type pill labels, error pulse animation, WCAG contrast text, and Flow Focus mode).
+
+### Features
+
+- Add screen-space packet sizing with zoom compensation (#1773)
+- Add chevron direction indicators scaled to path length (#1773)
+- Add connection type pill labels on hover (#1773)
+- Add error pulse animation for invalid connections (#1773)
+- Add Flow Focus mode toggle in View menu (#1773)
+- Add WCAG-compliant contrast text color for connection labels (#1773)
+
+### Documentation
+
+- Update stale version references across all docs (#1767, #1768)
+- Harmonize provider support claims with backend-required boundaries (#1767)
+- Clean up MkDocs nav to separate archived and planned docs (#1769)
+- Improve beginner onboarding with screenshots, desktop notice, and role separation (#1770)
+
+### Statistics
+
+- 2 PRs merged
+
 ## [v0.43.0] — 2026-04-13
 
 **Milestone 43 — Landing Page Credibility & Sharing**

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -89,7 +89,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 app = FastAPI(
     title="CloudBlocks API",
     description="Thin orchestration backend for CloudBlocks Platform",
-    version="0.43.0",
+    version="0.44.0",
     lifespan=lifespan,
 )
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloudblocks-api"
-version = "0.43.0"
+version = "0.44.0"
 description = "CloudBlocks API — optional backend for auth, GitHub sync, and learning tool integrations"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudblocks/web",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -73,11 +73,12 @@ CloudBlocks evolves through four stages — from visual cloud learning tool to e
 | M41       | Template Visual Hierarchy                    | ✅ Done |
 | M42       | Connection Packet Flow Animation             | ✅ Done |
 | M43       | Landing Page Credibility & Sharing           | ✅ Done |
+| M44       | Maintenance & Polish                         | ✅ Done |
 
 ### Version Transition
 
 ```
-v0.{milestone}.0 per milestone (current: v0.43.0)
+v0.{milestone}.0 per milestone (current: v0.44.0)
 ```
 
 Version numbers follow `v0.N.0` where N is the milestone number. This convention continues through V1 development. See `docs/design/VERSION_POLICY.md` for details.
@@ -126,8 +127,8 @@ Version numbers follow `v0.N.0` where N is the milestone number. This convention
 
 | Metric                   | Value                                                                                                     |
 | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| 0.x milestones completed | 43 (M0–M43, all closed)                                                                                   |
-| Tests passing            | 3,362                                                                                                     |
+| 0.x milestones completed | 44 (M0–M44, all closed)                                                                                   |
+| Tests passing            | 3,368+                                                                                                     |
 | Branch coverage          | ≥ 90%                                                                                                     |
 | Codebase                 | TypeScript (React 19) + Python (FastAPI) monorepo                                                         |
 | Architecture             | Block-based composition with `kind` + `traits` type system ([ADR-0013](../adr/0013-block-unification.md)) |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Visual cloud learning tool for beginners — learn cloud architecture patterns with guided templates and export Terraform starter code",
   "type": "module",
   "repository": {

--- a/packages/cloudblocks-domain/package.json
+++ b/packages/cloudblocks-domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/domain",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/schema",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Version bump 0.43.0 → 0.44.0 across all 6 package files
- Add CHANGELOG section for v0.44.0 (Milestone 44 — Maintenance & Polish)
- Update ROADMAP.md with M44 completion

## Milestone 44 Changes

### Features
- Screen-space packet sizing with zoom compensation (#1773)
- Chevron direction indicators scaled to path length (#1773)
- Connection type pill labels on hover (#1773)
- Error pulse animation for invalid connections (#1773)
- Flow Focus mode toggle in View menu (#1773)
- WCAG-compliant contrast text color for connection labels (#1773)

### Documentation
- Update stale version references across all docs (#1767, #1768)
- Harmonize provider support claims with backend-required boundaries (#1767)
- Clean up MkDocs nav to separate archived and planned docs (#1769)
- Improve beginner onboarding with screenshots, desktop notice, and role separation (#1770)

Closes #1767 Closes #1768 Closes #1769 Closes #1770 Closes #1773