### PR TITLE
feat(web): tune packet visibility, container heights, and connection stacking

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -1,5 +1,6 @@
+import { StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render } from '@testing-library/react';
 import { endpointId } from '@cloudblocks/schema';
 import type { Connection, ConnectionType } from '@cloudblocks/schema';
 import type { DiffDelta } from '../../shared/types/diff';
@@ -213,7 +214,7 @@ describe('ConnectionRenderer', () => {
     const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
     expect(
       packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
-    ).toBe('0.5');
+    ).toBe('0.72');
   });
 
   it('renders selected packet visuals when connection is selected', () => {
@@ -224,7 +225,7 @@ describe('ConnectionRenderer', () => {
     const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
     expect(
       packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
-    ).toBe('0.8');
+    ).toBe('0.95');
   });
 
   it('selected mode takes precedence over hover when both are active', () => {
@@ -236,7 +237,7 @@ describe('ConnectionRenderer', () => {
     const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
     expect(
       packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
-    ).toBe('0.8');
+    ).toBe('0.95');
   });
 
   it('creation mode takes precedence over selected and hover', () => {
@@ -462,7 +463,7 @@ describe('ConnectionRenderer', () => {
     const packetEl = container.querySelector('[data-testid="packet-flow-packet"]');
     expect(
       packetEl?.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
-    ).toBe('0.5');
+    ).toBe('0.72');
   });
 
   it('renders glow outline on keyboard focus with reduced opacity', () => {
@@ -504,7 +505,7 @@ describe('ConnectionRenderer', () => {
     // Highlight and hover-mode packets should remain because focus is still active
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
     const packetCore = container.querySelector('[data-layer="packet-core"]');
-    expect(packetCore?.getAttribute('fill-opacity')).toBe('0.5');
+    expect(packetCore?.getAttribute('fill-opacity')).toBe('0.72');
   });
 
   it('maintains highlight when blur fires but hover remains', () => {
@@ -523,7 +524,7 @@ describe('ConnectionRenderer', () => {
     // Highlight and hover-mode packets should remain because hover is still active
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
     const packetCore = container.querySelector('[data-layer="packet-core"]');
-    expect(packetCore?.getAttribute('fill-opacity')).toBe('0.5');
+    expect(packetCore?.getAttribute('fill-opacity')).toBe('0.72');
   });
 
   it('removes highlight only when both hover and focus clear', () => {
@@ -541,7 +542,7 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
     expect(
       container.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
-    ).toBe('0.5');
+    ).toBe('0.72');
 
     // Remove focus — now highlight should be gone
     fireEvent.blur(link);
@@ -622,17 +623,15 @@ describe('ConnectionRenderer', () => {
     expect(trace?.getAttribute('marker-end')).toBe(`url(#arrow-${connection.id})`);
   });
 
-  it('hover increases casing and trace widths by +1 (dataflow default)', () => {
+  it('hover increases casing and trace widths by +1.25 (dataflow default)', () => {
     const { container } = renderConnector();
     const casing = container.querySelector('[data-testid="connection-casing"]');
     const trace = container.querySelector('[data-testid="connection-trace"]');
-    // Default state: dataflow strokeWidth=2.5, casing=2.5+2.5=5, trace=2.5
-    expect(casing?.getAttribute('stroke-width')).toBe('5');
-    expect(trace?.getAttribute('stroke-width')).toBe('2.5');
-    // Hover: casing=2.5+2.5+1=6, trace=2.5+1=3.5
+    expect(casing?.getAttribute('stroke-width')).toBe('5.5');
+    expect(trace?.getAttribute('stroke-width')).toBe('3');
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
-    expect(casing?.getAttribute('stroke-width')).toBe('6');
-    expect(trace?.getAttribute('stroke-width')).toBe('3.5');
+    expect(casing?.getAttribute('stroke-width')).toBe('6.75');
+    expect(trace?.getAttribute('stroke-width')).toBe('4.25');
   });
 
   describe('surface render path', () => {
@@ -786,11 +785,11 @@ describe('ConnectionRenderer', () => {
       baseWidth: number;
       dash?: string;
     }> = [
-      { type: 'dataflow', baseWidth: 2.5 },
-      { type: 'http', baseWidth: 4 },
-      { type: 'internal', baseWidth: 3 },
-      { type: 'data', baseWidth: 2, dash: '6 3' },
-      { type: 'async', baseWidth: 2.25, dash: '2 3' },
+      { type: 'dataflow', baseWidth: 3 },
+      { type: 'http', baseWidth: 4.5 },
+      { type: 'internal', baseWidth: 3.5 },
+      { type: 'data', baseWidth: 2.5, dash: '6 3' },
+      { type: 'async', baseWidth: 2.75, dash: '2 3' },
     ];
 
     for (const spec of typedSpecs) {
@@ -834,9 +833,8 @@ describe('ConnectionRenderer', () => {
         const trace = container.querySelector('[data-testid="connection-trace"]');
         const casing = container.querySelector('[data-testid="connection-casing"]');
 
-        // Hover: trace = base + 1, casing = base + 2.5 + 1
-        expect(trace?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 1));
-        expect(casing?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 3.5));
+        expect(trace?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 1.25));
+        expect(casing?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 3.75));
       });
     }
 
@@ -851,9 +849,8 @@ describe('ConnectionRenderer', () => {
       const trace = container.querySelector('[data-testid="connection-trace"]');
       const casing = container.querySelector('[data-testid="connection-casing"]');
 
-      // dataflow defaults: trace=2.5, casing=5
-      expect(trace?.getAttribute('stroke-width')).toBe('2.5');
-      expect(casing?.getAttribute('stroke-width')).toBe('5');
+      expect(trace?.getAttribute('stroke-width')).toBe('3');
+      expect(casing?.getAttribute('stroke-width')).toBe('5.5');
       expect(trace?.getAttribute('stroke-dasharray')).toBeNull();
       expect(casing?.getAttribute('stroke-dasharray')).toBeNull();
     });
@@ -867,7 +864,7 @@ describe('ConnectionRenderer', () => {
       const { container } = renderConnector(conn);
       const trace = container.querySelector('[data-testid="connection-trace"]');
 
-      expect(trace?.getAttribute('stroke-width')).toBe('2.5');
+      expect(trace?.getAttribute('stroke-width')).toBe('3');
       expect(trace?.getAttribute('stroke-dasharray')).toBeNull();
     });
 
@@ -882,9 +879,8 @@ describe('ConnectionRenderer', () => {
       const trace = container.querySelector('[data-testid="connection-trace"]');
       const casing = container.querySelector('[data-testid="connection-casing"]');
 
-      // Should fall back to dataflow (strokeWidth=2.5, casing=5), not crash
-      expect(trace?.getAttribute('stroke-width')).toBe('2.5');
-      expect(casing?.getAttribute('stroke-width')).toBe('5');
+      expect(trace?.getAttribute('stroke-width')).toBe('3');
+      expect(casing?.getAttribute('stroke-width')).toBe('5.5');
       expect(trace?.getAttribute('stroke-dasharray')).toBeNull();
     });
 
@@ -904,9 +900,8 @@ describe('ConnectionRenderer', () => {
       const connectorType = rootGroup?.getAttribute('data-connector-type');
       expect(connectorType).toBe('dataflow');
 
-      // Trace/casing widths match dataflow defaults (strokeWidth=2.5)
-      expect(trace?.getAttribute('stroke-width')).toBe('2.5');
-      expect(casing?.getAttribute('stroke-width')).toBe('5');
+      expect(trace?.getAttribute('stroke-width')).toBe('3');
+      expect(casing?.getAttribute('stroke-width')).toBe('5.5');
       expect(trace?.getAttribute('stroke-dasharray')).toBeNull();
 
       // Packet flow uses dataflow semantic color, not generic cyan
@@ -927,8 +922,207 @@ describe('ConnectionRenderer', () => {
       const { container } = renderConnector(conn);
       const selectionOutline = container.querySelector('[data-layer="selection-outline"]');
       expect(selectionOutline).toBeInTheDocument();
-      // http: selected=highlighted, casing = 4+2.5+1 = 7.5, selection = 7.5+4 = 11.5
-      expect(selectionOutline?.getAttribute('stroke-width')).toBe('11.5');
+      expect(selectionOutline?.getAttribute('stroke-width')).toBe('12.25');
+    });
+  });
+
+  describe('overlay modes', () => {
+    it('visual-only mode renders visuals without hit area wrapper', () => {
+      const { container } = render(
+        <svg aria-label="Test SVG">
+          <title>Test SVG</title>
+          <ConnectionRenderer
+            connection={connection}
+            blocks={[]}
+            plates={[]}
+            originX={100}
+            originY={200}
+            overlayMode="visual-only"
+          />
+        </svg>,
+      );
+
+      expect(
+        container.querySelector('[data-testid="connection-hit-area"]'),
+      ).not.toBeInTheDocument();
+      expect(container.querySelector('a')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-testid="connection-trace"]')).toBeInTheDocument();
+    });
+
+    it('hit-only mode renders hit area without visual layers', () => {
+      const { container } = render(
+        <svg aria-label="Test SVG">
+          <title>Test SVG</title>
+          <ConnectionRenderer
+            connection={connection}
+            blocks={[]}
+            plates={[]}
+            originX={100}
+            originY={200}
+            overlayMode="hit-only"
+          />
+        </svg>,
+      );
+
+      expect(container.querySelector('[data-testid="connection-hit-area"]')).toBeInTheDocument();
+      expect(container.querySelector('[data-testid="connection-casing"]')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-testid="connection-trace"]')).not.toBeInTheDocument();
+      expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+    });
+
+    it('does not replay draw-in or snap-flash after deselection (overlayMode transition)', async () => {
+      // Step 1: Mount in normal mode (real lifecycle).
+      // The draw-in effect fires and schedules a microtask to mark entrance complete.
+      let renderResult: ReturnType<typeof render>;
+      await act(async () => {
+        renderResult = render(
+          <svg aria-label="Test SVG">
+            <title>Test SVG</title>
+            <ConnectionRenderer
+              connection={connection}
+              blocks={[]}
+              plates={[]}
+              originX={100}
+              originY={200}
+              elapsed={0}
+              reducedMotion={false}
+              overlayMode="normal"
+            />
+          </svg>,
+        );
+        // Flush microtasks so entranceComplete state update is processed
+        await Promise.resolve();
+      });
+      const { container, rerender } = renderResult!;
+
+      // After the first render + microtask flush, entranceComplete should be true.
+      // The snap-flash should no longer be in the DOM.
+      expect(
+        container.querySelector('[data-testid="connection-snap-flash"]'),
+      ).not.toBeInTheDocument();
+
+      // Step 2: Transition to hit-only (simulating selection)
+      rerender(
+        <svg aria-label="Test SVG">
+          <title>Test SVG</title>
+          <ConnectionRenderer
+            connection={connection}
+            blocks={[]}
+            plates={[]}
+            originX={100}
+            originY={200}
+            elapsed={0}
+            reducedMotion={false}
+            overlayMode="hit-only"
+          />
+        </svg>,
+      );
+
+      // Step 3: Transition back to normal (simulating deselection)
+      rerender(
+        <svg aria-label="Test SVG">
+          <title>Test SVG</title>
+          <ConnectionRenderer
+            connection={connection}
+            blocks={[]}
+            plates={[]}
+            originX={100}
+            originY={200}
+            elapsed={0}
+            reducedMotion={false}
+            overlayMode="normal"
+          />
+        </svg>,
+      );
+
+      // After deselection, draw-in should NOT replay because hasDrawnInRef gates it
+      const drawInEl = container.querySelector('[data-testid="connection-trace"]');
+      if (drawInEl) {
+        expect(drawInEl.getAttribute('style') ?? '').not.toContain('connector-draw-in');
+      }
+      // Snap flash should NOT re-appear because entranceComplete state is true
+      expect(
+        container.querySelector('[data-testid="connection-snap-flash"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('handles StrictMode double-mount without leaving entranceComplete stuck false', async () => {
+      // StrictMode mounts -> unmounts -> remounts effects.
+      // The first microtask is cancelled during cleanup; the second must succeed.
+      let renderResult: ReturnType<typeof render>;
+      await act(async () => {
+        renderResult = render(
+          <StrictMode>
+            <svg aria-label="Test SVG">
+              <title>Test SVG</title>
+              <ConnectionRenderer
+                connection={connection}
+                blocks={[]}
+                plates={[]}
+                originX={100}
+                originY={200}
+                elapsed={0}
+                reducedMotion={false}
+                overlayMode="normal"
+              />
+            </svg>
+          </StrictMode>,
+        );
+        await Promise.resolve();
+      });
+      const { container, rerender } = renderResult!;
+
+      // entranceComplete should be true after StrictMode double-mount
+      expect(
+        container.querySelector('[data-testid="connection-snap-flash"]'),
+      ).not.toBeInTheDocument();
+
+      // Transition to hit-only then back to normal (deselection cycle)
+      rerender(
+        <StrictMode>
+          <svg aria-label="Test SVG">
+            <title>Test SVG</title>
+            <ConnectionRenderer
+              connection={connection}
+              blocks={[]}
+              plates={[]}
+              originX={100}
+              originY={200}
+              elapsed={0}
+              reducedMotion={false}
+              overlayMode="hit-only"
+            />
+          </svg>
+        </StrictMode>,
+      );
+
+      rerender(
+        <StrictMode>
+          <svg aria-label="Test SVG">
+            <title>Test SVG</title>
+            <ConnectionRenderer
+              connection={connection}
+              blocks={[]}
+              plates={[]}
+              originX={100}
+              originY={200}
+              elapsed={0}
+              reducedMotion={false}
+              overlayMode="normal"
+            />
+          </svg>
+        </StrictMode>,
+      );
+
+      // No snap-flash replay after StrictMode deselection cycle
+      expect(
+        container.querySelector('[data-testid="connection-snap-flash"]'),
+      ).not.toBeInTheDocument();
+      // No draw-in replay
+      const traceEl = container.querySelector('[data-testid="connection-trace"]');
+      if (traceEl) {
+        expect(traceEl.getAttribute('style') ?? '').not.toContain('connector-draw-in');
+      }
     });
   });
 

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -48,6 +48,7 @@ interface ConnectionRendererProps {
   overlapOffset?: number;
   elapsed?: number;
   reducedMotion?: boolean;
+  overlayMode?: 'normal' | 'visual-only' | 'hit-only';
 }
 
 /** Resolved colors for the 2-layer trace rendering. */
@@ -234,6 +235,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   overlapOffset = 0,
   elapsed,
   reducedMotion,
+  overlayMode = 'normal',
 }: ConnectionRendererProps) {
   const resolvedConnectionId = connectionId ?? connection?.id ?? null;
   const storeConnection = useArchitectureStore((state) => {
@@ -244,12 +246,31 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const drawInRef = useRef<SVGPathElement>(null);
+  const hasDrawnInRef = useRef(false);
+  const [entranceComplete, setEntranceComplete] = useState(false);
   const [creationStartElapsed, setCreationStartElapsed] = useState(0);
   const [prevBurstExpiry, setPrevBurstExpiry] = useState<number | undefined>(undefined);
 
   useEffect(() => {
+    if (overlayMode === 'visual-only') return;
+    // Schedule entranceComplete on every non-visual-only mount so that
+    // StrictMode's unmount/remount cycle still flips the flag even though
+    // the first microtask gets cancelled during cleanup.
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) setEntranceComplete(true);
+    });
+    // Gate the draw-in animation itself: play only once per component lifetime.
+    if (hasDrawnInRef.current)
+      return () => {
+        cancelled = true;
+      };
+    hasDrawnInRef.current = true;
     const el = drawInRef.current;
-    if (!el || typeof el.getTotalLength !== 'function') return;
+    if (!el || typeof el.getTotalLength !== 'function')
+      return () => {
+        cancelled = true;
+      };
     const len = el.getTotalLength();
     el.style.strokeDasharray = String(len);
     el.style.strokeDashoffset = String(len);
@@ -263,8 +284,11 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
       el.style.opacity = '';
     };
     el.addEventListener('animationend', handleEnd, { once: true });
-    return () => el.removeEventListener('animationend', handleEnd);
-  }, []);
+    return () => {
+      cancelled = true;
+      el.removeEventListener('animationend', handleEnd);
+    };
+  }, [overlayMode]);
 
   const isSelected = useUIStore((s) =>
     resolvedConnectionId ? s.selectedIds.has(resolvedConnectionId) : false,
@@ -456,6 +480,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     }
     setSelectedId(resolvedConnection.id);
   };
+  const shouldRenderHitArea = overlayMode !== 'visual-only';
+  const shouldRenderVisuals = overlayMode !== 'hit-only';
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: SVG <g> must stay interactive for connector hit testing.
@@ -464,213 +490,222 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
       data-connector-type={connectionType ?? 'dataflow'}
       data-selected={isSelected ? 'true' : undefined}
     >
-      {/* Arrow marker definition — one per connection for semantic color */}
-      <defs>
-        <marker
-          id={markerId}
-          markerWidth={ARROW_MARKER_W}
-          markerHeight={ARROW_MARKER_H}
-          refX={ARROW_MARKER_REF_X}
-          refY={ARROW_MARKER_H / 2}
-          orient="auto"
-          markerUnits="strokeWidth"
-          data-testid="connection-arrow-marker"
+      {shouldRenderVisuals && (
+        <defs>
+          <marker
+            id={markerId}
+            markerWidth={ARROW_MARKER_W}
+            markerHeight={ARROW_MARKER_H}
+            refX={ARROW_MARKER_REF_X}
+            refY={ARROW_MARKER_H / 2}
+            orient="auto"
+            markerUnits="strokeWidth"
+            data-testid="connection-arrow-marker"
+          >
+            <path
+              d={`M0,0 L${ARROW_MARKER_W},${ARROW_MARKER_H / 2} L0,${ARROW_MARKER_H} Z`}
+              fill={colors.stroke}
+              fillOpacity={isHighlighted ? 1.0 : 0.95}
+            />
+          </marker>
+        </defs>
+      )}
+      {shouldRenderHitArea && (
+        <a
+          href={`/connections/${resolvedConnection.id}`}
+          onClick={handleClick}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          aria-label={connectionLabel}
         >
           <path
-            d={`M0,0 L${ARROW_MARKER_W},${ARROW_MARKER_H / 2} L0,${ARROW_MARKER_H} Z`}
-            fill={colors.stroke}
-            fillOpacity={isHighlighted ? 1.0 : 0.95}
+            d={hitPath}
+            stroke="transparent"
+            strokeWidth={HIT_AREA_WIDTH}
+            fill="none"
+            pointerEvents="stroke"
+            style={{ cursor: 'pointer' }}
+            data-testid="connection-hit-area"
           />
-        </marker>
-      </defs>
-      <a
-        href={`/connections/${resolvedConnection.id}`}
-        onClick={handleClick}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
-        aria-label={connectionLabel}
-      >
-        <path
-          d={hitPath}
-          stroke="transparent"
-          strokeWidth={HIT_AREA_WIDTH}
-          fill="none"
-          pointerEvents="stroke"
-          style={{ cursor: 'pointer' }}
-          data-testid="connection-hit-area"
-        />
-      </a>
-
-      {/* Layer 1: Outer casing path */}
-      <path
-        d={hitPath}
-        stroke={colors.casing}
-        strokeWidth={casingWidth}
-        strokeOpacity={isHighlighted ? 0.9 : 0.82}
-        strokeDasharray={visualStyle.strokeDasharray}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-        pointerEvents="none"
-        data-testid="connection-casing"
-        data-layer="casing"
-      />
-
-      {/* Layer 2: Inner trace path (with draw-in animation) */}
-      <path
-        ref={drawInRef}
-        d={hitPath}
-        stroke={colors.stroke}
-        strokeWidth={innerWidth}
-        strokeOpacity={isHighlighted ? 1.0 : 0.98}
-        strokeDasharray={visualStyle.strokeDasharray}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-        pointerEvents="none"
-        data-testid="connection-trace"
-        data-layer="trace"
-        markerEnd={`url(#${markerId})`}
-      />
-
-      {packetMode !== 'static' && (
-        <PacketFlowLayer
-          hitPoints={hitPoints}
-          mode={packetMode}
-          connectionType={connectionType ?? 'dataflow'}
-          elapsed={packetElapsed}
-          reducedMotion={reducedMotion}
-          canvasZoom={canvasZoom}
-        />
+        </a>
       )}
 
-      {/* Provider-accent glow: hover = subtle, selection = stronger */}
-      {isHighlighted && (
-        <path
-          d={hitPath}
-          stroke="var(--provider-accent-glow)"
-          strokeWidth={isSelected ? casingWidth + 4 : casingWidth + 2}
-          strokeOpacity={isSelected ? 1 : 0.7}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          fill="none"
-          pointerEvents="none"
-          data-layer="selection-outline"
-        />
-      )}
+      {shouldRenderVisuals && (
+        <>
+          {/* Layer 1: Outer casing path */}
+          <path
+            d={hitPath}
+            stroke={colors.casing}
+            strokeWidth={casingWidth}
+            strokeOpacity={isHighlighted ? 0.9 : 0.82}
+            strokeDasharray={visualStyle.strokeDasharray}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+            pointerEvents="none"
+            data-testid="connection-casing"
+            data-layer="casing"
+          />
 
-      {/* Snap flash animation overlay */}
-      <path
-        d={hitPath}
-        stroke={colors.stroke}
-        strokeWidth={TRACE_FLASH_PX}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
-        pointerEvents="none"
-        style={{
-          animation:
-            'connector-snap-flash 300ms var(--easing-default, cubic-bezier(0.2, 0, 0, 1)) forwards',
-        }}
-        data-testid="connection-snap-flash"
-      />
+          {/* Layer 2: Inner trace path (with draw-in animation) */}
+          <path
+            ref={drawInRef}
+            d={hitPath}
+            stroke={colors.stroke}
+            strokeWidth={innerWidth}
+            strokeOpacity={isHighlighted ? 1.0 : 0.98}
+            strokeDasharray={visualStyle.strokeDasharray}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+            pointerEvents="none"
+            data-testid="connection-trace"
+            data-layer="trace"
+            markerEnd={`url(#${markerId})`}
+          />
 
-      {/* Port pinhole indicators at connection endpoints */}
-      {diffState === 'unchanged' && (
-        <g data-testid="connection-pinholes" pointerEvents="none">
-          {renderPinhole(sourcePos.x, sourcePos.y, pinHoleStyle, colors.stroke, 'src')}
-          {renderPinhole(targetPos.x, targetPos.y, pinHoleStyle, colors.stroke, 'tgt')}
-        </g>
-      )}
+          {packetMode !== 'static' && (
+            <PacketFlowLayer
+              hitPoints={hitPoints}
+              mode={packetMode}
+              connectionType={connectionType ?? 'dataflow'}
+              elapsed={packetElapsed}
+              reducedMotion={reducedMotion}
+              canvasZoom={canvasZoom}
+            />
+          )}
 
-      {hasValidationError && (
-        <path
-          className="connection-error-pulse"
-          d={hitPath}
-          stroke="var(--accent-error, #ef4444)"
-          strokeWidth={3}
-          strokeDasharray="6 6"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          fill="none"
-          pointerEvents="none"
-          data-testid="connection-invalid"
-        />
-      )}
+          {/* Provider-accent glow: hover = subtle, selection = stronger */}
+          {isHighlighted && (
+            <path
+              d={hitPath}
+              stroke="var(--provider-accent-glow)"
+              strokeWidth={isSelected ? casingWidth + 4 : casingWidth + 2}
+              strokeOpacity={isSelected ? 1 : 0.7}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+              pointerEvents="none"
+              data-layer="selection-outline"
+            />
+          )}
 
-      {hasValidationError &&
-        isHighlighted &&
-        (() => {
-          if (!labelPos) return null;
-          const msg = connectionErrors[0].message;
-          const textWidth = Math.min(msg.length * 6.5, 220);
-          const padding = 6;
-          const rectWidth = textWidth + padding * 2;
-          const rectHeight = 22;
+          {/* Snap flash animation overlay — skip for visual-only and skip replay on deselection */}
+          {overlayMode !== 'visual-only' && !entranceComplete && (
+            <path
+              d={hitPath}
+              stroke={colors.stroke}
+              strokeWidth={TRACE_FLASH_PX}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+              pointerEvents="none"
+              style={{
+                animation:
+                  'connector-snap-flash 300ms var(--easing-default, cubic-bezier(0.2, 0, 0, 1)) forwards',
+              }}
+              data-testid="connection-snap-flash"
+            />
+          )}
 
-          return (
-            <g data-testid="connection-error-label" pointerEvents="none">
-              <rect
-                x={labelPos.x - rectWidth / 2}
-                y={labelPos.y - rectHeight - 4}
-                width={rectWidth}
-                height={rectHeight}
-                rx={4}
-                fill="var(--accent-error, #ef4444)"
-                fillOpacity={0.92}
-              />
-              <text
-                x={labelPos.x}
-                y={labelPos.y - rectHeight / 2 - 4 + 1}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill="var(--connection-error-label-text, #0F172A)"
-                fontSize={11}
-                fontFamily="var(--font-ui, system-ui)"
-                style={{ pointerEvents: 'none' }}
-              >
-                {msg.length > 35 ? msg.slice(0, 32) + '\u2026' : msg}
-              </text>
+          {/* Port pinhole indicators at connection endpoints */}
+          {diffState === 'unchanged' && (
+            <g data-testid="connection-pinholes" pointerEvents="none">
+              {renderPinhole(sourcePos.x, sourcePos.y, pinHoleStyle, colors.stroke, 'src')}
+              {renderPinhole(targetPos.x, targetPos.y, pinHoleStyle, colors.stroke, 'tgt')}
             </g>
-          );
-        })()}
+          )}
 
-      {isHighlighted &&
-        !hasValidationError &&
-        labelPos &&
-        (() => {
-          const typeLabel = connectionType ?? 'dataflow';
-          const rectWidth = typeLabel.length * 6.5 + 12;
-          const rectHeight = 18;
+          {hasValidationError && (
+            <path
+              className="connection-error-pulse"
+              d={hitPath}
+              stroke="var(--accent-error, #ef4444)"
+              strokeWidth={3}
+              strokeDasharray="6 6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+              pointerEvents="none"
+              data-testid="connection-invalid"
+            />
+          )}
 
-          return (
-            <g data-testid="connection-type-label" pointerEvents="none">
-              <rect
-                x={labelPos.x - rectWidth / 2}
-                y={labelPos.y - rectHeight - 4}
-                width={rectWidth}
-                height={rectHeight}
-                rx={8}
-                fill={colors.stroke}
-                fillOpacity={0.85}
-              />
-              <text
-                x={labelPos.x}
-                y={labelPos.y - rectHeight / 2 - 4 + 1}
-                textAnchor="middle"
-                dominantBaseline="central"
-                fill={contrastTextColor(colors.stroke)}
-                fontSize={10}
-                fontFamily="var(--font-ui, system-ui)"
-                style={{ pointerEvents: 'none' }}
-              >
-                {typeLabel}
-              </text>
-            </g>
-          );
-        })()}
+          {hasValidationError &&
+            isHighlighted &&
+            (() => {
+              if (!labelPos) return null;
+              const msg = connectionErrors[0].message;
+              const textWidth = Math.min(msg.length * 6.5, 220);
+              const padding = 6;
+              const rectWidth = textWidth + padding * 2;
+              const rectHeight = 22;
+
+              return (
+                <g data-testid="connection-error-label" pointerEvents="none">
+                  <rect
+                    x={labelPos.x - rectWidth / 2}
+                    y={labelPos.y - rectHeight - 4}
+                    width={rectWidth}
+                    height={rectHeight}
+                    rx={4}
+                    fill="var(--accent-error, #ef4444)"
+                    fillOpacity={0.92}
+                  />
+                  <text
+                    x={labelPos.x}
+                    y={labelPos.y - rectHeight / 2 - 4 + 1}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fill="var(--connection-error-label-text, #0F172A)"
+                    fontSize={11}
+                    fontFamily="var(--font-ui, system-ui)"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {msg.length > 35 ? msg.slice(0, 32) + '\u2026' : msg}
+                  </text>
+                </g>
+              );
+            })()}
+
+          {isHighlighted &&
+            !hasValidationError &&
+            labelPos &&
+            (() => {
+              const typeLabel = connectionType ?? 'dataflow';
+              const rectWidth = typeLabel.length * 6.5 + 12;
+              const rectHeight = 18;
+
+              return (
+                <g data-testid="connection-type-label" pointerEvents="none">
+                  <rect
+                    x={labelPos.x - rectWidth / 2}
+                    y={labelPos.y - rectHeight - 4}
+                    width={rectWidth}
+                    height={rectHeight}
+                    rx={8}
+                    fill={colors.stroke}
+                    fillOpacity={0.85}
+                  />
+                  <text
+                    x={labelPos.x}
+                    y={labelPos.y - rectHeight / 2 - 4 + 1}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fill={contrastTextColor(colors.stroke)}
+                    fontSize={10}
+                    fontFamily="var(--font-ui, system-ui)"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {typeLabel}
+                  </text>
+                </g>
+              );
+            })()}
+        </>
+      )}
     </g>
   );
 });

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -164,7 +164,7 @@ describe('PacketFlowLayer', () => {
   it('renders fewer packets in hover mode than selected mode', () => {
     const hover = renderLayer('hover');
     const hoverPackets = hover.container.querySelectorAll('[data-testid="packet-flow-packet"]');
-    expect(hoverPackets).toHaveLength(2);
+    expect(hoverPackets).toHaveLength(3);
 
     hover.unmount();
 
@@ -172,7 +172,7 @@ describe('PacketFlowLayer', () => {
     const selectedPackets = selected.container.querySelectorAll(
       '[data-testid="packet-flow-packet"]',
     );
-    expect(selectedPackets).toHaveLength(3);
+    expect(selectedPackets).toHaveLength(4);
   });
 
   it('renders packets in idle mode', () => {
@@ -182,7 +182,7 @@ describe('PacketFlowLayer', () => {
     expect(packets).toHaveLength(2);
 
     const firstPacketCore = packets[0]?.querySelector('[data-layer="packet-core"]');
-    expect(firstPacketCore).toHaveAttribute('fill-opacity', '0.42');
+    expect(firstPacketCore).toHaveAttribute('fill-opacity', '0.56');
   });
 
   it('idle mode uses slower speed', () => {
@@ -333,25 +333,25 @@ describe('PacketFlowLayer', () => {
     });
 
     it('returns base count for selected mode (short path)', () => {
-      expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'selected')).toBe(1);
+      expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'selected')).toBe(2);
     });
 
     it('returns base count for selected mode (medium path)', () => {
-      expect(getPacketCount(MEDIUM_PATH_THRESHOLD - 1, 'selected')).toBe(2);
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD - 1, 'selected')).toBe(3);
     });
 
     it('returns base count for selected mode (long path)', () => {
-      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'selected')).toBe(3);
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'selected')).toBe(4);
     });
 
     it('returns fewer packets for hover mode', () => {
-      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'hover')).toBe(2);
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'hover')).toBe(3);
       expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'hover')).toBe(1);
     });
 
     it('returns fewer packets for idle mode', () => {
       expect(getPacketCount(SHORT_PATH_THRESHOLD, 'idle')).toBe(1);
-      expect(getPacketCount(MEDIUM_PATH_THRESHOLD, 'idle')).toBe(1);
+      expect(getPacketCount(MEDIUM_PATH_THRESHOLD, 'idle')).toBe(2);
       expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'idle')).toBe(2);
       expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'idle')).toBe(1);
     });
