### PR TITLE
test(api): remove deprecated per-request cookie usage from integration suites

### DIFF
--- a/apps/api/app/tests/helpers/__init__.py
+++ b/apps/api/app/tests/helpers/__init__.py
@@ -1,0 +1,3 @@
+from .httpx import with_cookies
+
+__all__ = ["with_cookies"]

--- a/apps/api/app/tests/helpers/httpx.py
+++ b/apps/api/app/tests/helpers/httpx.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from httpx import AsyncClient
+
+
+def with_cookies(client: AsyncClient, cookies: Mapping[str, str]) -> AsyncClient:
+    client.cookies.clear()
+    for name, value in cookies.items():
+        client.cookies.set(name, value)
+    return client

--- a/apps/api/app/tests/integration/test_ai_e2e.py
+++ b/apps/api/app/tests/integration/test_ai_e2e.py
@@ -17,7 +17,6 @@ from httpx import AsyncClient
 
 from app.core.dependencies import get_key_manager
 from app.core.security import generate_id
-from app.tests.helpers import with_cookies
 from app.domain.models.ai_entities import AIApiKey, CostEstimate, CostResource
 from app.domain.models.entities import User
 from app.infrastructure.cost.infracost_client import InfracostClient
@@ -25,6 +24,7 @@ from app.infrastructure.db.connection import Database
 from app.infrastructure.db.repositories import SQLiteAIApiKeyRepository
 from app.infrastructure.llm.client import LLMError, OpenAIClient
 from app.infrastructure.llm.key_manager import KeyManager
+from app.tests.helpers import with_cookies
 
 VALID_THREE_TIER: dict[str, object] = {
     "plates": [
@@ -266,7 +266,10 @@ async def test_e2e_full_ai_workflow(
 ) -> None:
     """Full workflow: store key → generate → suggest → cost."""
 
-    key_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-test-e2e-key"},)
+    key_response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/keys",
+        json={"provider": "openai", "key": "sk-test-e2e-key"},
+    )
     assert key_response.status_code == 200
     key_payload = key_response.json()
     assert key_payload["provider"] == "openai"
@@ -290,11 +293,14 @@ async def test_e2e_full_ai_workflow(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    gen_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
-        "prompt": "Three-tier web app with ALB, ECS, and RDS",
-        "provider": "aws",
-        "complexity": "intermediate",
-    },)
+    gen_response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={
+            "prompt": "Three-tier web app with ALB, ECS, and RDS",
+            "provider": "aws",
+            "complexity": "intermediate",
+        },
+    )
     assert gen_response.status_code == 200
     gen_payload = cast(dict[str, object], gen_response.json())
     architecture = gen_payload["architecture"]
@@ -316,7 +322,10 @@ async def test_e2e_full_ai_workflow(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_suggest)
 
-    suggest_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": architecture, "provider": "aws"},)
+    suggest_response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/suggest",
+        json={"architecture": architecture, "provider": "aws"},
+    )
     assert suggest_response.status_code == 200
     suggest_payload = cast(dict[str, object], suggest_response.json())
     suggestions = suggest_payload["suggestions"]
@@ -336,7 +345,10 @@ async def test_e2e_full_ai_workflow(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    cost_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
+    cost_response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": architecture, "provider": "aws"},
+    )
     assert cost_response.status_code == 200
     cost_payload = cast(dict[str, object], cost_response.json())
     assert cost_payload["monthly_cost"] == 156.75
@@ -345,7 +357,9 @@ async def test_e2e_full_ai_workflow(
     assert isinstance(resources, list)
     assert len(resources) == 3
 
-    del_response = await with_cookies(client, auth_cookies).delete("/api/v1/ai/keys/openai", )
+    del_response = await with_cookies(client, auth_cookies).delete(
+        "/api/v1/ai/keys/openai",
+    )
     assert del_response.status_code == 200
     assert del_response.json()["deleted"] is True
 
@@ -374,11 +388,14 @@ async def test_e2e_generate_azure_provider(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
-        "prompt": "Web app with Application Gateway and SQL Database",
-        "provider": "azure",
-        "complexity": "simple",
-    },)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={
+            "prompt": "Web app with Application Gateway and SQL Database",
+            "provider": "azure",
+            "complexity": "simple",
+        },
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], response.json())
@@ -413,11 +430,14 @@ async def test_e2e_generate_gcp_provider(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
-        "prompt": "Cloud Run with Cloud SQL",
-        "provider": "gcp",
-        "complexity": "simple",
-    },)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={
+            "prompt": "Cloud Run with Cloud SQL",
+            "provider": "gcp",
+            "complexity": "simple",
+        },
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], response.json())
@@ -468,7 +488,10 @@ async def test_e2e_cost_azure_architecture(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": VALID_AZURE_ARCHITECTURE, "provider": "azure"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": VALID_AZURE_ARCHITECTURE, "provider": "azure"},
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -516,7 +539,10 @@ async def test_e2e_cost_gcp_architecture(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": VALID_GCP_ARCHITECTURE, "provider": "gcp"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": VALID_GCP_ARCHITECTURE, "provider": "gcp"},
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -577,7 +603,10 @@ async def test_e2e_generate_llm_failure_propagates(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate_fail)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "test", "provider": "aws", "complexity": "simple"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={"prompt": "test", "provider": "aws", "complexity": "simple"},
+    )
 
     assert response.status_code == 500
     payload = response.json()
@@ -609,7 +638,10 @@ async def test_e2e_suggest_llm_failure_propagates(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate_fail)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": VALID_THREE_TIER, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/suggest",
+        json={"architecture": VALID_THREE_TIER, "provider": "aws"},
+    )
 
     assert response.status_code == 500
     payload = cast(dict[str, object], response.json())
@@ -641,7 +673,10 @@ async def test_e2e_cost_empty_architecture(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": {"blocks": []}, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": {"blocks": []}, "provider": "aws"},
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -706,7 +741,10 @@ async def test_e2e_cost_unknown_subtypes_skipped(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": architecture, "provider": "aws"},
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -773,7 +811,14 @@ async def test_e2e_generate_with_validation_warnings(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build something", "provider": "aws", "complexity": "simple"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={
+            "prompt": "build something",
+            "provider": "aws",
+            "complexity": "simple",
+        },
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], response.json())
@@ -794,7 +839,10 @@ async def test_e2e_api_key_lifecycle(
 ) -> None:
     """Full key lifecycle: create → list → delete → confirm deleted."""
 
-    create_resp = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-lifecycle-test"},)
+    create_resp = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/keys",
+        json={"provider": "openai", "key": "sk-lifecycle-test"},
+    )
     assert create_resp.status_code == 200
     assert create_resp.json()["provider"] == "openai"
 
@@ -844,10 +892,13 @@ async def test_e2e_suggest_all_providers(
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
     for provider, architecture in provider_architectures:
-        response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": architecture, "provider": provider},)
-        assert (
-            response.status_code == 200
-        ), f"Suggest failed for provider {provider}: {response.text}"
+        response = await with_cookies(client, auth_cookies).post(
+            "/api/v1/ai/suggest",
+            json={"architecture": architecture, "provider": provider},
+        )
+        assert response.status_code == 200, (
+            f"Suggest failed for provider {provider}: {response.text}"
+        )
         payload = response.json()
         assert len(payload["suggestions"]) == 3
         assert "security" in payload["score"]
@@ -880,11 +931,14 @@ async def test_e2e_complexity_levels(
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
     for complexity in ("simple", "intermediate", "advanced"):
-        response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
-            "prompt": f"Test {complexity}",
-            "provider": "aws",
-            "complexity": complexity,
-        },)
+        response = await with_cookies(client, auth_cookies).post(
+            "/api/v1/ai/generate",
+            json={
+                "prompt": f"Test {complexity}",
+                "provider": "aws",
+                "complexity": complexity,
+            },
+        )
         assert response.status_code == 200, f"Generate failed for complexity {complexity}"
 
     # Verify each complexity target was included in the system prompt

--- a/apps/api/app/tests/integration/test_ai_e2e.py
+++ b/apps/api/app/tests/integration/test_ai_e2e.py
@@ -17,6 +17,7 @@ from httpx import AsyncClient
 
 from app.core.dependencies import get_key_manager
 from app.core.security import generate_id
+from app.tests.helpers import with_cookies
 from app.domain.models.ai_entities import AIApiKey, CostEstimate, CostResource
 from app.domain.models.entities import User
 from app.infrastructure.cost.infracost_client import InfracostClient
@@ -265,17 +266,13 @@ async def test_e2e_full_ai_workflow(
 ) -> None:
     """Full workflow: store key → generate → suggest → cost."""
 
-    key_response = await client.post(
-        "/api/v1/ai/keys",
-        cookies=auth_cookies,
-        json={"provider": "openai", "key": "sk-test-e2e-key"},
-    )
+    key_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-test-e2e-key"},)
     assert key_response.status_code == 200
     key_payload = key_response.json()
     assert key_payload["provider"] == "openai"
     assert "created_at" in key_payload
 
-    list_response = await client.get("/api/v1/ai/keys", cookies=auth_cookies)
+    list_response = await with_cookies(client, auth_cookies).get("/api/v1/ai/keys")
     assert list_response.status_code == 200
     keys = list_response.json()
     assert any(k["provider"] == "openai" for k in keys)
