### PR TITLE
feat(web): rounded orthogonal connection corners

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -28,6 +28,7 @@ vi.mock('../../shared/tokens/designTokens', () => ({
   PORT_DOT_RX: 4,
   PORT_DOT_RY: 2.5,
   PORT_DOT_STROKE_WIDTH: 1.5,
+  CONNECTION_CORNER_RADIUS: 12,
 }));
 
 vi.mock('../../shared/utils/diff', () => ({

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -38,6 +38,7 @@ import { offsetScreenPoints } from './overlapOffset';
 import { PacketFlowLayer } from './PacketFlowLayer';
 import { contrastTextColor } from './contrastTextColor';
 import { CONNECTION_TYPE_LABELS } from '../../shared/tokens/connectionTypeLabels';
+import { buildRoundedConnectionGeometry } from './roundedConnectionPath';
 
 interface ConnectionRendererProps {
   connectionId?: string;
@@ -111,15 +112,6 @@ function getColors(
     casing: base.casing,
     opacity: 1.0,
   };
-}
-
-function pointsToPath(points: readonly ScreenPoint[]): string {
-  if (points.length === 0) return '';
-  let d = `M ${points[0].x} ${points[0].y}`;
-  for (let i = 1; i < points.length; i += 1) {
-    d += ` L ${points[i].x} ${points[i].y}`;
-  }
-  return d;
 }
 
 function sameWorldPoint(a: WorldPoint3, b: WorldPoint3): boolean {
@@ -438,17 +430,17 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     if (!surfaceRoute) return null;
 
     const rawPoints = getRouteCenterlinePoints(surfaceRoute, originX, originY);
-    const hitPoints = overlapOffset ? offsetScreenPoints(rawPoints, overlapOffset) : rawPoints;
-    const hitPath = pointsToPath(hitPoints);
+    const offsetPoints = overlapOffset ? offsetScreenPoints(rawPoints, overlapOffset) : rawPoints;
+    const { path: hitPath, flowPoints } = buildRoundedConnectionGeometry(offsetPoints);
 
-    if (hitPoints.length < 2) return null;
+    if (flowPoints.length < 2) return null;
 
     return {
       hitPath,
-      hitPoints,
-      labelPos: getLabelPosition(hitPoints),
-      sourcePos: hitPoints[0],
-      targetPos: hitPoints[hitPoints.length - 1],
+      hitPoints: flowPoints,
+      labelPos: getLabelPosition(flowPoints),
+      sourcePos: flowPoints[0],
+      targetPos: flowPoints[flowPoints.length - 1],
     };
   }, [surfaceRoute, originX, originY, overlapOffset]);
 

--- a/apps/web/src/entities/connection/__tests__/roundedConnectionPath.test.ts
+++ b/apps/web/src/entities/connection/__tests__/roundedConnectionPath.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect } from 'vitest';
+import type { ScreenPoint } from '../../../shared/utils/isometric';
+import {
+  buildRoundedConnectionGeometry,
+  dedupeConsecutivePoints,
+  sampleArcInterior,
+} from '../roundedConnectionPath';
+
+// ─── dedupeConsecutivePoints ─────────────────────────────────────────
+
+describe('dedupeConsecutivePoints', () => {
+  it('returns empty array for empty input', () => {
+    expect(dedupeConsecutivePoints([])).toEqual([]);
+  });
+
+  it('preserves a single point', () => {
+    const pts: ScreenPoint[] = [{ x: 10, y: 20 }];
+    expect(dedupeConsecutivePoints(pts)).toEqual([{ x: 10, y: 20 }]);
+  });
+
+  it('removes exact consecutive duplicates', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+      { x: 10, y: 10 },
+      { x: 10, y: 10 },
+      { x: 10, y: 10 },
+      { x: 20, y: 20 },
+    ];
+    const result = dedupeConsecutivePoints(pts);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ x: 0, y: 0 });
+    expect(result[1]).toEqual({ x: 10, y: 10 });
+    expect(result[2]).toEqual({ x: 20, y: 20 });
+  });
+
+  it('preserves non-consecutive duplicates', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 10, y: 10 },
+      { x: 0, y: 0 },
+    ];
+    const result = dedupeConsecutivePoints(pts);
+    expect(result).toHaveLength(3);
+  });
+
+  it('removes near-duplicate points within EPS', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 1e-5, y: 1e-5 },
+      { x: 10, y: 10 },
+    ];
+    const result = dedupeConsecutivePoints(pts);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ─── sampleArcInterior ──────────────────────────────────────────────
+
+describe('sampleArcInterior', () => {
+  it('produces interior points for a 90° right turn', () => {
+    const out: ScreenPoint[] = [];
+    const radius = 12;
+    // Incoming direction: rightward (+x)
+    const inDir: ScreenPoint = { x: 1, y: 0 };
+    // Outgoing direction: downward (+y)
+    const outDir: ScreenPoint = { x: 0, y: 1 };
+    // Entry and exit points for a 90° corner at (100, 100)
+    const entry: ScreenPoint = { x: 100 - radius, y: 100 };
+    const exit: ScreenPoint = { x: 100, y: 100 + radius };
+    const cross = inDir.x * outDir.y - inDir.y * outDir.x; // 1 (CW)
+
+    sampleArcInterior(out, entry, exit, inDir, outDir, radius, cross);
+
+    expect(out.length).toBeGreaterThanOrEqual(1);
+    // All sampled points should be roughly at radius distance from center
+    // Center should be at (100 - radius, 100 + radius) for CW turn
+    // Actually center = entry + perpSign * (-inDir.y, inDir.x) * radius
+    // perpSign = 1 (cross > 0), so center = (88, 100) + (0, 12) = (88, 112)
+    const cx = entry.x + 1 * -inDir.y * radius; // 88 + 0 = 88
+    const cy = entry.y + 1 * inDir.x * radius; // 100 + 12 = 112
+    for (const p of out) {
+      const dist = Math.hypot(p.x - cx, p.y - cy);
+      expect(dist).toBeCloseTo(radius, 0);
+    }
+  });
+
+  it('produces no points for collinear directions', () => {
+    const out: ScreenPoint[] = [];
+    const inDir: ScreenPoint = { x: 1, y: 0 };
+    const outDir: ScreenPoint = { x: 1, y: 0 };
+    sampleArcInterior(out, { x: 0, y: 0 }, { x: 10, y: 0 }, inDir, outDir, 12, 0);
+    expect(out).toHaveLength(0);
+  });
+});
+
+// ─── buildRoundedConnectionGeometry ─────────────────────────────────
+
+describe('buildRoundedConnectionGeometry', () => {
+  // Edge cases
+
+  it('returns empty path for empty input', () => {
+    const result = buildRoundedConnectionGeometry([]);
+    expect(result.path).toBe('');
+    expect(result.flowPoints).toHaveLength(0);
+  });
+
+  it('returns M-only path for single point', () => {
+    const result = buildRoundedConnectionGeometry([{ x: 5, y: 10 }]);
+    expect(result.path).toBe('M 5 10');
+    expect(result.flowPoints).toHaveLength(1);
+  });
+
+  it('returns straight line for two points', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts);
+    expect(result.path).toBe('M 0 0 L 100 0');
+    expect(result.flowPoints.length).toBeGreaterThanOrEqual(2);
+    // First and last flow points should match input
+    expect(result.flowPoints[0]).toEqual({ x: 0, y: 0 });
+    expect(result.flowPoints[result.flowPoints.length - 1]).toEqual({
+      x: 100,
+      y: 0,
+    });
+  });
+
+  it('deduplicates identical consecutive points before building', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 0 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts);
+    // Should behave like 2 points → straight line
+    expect(result.path).toBe('M 0 0 L 100 0');
+  });
+
+  // Orthogonal L-shape (3 points, 90° turn)
+
+  it('produces arc command for L-shaped path (90° turn)', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12);
+
+    // Path should contain an A (arc) command
+    expect(result.path).toContain('A ');
+    // Path should start with M
+    expect(result.path).toMatch(/^M /);
+    // Path should contain L commands (straight segments)
+    expect(result.path).toContain('L ');
+  });
+
+  it('flowPoints covers entire path for L-shape', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12);
+
+    // Should have many flow points (sampled at ~6px)
+    // Total path length ≈ 200px, so ~33 samples minimum
+    expect(result.flowPoints.length).toBeGreaterThan(10);
+
+    // First flow point is the start
+    expect(result.flowPoints[0].x).toBeCloseTo(0, 1);
+    expect(result.flowPoints[0].y).toBeCloseTo(0, 1);
+
+    // Last flow point is the end
+    const last = result.flowPoints[result.flowPoints.length - 1];
+    expect(last.x).toBeCloseTo(100, 1);
+    expect(last.y).toBeCloseTo(100, 1);
+  });
+
+  // U-shape (4 points, two 90° turns)
+
+  it('produces two arc commands for U-shaped path', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 80 },
+      { x: 0, y: 80 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12);
+    const arcCount = (result.path.match(/A /g) ?? []).length;
+    expect(arcCount).toBe(2);
+  });
+
+  // Collinear points (no turn needed)
+
+  it('emits straight line for collinear points (no arcs)', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 50, y: 0 },
+      { x: 100, y: 0 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12);
+    // Collinear → cross product = 0 → no arc
+    expect(result.path).not.toContain('A ');
+  });
+
+  // Radius clamping (short segments)
+
+  it('clamps radius for short segments to avoid overlap', () => {
+    // Two segments of 20px each, radius 12 → trim ≈ 12 (for 90°)
+    // max trim = min(20/2, 20/2) = 10, so it should clamp
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 20, y: 0 },
+      { x: 20, y: 20 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12);
+
+    // Should still produce an arc, just with a smaller effective trim
+    expect(result.path).toContain('A ');
+
+    // Flow points should still be ordered (monotonic progression)
+    for (let i = 1; i < result.flowPoints.length; i++) {
+      const prev = result.flowPoints[i - 1];
+      const curr = result.flowPoints[i];
+      const dist = Math.hypot(curr.x - prev.x, curr.y - prev.y);
+      // Adjacent flow points should be reasonably close
+      expect(dist).toBeLessThan(25);
+    }
+  });
+
+  // Arrow end reservation
+
+  it('preserves straight segment at path end for arrow marker', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 40 }, // Last segment is 40px
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12, 18);
+
+    // The last flow point should be the endpoint
+    const last = result.flowPoints[result.flowPoints.length - 1];
+    expect(last.x).toBeCloseTo(100, 1);
+    expect(last.y).toBeCloseTo(40, 1);
+
+    // There should be enough straight segment at the end
+    // The last few flow points should be on the vertical line x=100
+    const lastFew = result.flowPoints.slice(-3);
+    for (const p of lastFew) {
+      expect(p.x).toBeCloseTo(100, 1);
+    }
+  });
+
+  // Custom radius parameter
+
+  it('accepts custom radius', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 200, y: 0 },
+      { x: 200, y: 200 },
+    ];
+    const smallRadius = buildRoundedConnectionGeometry(pts, 5);
+    const largeRadius = buildRoundedConnectionGeometry(pts, 30);
+
+    // Both should have arcs
+    expect(smallRadius.path).toContain('A ');
+    expect(largeRadius.path).toContain('A ');
+
+    // Larger radius → more arc samples → more flow points (roughly)
+    // This is a rough heuristic check
+    expect(largeRadius.flowPoints.length).toBeGreaterThanOrEqual(smallRadius.flowPoints.length - 5);
+  });
+
+  // Complex path (zigzag with multiple turns)
+
+  it('handles zigzag path with multiple turns', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 60, y: 0 },
+      { x: 60, y: 60 },
+      { x: 120, y: 60 },
+      { x: 120, y: 120 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12);
+
+    // Should have 3 arcs (3 interior vertices)
+    const arcCount = (result.path.match(/A /g) ?? []).length;
+    expect(arcCount).toBe(3);
+
+    // Flow points should be dense and ordered
+    expect(result.flowPoints.length).toBeGreaterThan(15);
+  });
+
+  // Sweep direction
+
+  it('uses correct sweep flag for left vs right turns', () => {
+    // Right turn (CW): going right then down
+    const rightTurn: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const rResult = buildRoundedConnectionGeometry(rightTurn, 12);
+
+    // Left turn (CCW): going right then up
+    const leftTurn: ScreenPoint[] = [
+      { x: 0, y: 100 },
+      { x: 100, y: 100 },
+      { x: 100, y: 0 },
+    ];
+    const lResult = buildRoundedConnectionGeometry(leftTurn, 12);
+
+    // Both should produce valid paths with arcs
+    expect(rResult.path).toContain('A ');
+    expect(lResult.path).toContain('A ');
+
+    // The sweep flags should differ (one has 0, other has 1)
+    const rSweep = rResult.path.match(/A \d+ \d+ 0 0 (\d)/)?.[1];
+    const lSweep = lResult.path.match(/A \d+ \d+ 0 0 (\d)/)?.[1];
+    expect(rSweep).toBeDefined();
+    expect(lSweep).toBeDefined();
+    expect(rSweep).not.toBe(lSweep);
+  });
+
+  // Return type contract
+
+  it('always returns path string and flowPoints array', () => {
+    const cases: ScreenPoint[][] = [
+      [],
+      [{ x: 0, y: 0 }],
+      [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+      [
+        { x: 0, y: 0 },
+        { x: 50, y: 0 },
+        { x: 50, y: 50 },
+      ],
+    ];
+
+    for (const pts of cases) {
+      const result = buildRoundedConnectionGeometry(pts, 12);
+      expect(typeof result.path).toBe('string');
+      expect(Array.isArray(result.flowPoints)).toBe(true);
+      for (const p of result.flowPoints) {
+        expect(typeof p.x).toBe('number');
+        expect(typeof p.y).toBe('number');
+        expect(Number.isFinite(p.x)).toBe(true);
+        expect(Number.isFinite(p.y)).toBe(true);
+      }
+    }
+  });
+
+  // Flow points are monotonically progressing along the path
+
+  it('flow points progress monotonically along path', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, 12);
+
+    // Compute cumulative distance — should be monotonically increasing
+    let cumDist = 0;
+    for (let i = 1; i < result.flowPoints.length; i++) {
+      const prev = result.flowPoints[i - 1];
+      const curr = result.flowPoints[i];
+      const segDist = Math.hypot(curr.x - prev.x, curr.y - prev.y);
+      cumDist += segDist;
+    }
+    // Total distance should be roughly equal to path length (~200px minus trim)
+    expect(cumDist).toBeGreaterThan(150);
+    expect(cumDist).toBeLessThan(250);
+  });
+
+  // Very short overall path (< radius)
+
+  it('handles path shorter than radius gracefully', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 5, y: 0 },
+      { x: 5, y: 5 },
+    ];
+    // radius 12 is larger than segment lengths (5px)
+    const result = buildRoundedConnectionGeometry(pts, 12);
+    expect(result.path).toBeTruthy();
+    expect(result.flowPoints.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/web/src/entities/connection/roundedConnectionPath.ts
+++ b/apps/web/src/entities/connection/roundedConnectionPath.ts
@@ -1,0 +1,303 @@
+/**
+ * Rounded orthogonal connection path builder.
+ *
+ * Converts a polyline of screen-space points into an SVG path with
+ * arc-rounded corners. Also produces a densely-sampled `flowPoints`
+ * array for PacketFlowLayer animation.
+ *
+ * Algorithm designed by Oracle consultation (ADR-0018, Issue #1830).
+ *
+ * Key decisions:
+ *  - SVG Arc (`A`) commands, not quadratic Bezier — consistent radius
+ *    at any projected angle.
+ *  - Tangent trim: radius × tan(turnAngle/2), clamped to half of the
+ *    shorter adjacent segment.
+ *  - Sweep flag: cross > 0 ? 1 : 0 (clockwise in SVG screen coords).
+ *  - Arrow reservation: straight segment reserved at path end for
+ *    markerEnd orientation.
+ *  - Arc sampling at ~6px intervals for smooth packet flow.
+ */
+
+import type { ScreenPoint } from '../../shared/utils/isometric';
+import { CONNECTION_CORNER_RADIUS } from '../../shared/tokens/designTokens';
+
+/** Return type for buildRoundedConnectionGeometry(). */
+export interface RoundedPathGeometry {
+  /** SVG path `d` attribute string. */
+  path: string;
+  /** Densely-sampled screen points for PacketFlowLayer animation. */
+  flowPoints: ScreenPoint[];
+}
+
+const EPS = 1e-3;
+const ARC_SAMPLE_PX = 6;
+const MIN_ARROW_STRAIGHT_PX = 18;
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+/** Remove consecutive duplicate points (within EPS distance). */
+export function dedupeConsecutivePoints(points: readonly ScreenPoint[]): ScreenPoint[] {
+  if (points.length === 0) return [];
+  const result: ScreenPoint[] = [points[0]];
+  for (let i = 1; i < points.length; i++) {
+    const prev = result[result.length - 1];
+    const cur = points[i];
+    if (Math.hypot(cur.x - prev.x, cur.y - prev.y) > EPS) {
+      result.push(cur);
+    }
+  }
+  return result;
+}
+
+/**
+ * Linearly interpolate between two points.
+ */
+function lerp(a: ScreenPoint, b: ScreenPoint, t: number): ScreenPoint {
+  return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+}
+
+/**
+ * Sample interior points along a circular arc.
+ *
+ * Pushes sampled points into `out` (does NOT include entry/exit — the
+ * caller adds those as part of the polyline construction).
+ *
+ * @param out      - accumulator for flow points
+ * @param entry    - arc start point (tangent trim point on incoming segment)
+ * @param exit     - arc end point (tangent trim point on outgoing segment)
+ * @param inDir    - unit direction of incoming segment
+ * @param outDir   - unit direction of outgoing segment
+ * @param radius   - arc radius in px
+ * @param cross    - 2D cross product of inDir × outDir (sign → sweep)
+ */
+export function sampleArcInterior(
+  out: ScreenPoint[],
+  entry: ScreenPoint,
+  exit: ScreenPoint,
+  inDir: ScreenPoint,
+  outDir: ScreenPoint,
+  radius: number,
+  cross: number,
+): void {
+  // Approximate arc length for sample count.
+  // turnAngle = angle between in and out directions.
+  const dot = inDir.x * outDir.x + inDir.y * outDir.y;
+  const clampedDot = Math.max(-1, Math.min(1, dot));
+  const turnAngle = Math.acos(clampedDot);
+  if (turnAngle < EPS) return; // Nearly collinear — no samples needed.
+
+  const arcLength = radius * turnAngle;
+  const sampleCount = Math.max(1, Math.round(arcLength / ARC_SAMPLE_PX));
+
+  // Find center of the arc circle.
+  // The center lies at distance `radius` from both entry and exit,
+  // perpendicular to the respective segment directions.
+  // For the incoming segment, perpendicular direction rotated toward the turn:
+  const perpSign = cross > 0 ? 1 : -1;
+  const cx = entry.x + perpSign * -inDir.y * radius;
+  const cy = entry.y + perpSign * inDir.x * radius;
+
+  // Start and end angles (atan2 from center to entry/exit).
+  const startAngle = Math.atan2(entry.y - cy, entry.x - cx);
+  const endAngle = Math.atan2(exit.y - cy, exit.x - cx);
+
+  // Determine sweep direction.
+  let angleDelta = endAngle - startAngle;
+  if (cross > 0) {
+    // Clockwise sweep (SVG sweep=1 means clockwise in screen coords).
+    // We need angleDelta to be negative (CW in math coords = screen CW).
+    if (angleDelta > 0) angleDelta -= 2 * Math.PI;
+  } else {
+    // Counter-clockwise sweep (SVG sweep=0).
+    if (angleDelta < 0) angleDelta += 2 * Math.PI;
+  }
+
+  for (let i = 1; i < sampleCount; i++) {
+    const t = i / sampleCount;
+    const angle = startAngle + angleDelta * t;
+    out.push({
+      x: cx + radius * Math.cos(angle),
+      y: cy + radius * Math.sin(angle),
+    });
+  }
+}
+
+// ─── Main builder ────────────────────────────────────────────────────
+
+/**
+ * Build a rounded SVG path and dense flow-point array from a polyline.
+ *
+ * @param inputPoints        - Screen-space polyline (≥2 points)
+ * @param radius             - Corner arc radius in px (default: CONNECTION_CORNER_RADIUS)
+ * @param endStraightReserve - Minimum straight px reserved at path end for
+ *                             arrow marker orientation (default: MIN_ARROW_STRAIGHT_PX)
+ */
+export function buildRoundedConnectionGeometry(
+  inputPoints: readonly ScreenPoint[],
+  radius: number = CONNECTION_CORNER_RADIUS,
+  endStraightReserve: number = MIN_ARROW_STRAIGHT_PX,
+): RoundedPathGeometry {
+  const pts = dedupeConsecutivePoints(inputPoints);
+
+  // Edge case: 0-1 points → degenerate.
+  if (pts.length === 0) {
+    return { path: '', flowPoints: [] };
+  }
+  if (pts.length === 1) {
+    return {
+      path: `M ${pts[0].x} ${pts[0].y}`,
+      flowPoints: [pts[0]],
+    };
+  }
+
+  // Edge case: 2 points → straight line, no corners.
+  if (pts.length === 2) {
+    return {
+      path: `M ${pts[0].x} ${pts[0].y} L ${pts[1].x} ${pts[1].y}`,
+      flowPoints: [...pts],
+    };
+  }
+
+  // Precompute segment lengths and unit directions.
+  const n = pts.length;
+  const segLen: number[] = [];
+  const segDir: ScreenPoint[] = [];
+  for (let i = 0; i < n - 1; i++) {
+    const dx = pts[i + 1].x - pts[i].x;
+    const dy = pts[i + 1].y - pts[i].y;
+    const len = Math.hypot(dx, dy);
+    segLen.push(len);
+    segDir.push(len > EPS ? { x: dx / len, y: dy / len } : { x: 0, y: 0 });
+  }
+
+  // For each interior vertex, compute the trim distance.
+  // trim = radius * tan(turnAngle / 2), clamped to min(inLen/2, outLen/2).
+  const trimDist: number[] = new Array(n).fill(0);
+  for (let i = 1; i < n - 1; i++) {
+    const inD = segDir[i - 1];
+    const outD = segDir[i];
+    const cross = inD.x * outD.y - inD.y * outD.x;
+    const dot = inD.x * outD.x + inD.y * outD.y;
+
+    // Collinear or near-collinear → no rounding needed.
+    if (Math.abs(cross) < EPS) {
+      trimDist[i] = 0;
+      continue;
+    }
+
+    const turnAngle = Math.acos(Math.max(-1, Math.min(1, dot)));
+    const halfTan = Math.tan(turnAngle / 2);
+    const rawTrim = radius * halfTan;
+
+    // Also respect endStraightReserve on the last segment.
+    const inAvail = segLen[i - 1] / 2;
+    let outAvail = segLen[i] / 2;
+    if (i === n - 2) {
+      // Last interior vertex — reserve straight segment at the end for arrow.
+      const arrowReserve = Math.max(endStraightReserve, radius * 1.5);
+      outAvail = Math.max(0, segLen[i] - arrowReserve) / 2;
+    }
+
+    trimDist[i] = Math.min(rawTrim, inAvail, outAvail);
+  }
+
+  // Build path string and flow points.
+  const pathParts: string[] = [];
+  const flowPoints: ScreenPoint[] = [];
+
+  // Start point.
+  pathParts.push(`M ${pts[0].x} ${pts[0].y}`);
+  flowPoints.push(pts[0]);
+
+  for (let i = 1; i < n; i++) {
+    const trim = trimDist[i];
+    const prevTrim = trimDist[i - 1] ?? 0;
+
+    if (i < n - 1 && trim > EPS) {
+      // This is an interior vertex with rounding.
+      const inD = segDir[i - 1];
+      const outD = segDir[i];
+      const cross = inD.x * outD.y - inD.y * outD.x;
+
+      // Entry point: trim back from vertex along incoming segment.
+      const entry: ScreenPoint = {
+        x: pts[i].x - inD.x * trim,
+        y: pts[i].y - inD.y * trim,
+      };
+
+      // Exit point: trim forward from vertex along outgoing segment.
+      const exit: ScreenPoint = {
+        x: pts[i].x + outD.x * trim,
+        y: pts[i].y + outD.y * trim,
+      };
+
+      // Line to entry point (from previous exit or start).
+      pathParts.push(`L ${entry.x} ${entry.y}`);
+
+      // Sample intermediate flow points along the straight segment.
+      const straightStart =
+        i === 1
+          ? pts[0]
+          : (() => {
+              // Previous exit point.
+              const prevInD = segDir[i - 2];
+              const prevOutD = segDir[i - 1];
+              const prevCross = prevInD.x * prevOutD.y - prevInD.y * prevOutD.x;
+              if (Math.abs(prevCross) < EPS || prevTrim < EPS) return pts[i - 1];
+              return {
+                x: pts[i - 1].x + prevOutD.x * prevTrim,
+                y: pts[i - 1].y + prevOutD.y * prevTrim,
+              };
+            })();
+      sampleStraightSegment(flowPoints, straightStart, entry);
+
+      // Arc to exit point.
+      const sweepFlag = cross > 0 ? 1 : 0;
+      pathParts.push(`A ${radius} ${radius} 0 0 ${sweepFlag} ${exit.x} ${exit.y}`);
+
+      // Sample arc interior for flow points.
+      sampleArcInterior(flowPoints, entry, exit, inD, outD, radius, cross);
+      flowPoints.push(exit);
+    } else {
+      // Last point or no rounding needed — straight line.
+      pathParts.push(`L ${pts[i].x} ${pts[i].y}`);
+
+      // Sample straight segment for flow points.
+      const straightStart = (() => {
+        if (i === 1) return pts[0];
+        const prevI = i - 1;
+        if (trimDist[prevI] > EPS && prevI > 0 && prevI < n - 1) {
+          const prevOutD = segDir[prevI];
+          return {
+            x: pts[prevI].x + prevOutD.x * trimDist[prevI],
+            y: pts[prevI].y + prevOutD.y * trimDist[prevI],
+          };
+        }
+        return pts[prevI];
+      })();
+      sampleStraightSegment(flowPoints, straightStart, pts[i]);
+    }
+  }
+
+  return {
+    path: pathParts.join(' '),
+    flowPoints,
+  };
+}
+
+/**
+ * Sample intermediate points along a straight segment at ~ARC_SAMPLE_PX
+ * intervals. Pushes intermediate points (not start) and the endpoint.
+ */
+function sampleStraightSegment(out: ScreenPoint[], start: ScreenPoint, end: ScreenPoint): void {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const len = Math.hypot(dx, dy);
+  if (len < EPS) return;
+
+  const sampleCount = Math.max(1, Math.round(len / ARC_SAMPLE_PX));
+  for (let i = 1; i < sampleCount; i++) {
+    out.push(lerp(start, end, i / sampleCount));
+  }
+  out.push(end);
+}

--- a/apps/web/src/shared/tokens/designTokens.ts
+++ b/apps/web/src/shared/tokens/designTokens.ts
@@ -64,3 +64,8 @@ export const PORT_GLOW_RADIUS = 4; // SVG filter blur radius for port glow
 //   fontSize = Math.max(LABEL_FACE_MIN_PX, Math.round(sideWallPx * LABEL_FACE_SCALE))
 export const LABEL_FACE_MIN_PX = 8;
 export const LABEL_FACE_SCALE = 0.28;
+
+// -- Connection Corner Radius --
+// Radius in screen px for rounded orthogonal connection corners.
+// Safe for 32-128px segment lengths. Must be ≤ min(segLen)/2.
+export const CONNECTION_CORNER_RADIUS = 12;


### PR DESCRIPTION
## Summary

Implements smooth rounded corners on orthogonal (Manhattan-routed) connections using SVG Arc (`A`) commands, replacing the previous sharp 90-degree bends.

Fixes #1830

## Changes

### New: `roundedConnectionPath.ts` (304 lines)
- `buildRoundedConnectionGeometry()` — core algorithm converting orthogonal polylines to rounded SVG paths
- SVG Arc (`A`) commands with `CONNECTION_CORNER_RADIUS = 12px`
- Tangent trim: `radius * tan(turnAngle / 2)`, clamped to half-segment
- Sweep flag: `cross > 0 ? 1 : 0` (clockwise in SVG screen coords)
- Arrow reservation: `max(18, radius * 1.5)px` straight at path end for markerEnd orientation
- Dense `flowPoints` resampling (~6px intervals) for PacketFlowLayer animation
- Edge cases: 2-point straight lines, collinear segments, duplicate point deduplication

### New: `roundedConnectionPath.test.ts` (394 lines, 23 tests)
- Covers straight lines, single/multi-turn paths, collinear segments, duplicate points, radius clamping, arrow reservation, flowPoints density

### Modified: `ConnectionRenderer.tsx`
- Removed dead `pointsToPath()` helper
- Integrated `buildRoundedConnectionGeometry()` for committed connection rendering
- Feeds dense `flowPoints` to PacketFlowLayer for accurate packet animation

### Modified: `designTokens.ts`
- Added `CONNECTION_CORNER_RADIUS = 12`

### Modified: `ConnectionRenderer.test.tsx`
- Updated designTokens mock to include `CONNECTION_CORNER_RADIUS`

## Design Decisions

- **SVG Arc over Quadratic Bezier**: Arc gives consistent screen-space radius at any projected angle (per Oracle consultation)
- **`surfaceRouting.ts` unchanged**: All improvements are presentation-layer only
- **Isometric view preserved**: No coordinate system changes

## Testing

- All 3427 tests passing
- Build clean, lint clean
- Branch coverage maintained >= 90%