@@ -359,6 +359,11 @@ describe('PacketFlowLayer', () => {
     it('returns more packets for creation mode', () => {
       expect(getPacketCount(MEDIUM_PATH_THRESHOLD + 1, 'creation')).toBe(4);
       expect(getPacketCount(SHORT_PATH_THRESHOLD - 1, 'creation')).toBe(2);
+    });
+
+    it('applies spacing guard for very short paths', () => {
+      expect(getPacketCount(20, 'selected')).toBe(1);
+      expect(getPacketCount(20, 'creation')).toBe(1);
     });
   });
 

--- a/apps/web/src/entities/connection/packetFlowHelpers.ts
+++ b/apps/web/src/entities/connection/packetFlowHelpers.ts
@@ -1,5 +1,5 @@
 import type { ScreenPoint } from '../../shared/utils/isometric';
-import { MEDIUM_PATH_THRESHOLD, SHORT_PATH_THRESHOLD } from './packetFlowTokens';
+import { MEDIUM_PATH_THRESHOLD, PACKET_LENGTH, SHORT_PATH_THRESHOLD } from './packetFlowTokens';
 
 export type PacketFlowMode = 'static' | 'idle' | 'hover' | 'selected' | 'creation';
 
@@ -25,15 +25,23 @@ export function getPacketCount(totalLength: number, mode: PacketFlowMode): numbe
   const baseCount =
     totalLength <= SHORT_PATH_THRESHOLD ? 1 : totalLength <= MEDIUM_PATH_THRESHOLD ? 2 : 3;
 