@@ -293,15 +290,11 @@ async def test_e2e_full_ai_workflow(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    gen_response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={
-            "prompt": "Three-tier web app with ALB, ECS, and RDS",
-            "provider": "aws",
-            "complexity": "intermediate",
-        },
-    )
+    gen_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
+        "prompt": "Three-tier web app with ALB, ECS, and RDS",
+        "provider": "aws",
+        "complexity": "intermediate",
+    },)
     assert gen_response.status_code == 200
     gen_payload = cast(dict[str, object], gen_response.json())
     architecture = gen_payload["architecture"]
@@ -323,11 +316,7 @@ async def test_e2e_full_ai_workflow(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_suggest)
 
-    suggest_response = await client.post(
-        "/api/v1/ai/suggest",
-        cookies=auth_cookies,
-        json={"architecture": architecture, "provider": "aws"},
-    )
+    suggest_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": architecture, "provider": "aws"},)
     assert suggest_response.status_code == 200
     suggest_payload = cast(dict[str, object], suggest_response.json())
     suggestions = suggest_payload["suggestions"]
@@ -347,11 +336,7 @@ async def test_e2e_full_ai_workflow(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    cost_response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": architecture, "provider": "aws"},
-    )
+    cost_response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
     assert cost_response.status_code == 200
     cost_payload = cast(dict[str, object], cost_response.json())
     assert cost_payload["monthly_cost"] == 156.75
@@ -360,10 +345,7 @@ async def test_e2e_full_ai_workflow(
     assert isinstance(resources, list)
     assert len(resources) == 3
 
-    del_response = await client.delete(
-        "/api/v1/ai/keys/openai",
-        cookies=auth_cookies,
-    )
+    del_response = await with_cookies(client, auth_cookies).delete("/api/v1/ai/keys/openai", )
     assert del_response.status_code == 200
     assert del_response.json()["deleted"] is True
 
@@ -392,15 +374,11 @@ async def test_e2e_generate_azure_provider(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={
-            "prompt": "Web app with Application Gateway and SQL Database",
-            "provider": "azure",
-            "complexity": "simple",
-        },
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
+        "prompt": "Web app with Application Gateway and SQL Database",
+        "provider": "azure",
+        "complexity": "simple",
+    },)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], response.json())
@@ -435,15 +413,11 @@ async def test_e2e_generate_gcp_provider(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={
-            "prompt": "Cloud Run with Cloud SQL",
-            "provider": "gcp",
-            "complexity": "simple",
-        },
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
+        "prompt": "Cloud Run with Cloud SQL",
+        "provider": "gcp",
+        "complexity": "simple",
+    },)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], response.json())
@@ -494,11 +468,7 @@ async def test_e2e_cost_azure_architecture(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": VALID_AZURE_ARCHITECTURE, "provider": "azure"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": VALID_AZURE_ARCHITECTURE, "provider": "azure"},)
 
     assert response.status_code == 200
     payload = response.json()
@@ -546,11 +516,7 @@ async def test_e2e_cost_gcp_architecture(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": VALID_GCP_ARCHITECTURE, "provider": "gcp"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": VALID_GCP_ARCHITECTURE, "provider": "gcp"},)
 
     assert response.status_code == 200
     payload = response.json()
@@ -611,11 +577,7 @@ async def test_e2e_generate_llm_failure_propagates(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate_fail)
 
-    response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={"prompt": "test", "provider": "aws", "complexity": "simple"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "test", "provider": "aws", "complexity": "simple"},)
 
     assert response.status_code == 500
     payload = response.json()
@@ -647,11 +609,7 @@ async def test_e2e_suggest_llm_failure_propagates(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate_fail)
 
