### PR TITLE
docs: align backend validation commands to python3 -m pytest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,4 +204,4 @@ Versioning convention: **Milestone N = v0.N.0**. Patch releases (v0.N.1, v0.N.2)
 
 - `pnpm build`
 - `pnpm lint`
-- `cd apps/api && pytest`
+- `python3 -m pytest apps/api`

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -12,7 +12,7 @@ pip install -e ".[dev]"
 uvicorn app.main:app --reload --port 8000
 
 # Run tests
-pytest
+python3 -m pytest
 
 # Run linter
 ruff check .

--- a/docs/design/NFR_TARGETS.md
+++ b/docs/design/NFR_TARGETS.md
@@ -56,7 +56,7 @@ These files are excluded from coverage calculations (documented in `vitest.confi
 ### Enforcement
 
 - Coverage thresholds configured in `vitest.config.ts` → build fails if below 90%
-- Backend coverage checked in CI via `pytest --cov --cov-fail-under=90`
+- Backend coverage checked in CI via `python3 -m pytest apps/api --cov=app --cov-fail-under=90`
 
 ---
 

--- a/docs/design/RELEASE_GATES.md
+++ b/docs/design/RELEASE_GATES.md
@@ -31,9 +31,9 @@ Every release to `main` (or tagged release) must pass ALL of the following gates
 | Check             | Command                                               | Criteria                                       | Level       |
 | ----------------- | ----------------------------------------------------- | ---------------------------------------------- | ----------- |
 | Frontend tests    | `cd apps/web && npx vitest run`                       | All pass                                       | **Blocker** |
-| Backend tests     | `cd apps/api && pytest app/tests/ -v`                 | All pass                                       | **Blocker** |
+| Backend tests     | `python3 -m pytest apps/api/app/tests/ -v`                | All pass                                       | **Blocker** |
 | Frontend coverage | `cd apps/web && npx vitest run --coverage`            | ≥ 90% (statements, branches, functions, lines) | **Blocker** |
-| Backend coverage  | `cd apps/api && pytest --cov=app --cov-fail-under=90` | ≥ 90%                                          | **Blocker** |
+| Backend coverage  | `python3 -m pytest apps/api --cov=app --cov-fail-under=90`| ≥ 90%                                          | **Blocker** |
 
 ### Gate 4: Security
 
@@ -393,7 +393,7 @@ Record baseline measurements after each milestone release. Compare against thres
 | **Backend coverage**    | ≥ 90%  | pytest-cov  |
 
 - Coverage thresholds configured in `vitest.config.ts` → tests/CI fail if below 90%
-- Backend coverage checked in CI via `pytest --cov --cov-fail-under=90`
+- Backend coverage checked in CI via `python3 -m pytest apps/api --cov=app --cov-fail-under=90`
 
 #### CI Reliability
 

--- a/docs/guides/RELEASE_RUNBOOK.md
+++ b/docs/guides/RELEASE_RUNBOOK.md
@@ -31,8 +31,8 @@ Complete every item before proceeding to tagging. A single ❌ in a **Blocker** 
 | --- | ----------------------- | ---------------------------------------------------------------------------------- | ----- |
 | 6   | Frontend tests pass     | `cd apps/web && npx vitest run`                                                    | ☐     |
 | 7   | Frontend coverage ≥ 90% | `cd apps/web && npx vitest run --coverage`                                         | ☐     |
-| 8   | Backend tests pass      | `cd apps/api && pytest app/tests/ -v`                                              | ☐     |
-| 9   | Backend coverage ≥ 90%  | `cd apps/api && pytest --cov=app --cov-fail-under=90`                              | ☐     |
+| 8   | Backend tests pass      | `python3 -m pytest apps/api/app/tests/ -v`                                        | ☐     |
+| 9   | Backend coverage ≥ 90%  | `python3 -m pytest apps/api --cov=app --cov-fail-under=90`                         | ☐     |
 | 10  | Package tests pass      | `pnpm --filter @cloudblocks/schema test && pnpm --filter @cloudblocks/domain test` | ☐     |
 
 ### Gate 4: Security


### PR DESCRIPTION
## Summary
- Replace bare `pytest` and `cd apps/api && pytest` invocations with `python3 -m pytest apps/api` across all policy and release docs
- Updated files: AGENTS.md, RELEASE_RUNBOOK.md, RELEASE_GATES.md, NFR_TARGETS.md, apps/api/README.md
- The bare `pytest` command fails without an activated virtualenv; `python3 -m pytest` works from any contributor shell

Fixes #1811
Part of #1809