### PR TITLE
docs: add MkDocs documentation site link alongside Live Demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Python](https://img.shields.io/badge/Python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.110+-009688?logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://yeongseon.github.io/cloudblocks/)
+[![Docs](https://img.shields.io/badge/docs-site-blue)](https://yeongseon.github.io/cloudblocks/docs/)
 
 <p align="center">
   <img src="docs/assets/logo.svg" alt="CloudBlocks logo" width="96" height="96" />
@@ -18,7 +19,7 @@
 
 Start from built-in architecture templates, learn cloud infrastructure patterns with guided scenarios, and export Terraform starter code — all in the browser. No cloud account or backend required.
 
-> **[▶ Try the Live Demo](https://yeongseon.github.io/cloudblocks/)** — Frontend-only playground. Visual builder, templates, learning scenarios, and Terraform starter export work instantly. AI and GitHub features require the backend ([setup guide](docs/guides/TUTORIALS.md)).
+> **[▶ Try the Live Demo](https://yeongseon.github.io/cloudblocks/)** | **[📖 Documentation](https://yeongseon.github.io/cloudblocks/docs/)** — Frontend-only playground. Visual builder, templates, learning scenarios, and Terraform starter export work instantly. AI and GitHub features require the backend ([setup guide](docs/guides/TUTORIALS.md)).
 
 ## Demo
 
@@ -78,7 +79,7 @@ Open [http://localhost:5173](http://localhost:5173) to start learning.
 
 ## Documentation
 
-Full documentation is available in the [`docs/`](docs/) directory:
+Full documentation is available on the **[Documentation Site](https://yeongseon.github.io/cloudblocks/docs/)** or in the [`docs/`](docs/) directory:
 
 - [Getting Started](docs/guides/TUTORIALS.md)
 - [Architecture](docs/concept/ARCHITECTURE.md)

--- a/docs/user-guide/first-architecture.md
+++ b/docs/user-guide/first-architecture.md
@@ -12,6 +12,7 @@ Learn your first cloud architecture in 5 minutes using a built-in template with 
 ## Step 1 — Open CloudBlocks
 
 - **Live Demo**: Visit [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/)
+- **Documentation**: Browse the full docs at [https://yeongseon.github.io/cloudblocks/docs/](https://yeongseon.github.io/cloudblocks/docs/)
 - **Local**: Clone and run (see [Quick Start](quick-start.md))
 
 When CloudBlocks opens, click **Get Started** to enter the builder.

--- a/docs/user-guide/quick-start.md
+++ b/docs/user-guide/quick-start.md
@@ -14,7 +14,8 @@ Build your first cloud architecture in under 5 minutes. No cloud account require
 You can use CloudBlocks directly in your browser or run it locally.
 
 - **Option A: Live Demo** — Visit [https://yeongseon.github.io/cloudblocks/](https://yeongseon.github.io/cloudblocks/) to start immediately.
-- **Option B: Run Locally**:
+- **Option B: Documentation Site** — Browse the full docs at [https://yeongseon.github.io/cloudblocks/docs/](https://yeongseon.github.io/cloudblocks/docs/).
+- **Option C: Run Locally**:
 
 ```bash
 git clone https://github.com/yeongseon/cloudblocks.git


### PR DESCRIPTION
## Summary

- Add `Docs` badge to README.md linking to `https://yeongseon.github.io/cloudblocks/docs/`
- Update the callout block to show both Live Demo and Documentation links side by side
- Update the Documentation section to link to the hosted docs site
- Add documentation site link to `docs/user-guide/quick-start.md` and `docs/user-guide/first-architecture.md`

Fixes #1824