-    response = await client.post(
-        "/api/v1/ai/suggest",
-        cookies=auth_cookies,
-        json={"architecture": VALID_THREE_TIER, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": VALID_THREE_TIER, "provider": "aws"},)
 
     assert response.status_code == 500
     payload = cast(dict[str, object], response.json())
@@ -683,11 +641,7 @@ async def test_e2e_cost_empty_architecture(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": {"blocks": []}, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": {"blocks": []}, "provider": "aws"},)
 
     assert response.status_code == 200
     payload = response.json()
@@ -752,11 +706,7 @@ async def test_e2e_cost_unknown_subtypes_skipped(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": architecture, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
 
     assert response.status_code == 200
     payload = response.json()
@@ -823,11 +773,7 @@ async def test_e2e_generate_with_validation_warnings(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={"prompt": "build something", "provider": "aws", "complexity": "simple"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build something", "provider": "aws", "complexity": "simple"},)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], response.json())
@@ -848,24 +794,20 @@ async def test_e2e_api_key_lifecycle(
 ) -> None:
     """Full key lifecycle: create → list → delete → confirm deleted."""
 
-    create_resp = await client.post(
-        "/api/v1/ai/keys",
-        cookies=auth_cookies,
-        json={"provider": "openai", "key": "sk-lifecycle-test"},
-    )
+    create_resp = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-lifecycle-test"},)
     assert create_resp.status_code == 200
     assert create_resp.json()["provider"] == "openai"
 
-    list_resp = await client.get("/api/v1/ai/keys", cookies=auth_cookies)
+    list_resp = await with_cookies(client, auth_cookies).get("/api/v1/ai/keys")
     assert list_resp.status_code == 200
     providers = [k["provider"] for k in list_resp.json()]
     assert "openai" in providers
 
-    del_resp = await client.delete("/api/v1/ai/keys/openai", cookies=auth_cookies)
+    del_resp = await with_cookies(client, auth_cookies).delete("/api/v1/ai/keys/openai")
     assert del_resp.status_code == 200
     assert del_resp.json()["deleted"] is True
 
-    list_after = await client.get("/api/v1/ai/keys", cookies=auth_cookies)
+    list_after = await with_cookies(client, auth_cookies).get("/api/v1/ai/keys")
     assert list_after.status_code == 200
     providers_after = [k["provider"] for k in list_after.json()]
     assert "openai" not in providers_after
@@ -902,11 +844,7 @@ async def test_e2e_suggest_all_providers(
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
     for provider, architecture in provider_architectures:
-        response = await client.post(
-            "/api/v1/ai/suggest",
-            cookies=auth_cookies,
-            json={"architecture": architecture, "provider": provider},
-        )
+        response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": architecture, "provider": provider},)
         assert (
             response.status_code == 200
         ), f"Suggest failed for provider {provider}: {response.text}"
@@ -942,15 +880,11 @@ async def test_e2e_complexity_levels(
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
     for complexity in ("simple", "intermediate", "advanced"):
-        response = await client.post(
-            "/api/v1/ai/generate",
-            cookies=auth_cookies,
-            json={
-                "prompt": f"Test {complexity}",
-                "provider": "aws",
-                "complexity": complexity,
-            },
-        )
+        response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={
+            "prompt": f"Test {complexity}",
+            "provider": "aws",
+            "complexity": complexity,
+        },)
         assert response.status_code == 200, f"Generate failed for complexity {complexity}"
 
     # Verify each complexity target was included in the system prompt

--- a/apps/api/app/tests/integration/test_ai_key_routes.py
+++ b/apps/api/app/tests/integration/test_ai_key_routes.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
-from app.tests.helpers import with_cookies
 from app.infrastructure.db.repositories import SQLiteAIApiKeyRepository
+from app.tests.helpers import with_cookies
 
 
 @pytest.mark.asyncio
@@ -25,7 +25,10 @@ async def test_post_ai_keys_with_auth_stores_encrypted_key(
     test_user,
     db,
 ) -> None:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-secret-value"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/keys",
+        json={"provider": "openai", "key": "sk-secret-value"},
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -43,7 +46,10 @@ async def test_get_ai_keys_returns_provider_list_without_keys(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    save = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-first"},)
+    save = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/keys",
+        json={"provider": "openai", "key": "sk-first"},
+    )
     assert save.status_code == 200
 
     response = await with_cookies(client, auth_cookies).get("/api/v1/ai/keys")
@@ -63,7 +69,10 @@ async def test_delete_ai_key_removes_provider_key(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    save = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-delete-me"},)
+    save = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/keys",
+        json={"provider": "openai", "key": "sk-delete-me"},
+    )
     assert save.status_code == 200
 
     delete = await with_cookies(client, auth_cookies).delete("/api/v1/ai/keys/openai")
@@ -77,7 +86,10 @@ async def test_get_ai_keys_after_delete_returns_empty_list(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    save = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-delete-check"},)
+    save = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/keys",
+        json={"provider": "openai", "key": "sk-delete-check"},
+    )
     assert save.status_code == 200
 
     delete = await with_cookies(client, auth_cookies).delete("/api/v1/ai/keys/openai")

--- a/apps/api/app/tests/integration/test_ai_key_routes.py
+++ b/apps/api/app/tests/integration/test_ai_key_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 from httpx import AsyncClient
 
+from app.tests.helpers import with_cookies
 from app.infrastructure.db.repositories import SQLiteAIApiKeyRepository
 
 
@@ -24,11 +25,7 @@ async def test_post_ai_keys_with_auth_stores_encrypted_key(
     test_user,
     db,
 ) -> None:
-    response = await client.post(
-        "/api/v1/ai/keys",
-        cookies=auth_cookies,
-        json={"provider": "openai", "key": "sk-secret-value"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-secret-value"},)
 
     assert response.status_code == 200
     payload = response.json()
@@ -46,14 +43,10 @@ async def test_get_ai_keys_returns_provider_list_without_keys(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    save = await client.post(
-        "/api/v1/ai/keys",
-        cookies=auth_cookies,
-        json={"provider": "openai", "key": "sk-first"},
-    )
+    save = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-first"},)
     assert save.status_code == 200
 
-    response = await client.get("/api/v1/ai/keys", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/ai/keys")
 
     assert response.status_code == 200
     payload = response.json()
@@ -70,14 +63,10 @@ async def test_delete_ai_key_removes_provider_key(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    save = await client.post(
-        "/api/v1/ai/keys",
-        cookies=auth_cookies,
-        json={"provider": "openai", "key": "sk-delete-me"},
-    )
+    save = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-delete-me"},)
     assert save.status_code == 200
 
-    delete = await client.delete("/api/v1/ai/keys/openai", cookies=auth_cookies)
+    delete = await with_cookies(client, auth_cookies).delete("/api/v1/ai/keys/openai")
 
     assert delete.status_code == 200
     assert delete.json() == {"provider": "openai", "deleted": True}
@@ -88,17 +77,13 @@ async def test_get_ai_keys_after_delete_returns_empty_list(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    save = await client.post(
-        "/api/v1/ai/keys",
-        cookies=auth_cookies,
-        json={"provider": "openai", "key": "sk-delete-check"},
-    )
+    save = await with_cookies(client, auth_cookies).post("/api/v1/ai/keys", json={"provider": "openai", "key": "sk-delete-check"},)
     assert save.status_code == 200
 
-    delete = await client.delete("/api/v1/ai/keys/openai", cookies=auth_cookies)
+    delete = await with_cookies(client, auth_cookies).delete("/api/v1/ai/keys/openai")
     assert delete.status_code == 200
 
-    response = await client.get("/api/v1/ai/keys", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/ai/keys")
 
     assert response.status_code == 200
     assert response.json() == []

--- a/apps/api/app/tests/integration/test_ai_routes.py
+++ b/apps/api/app/tests/integration/test_ai_routes.py
@@ -10,7 +10,6 @@ from httpx import AsyncClient
 
 from app.core.dependencies import get_key_manager
 from app.core.security import generate_id
-from app.tests.helpers import with_cookies
 from app.domain.models.ai_entities import AIApiKey, CostEstimate, CostResource
 from app.domain.models.entities import User
 from app.infrastructure.cost.infracost_client import InfracostClient
@@ -18,6 +17,7 @@ from app.infrastructure.db.connection import Database
 from app.infrastructure.db.repositories import SQLiteAIApiKeyRepository
 from app.infrastructure.llm.client import LLMError, OpenAIClient
 from app.infrastructure.llm.key_manager import KeyManager
+from app.tests.helpers import with_cookies
 
 
 async def _store_openai_key(db: Database, user_id: str) -> None:
@@ -64,7 +64,10 @@ async def test_generate_success(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -88,7 +91,10 @@ async def test_generate_no_api_key(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},
+    )
 
     assert response.status_code == 400
     payload = cast(dict[str, object], json.loads(response.text))
@@ -149,7 +155,10 @@ async def test_generate_returns_validation_warnings(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build it", "provider": "aws", "complexity": "simple"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/generate",
+        json={"prompt": "build it", "provider": "aws", "complexity": "simple"},
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -194,7 +203,10 @@ async def test_suggest_success(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": {"plates": [], "blocks": []}, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/suggest",
+        json={"architecture": {"plates": [], "blocks": []}, "provider": "aws"},
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -229,7 +241,10 @@ async def test_suggest_llm_error(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": {"blocks": []}, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/suggest",
+        json={"architecture": {"blocks": []}, "provider": "aws"},
+    )
 
     assert response.status_code == 500
     payload = cast(dict[str, object], response.json())
@@ -243,7 +258,10 @@ async def test_suggest_no_api_key(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": {}, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/suggest",
+        json={"architecture": {}, "provider": "aws"},
+    )
 
     assert response.status_code == 400
     payload = cast(dict[str, object], json.loads(response.text))
@@ -318,7 +336,10 @@ async def test_cost_success(
         ],
     }
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": architecture, "provider": "aws"},
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -371,7 +392,10 @@ async def test_cost_success_with_nodes_format(
         ]
     }
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": architecture, "provider": "aws"},
+    )
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -407,7 +431,10 @@ async def test_cost_infracost_error(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": {"blocks": []}, "provider": "aws"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/ai/cost",
+        json={"architecture": {"blocks": []}, "provider": "aws"},
+    )
 
     assert response.status_code == 500
     payload = cast(dict[str, object], json.loads(response.text))

--- a/apps/api/app/tests/integration/test_ai_routes.py
+++ b/apps/api/app/tests/integration/test_ai_routes.py
@@ -10,6 +10,7 @@ from httpx import AsyncClient
 
 from app.core.dependencies import get_key_manager
 from app.core.security import generate_id
+from app.tests.helpers import with_cookies
 from app.domain.models.ai_entities import AIApiKey, CostEstimate, CostResource
 from app.domain.models.entities import User
 from app.infrastructure.cost.infracost_client import InfracostClient
@@ -63,11 +64,7 @@ async def test_generate_success(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -91,11 +88,7 @@ async def test_generate_no_api_key(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build architecture", "provider": "aws", "complexity": "simple"},)
 
     assert response.status_code == 400
     payload = cast(dict[str, object], json.loads(response.text))
@@ -156,11 +149,7 @@ async def test_generate_returns_validation_warnings(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await client.post(
-        "/api/v1/ai/generate",
-        cookies=auth_cookies,
-        json={"prompt": "build it", "provider": "aws", "complexity": "simple"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/generate", json={"prompt": "build it", "provider": "aws", "complexity": "simple"},)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -205,11 +194,7 @@ async def test_suggest_success(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await client.post(
-        "/api/v1/ai/suggest",
-        cookies=auth_cookies,
-        json={"architecture": {"plates": [], "blocks": []}, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": {"plates": [], "blocks": []}, "provider": "aws"},)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -244,11 +229,7 @@ async def test_suggest_llm_error(
 
     monkeypatch.setattr(OpenAIClient, "generate", mock_generate)
 
-    response = await client.post(
-        "/api/v1/ai/suggest",
-        cookies=auth_cookies,
-        json={"architecture": {"blocks": []}, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": {"blocks": []}, "provider": "aws"},)
 
     assert response.status_code == 500
     payload = cast(dict[str, object], response.json())
@@ -262,11 +243,7 @@ async def test_suggest_no_api_key(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.post(
-        "/api/v1/ai/suggest",
-        cookies=auth_cookies,
-        json={"architecture": {}, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/suggest", json={"architecture": {}, "provider": "aws"},)
 
     assert response.status_code == 400
     payload = cast(dict[str, object], json.loads(response.text))
@@ -341,11 +318,7 @@ async def test_cost_success(
         ],
     }
 
-    response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": architecture, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -398,11 +371,7 @@ async def test_cost_success_with_nodes_format(
         ]
     }
 
-    response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": architecture, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": architecture, "provider": "aws"},)
 
     assert response.status_code == 200
     payload = cast(dict[str, object], json.loads(response.text))
@@ -438,11 +407,7 @@ async def test_cost_infracost_error(
 
     monkeypatch.setattr(InfracostClient, "estimate", mock_estimate)
 
-    response = await client.post(
-        "/api/v1/ai/cost",
-        cookies=auth_cookies,
-        json={"architecture": {"blocks": []}, "provider": "aws"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/ai/cost", json={"architecture": {"blocks": []}, "provider": "aws"},)
 
     assert response.status_code == 500
     payload = cast(dict[str, object], json.loads(response.text))

--- a/apps/api/app/tests/integration/test_auth_routes.py
+++ b/apps/api/app/tests/integration/test_auth_routes.py
@@ -5,12 +5,12 @@ from httpx import AsyncClient
 
 from app.core.config import settings
 from app.core.security import decrypt_oauth_state, decrypt_token
-from app.tests.helpers import with_cookies
 from app.infrastructure.db.repositories import (
     SQLiteIdentityRepository,
     SQLiteSessionRepository,
     SQLiteUserRepository,
 )
+from app.tests.helpers import with_cookies
 
 
 @pytest.mark.asyncio
@@ -51,8 +51,11 @@ async def test_github_callback_creates_new_user_and_sets_session_cookie(
     }
     mock_github.get_user_emails.return_value = [{"email": "new-user@example.com", "primary": True}]
 
-    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
-    params={"code": "oauth-code", "state": state}, follow_redirects=False,)
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get(
+        "/api/v1/auth/github/callback",
+        params={"code": "oauth-code", "state": state},
+        follow_redirects=False,
+    )
 
     assert response.status_code == 302
     assert response.headers["location"] == settings.frontend_url
@@ -94,8 +97,11 @@ async def test_github_callback_updates_existing_user_on_relogin(
     }
     mock_github.get_user_emails.return_value = [{"email": "updated@example.com", "primary": True}]
 
-    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
-    params={"code": "oauth-code", "state": state}, follow_redirects=False,)
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get(
+        "/api/v1/auth/github/callback",
+        params={"code": "oauth-code", "state": state},
+        follow_redirects=False,
+    )
 
     assert response.status_code == 302
     assert "cb_session" in response.cookies
@@ -132,8 +138,11 @@ async def test_github_callback_stores_encrypted_access_token(
         {"email": "token-test@example.com", "primary": True},
     ]
 
-    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
-    params={"code": "oauth-code", "state": state}, follow_redirects=False,)
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get(
+        "/api/v1/auth/github/callback",
+        params={"code": "oauth-code", "state": state},
+        follow_redirects=False,
+    )
     assert response.status_code == 302
 
     identity = await SQLiteIdentityRepository(db).find_by_provider("github", "777777")
@@ -152,8 +161,11 @@ async def test_github_callback_rejects_invalid_state(client: AsyncClient, mock_g
     mock_github.get_user.return_value = {"id": 1, "login": "u", "name": "u", "email": None}
     mock_github.get_user_emails.return_value = [{"email": "u@example.com", "primary": True}]
 
-    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
-    params={"code": "oauth-code", "state": "bad-state"}, follow_redirects=False,)
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get(
+        "/api/v1/auth/github/callback",
+        params={"code": "oauth-code", "state": "bad-state"},
+        follow_redirects=False,
+    )
 
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "UNAUTHORIZED"
@@ -198,7 +210,9 @@ async def test_session_endpoint_returns_401_without_cookie(client: AsyncClient) 
 async def test_session_endpoint_returns_401_for_invalid_session(
     client: AsyncClient,
 ) -> None:
-    response = await with_cookies(client, {"cb_session": "invalid-session-token"}).get("/api/v1/auth/session", )
+    response = await with_cookies(client, {"cb_session": "invalid-session-token"}).get(
+        "/api/v1/auth/session",
+    )
 
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "UNAUTHORIZED"

--- a/apps/api/app/tests/integration/test_auth_routes.py
+++ b/apps/api/app/tests/integration/test_auth_routes.py
@@ -5,6 +5,7 @@ from httpx import AsyncClient
 
 from app.core.config import settings
 from app.core.security import decrypt_oauth_state, decrypt_token
+from app.tests.helpers import with_cookies
 from app.infrastructure.db.repositories import (
     SQLiteIdentityRepository,
     SQLiteSessionRepository,
@@ -50,12 +51,8 @@ async def test_github_callback_creates_new_user_and_sets_session_cookie(
     }
     mock_github.get_user_emails.return_value = [{"email": "new-user@example.com", "primary": True}]
 
-    response = await client.get(
-        "/api/v1/auth/github/callback",
-        params={"code": "oauth-code", "state": state},
-        cookies={"cb_oauth": oauth_cookie},
-        follow_redirects=False,
-    )
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
+    params={"code": "oauth-code", "state": state}, follow_redirects=False,)
 
     assert response.status_code == 302
     assert response.headers["location"] == settings.frontend_url
@@ -97,12 +94,8 @@ async def test_github_callback_updates_existing_user_on_relogin(
     }
     mock_github.get_user_emails.return_value = [{"email": "updated@example.com", "primary": True}]
 
-    response = await client.get(
-        "/api/v1/auth/github/callback",
-        params={"code": "oauth-code", "state": state},
-        cookies={"cb_oauth": oauth_cookie},
-        follow_redirects=False,
-    )
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
+    params={"code": "oauth-code", "state": state}, follow_redirects=False,)
 
     assert response.status_code == 302
     assert "cb_session" in response.cookies
@@ -139,12 +132,8 @@ async def test_github_callback_stores_encrypted_access_token(
         {"email": "token-test@example.com", "primary": True},
     ]
 
-    response = await client.get(
-        "/api/v1/auth/github/callback",
-        params={"code": "oauth-code", "state": state},
-        cookies={"cb_oauth": oauth_cookie},
-        follow_redirects=False,
-    )
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
+    params={"code": "oauth-code", "state": state}, follow_redirects=False,)
     assert response.status_code == 302
 
     identity = await SQLiteIdentityRepository(db).find_by_provider("github", "777777")
@@ -163,12 +152,8 @@ async def test_github_callback_rejects_invalid_state(client: AsyncClient, mock_g
     mock_github.get_user.return_value = {"id": 1, "login": "u", "name": "u", "email": None}
     mock_github.get_user_emails.return_value = [{"email": "u@example.com", "primary": True}]
 
-    response = await client.get(
-        "/api/v1/auth/github/callback",
-        params={"code": "oauth-code", "state": "bad-state"},
-        cookies={"cb_oauth": oauth_cookie},
-        follow_redirects=False,
-    )
+    response = await with_cookies(client, {"cb_oauth": oauth_cookie}).get("/api/v1/auth/github/callback",
+    params={"code": "oauth-code", "state": "bad-state"}, follow_redirects=False,)
 
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "UNAUTHORIZED"
@@ -192,7 +177,7 @@ async def test_session_endpoint_returns_user_for_valid_session(
     auth_cookies: dict[str, str],
     test_user,
 ) -> None:
-    response = await client.get("/api/v1/auth/session", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/auth/session")
 
     assert response.status_code == 200
     payload = response.json()
@@ -213,10 +198,7 @@ async def test_session_endpoint_returns_401_without_cookie(client: AsyncClient) 
 async def test_session_endpoint_returns_401_for_invalid_session(
     client: AsyncClient,
 ) -> None:
-    response = await client.get(
-        "/api/v1/auth/session",
-        cookies={"cb_session": "invalid-session-token"},
-    )
+    response = await with_cookies(client, {"cb_session": "invalid-session-token"}).get("/api/v1/auth/session", )
 
     assert response.status_code == 401
     assert response.json()["error"]["code"] == "UNAUTHORIZED"
@@ -230,7 +212,7 @@ async def test_logout_with_session_revokes_and_clears_cookie(
 ) -> None:
     session_token = auth_cookies["cb_session"]
 
-    response = await client.post("/api/v1/auth/logout", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).post("/api/v1/auth/logout")
 
     assert response.status_code == 200
     assert response.json() == {"message": "Logged out successfully"}
@@ -254,7 +236,7 @@ async def test_get_me_with_session_returns_user(
     auth_cookies: dict[str, str],
     test_user,
 ) -> None:
-    response = await client.get("/api/v1/auth/me", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/auth/me")
 
     assert response.status_code == 200
     payload = response.json()

--- a/apps/api/app/tests/integration/test_generation_routes.py
+++ b/apps/api/app/tests/integration/test_generation_routes.py
@@ -7,13 +7,16 @@ import pytest
 from httpx import AsyncClient
 
 from app.core.security import generate_id, generate_session_token
-from app.tests.helpers import with_cookies
 from app.domain.models.entities import Session, User
 from app.infrastructure.db.repositories import SQLiteSessionRepository, SQLiteUserRepository
+from app.tests.helpers import with_cookies
 
 
 async def _create_workspace(client: AsyncClient, auth_cookies: dict[str, str]) -> dict[str, Any]:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Generation Workspace"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Generation Workspace"},
+    )
     assert response.status_code == 201
     return response.json()
 
@@ -48,7 +51,10 @@ async def test_trigger_generation_returns_pending_run(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/generate", json={"generator": "terraform", "provider": "azure"},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/generate",
+        json={"generator": "terraform", "provider": "azure"},
+    )
 
     assert response.status_code == 202
     payload = response.json()
@@ -63,7 +69,10 @@ async def test_trigger_generation_workspace_not_found_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/missing/generate", json={"generator": "terraform", "provider": "azure"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/missing/generate",
+        json={"generator": "terraform", "provider": "azure"},
+    )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -78,7 +87,10 @@ async def test_trigger_generation_not_owner_returns_403(
     workspace = await _create_workspace(client, auth_cookies)
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await with_cookies(client, other_cookies).post(f"/api/v1/workspaces/{workspace['id']}/generate", json={"generator": "terraform", "provider": "azure"},)
+    response = await with_cookies(client, other_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/generate",
+        json={"generator": "terraform", "provider": "azure"},
+    )
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -90,10 +102,15 @@ async def test_get_generation_status_returns_run(
     auth_cookies: dict[str, str],
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
-    create_run = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/generate", json={"generator": "terraform", "provider": "azure"},)
+    create_run = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/generate",
+        json={"generator": "terraform", "provider": "azure"},
+    )
     run_id = create_run.json()["id"]
 
-    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/generate/{run_id}", )
+    response = await with_cookies(client, auth_cookies).get(
+        f"/api/v1/workspaces/{workspace['id']}/generate/{run_id}",
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -109,7 +126,9 @@ async def test_get_generation_status_run_not_found_returns_404(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/generate/missing-run", )
+    response = await with_cookies(client, auth_cookies).get(
+        f"/api/v1/workspaces/{workspace['id']}/generate/missing-run",
+    )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -120,7 +139,9 @@ async def test_get_generation_status_workspace_not_found_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await with_cookies(client, auth_cookies).get("/api/v1/workspaces/missing/generate/any-run", )
+    response = await with_cookies(client, auth_cookies).get(
+        "/api/v1/workspaces/missing/generate/any-run",
+    )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -133,7 +154,9 @@ async def test_preview_generation_returns_placeholder(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/preview", )
+    response = await with_cookies(client, auth_cookies).get(
+        f"/api/v1/workspaces/{workspace['id']}/preview",
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -162,7 +185,9 @@ async def test_preview_generation_not_owner_returns_403(
     workspace = await _create_workspace(client, auth_cookies)
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await with_cookies(client, other_cookies).get(f"/api/v1/workspaces/{workspace['id']}/preview", )
+    response = await with_cookies(client, other_cookies).get(
+        f"/api/v1/workspaces/{workspace['id']}/preview",
+    )
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"

--- a/apps/api/app/tests/integration/test_generation_routes.py
+++ b/apps/api/app/tests/integration/test_generation_routes.py
@@ -7,16 +7,13 @@ import pytest
 from httpx import AsyncClient
 
 from app.core.security import generate_id, generate_session_token
+from app.tests.helpers import with_cookies
 from app.domain.models.entities import Session, User
 from app.infrastructure.db.repositories import SQLiteSessionRepository, SQLiteUserRepository
 
 
 async def _create_workspace(client: AsyncClient, auth_cookies: dict[str, str]) -> dict[str, Any]:
-    response = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Generation Workspace"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Generation Workspace"},)
     assert response.status_code == 201
     return response.json()
 
@@ -51,11 +48,7 @@ async def test_trigger_generation_returns_pending_run(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/generate",
-        cookies=auth_cookies,
-        json={"generator": "terraform", "provider": "azure"},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/generate", json={"generator": "terraform", "provider": "azure"},)
 
     assert response.status_code == 202
     payload = response.json()
@@ -70,11 +63,7 @@ async def test_trigger_generation_workspace_not_found_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.post(
-        "/api/v1/workspaces/missing/generate",
-        cookies=auth_cookies,
-        json={"generator": "terraform", "provider": "azure"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/missing/generate", json={"generator": "terraform", "provider": "azure"},)
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -89,11 +78,7 @@ async def test_trigger_generation_not_owner_returns_403(
     workspace = await _create_workspace(client, auth_cookies)
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/generate",
-        cookies=other_cookies,
-        json={"generator": "terraform", "provider": "azure"},
-    )
+    response = await with_cookies(client, other_cookies).post(f"/api/v1/workspaces/{workspace['id']}/generate", json={"generator": "terraform", "provider": "azure"},)
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -105,17 +90,10 @@ async def test_get_generation_status_returns_run(
     auth_cookies: dict[str, str],
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
-    create_run = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/generate",
-        cookies=auth_cookies,
-        json={"generator": "terraform", "provider": "azure"},
-    )
+    create_run = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/generate", json={"generator": "terraform", "provider": "azure"},)
     run_id = create_run.json()["id"]
 
-    response = await client.get(
-        f"/api/v1/workspaces/{workspace['id']}/generate/{run_id}",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/generate/{run_id}", )
 
     assert response.status_code == 200
     payload = response.json()
@@ -131,10 +109,7 @@ async def test_get_generation_status_run_not_found_returns_404(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await client.get(
-        f"/api/v1/workspaces/{workspace['id']}/generate/missing-run",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/generate/missing-run", )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -145,10 +120,7 @@ async def test_get_generation_status_workspace_not_found_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.get(
-        "/api/v1/workspaces/missing/generate/any-run",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).get("/api/v1/workspaces/missing/generate/any-run", )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -161,10 +133,7 @@ async def test_preview_generation_returns_placeholder(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await client.get(
-        f"/api/v1/workspaces/{workspace['id']}/preview",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/preview", )
 
     assert response.status_code == 200
     payload = response.json()
@@ -178,7 +147,7 @@ async def test_preview_generation_workspace_not_found_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.get("/api/v1/workspaces/missing/preview", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/workspaces/missing/preview")
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -193,10 +162,7 @@ async def test_preview_generation_not_owner_returns_403(
     workspace = await _create_workspace(client, auth_cookies)
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await client.get(
-        f"/api/v1/workspaces/{workspace['id']}/preview",
-        cookies=other_cookies,
-    )
+    response = await with_cookies(client, other_cookies).get(f"/api/v1/workspaces/{workspace['id']}/preview", )
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"

--- a/apps/api/app/tests/integration/test_github_routes.py
+++ b/apps/api/app/tests/integration/test_github_routes.py
@@ -10,6 +10,7 @@ from httpx import AsyncClient
 
 from app.core.errors import GitHubError
 from app.core.security import generate_id, generate_session_token
+from app.tests.helpers import with_cookies
 from app.domain.models.entities import Session, User
 from app.infrastructure.db.repositories import SQLiteSessionRepository, SQLiteUserRepository
 
@@ -65,7 +66,7 @@ async def _create_workspace(
         "github_branch": "main",
     }
     payload.update(kwargs)
-    response = await client.post("/api/v1/workspaces/", cookies=auth_cookies, json=payload)
+    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json=payload)
     assert response.status_code == 201
     return response.json()
 
@@ -110,10 +111,7 @@ async def test_list_github_repos_returns_formatted_list(
         }
     ]
 
-    response = await client.get(
-        "/api/v1/github/repos",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).get("/api/v1/github/repos", )
 
     assert response.status_code == 200
     payload = response.json()["repos"]
@@ -128,7 +126,7 @@ async def test_list_github_repos_without_token_returns_502(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.get("/api/v1/github/repos", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/github/repos")
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
@@ -148,11 +146,7 @@ async def test_create_github_repo_returns_created_repo(
         "default_branch": "main",
     }
 
-    response = await client.post(
-        "/api/v1/github/repos",
-        cookies=auth_cookies,
-        json={"name": "new-repo", "description": "desc", "private": True},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/github/repos", json={"name": "new-repo", "description": "desc", "private": True},)
 
     assert response.status_code == 201
     assert response.json()["full_name"] == "acme/new-repo"
@@ -178,11 +172,7 @@ async def test_sync_workspace_to_github_with_existing_file_uses_sha(
     mock_github.get_repo_contents.return_value = {"sha": "existing-sha"}
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-1"}}
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace_id}/sync",
-        cookies=auth_cookies,
-        json={"architecture": architecture, "commit_message": "sync update"},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace_id}/sync", json={"architecture": architecture, "commit_message": "sync update"},)
 
     assert response.status_code == 200
     assert response.json()["commit_sha"] == "commit-sha-1"
@@ -219,11 +209,7 @@ async def test_sync_workspace_to_github_with_new_file_uses_none_sha(
     mock_github.get_repo_contents.side_effect = GitHubError("missing", details={"status_code": 404})
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-2"}}
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace_id}/sync",
-        cookies=auth_cookies,
-        json={"architecture": VALID_ARCHITECTURE},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace_id}/sync", json={"architecture": VALID_ARCHITECTURE},)
 
     assert response.status_code == 200
     args = mock_github.create_or_update_file.await_args.args
@@ -244,11 +230,7 @@ async def test_sync_workspace_non_404_github_error_propagates_as_502(
         "rate limit exceeded", details={"status_code": 403}
     )
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace_id}/sync",
-        cookies=auth_cookies,
-        json={"architecture": VALID_ARCHITECTURE},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace_id}/sync", json={"architecture": VALID_ARCHITECTURE},)
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
@@ -260,11 +242,7 @@ async def test_sync_workspace_without_linked_repo_returns_502(
     auth_cookies: dict[str, str],
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies, github_repo=None)
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/sync",
-        cookies=auth_cookies,
-        json={"architecture": VALID_ARCHITECTURE},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE},)
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
@@ -275,11 +253,7 @@ async def test_sync_workspace_not_found_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.post(
-        "/api/v1/workspaces/missing/sync",
-        cookies=auth_cookies,
-        json={"architecture": VALID_ARCHITECTURE},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/missing/sync", json={"architecture": VALID_ARCHITECTURE},)
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -294,11 +268,7 @@ async def test_sync_workspace_not_owner_returns_403(
     workspace = await _create_workspace(client, auth_cookies)
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/sync",
-        cookies=other_cookies,
-        json={"architecture": VALID_ARCHITECTURE},
-    )
+    response = await with_cookies(client, other_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE},)
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -316,10 +286,7 @@ async def test_pull_workspace_architecture_from_github(
     encoded = base64.b64encode(json.dumps(architecture).encode()).decode()
     mock_github.get_repo_contents.return_value = {"content": encoded}
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/pull",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
 
     assert response.status_code == 200
     assert response.json() == {"architecture": architecture}
@@ -335,10 +302,7 @@ async def test_pull_workspace_architecture_file_not_found_returns_404(
     workspace = await _create_workspace(client, auth_cookies)
     mock_github.get_repo_contents.side_effect = GitHubError("no file", details={"status_code": 404})
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/pull",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -356,10 +320,7 @@ async def test_pull_workspace_non_404_github_error_propagates_as_502(
         "internal server error", details={"status_code": 500}
     )
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/pull",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
@@ -375,10 +336,7 @@ async def test_pull_workspace_architecture_unexpected_format_returns_502(
     workspace = await _create_workspace(client, auth_cookies)
     mock_github.get_repo_contents.return_value = ["unexpected"]
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/pull",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
@@ -402,17 +360,13 @@ async def test_create_pull_request_for_workspace_returns_pr_details(
         "number": 7,
     }
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/pr",
-        cookies=auth_cookies,
-        json={
-            "architecture": VALID_ARCHITECTURE,
-            "title": "Update architecture",
-            "body": "Automated update",
-            "branch": "cloudblocks/pr-branch",
-            "commit_message": "commit from tests",
-        },
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pr", json={
+        "architecture": VALID_ARCHITECTURE,
+        "title": "Update architecture",
+        "body": "Automated update",
+        "branch": "cloudblocks/pr-branch",
+        "commit_message": "commit from tests",
+    },)
 
     assert response.status_code == 201
     payload = response.json()
@@ -430,11 +384,7 @@ async def test_sync_with_missing_architecture_fields_returns_400(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/sync",
-        cookies=auth_cookies,
-        json={"architecture": {"plates": []}},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": {"plates": []}},)
 
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
@@ -449,11 +399,7 @@ async def test_sync_with_invalid_plates_type_returns_400(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/sync",
-        cookies=auth_cookies,
-        json={"architecture": {**VALID_ARCHITECTURE, "plates": "not-a-list"}},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": {**VALID_ARCHITECTURE, "plates": "not-a-list"}},)
 
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
@@ -468,15 +414,11 @@ async def test_pr_with_missing_architecture_fields_returns_400(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/pr",
-        cookies=auth_cookies,
-        json={
-            "architecture": {"plates": []},
-            "title": "Update architecture",
-            "body": "Automated update",
-        },
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pr", json={
+        "architecture": {"plates": []},
+        "title": "Update architecture",
+        "body": "Automated update",
+    },)
 
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
@@ -493,11 +435,7 @@ async def test_sync_with_valid_full_architecture_succeeds(
     mock_github.get_repo_contents.return_value = {"sha": "existing-sha"}
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-valid"}}
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/sync",
-        cookies=auth_cookies,
-        json={"architecture": VALID_ARCHITECTURE},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE},)
 
     assert response.status_code == 200
     assert response.json()["commit_sha"] == "commit-sha-valid"
@@ -514,11 +452,7 @@ async def test_sync_with_valid_nodes_architecture_succeeds(
     mock_github.get_repo_contents.return_value = {"sha": "existing-sha"}
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-nodes"}}
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/sync",
-        cookies=auth_cookies,
-        json={"architecture": VALID_ARCHITECTURE_NODES},
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE_NODES},)
 
     assert response.status_code == 200
     assert response.json()["commit_sha"] == "commit-sha-nodes"
@@ -542,17 +476,13 @@ async def test_pr_with_valid_nodes_architecture_succeeds(
         "number": 8,
     }
 
-    response = await client.post(
-        f"/api/v1/workspaces/{workspace['id']}/pr",
-        cookies=auth_cookies,
-        json={
-            "architecture": VALID_ARCHITECTURE_NODES,
-            "title": "Update architecture",
-            "body": "Automated update",
-            "branch": "cloudblocks/nodes-pr",
-            "commit_message": "commit from tests",
-        },
-    )
+    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pr", json={
+        "architecture": VALID_ARCHITECTURE_NODES,
+        "title": "Update architecture",
+        "body": "Automated update",
+        "branch": "cloudblocks/nodes-pr",
+        "commit_message": "commit from tests",
+    },)
 
     assert response.status_code == 201
     assert response.json()["number"] == 8
@@ -577,10 +507,7 @@ async def test_list_workspace_commits_returns_formatted_commits(
         }
     ]
 
-    response = await client.get(
-        f"/api/v1/workspaces/{workspace['id']}/commits",
-        cookies=auth_cookies,
-    )
+    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/commits", )
 
     assert response.status_code == 200
     payload = response.json()["commits"]

--- a/apps/api/app/tests/integration/test_github_routes.py
+++ b/apps/api/app/tests/integration/test_github_routes.py
@@ -10,9 +10,9 @@ from httpx import AsyncClient
 
 from app.core.errors import GitHubError
 from app.core.security import generate_id, generate_session_token
-from app.tests.helpers import with_cookies
 from app.domain.models.entities import Session, User
 from app.infrastructure.db.repositories import SQLiteSessionRepository, SQLiteUserRepository
+from app.tests.helpers import with_cookies
 
 VALID_ARCHITECTURE: dict[str, Any] = {
     "id": "arch-1",
@@ -111,7 +111,9 @@ async def test_list_github_repos_returns_formatted_list(
         }
     ]
 
-    response = await with_cookies(client, auth_cookies).get("/api/v1/github/repos", )
+    response = await with_cookies(client, auth_cookies).get(
+        "/api/v1/github/repos",
+    )
 
     assert response.status_code == 200
     payload = response.json()["repos"]
@@ -146,7 +148,10 @@ async def test_create_github_repo_returns_created_repo(
         "default_branch": "main",
     }
 
-    response = await with_cookies(client, auth_cookies).post("/api/v1/github/repos", json={"name": "new-repo", "description": "desc", "private": True},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/github/repos",
+        json={"name": "new-repo", "description": "desc", "private": True},
+    )
 
     assert response.status_code == 201
     assert response.json()["full_name"] == "acme/new-repo"
@@ -172,7 +177,10 @@ async def test_sync_workspace_to_github_with_existing_file_uses_sha(
     mock_github.get_repo_contents.return_value = {"sha": "existing-sha"}
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-1"}}
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace_id}/sync", json={"architecture": architecture, "commit_message": "sync update"},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace_id}/sync",
+        json={"architecture": architecture, "commit_message": "sync update"},
+    )
 
     assert response.status_code == 200
     assert response.json()["commit_sha"] == "commit-sha-1"
@@ -209,7 +217,10 @@ async def test_sync_workspace_to_github_with_new_file_uses_none_sha(
     mock_github.get_repo_contents.side_effect = GitHubError("missing", details={"status_code": 404})
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-2"}}
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace_id}/sync", json={"architecture": VALID_ARCHITECTURE},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace_id}/sync",
+        json={"architecture": VALID_ARCHITECTURE},
+    )
 
     assert response.status_code == 200
     args = mock_github.create_or_update_file.await_args.args
@@ -230,11 +241,15 @@ async def test_sync_workspace_non_404_github_error_propagates_as_502(
         "rate limit exceeded", details={"status_code": 403}
     )
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace_id}/sync", json={"architecture": VALID_ARCHITECTURE},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace_id}/sync",
+        json={"architecture": VALID_ARCHITECTURE},
+    )
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
     assert "rate limit" in response.json()["error"]["message"]
+
 
 @pytest.mark.asyncio
 async def test_sync_workspace_without_linked_repo_returns_502(
@@ -242,7 +257,10 @@ async def test_sync_workspace_without_linked_repo_returns_502(
     auth_cookies: dict[str, str],
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies, github_repo=None)
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/sync",
+        json={"architecture": VALID_ARCHITECTURE},
+    )
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
@@ -253,7 +271,10 @@ async def test_sync_workspace_not_found_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/missing/sync", json={"architecture": VALID_ARCHITECTURE},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/missing/sync",
+        json={"architecture": VALID_ARCHITECTURE},
+    )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -268,7 +289,10 @@ async def test_sync_workspace_not_owner_returns_403(
     workspace = await _create_workspace(client, auth_cookies)
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await with_cookies(client, other_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE},)
+    response = await with_cookies(client, other_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/sync",
+        json={"architecture": VALID_ARCHITECTURE},
+    )
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -286,7 +310,9 @@ async def test_pull_workspace_architecture_from_github(
     encoded = base64.b64encode(json.dumps(architecture).encode()).decode()
     mock_github.get_repo_contents.return_value = {"content": encoded}
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/pull",
+    )
 
     assert response.status_code == 200
     assert response.json() == {"architecture": architecture}
@@ -302,7 +328,9 @@ async def test_pull_workspace_architecture_file_not_found_returns_404(
     workspace = await _create_workspace(client, auth_cookies)
     mock_github.get_repo_contents.side_effect = GitHubError("no file", details={"status_code": 404})
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/pull",
+    )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -320,11 +348,14 @@ async def test_pull_workspace_non_404_github_error_propagates_as_502(
         "internal server error", details={"status_code": 500}
     )
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/pull",
+    )
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
     assert "internal server error" in response.json()["error"]["message"]
+
 
 @pytest.mark.asyncio
 async def test_pull_workspace_architecture_unexpected_format_returns_502(
@@ -336,7 +367,9 @@ async def test_pull_workspace_architecture_unexpected_format_returns_502(
     workspace = await _create_workspace(client, auth_cookies)
     mock_github.get_repo_contents.return_value = ["unexpected"]
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pull", )
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/pull",
+    )
 
     assert response.status_code == 502
     assert response.json()["error"]["code"] == "GITHUB_ERROR"
@@ -360,13 +393,16 @@ async def test_create_pull_request_for_workspace_returns_pr_details(
         "number": 7,
     }
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pr", json={
-        "architecture": VALID_ARCHITECTURE,
-        "title": "Update architecture",
-        "body": "Automated update",
-        "branch": "cloudblocks/pr-branch",
-        "commit_message": "commit from tests",
-    },)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/pr",
+        json={
+            "architecture": VALID_ARCHITECTURE,
+            "title": "Update architecture",
+            "body": "Automated update",
+            "branch": "cloudblocks/pr-branch",
+            "commit_message": "commit from tests",
+        },
+    )
 
     assert response.status_code == 201
     payload = response.json()
@@ -384,7 +420,10 @@ async def test_sync_with_missing_architecture_fields_returns_400(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": {"plates": []}},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/sync",
+        json={"architecture": {"plates": []}},
+    )
 
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
@@ -399,7 +438,10 @@ async def test_sync_with_invalid_plates_type_returns_400(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": {**VALID_ARCHITECTURE, "plates": "not-a-list"}},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/sync",
+        json={"architecture": {**VALID_ARCHITECTURE, "plates": "not-a-list"}},
+    )
 
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
@@ -414,11 +456,14 @@ async def test_pr_with_missing_architecture_fields_returns_400(
 ) -> None:
     workspace = await _create_workspace(client, auth_cookies)
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pr", json={
-        "architecture": {"plates": []},
-        "title": "Update architecture",
-        "body": "Automated update",
-    },)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/pr",
+        json={
+            "architecture": {"plates": []},
+            "title": "Update architecture",
+            "body": "Automated update",
+        },
+    )
 
     assert response.status_code == 400
     assert response.json()["error"]["code"] == "VALIDATION_ERROR"
@@ -435,7 +480,10 @@ async def test_sync_with_valid_full_architecture_succeeds(
     mock_github.get_repo_contents.return_value = {"sha": "existing-sha"}
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-valid"}}
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/sync",
+        json={"architecture": VALID_ARCHITECTURE},
+    )
 
     assert response.status_code == 200
     assert response.json()["commit_sha"] == "commit-sha-valid"
@@ -452,7 +500,10 @@ async def test_sync_with_valid_nodes_architecture_succeeds(
     mock_github.get_repo_contents.return_value = {"sha": "existing-sha"}
     mock_github.create_or_update_file.return_value = {"commit": {"sha": "commit-sha-nodes"}}
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/sync", json={"architecture": VALID_ARCHITECTURE_NODES},)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/sync",
+        json={"architecture": VALID_ARCHITECTURE_NODES},
+    )
 
     assert response.status_code == 200
     assert response.json()["commit_sha"] == "commit-sha-nodes"
@@ -476,13 +527,16 @@ async def test_pr_with_valid_nodes_architecture_succeeds(
         "number": 8,
     }
 
-    response = await with_cookies(client, auth_cookies).post(f"/api/v1/workspaces/{workspace['id']}/pr", json={
-        "architecture": VALID_ARCHITECTURE_NODES,
-        "title": "Update architecture",
-        "body": "Automated update",
-        "branch": "cloudblocks/nodes-pr",
-        "commit_message": "commit from tests",
-    },)
+    response = await with_cookies(client, auth_cookies).post(
+        f"/api/v1/workspaces/{workspace['id']}/pr",
+        json={
+            "architecture": VALID_ARCHITECTURE_NODES,
+            "title": "Update architecture",
+            "body": "Automated update",
+            "branch": "cloudblocks/nodes-pr",
+            "commit_message": "commit from tests",
+        },
+    )
 
     assert response.status_code == 201
     assert response.json()["number"] == 8
@@ -507,7 +561,9 @@ async def test_list_workspace_commits_returns_formatted_commits(
         }
     ]
 
-    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace['id']}/commits", )
+    response = await with_cookies(client, auth_cookies).get(
+        f"/api/v1/workspaces/{workspace['id']}/commits",
+    )
 
     assert response.status_code == 200
     payload = response.json()["commits"]

--- a/apps/api/app/tests/integration/test_workspace_routes.py
+++ b/apps/api/app/tests/integration/test_workspace_routes.py
@@ -6,6 +6,7 @@ import pytest
 from httpx import AsyncClient
 
 from app.core.security import generate_id, generate_session_token
+from app.tests.helpers import with_cookies
 from app.domain.models.entities import Session, User
 from app.infrastructure.db.repositories import SQLiteSessionRepository, SQLiteUserRepository
 
@@ -38,7 +39,7 @@ async def test_list_workspaces_returns_empty_for_new_user(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.get("/api/v1/workspaces/", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/workspaces/")
 
     assert response.status_code == 200
     assert response.json() == {"workspaces": []}
@@ -49,18 +50,10 @@ async def test_list_workspaces_returns_created_workspaces(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Workspace A"},
-    )
-    await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Workspace B", "generator": "pulumi", "provider": "aws"},
-    )
+    await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Workspace A"},)
+    await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Workspace B", "generator": "pulumi", "provider": "aws"},)
 
-    response = await client.get("/api/v1/workspaces/", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/workspaces/")
 
     assert response.status_code == 200
     payload = response.json()["workspaces"]
@@ -75,11 +68,7 @@ async def test_create_workspace_with_minimal_body_returns_201(
     auth_cookies: dict[str, str],
     test_user,
 ) -> None:
-    response = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Minimal Workspace"},
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Minimal Workspace"},)
 
     assert response.status_code == 201
     payload = response.json()
@@ -94,16 +83,12 @@ async def test_create_workspace_with_all_fields_returns_201(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={
-            "name": "Full Workspace",
-            "generator": "bicep",
-            "provider": "azure",
-            "github_repo": "acme/platform-infra",
-        },
-    )
+    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={
+        "name": "Full Workspace",
+        "generator": "bicep",
+        "provider": "azure",
+        "github_repo": "acme/platform-infra",
+    },)
 
     assert response.status_code == 201
     payload = response.json()
@@ -126,14 +111,10 @@ async def test_get_workspace_returns_workspace_for_owner(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Owned Workspace"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Owned Workspace"},)
     workspace_id = created.json()["id"]
 
-    response = await client.get(f"/api/v1/workspaces/{workspace_id}", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace_id}")
 
     assert response.status_code == 200
     assert response.json()["id"] == workspace_id
@@ -144,7 +125,7 @@ async def test_get_workspace_non_existent_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.get("/api/v1/workspaces/does-not-exist", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).get("/api/v1/workspaces/does-not-exist")
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -156,15 +137,11 @@ async def test_get_workspace_of_other_user_returns_403(
     auth_cookies: dict[str, str],
     db,
 ) -> None:
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Private Workspace"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Private Workspace"},)
     workspace_id = created.json()["id"]
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await client.get(f"/api/v1/workspaces/{workspace_id}", cookies=other_cookies)
+    response = await with_cookies(client, other_cookies).get(f"/api/v1/workspaces/{workspace_id}")
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -183,18 +160,10 @@ async def test_update_workspace_name_returns_200(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Before"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Before"},)
     workspace_id = created.json()["id"]
 
-    response = await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={"name": "After"},
-    )
+    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"name": "After"},)
 
     assert response.status_code == 200
     assert response.json()["name"] == "After"
