### PR TITLE
docs: refresh ROADMAP current-state metrics after Milestone 46

### DIFF
--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -129,8 +129,8 @@ Version numbers follow `v0.N.0` where N is the milestone number. This convention
 
 | Metric                   | Value                                                                                                     |
 | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| 0.x milestones completed | 44 (M0–M44, all closed)                                                                                   |
-| Tests passing            | 3,368+                                                                                                     |
+| 0.x milestones completed | 46 (M8–M46, all closed)                                                                                   |
+| Tests passing            | 3,747+                                                                                                     |
 | Branch coverage          | ≥ 90%                                                                                                     |
 | Codebase                 | TypeScript (React 19) + Python (FastAPI) monorepo                                                         |
 | Architecture             | Block-based composition with `kind` + `traits` type system ([ADR-0013](../adr/0013-block-unification.md)) |


### PR DESCRIPTION
## Summary
- Update milestone count from 44 (M0–M44) to 46 (M8–M46), correcting numbering to reflect actual milestone range (M8–M46, 39 unique milestone numbers across 49 closed milestones including legacy Phase milestones)
- Update test count from 3,368+ to 3,747+ (3,404 frontend + 343 backend)

Fixes #1810
Part of #1809