### PR TITLE
chore: release v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 ---
 
+## [v0.47.0] — 2026-04-14
+
+**Milestone 47 — Repository Review Follow-up**
+
+Cross-cutting documentation and test hygiene pass following the repository review. Refreshed metrics, reconciled internal references, removed deprecated API patterns, and added the MkDocs documentation site link across the repo.
+
+### Changed
+
+- Refreshed ROADMAP.md metrics: 3,404 frontend tests, 335 backend tests, 47 milestones shipped
+- Aligned backend validation commands across AGENTS.md, RELEASE_GATES.md, RELEASE_RUNBOOK.md, NFR_TARGETS.md, and apps/api/README.md (`python3 -m pytest` everywhere)
+- Repaired ADR path references in THEME_SYSTEM_SPEC.md and VERSION_POLICY.md to use `docs/adr/` prefix
+- Reconciled ARCHITECTURE.md: fixed broken doc links and updated frontend module tree to match current FSD structure
+- Updated MODULE_BOUNDARIES.md from 5 slices to 7 (added `learning` and `generate`)
+- Reconciled THEME_SYSTEM_SPEC.md port-visibility rules with actual uiStore implementation (`showPorts` replaces `portVisibility`)
+
+### Fixed
+
+- Removed deprecated per-request `cookies` parameter from httpx `AsyncClient` calls across 7 integration test files; introduced `with_cookies()` helper (137 warnings → 0)
+
+### Added
+
+- MkDocs documentation site badge and link in README.md callout and Documentation section
+- Documentation site links in quick-start and first-architecture user guides
+
 ## [v0.46.0] — 2026-04-14
 
 **Milestone 46 — Packet Flow UX & Visual Hierarchy**

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -89,7 +89,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 app = FastAPI(
     title="CloudBlocks API",
     description="Thin orchestration backend for CloudBlocks Platform",
-    version="0.46.0",
+    version="0.47.0",
     lifespan=lifespan,
 )
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloudblocks-api"
-version = "0.46.0"
+version = "0.47.0"
 description = "CloudBlocks API — optional backend for auth, GitHub sync, and learning tool integrations"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudblocks/web",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Visual cloud learning tool for beginners — learn cloud architecture patterns with guided templates and export Terraform starter code",
   "type": "module",
   "repository": {

--- a/packages/cloudblocks-domain/package.json
+++ b/packages/cloudblocks-domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/domain",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/schema",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Version bump `0.46.0` → `0.47.0` across all 6 version sources
- CHANGELOG entry for Milestone 47 — Repository Review Follow-up

## Release Checklist

- [x] All 8 M47 issues resolved and merged (#1817, #1818, #1819, #1820, #1821, #1822, #1823, #1825)
- [x] Epic #1809 closed
- [x] Release gates passed: `pnpm build`, `pnpm lint`, frontend tests (3,404), backend tests (335)
- [x] Demo verification via Playwright: app loads, canvas renders, templates open, validation works
- [x] Version bump: `./scripts/check-versions.sh` → PASS
- [x] CHANGELOG entry added

## Changes

### Docs
- Refreshed ROADMAP.md metrics
- Aligned backend validation commands across 5 files
- Repaired ADR path references in THEME_SYSTEM_SPEC.md and VERSION_POLICY.md
- Reconciled ARCHITECTURE.md links and frontend module tree
- Updated MODULE_BOUNDARIES.md from 5 to 7 slices
- Reconciled THEME_SYSTEM_SPEC.md port-visibility rules with uiStore
- Added MkDocs documentation site badge and links

### Test
- Removed deprecated per-request `cookies` parameter from httpx integration tests (137 warnings → 0)