@@ -205,24 +174,16 @@ async def test_update_workspace_multiple_fields_returns_200(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Original"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Original"},)
     workspace_id = created.json()["id"]
 
-    response = await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={
-            "name": "Updated",
-            "generator": "pulumi",
-            "provider": "aws",
-            "github_repo": "acme/updated",
-            "github_branch": "develop",
-        },
-    )
+    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={
+        "name": "Updated",
+        "generator": "pulumi",
+        "provider": "aws",
+        "github_repo": "acme/updated",
+        "github_branch": "develop",
+    },)
 
     assert response.status_code == 200
     payload = response.json()
@@ -238,11 +199,7 @@ async def test_update_workspace_non_existent_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.put(
-        "/api/v1/workspaces/missing-id",
-        cookies=auth_cookies,
-        json={"name": "Nope"},
-    )
+    response = await with_cookies(client, auth_cookies).put("/api/v1/workspaces/missing-id", json={"name": "Nope"},)
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -254,19 +211,11 @@ async def test_update_workspace_not_owner_returns_403(
     auth_cookies: dict[str, str],
     db,
 ) -> None:
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Owner Workspace"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Owner Workspace"},)
     workspace_id = created.json()["id"]
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=other_cookies,
-        json={"name": "Should Fail"},
-    )
+    response = await with_cookies(client, other_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"name": "Should Fail"},)
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -277,18 +226,14 @@ async def test_delete_workspace_owned_returns_204(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Delete Me"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Delete Me"},)
     workspace_id = created.json()["id"]
 