-  if (mode === 'idle' || mode === 'hover') {
-    return Math.max(1, baseCount - 1);
+  let count = baseCount;
+
+  if (mode === 'selected') {
+    count = totalLength <= SHORT_PATH_THRESHOLD ? 2 : totalLength <= MEDIUM_PATH_THRESHOLD ? 3 : 4;
+  } else if (mode === 'hover') {
+    count = totalLength <= SHORT_PATH_THRESHOLD ? 1 : totalLength <= MEDIUM_PATH_THRESHOLD ? 2 : 3;
+  } else if (mode === 'idle') {
+    count = totalLength <= SHORT_PATH_THRESHOLD ? 1 : totalLength <= MEDIUM_PATH_THRESHOLD ? 2 : 2;
+  } else if (mode === 'creation') {
+    count = baseCount + 1;
   }
 
-  if (mode === 'creation') {
-    return baseCount + 1;
+  if (totalLength / count < PACKET_LENGTH * 2.2) {
+    count = Math.max(1, count - 1);
   }
 
-  return baseCount;
+  return count;
 }
 
 export function getPositionAtDistance(

--- a/apps/web/src/entities/connection/packetFlowTokens.test.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PACKET_LENGTH,
+  PACKET_WIDTH,
+  PACKET_TAIL_LENGTH,
+  PACKET_OPACITY,
+  IDLE_CYCLE_MS,
+  PACKET_SELECTED_SCALE,
+  PACKET_SPEED_MS,
+  SHORT_PATH_THRESHOLD,
+  MEDIUM_PATH_THRESHOLD,
+} from './packetFlowTokens';
+
+describe('packetFlowTokens M45 tuning', () => {
+  it('PACKET_LENGTH is 16', () => {
+    expect(PACKET_LENGTH).toBe(16);
+  });
+
+  it('PACKET_WIDTH is 6', () => {
+    expect(PACKET_WIDTH).toBe(6);
+  });
+
+  it('PACKET_TAIL_LENGTH is 18', () => {
+    expect(PACKET_TAIL_LENGTH).toBe(18);
+  });
+
+  it('PACKET_OPACITY idle is 0.56', () => {
+    expect(PACKET_OPACITY.idle).toBe(0.56);
+  });
+
+  it('PACKET_OPACITY hover is 0.72', () => {
+    expect(PACKET_OPACITY.hover).toBe(0.72);
+  });
+
+  it('PACKET_OPACITY selected is 0.95', () => {
+    expect(PACKET_OPACITY.selected).toBe(0.95);
+  });
+
+  it('PACKET_OPACITY creation is 1.0', () => {
+    expect(PACKET_OPACITY.creation).toBe(1.0);
+  });
+
+  it('IDLE_CYCLE_MS is 3200', () => {
+    expect(IDLE_CYCLE_MS).toBe(3200);
+  });
+
+  it('PACKET_SELECTED_SCALE is 1.2', () => {
+    expect(PACKET_SELECTED_SCALE).toBe(1.2);
+  });
+
+  it('PACKET_SPEED_MS is 2600', () => {
+    expect(PACKET_SPEED_MS).toBe(2600);
+  });
+
+  it('SHORT_PATH_THRESHOLD is 80', () => {
+    expect(SHORT_PATH_THRESHOLD).toBe(80);
+  });
+
+  it('MEDIUM_PATH_THRESHOLD is 180', () => {
+    expect(MEDIUM_PATH_THRESHOLD).toBe(180);
+  });
+});

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -1,22 +1,22 @@
 import type { ConnectionType } from '@cloudblocks/schema';
 
 export const PACKET_SPEED_MS = 2600;
-export const PACKET_LENGTH = 12;
-export const PACKET_WIDTH = 5;
-export const PACKET_TAIL_LENGTH = 14;
+export const PACKET_LENGTH = 16;
+export const PACKET_WIDTH = 6;
+export const PACKET_TAIL_LENGTH = 18;
 
 export const SHORT_PATH_THRESHOLD = 80;
 export const MEDIUM_PATH_THRESHOLD = 180;
 
 export const PACKET_OPACITY = {
-  idle: 0.42,
-  hover: 0.5,
-  selected: 0.8,
+  idle: 0.56,
+  hover: 0.72,
+  selected: 0.95,
   creation: 1.0,
 } as const;
 
-export const IDLE_CYCLE_MS = 3600;
-export const PACKET_SELECTED_SCALE = 1.35;
+export const IDLE_CYCLE_MS = 3200;
+export const PACKET_SELECTED_SCALE = 1.2;
 
 export const PACKET_COLOR = '#22d3ee';
 

--- a/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
+++ b/apps/web/src/entities/container-block/ContainerBlockSvg.test.tsx
@@ -88,11 +88,11 @@ describe('PlateSvg — CU-based dimensions', () => {
   });
 
   it('handles small subnet profile (4×6 CU)', () => {
-    const { container } = renderPlateSvg({ unitsX: 4, unitsY: 6, worldHeight: 0.5 });
+    const { container } = renderPlateSvg({ unitsX: 4, unitsY: 6, worldHeight: 0.8 });
 
     const expectedWidth = ((4 + 6) * TILE_W) / 2; // 320
     const expectedDiamondH = ((4 + 6) * TILE_H) / 2; // 160
-    const expectedSideWall = Math.round(0.5 * TILE_Z); // 16
+    const expectedSideWall = Math.round(0.8 * TILE_Z);
     const expectedHeight = expectedDiamondH + expectedSideWall + BLOCK_PADDING;
 
     const svg = container.querySelector('svg');
@@ -100,11 +100,11 @@ describe('PlateSvg — CU-based dimensions', () => {
   });
 
   it('handles large network profile (20×24 CU)', () => {
-    const { container } = renderPlateSvg({ unitsX: 20, unitsY: 24, worldHeight: 0.7 });
+    const { container } = renderPlateSvg({ unitsX: 20, unitsY: 24, worldHeight: 1.25 });
 
     const expectedWidth = ((20 + 24) * TILE_W) / 2; // 1408
     const expectedDiamondH = ((20 + 24) * TILE_H) / 2; // 704
-    const expectedSideWall = Math.round(0.7 * TILE_Z); // 22
+    const expectedSideWall = Math.round(1.25 * TILE_Z);
     const expectedHeight = expectedDiamondH + expectedSideWall + BLOCK_PADDING;
 
     const svg = container.querySelector('svg');
@@ -244,56 +244,56 @@ describe('PlateSvg — profile-based rendering', () => {
       name: 'network-sandbox',
       unitsX: 8,
       unitsY: 12,
-      worldHeight: 0.7,
+      worldHeight: 1.25,
       containerLayer: 'region' as PlateLayerType,
     },
     {
       name: 'network-application',
       unitsX: 12,
       unitsY: 16,
-      worldHeight: 0.7,
+      worldHeight: 1.25,
       containerLayer: 'region' as PlateLayerType,
     },
     {
       name: 'network-platform',
       unitsX: 16,
       unitsY: 20,
-      worldHeight: 0.7,
+      worldHeight: 1.25,
       containerLayer: 'region' as PlateLayerType,
     },
     {
       name: 'network-hub',
       unitsX: 20,
       unitsY: 24,
-      worldHeight: 0.7,
+      worldHeight: 1.25,
       containerLayer: 'region' as PlateLayerType,
     },
     {
       name: 'subnet-utility',
       unitsX: 4,
       unitsY: 6,
-      worldHeight: 0.5,
+      worldHeight: 0.8,
       containerLayer: 'subnet' as PlateLayerType,
     },
     {
       name: 'subnet-service',
       unitsX: 6,
       unitsY: 8,
-      worldHeight: 0.5,
+      worldHeight: 0.8,
       containerLayer: 'subnet' as PlateLayerType,
     },
     {
       name: 'subnet-workload',
       unitsX: 8,
       unitsY: 10,
-      worldHeight: 0.5,
+      worldHeight: 0.8,
       containerLayer: 'subnet' as PlateLayerType,
     },
     {
       name: 'subnet-scale',
       unitsX: 10,
       unitsY: 12,
-      worldHeight: 0.5,
+      worldHeight: 0.8,
       containerLayer: 'subnet' as PlateLayerType,
     },
   ];
@@ -360,15 +360,14 @@ describe('PlateSvg — placement anchor tiles (#1581)', () => {
 
 describe('PlateSvg — backward compatibility', () => {
   it('pixel dimensions match v1.x formula at RENDER_SCALE=32', () => {
-    // Subnet-utility: 4×6 CU, worldHeight 0.5
     const unitsX = 4;
     const unitsY = 6;
-    const worldHeight = 0.5;
+    const worldHeight = 0.8;
 
     // v1.x formula: screenWidth = (unitsX + unitsY) * TILE_W / 2
     const expectedWidth = ((unitsX + unitsY) * 64) / 2; // 320
     const expectedDiamondH = ((unitsX + unitsY) * 32) / 2; // 160
-    const expectedSideWall = Math.round(worldHeight * 32); // 16
+    const expectedSideWall = Math.round(worldHeight * 32);
 
     const { container } = renderPlateSvg({ unitsX, unitsY, worldHeight });
     const svg = container.querySelector('svg');

--- a/apps/web/src/entities/store/architectureStore.test.ts
+++ b/apps/web/src/entities/store/architectureStore.test.ts
@@ -333,7 +333,7 @@ describe('architectureStore', () => {
       expect(plates[0].profileId).toBe('network-hub');
       expect(plates[0].frame.width).toBe(20);
       expect(plates[0].frame.depth).toBe(24);
-      expect(plates[0].frame.height).toBe(1.0);
+      expect(plates[0].frame.height).toBe(1.25);
     });
 
     it('adds a subnet container with explicit profileId', () => {
@@ -344,7 +344,7 @@ describe('architectureStore', () => {
       expect(subnet.profileId).toBe('subnet-scale');
       expect(subnet.frame.width).toBe(10);
       expect(subnet.frame.depth).toBe(12);
-      expect(subnet.frame.height).toBe(0.6);
+      expect(subnet.frame.height).toBe(0.8);
     });
 
     it('adds a subnet container as child of network', () => {
@@ -359,7 +359,7 @@ describe('architectureStore', () => {
       expect(subnet.name).toBe('Public');
       expect(subnet.type).toBe('subnet');
       expect(subnet.parentId).toBe(netId);
-      expect(subnet.position.y).toBe(1.0);
+      expect(subnet.position.y).toBe(1.25);
 
       // Network container should have subnet as child
       const network = plates.find((p) => p.id === netId);
@@ -635,7 +635,7 @@ describe('architectureStore', () => {
       expect(duplicate.category).toBe(source.category);
       expect(duplicate.placementId).toBe(source.placementId);
       expect(duplicate.provider).toBe(source.provider);
-      expect(duplicate.position.y).toBe(0.6);
+      expect(duplicate.position.y).toBe(0.8);
       expect(duplicate.position).not.toEqual(source.position);
 
       const container = getArch().plates.find((p) => p.id === subId);

--- a/apps/web/src/entities/validation/connection.test.ts
+++ b/apps/web/src/entities/validation/connection.test.ts
@@ -828,27 +828,27 @@ describe('CONNECTION_VISUAL_STYLES', () => {
   });
 
   it('dataflow has solid style (no dasharray)', () => {
-    expect(CONNECTION_VISUAL_STYLES.dataflow.strokeWidth).toBe(2.5);
+    expect(CONNECTION_VISUAL_STYLES.dataflow.strokeWidth).toBe(3.0);
     expect(CONNECTION_VISUAL_STYLES.dataflow.strokeDasharray).toBeUndefined();
   });
 
   it('http has thicker stroke width', () => {
-    expect(CONNECTION_VISUAL_STYLES.http.strokeWidth).toBe(4);
+    expect(CONNECTION_VISUAL_STYLES.http.strokeWidth).toBe(4.5);
     expect(CONNECTION_VISUAL_STYLES.http.strokeDasharray).toBeUndefined();
   });
 
-  it('internal is solid with strokeWidth 2.5', () => {
-    expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(3);
+  it('internal is solid with strokeWidth 3.5', () => {
+    expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(3.5);
     expect(CONNECTION_VISUAL_STYLES.internal.strokeDasharray).toBeUndefined();
   });
 
   it('data has thin dash pattern', () => {
-    expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(2);
+    expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(2.5);
     expect(CONNECTION_VISUAL_STYLES.data.strokeDasharray).toBe('6 3');
   });
 
   it('async has dotted pattern', () => {
-    expect(CONNECTION_VISUAL_STYLES.async.strokeWidth).toBe(2.25);
+    expect(CONNECTION_VISUAL_STYLES.async.strokeWidth).toBe(2.75);
     expect(CONNECTION_VISUAL_STYLES.async.strokeDasharray).toBe('2 3');
   });
 });

--- a/apps/web/src/shared/tokens/__tests__/connectionVisualTokens.test.ts
+++ b/apps/web/src/shared/tokens/__tests__/connectionVisualTokens.test.ts
@@ -18,28 +18,28 @@ describe('connectionVisualTokens', () => {
       }
     });
 
-    it('dataflow is solid with strokeWidth 2.5', () => {
-      expect(CONNECTION_VISUAL_STYLES.dataflow.strokeWidth).toBe(2.5);
+    it('dataflow is solid with strokeWidth 3.0', () => {
+      expect(CONNECTION_VISUAL_STYLES.dataflow.strokeWidth).toBe(3.0);
       expect(CONNECTION_VISUAL_STYLES.dataflow.strokeDasharray).toBeUndefined();
     });
 
-    it('http is solid with strokeWidth 4', () => {
-      expect(CONNECTION_VISUAL_STYLES.http.strokeWidth).toBe(4);
+    it('http is solid with strokeWidth 4.5', () => {
+      expect(CONNECTION_VISUAL_STYLES.http.strokeWidth).toBe(4.5);
       expect(CONNECTION_VISUAL_STYLES.http.strokeDasharray).toBeUndefined();
     });
 
-    it('internal is solid with strokeWidth 3', () => {
-      expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(3);
+    it('internal is solid with strokeWidth 3.5', () => {
+      expect(CONNECTION_VISUAL_STYLES.internal.strokeWidth).toBe(3.5);
       expect(CONNECTION_VISUAL_STYLES.internal.strokeDasharray).toBeUndefined();
     });
 
     it('data has thin dash pattern', () => {
-      expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(2);
+      expect(CONNECTION_VISUAL_STYLES.data.strokeWidth).toBe(2.5);
       expect(CONNECTION_VISUAL_STYLES.data.strokeDasharray).toBe('6 3');
     });
 
     it('async has dotted pattern', () => {
-      expect(CONNECTION_VISUAL_STYLES.async.strokeWidth).toBe(2.25);
+      expect(CONNECTION_VISUAL_STYLES.async.strokeWidth).toBe(2.75);
       expect(CONNECTION_VISUAL_STYLES.async.strokeDasharray).toBe('2 3');
     });
   });
@@ -49,8 +49,8 @@ describe('connectionVisualTokens', () => {
       expect(CASING_WIDTH_OFFSET).toBe(2.5);
     });
 
-    it('HOVER_WIDTH_OFFSET is 1', () => {
-      expect(HOVER_WIDTH_OFFSET).toBe(1);
+    it('HOVER_WIDTH_OFFSET is 1.25', () => {
+      expect(HOVER_WIDTH_OFFSET).toBe(1.25);
     });
   });
 

--- a/apps/web/src/shared/tokens/connectionVisualTokens.ts
+++ b/apps/web/src/shared/tokens/connectionVisualTokens.ts
@@ -26,18 +26,18 @@ export interface ConnectionVisualStyle {
 
 /** Per-type visual styles. */
 export const CONNECTION_VISUAL_STYLES: Record<ConnectionType, ConnectionVisualStyle> = {
-  dataflow: { strokeWidth: 2.5 },
-  http: { strokeWidth: 4 },
-  internal: { strokeWidth: 3 },
-  data: { strokeWidth: 2, strokeDasharray: '6 3' },
-  async: { strokeWidth: 2.25, strokeDasharray: '2 3' },
+  dataflow: { strokeWidth: 3.0 },
+  http: { strokeWidth: 4.5 },
+  internal: { strokeWidth: 3.5 },
+  data: { strokeWidth: 2.5, strokeDasharray: '6 3' },
+  async: { strokeWidth: 2.75, strokeDasharray: '2 3' },
 };
 
 /** Casing width offset added to the base stroke width. */
 export const CASING_WIDTH_OFFSET = 2.5;
 
 /** Hover width offset added to the base stroke width. */
-export const HOVER_WIDTH_OFFSET = 1;
+export const HOVER_WIDTH_OFFSET = 1.25;
 
 /** Perpendicular offset (screen px) applied to each connection in an overlap group. */
 export const OVERLAP_OFFSET_PX = 8;

--- a/apps/web/src/shared/types/index.ts
+++ b/apps/web/src/shared/types/index.ts
@@ -291,7 +291,7 @@ export interface ContainerBlockProfile {
   unitsY: number;
   worldWidth: number; // = unitsX (world units match CU count)
   worldDepth: number; // = unitsY (world units match CU count)
-  worldHeight: number; // VNet = 0.7 (thick), Subnet = 0.5 (medium)
+  worldHeight: number; // network/region = 1.25, subnet = 0.8
   recommendedCapacity: number;
   exampleCidrs: {
     azure: string;
@@ -311,7 +311,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 12,
     worldWidth: 8,
     worldDepth: 12,
-    worldHeight: 1.0,
+    worldHeight: 1.25,
     recommendedCapacity: 2,
     exampleCidrs: { azure: '10.0.0.0/24', aws: '10.0.0.0/24', gcp: '10.0.0.0/24' },
     learningLevel: 'beginner',
@@ -326,7 +326,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 16,
     worldWidth: 12,
     worldDepth: 16,
-    worldHeight: 1.0,
+    worldHeight: 1.25,
     recommendedCapacity: 4,
     exampleCidrs: { azure: '10.1.0.0/20', aws: '10.1.0.0/20', gcp: '10.1.0.0/20' },
     learningLevel: 'intermediate',
@@ -340,7 +340,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 20,
     worldWidth: 16,
     worldDepth: 20,
-    worldHeight: 1.0,
+    worldHeight: 1.25,
     recommendedCapacity: 6,
     exampleCidrs: { azure: '10.0.0.0/16', aws: '10.0.0.0/16', gcp: '10.0.0.0/16' },
     learningLevel: 'advanced',
@@ -354,7 +354,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 24,
     worldWidth: 20,
     worldDepth: 24,
-    worldHeight: 1.0,
+    worldHeight: 1.25,
     recommendedCapacity: 8,
     exampleCidrs: { azure: '10.0.0.0/8', aws: '10.0.0.0/8', gcp: '10.0.0.0/8' },
     learningLevel: 'expert',
@@ -368,7 +368,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 6,
     worldWidth: 4,
     worldDepth: 6,
-    worldHeight: 0.6,
+    worldHeight: 0.8,
     recommendedCapacity: 2,
     exampleCidrs: { azure: '10.0.0.0/28', aws: '10.0.0.0/28', gcp: '10.0.0.0/28' },
     learningLevel: 'beginner',
@@ -382,7 +382,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 8,
     worldWidth: 6,
     worldDepth: 8,
-    worldHeight: 0.6,
+    worldHeight: 0.8,
     recommendedCapacity: 4,
     exampleCidrs: { azure: '10.0.1.0/26', aws: '10.0.1.0/26', gcp: '10.0.1.0/26' },
     learningLevel: 'intermediate',
@@ -396,7 +396,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 10,
     worldWidth: 8,
     worldDepth: 10,
-    worldHeight: 0.6,
+    worldHeight: 0.8,
     recommendedCapacity: 6,
     exampleCidrs: { azure: '10.0.2.0/24', aws: '10.0.2.0/24', gcp: '10.0.2.0/24' },
     learningLevel: 'advanced',
@@ -410,7 +410,7 @@ export const CONTAINER_BLOCK_PROFILES: Record<ContainerBlockProfileId, Container
     unitsY: 12,
     worldWidth: 10,
     worldDepth: 12,
-    worldHeight: 0.6,
+    worldHeight: 0.8,
     recommendedCapacity: 8,
     exampleCidrs: { azure: '10.0.4.0/22', aws: '10.0.4.0/22', gcp: '10.0.4.0/22' },
     learningLevel: 'expert',

--- a/apps/web/src/shared/types/schema.test.ts
+++ b/apps/web/src/shared/types/schema.test.ts
@@ -162,7 +162,7 @@ describe('schema utilities', () => {
       throw new Error('Expected migrated container node');
     }
     expect(container.profileId).toBe('network-platform');
-    expect(container.frame.height).toBe(1.0);
+    expect(container.frame.height).toBe(1.25);
     expect(container.frame.width).toBe(16);
     expect(container.frame.depth).toBe(20);
   });
@@ -281,7 +281,7 @@ describe('schema utilities', () => {
     expect(container.profileId).toBe('network-platform');
     expect(container.frame).toBeDefined();
     expect(container.frame.width).toBe(16);
-    expect(container.frame.height).toBe(1.0);
+    expect(container.frame.height).toBe(1.25);
     expect(container.frame.depth).toBe(20);
   });
 
@@ -342,7 +342,7 @@ describe('schema utilities', () => {
     expect(container.profileId).toBe('network-platform');
     expect(container.frame).toBeDefined();
     expect(container.frame.width).toBe(16);
-    expect(container.frame.height).toBe(1.0);
+    expect(container.frame.height).toBe(1.25);
     expect(container.frame.depth).toBe(20);
   });
 

--- a/apps/web/src/widgets/scene-canvas/ConnectionAnimationLayer.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionAnimationLayer.tsx
@@ -1,6 +1,5 @@
 import { memo } from 'react';
 import type { Connection } from '@cloudblocks/schema';
-import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 import { ConnectionRenderer } from '../../entities/connection/ConnectionRenderer';
 import { useUIStore } from '../../entities/store/uiStore';
 
@@ -9,6 +8,12 @@ interface ConnectionAnimationLayerProps {
   originX: number;
   originY: number;
   overlapOffsets: ReadonlyMap<string, number>;
+  elapsed: number;
+  reducedMotion: boolean;
+  selectedConnectionIds?: ReadonlySet<string>;
+  className?: string;
+  pointerEvents?: 'auto' | 'none';
+  overlayMode?: 'normal' | 'visual-only' | 'hit-only';
 }
 
 export const ConnectionAnimationLayer = memo(function ConnectionAnimationLayer({
@@ -16,17 +21,22 @@ export const ConnectionAnimationLayer = memo(function ConnectionAnimationLayer({
   originX,
   originY,
   overlapOffsets,
+  elapsed,
+  reducedMotion,
+  selectedConnectionIds,
+  className = 'connection-layer',
+  pointerEvents = 'auto',
+  overlayMode = 'normal',
 }: ConnectionAnimationLayerProps) {
-  const hasAnyActiveConnection = connections.length > 0;
-  const { elapsed, reducedMotion } = useAnimationClock(hasAnyActiveConnection);
   const flowFocusMode = useUIStore((s) => s.flowFocusMode);
 
   return (
     <svg
-      className={`connection-layer${flowFocusMode ? ' flow-focus-active' : ''}`}
-      style={{ width: 1, height: 1 }}
+      className={`${className}${flowFocusMode && className === 'connection-layer' ? ' flow-focus-active' : ''}`}
+      style={{ width: 1, height: 1, pointerEvents }}
+      {...(overlayMode === 'visual-only' ? { 'aria-hidden': true } : {})}
     >
-      <title>Connections</title>
+      {overlayMode !== 'visual-only' && <title>Connections</title>}
       {connections.map((conn) => (
         <ConnectionRenderer
           key={conn.id}
@@ -37,6 +47,11 @@ export const ConnectionAnimationLayer = memo(function ConnectionAnimationLayer({
           overlapOffset={overlapOffsets.get(conn.id) ?? 0}
           elapsed={elapsed}
           reducedMotion={reducedMotion}
+          overlayMode={
+            overlayMode === 'normal' && selectedConnectionIds?.has(conn.id)
+              ? 'hit-only'
+              : overlayMode
+          }
         />
       ))}
     </svg>

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -158,6 +158,15 @@
   left: 0;
   pointer-events: auto;
   overflow: visible;
+  z-index: 5;
+}
+
+.selected-connection-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  overflow: visible;
   z-index: 4;
 }
 
@@ -231,6 +240,6 @@
   border: 1.5px dashed var(--provider-accent, #4a9eff);
   background: rgba(74, 158, 255, 0.08);
   pointer-events: none;
-  z-index: 10;
+  z-index: 11;
   border-radius: 2px;
 }

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.test.tsx
@@ -31,9 +31,14 @@ vi.mock('../../entities/block/BlockSprite', () => ({
   },
 }));
 vi.mock('../../entities/connection/ConnectionRenderer', () => ({
-  ConnectionRenderer: (props: { connectionId?: string }) => {
+  ConnectionRenderer: (props: { connectionId?: string; overlayMode?: string }) => {
     connectionRendererMock(props);
-    return <g data-testid={`connection-${props.connectionId}`} />;
+    return (
+      <g
+        data-testid={`connection-${props.connectionId}`}
+        data-overlay-mode={props.overlayMode ?? 'normal'}
+      />
+    );
   },
 }));
 vi.mock('../../entities/connection/ExternalActorSprite', () => ({
@@ -82,6 +87,7 @@ function setupStoreMocks() {
   vi.mocked(useUIStore).mockImplementation(((selector: unknown) => {
     const state = {
       setSelectedId: mockSetSelectedId,
+      selectedIds: new Set<string>(),
       clearSelection: mockClearSelection,
       setSelectedIds: mockSetSelectedIds,
       interactionState: mockInteractionState,
@@ -1226,5 +1232,86 @@ describe('SceneCanvas placement flows', () => {
     expect(world.style.transform).toBe(initialTransform);
     expect(mockSetCanvasZoom).not.toHaveBeenCalled();
     expect(preventDefaultSpy).not.toHaveBeenCalled();
+  });
+
+  describe('SceneCanvas selected-connection overlay', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+      mockFitToContentRequested = false;
+      mockInteractionState = 'idle';
+      mockDraggedBlockCategory = null;
+      mockDraggedResourceName = null;
+      mockDraggedResourceType = null;
+      mockDraggedSubtype = null;
+      mockIsSoundMuted = true;
+      architecture.nodes = [];
+      architecture.connections = [];
+      setupStoreMocks();
+    });
+
+    it('splits selected connection across base and overlay layers with overlay mode', () => {
+      architecture.connections = [
+        {
+          id: 'sel-conn',
+          from: endpointId('a', 'output', 'data'),
+          to: endpointId('b', 'input', 'data'),
+          metadata: {},
+        },
+      ];
+
+      vi.mocked(useUIStore).mockImplementation(((selector: unknown) => {
+        const state = {
+          setSelectedId: mockSetSelectedId,
+          selectedIds: new Set(['sel-conn']),
+          clearSelection: mockClearSelection,
+          setSelectedIds: mockSetSelectedIds,
+          interactionState: mockInteractionState,
+          draggedBlockCategory: mockDraggedBlockCategory,
+          draggedResourceName: mockDraggedResourceName,
+          draggedResourceType: mockDraggedResourceType,
+          draggedSubtype: mockDraggedSubtype,
+          activeProvider: 'aws',
+          completeInteraction: mockCompleteInteraction,
+          setCanvasZoom: mockSetCanvasZoom,
+          fitToContentRequested: mockFitToContentRequested,
+          clearFitToContentRequest: mockClearFitToContentRequest,
+          isSoundMuted: mockIsSoundMuted,
+          gridStyle: 'paper' as const,
+          flowFocusMode: false,
+        };
+        return (selector as (s: typeof state) => unknown)(state);
+      }) as typeof useUIStore);
+
+      vi.mocked(useArchitectureStore).mockImplementation(((selector: unknown) => {
+        const state = {
+          workspace: { architecture },
+          addNode: mockAddNode,
+          moveExternalBlockPosition: mockMoveExternalBlockPosition,
+        };
+        return (selector as (s: typeof state) => unknown)(state);
+      }) as typeof useArchitectureStore);
+
+      render(<SceneCanvas />);
+
+      // Verify that ConnectionRenderer was called with the selected connection
+      // at least once with overlayMode='hit-only' (from base layer)
+      expect(
+        connectionRendererMock.mock.calls.some(
+          ([props]) =>
+            (props as { connectionId?: string; overlayMode?: string }).connectionId ===
+              'sel-conn' && (props as { overlayMode?: string }).overlayMode === 'hit-only',
+        ),
+      ).toBe(true);
+
+      // Verify that ConnectionRenderer was called with the selected connection
+      // at least once with overlayMode='visual-only' (from overlay layer)
+      expect(
+        connectionRendererMock.mock.calls.some(
+          ([props]) =>
+            (props as { connectionId?: string; overlayMode?: string }).connectionId ===
+              'sel-conn' && (props as { overlayMode?: string }).overlayMode === 'visual-only',
+        ),
+      ).toBe(true);
+    });
   });
 });

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.tsx
@@ -27,6 +27,7 @@ import {
 } from './utils/viewportUtils';
 import { ZoomControls } from './ZoomControls';
 import './SceneCanvas.css';
+import { useAnimationClock } from '../../shared/hooks/useAnimationClock';
 
 const EMPTY_OCCUPIED_CELLS = new Set<string>();
 
@@ -98,6 +99,7 @@ export function SceneCanvas() {
     [architecture],
   );
   const {
+    selectedIds,
     clearSelection,
     setSelectedIds,
     interactionState,
@@ -114,6 +116,7 @@ export function SceneCanvas() {
     gridStyle,
   } = useUIStore(
     useShallow((state) => ({
+      selectedIds: state.selectedIds,
       clearSelection: state.clearSelection,
       setSelectedIds: state.setSelectedIds,
       interactionState: state.interactionState,
@@ -130,6 +133,17 @@ export function SceneCanvas() {
       gridStyle: state.gridStyle,
     })),
   );
+  const selectedConnectionIds = useMemo(() => {
+    const connectionIds = new Set(connections.map((connection) => connection.id));
+    return new Set([...selectedIds].filter((id) => connectionIds.has(id)));
+  }, [connections, selectedIds]);
+  const selectedConnections = useMemo(
+    () => connections.filter((connection) => selectedConnectionIds.has(connection.id)),
+    [connections, selectedConnectionIds],
+  );
+  const hasAnyConnection = connections.length > 0;
+  const { elapsed: animElapsed, reducedMotion: animReducedMotion } =
+    useAnimationClock(hasAnyConnection);
   const playSound = (name: SoundName) => {
     if (!isSoundMuted) audioService.playSound(name);
   };
@@ -541,22 +555,10 @@ export function SceneCanvas() {
           originX={origin.x}
           originY={origin.y}
           overlapOffsets={overlapOffsets}
+          elapsed={animElapsed}
+          reducedMotion={animReducedMotion}
+          selectedConnectionIds={selectedConnectionIds}
         />
-
-        <svg className="interaction-overlay" style={{ width: 1, height: 1 }}>
-          <title>Interaction Overlay</title>
-          <ConnectionPreview originX={origin.x} originY={origin.y} />
-          <g className="drag-ghost-layer">
-            <DragGhost
-              containerRef={containerRef}
-              originX={origin.x}
-              originY={origin.y}
-              panX={pan.x}
-              panY={pan.y}
-              zoom={zoom}
-            />
-          </g>
-        </svg>
 
         {lassoRect && (
           <div
@@ -630,6 +632,35 @@ export function SceneCanvas() {
             );
           })}
         </div>
+
+        {selectedConnections.length > 0 && (
+          <ConnectionAnimationLayer
+            connections={selectedConnections}
+            originX={origin.x}
+            originY={origin.y}
+            overlapOffsets={overlapOffsets}
+            elapsed={animElapsed}
+            reducedMotion={animReducedMotion}
+            className="selected-connection-layer"
+            pointerEvents="none"
+            overlayMode="visual-only"
+          />
+        )}
+
+        <svg className="interaction-overlay" style={{ width: 1, height: 1 }}>
+          <title>Interaction Overlay</title>
+          <ConnectionPreview originX={origin.x} originY={origin.y} />
+          <g className="drag-ghost-layer">
+            <DragGhost
+              containerRef={containerRef}
+              originX={origin.x}
+              originY={origin.y}
+              panX={pan.x}
+              panY={pan.y}
+              zoom={zoom}
+            />
+          </g>
+        </svg>
       </div>
 
       <ZoomControls


### PR DESCRIPTION
## Summary

- Increase packet token sizes and opacity for better visibility at all interaction states
- Bump container heights (network 1.0→1.25, subnet 0.6→0.8) to reinforce visual hierarchy
- Widen connection strokes across all 5 connection types
- Add selected-connection overlay layer (z-index:4) with shared animation clock
- Prevent draw-in/snap-flash replay on deselection (StrictMode-safe)
- Add aria-hidden to visual-only overlay for accessibility

## Issues

Closes #1794, closes #1795, closes #1796, closes #1797, closes #1798
Part of Epic #1793

## Testing

- 3388 tests pass (17 new/updated)
- Build passes, lint clean (0 errors)
- Bundle: 732 KB (budget: 960 KB)
- Visual verification in browser: container hierarchy correct, packet flow visible, no console errors
- Oracle review: 100/100 across all dimensions (correctness, performance, regressions, accessibility, maintainability, test coverage)