-    response = await client.delete(f"/api/v1/workspaces/{workspace_id}", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).delete(f"/api/v1/workspaces/{workspace_id}")
 
     assert response.status_code == 204
 
-    get_response = await client.get(f"/api/v1/workspaces/{workspace_id}", cookies=auth_cookies)
+    get_response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace_id}")
     assert get_response.status_code == 404
 
 
@@ -297,7 +242,7 @@ async def test_delete_workspace_non_existent_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await client.delete("/api/v1/workspaces/missing-id", cookies=auth_cookies)
+    response = await with_cookies(client, auth_cookies).delete("/api/v1/workspaces/missing-id")
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -309,15 +254,11 @@ async def test_delete_workspace_not_owner_returns_403(
     auth_cookies: dict[str, str],
     db,
 ) -> None:
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "Not Yours"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Not Yours"},)
     workspace_id = created.json()["id"]
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await client.delete(f"/api/v1/workspaces/{workspace_id}", cookies=other_cookies)
+    response = await with_cookies(client, other_cookies).delete(f"/api/v1/workspaces/{workspace_id}")
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -329,26 +270,14 @@ async def test_update_workspace_omitting_github_repo_preserves_value(
     auth_cookies: dict[str, str],
 ) -> None:
     """When github_repo is omitted from the request body, the existing value is preserved."""
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "GH Test"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "GH Test"},)
     workspace_id = created.json()["id"]
 
     # Set github_repo first
-    await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={"github_repo": "owner/repo"},
-    )
+    await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_repo": "owner/repo"},)
 
     # Update only the name — github_repo should be preserved
-    response = await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={"name": "Renamed"},
-    )
+    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"name": "Renamed"},)
 
     assert response.status_code == 200
     data = response.json()
@@ -362,26 +291,14 @@ async def test_update_workspace_null_github_repo_clears_value(
     auth_cookies: dict[str, str],
 ) -> None:
     """Explicitly sending github_repo=null clears the linked repository."""
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "GH Test"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "GH Test"},)
     workspace_id = created.json()["id"]
 
     # Set github_repo first
-    await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={"github_repo": "owner/repo"},
-    )
+    await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_repo": "owner/repo"},)
 
     # Explicitly null it
-    response = await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={"github_repo": None},
-    )
+    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_repo": None},)
 
     assert response.status_code == 200
     assert response.json()["github_repo"] is None
@@ -393,26 +310,14 @@ async def test_update_workspace_null_github_branch_resets_to_main(
     auth_cookies: dict[str, str],
 ) -> None:
     """Explicitly sending github_branch=null resets the branch to 'main'."""
-    created = await client.post(
-        "/api/v1/workspaces/",
-        cookies=auth_cookies,
-        json={"name": "GH Test"},
-    )
+    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "GH Test"},)
     workspace_id = created.json()["id"]
 
     # Set a custom branch
-    await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={"github_branch": "develop"},
-    )
+    await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_branch": "develop"},)
 
     # Null it — should reset to main
-    response = await client.put(
-        f"/api/v1/workspaces/{workspace_id}",
-        cookies=auth_cookies,
-        json={"github_branch": None},
-    )
+    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_branch": None},)
 
     assert response.status_code == 200
     assert response.json()["github_branch"] == "main"

--- a/apps/api/app/tests/integration/test_workspace_routes.py
+++ b/apps/api/app/tests/integration/test_workspace_routes.py
@@ -6,9 +6,9 @@ import pytest
 from httpx import AsyncClient
 
 from app.core.security import generate_id, generate_session_token
-from app.tests.helpers import with_cookies
 from app.domain.models.entities import Session, User
 from app.infrastructure.db.repositories import SQLiteSessionRepository, SQLiteUserRepository
+from app.tests.helpers import with_cookies
 
 
 async def _create_other_user_cookies(db) -> dict[str, str]:
@@ -50,8 +50,14 @@ async def test_list_workspaces_returns_created_workspaces(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Workspace A"},)
-    await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Workspace B", "generator": "pulumi", "provider": "aws"},)
+    await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Workspace A"},
+    )
+    await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Workspace B", "generator": "pulumi", "provider": "aws"},
+    )
 
     response = await with_cookies(client, auth_cookies).get("/api/v1/workspaces/")
 
@@ -68,7 +74,10 @@ async def test_create_workspace_with_minimal_body_returns_201(
     auth_cookies: dict[str, str],
     test_user,
 ) -> None:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Minimal Workspace"},)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Minimal Workspace"},
+    )
 
     assert response.status_code == 201
     payload = response.json()
@@ -83,12 +92,15 @@ async def test_create_workspace_with_all_fields_returns_201(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={
-        "name": "Full Workspace",
-        "generator": "bicep",
-        "provider": "azure",
-        "github_repo": "acme/platform-infra",
-    },)
+    response = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={
+            "name": "Full Workspace",
+            "generator": "bicep",
+            "provider": "azure",
+            "github_repo": "acme/platform-infra",
+        },
+    )
 
     assert response.status_code == 201
     payload = response.json()
@@ -111,7 +123,10 @@ async def test_get_workspace_returns_workspace_for_owner(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Owned Workspace"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Owned Workspace"},
+    )
     workspace_id = created.json()["id"]
 
     response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace_id}")
@@ -137,7 +152,10 @@ async def test_get_workspace_of_other_user_returns_403(
     auth_cookies: dict[str, str],
     db,
 ) -> None:
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Private Workspace"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Private Workspace"},
+    )
     workspace_id = created.json()["id"]
     other_cookies = await _create_other_user_cookies(db)
 
@@ -160,10 +178,16 @@ async def test_update_workspace_name_returns_200(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Before"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Before"},
+    )
     workspace_id = created.json()["id"]
 
-    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"name": "After"},)
+    response = await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"name": "After"},
+    )
 
     assert response.status_code == 200
     assert response.json()["name"] == "After"
@@ -174,16 +198,22 @@ async def test_update_workspace_multiple_fields_returns_200(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Original"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Original"},
+    )
     workspace_id = created.json()["id"]
 
-    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={
-        "name": "Updated",
-        "generator": "pulumi",
-        "provider": "aws",
-        "github_repo": "acme/updated",
-        "github_branch": "develop",
-    },)
+    response = await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={
+            "name": "Updated",
+            "generator": "pulumi",
+            "provider": "aws",
+            "github_repo": "acme/updated",
+            "github_branch": "develop",
+        },
+    )
 
     assert response.status_code == 200
     payload = response.json()
@@ -199,7 +229,10 @@ async def test_update_workspace_non_existent_returns_404(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    response = await with_cookies(client, auth_cookies).put("/api/v1/workspaces/missing-id", json={"name": "Nope"},)
+    response = await with_cookies(client, auth_cookies).put(
+        "/api/v1/workspaces/missing-id",
+        json={"name": "Nope"},
+    )
 
     assert response.status_code == 404
     assert response.json()["error"]["code"] == "NOT_FOUND"
@@ -211,11 +244,17 @@ async def test_update_workspace_not_owner_returns_403(
     auth_cookies: dict[str, str],
     db,
 ) -> None:
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Owner Workspace"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Owner Workspace"},
+    )
     workspace_id = created.json()["id"]
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await with_cookies(client, other_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"name": "Should Fail"},)
+    response = await with_cookies(client, other_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"name": "Should Fail"},
+    )
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -226,14 +265,19 @@ async def test_delete_workspace_owned_returns_204(
     client: AsyncClient,
     auth_cookies: dict[str, str],
 ) -> None:
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Delete Me"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Delete Me"},
+    )
     workspace_id = created.json()["id"]
 
     response = await with_cookies(client, auth_cookies).delete(f"/api/v1/workspaces/{workspace_id}")
 
     assert response.status_code == 204
 
-    get_response = await with_cookies(client, auth_cookies).get(f"/api/v1/workspaces/{workspace_id}")
+    get_response = await with_cookies(client, auth_cookies).get(
+        f"/api/v1/workspaces/{workspace_id}"
+    )
     assert get_response.status_code == 404
 
 
@@ -254,11 +298,16 @@ async def test_delete_workspace_not_owner_returns_403(
     auth_cookies: dict[str, str],
     db,
 ) -> None:
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "Not Yours"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "Not Yours"},
+    )
     workspace_id = created.json()["id"]
     other_cookies = await _create_other_user_cookies(db)
 
-    response = await with_cookies(client, other_cookies).delete(f"/api/v1/workspaces/{workspace_id}")
+    response = await with_cookies(client, other_cookies).delete(
+        f"/api/v1/workspaces/{workspace_id}"
+    )
 
     assert response.status_code == 403
     assert response.json()["error"]["code"] == "FORBIDDEN"
@@ -270,14 +319,23 @@ async def test_update_workspace_omitting_github_repo_preserves_value(
     auth_cookies: dict[str, str],
 ) -> None:
     """When github_repo is omitted from the request body, the existing value is preserved."""
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "GH Test"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "GH Test"},
+    )
     workspace_id = created.json()["id"]
 
     # Set github_repo first
-    await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_repo": "owner/repo"},)
+    await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"github_repo": "owner/repo"},
+    )
 
     # Update only the name — github_repo should be preserved
-    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"name": "Renamed"},)
+    response = await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"name": "Renamed"},
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -291,14 +349,23 @@ async def test_update_workspace_null_github_repo_clears_value(
     auth_cookies: dict[str, str],
 ) -> None:
     """Explicitly sending github_repo=null clears the linked repository."""
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "GH Test"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "GH Test"},
+    )
     workspace_id = created.json()["id"]
 
     # Set github_repo first
-    await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_repo": "owner/repo"},)
+    await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"github_repo": "owner/repo"},
+    )
 
     # Explicitly null it
-    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_repo": None},)
+    response = await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"github_repo": None},
+    )
 
     assert response.status_code == 200
     assert response.json()["github_repo"] is None
@@ -310,14 +377,23 @@ async def test_update_workspace_null_github_branch_resets_to_main(
     auth_cookies: dict[str, str],
 ) -> None:
     """Explicitly sending github_branch=null resets the branch to 'main'."""
-    created = await with_cookies(client, auth_cookies).post("/api/v1/workspaces/", json={"name": "GH Test"},)
+    created = await with_cookies(client, auth_cookies).post(
+        "/api/v1/workspaces/",
+        json={"name": "GH Test"},
+    )
     workspace_id = created.json()["id"]
 
     # Set a custom branch
-    await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_branch": "develop"},)
+    await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"github_branch": "develop"},
+    )
 
     # Null it — should reset to main
-    response = await with_cookies(client, auth_cookies).put(f"/api/v1/workspaces/{workspace_id}", json={"github_branch": None},)
+    response = await with_cookies(client, auth_cookies).put(
+        f"/api/v1/workspaces/{workspace_id}",
+        json={"github_branch": None},
+    )
 
     assert response.status_code == 200
     assert response.json()["github_branch"] == "main"


### PR DESCRIPTION
## Summary
- Centralize authenticated cookie setup via `with_cookies()` helper in `apps/api/app/tests/helpers/httpx.py`
- Remove all per-request `cookies=` arguments from 7 integration test files
- Eliminates all 137 httpx deprecation warnings
- All 343 tests passing at 97.16% coverage (no regressions)

### Files changed
- **New**: `apps/api/app/tests/helpers/__init__.py`, `apps/api/app/tests/helpers/httpx.py`
- **Modified**: `test_auth_routes.py`, `test_workspace_routes.py`, `test_github_routes.py`, `test_generation_routes.py`, `test_ai_routes.py`, `test_ai_key_routes.py`, `test_ai_e2e.py`

Fixes #1813
Part of #1809