### PR TITLE
feat(web): preview and committed connection path visual consistency

### DIFF
--- a/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
@@ -11,6 +11,8 @@ import type { ResourceBlock, ContainerBlock } from '@cloudblocks/schema';
 import { PORT_OUT_PX } from '../../shared/tokens/designTokens';
 import { canConnect } from '../../entities/validation/connection';
 import type { EndpointType } from '../../shared/types/endpoint';
+import { getPreviewRoutePoints } from './previewRoutePoints';
+import { buildRoundedConnectionGeometry } from '../../entities/connection/roundedConnectionPath';
 
 interface ConnectionPreviewProps {
   originX: number;
@@ -214,9 +216,8 @@ export function ConnectionPreview({ originX, originY }: ConnectionPreviewProps) 
   }
 
   const target = snappedTarget ?? cursor ?? sourceScreen;
-  const midX = (sourceScreen.x + target.x) / 2;
-  const midY = Math.min(sourceScreen.y, target.y) - 40;
-  const pathD = `M ${sourceScreen.x} ${sourceScreen.y} Q ${midX} ${midY} ${target.x} ${target.y}`;
+  const routePoints = getPreviewRoutePoints(sourceScreen, target);
+  const { path: pathD } = buildRoundedConnectionGeometry(routePoints);
 
   return (
     <path

--- a/apps/web/src/widgets/scene-canvas/__tests__/previewRoutePoints.test.ts
+++ b/apps/web/src/widgets/scene-canvas/__tests__/previewRoutePoints.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { getPreviewRoutePoints } from '../previewRoutePoints';
+
+const R = 12; // CONNECTION_CORNER_RADIUS default
+
+describe('getPreviewRoutePoints', () => {
+  it('returns straight line when source and target are very close', () => {
+    const source = { x: 100, y: 200 };
+    const target = { x: 110, y: 210 }; // dx=10, dy=10, both < 2*R=24
+    const result = getPreviewRoutePoints(source, target);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(source);
+    expect(result[1]).toEqual(target);
+  });
+
+  it('returns straight line when source equals target', () => {
+    const source = { x: 100, y: 200 };
+    const result = getPreviewRoutePoints(source, source);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(source);
+    expect(result[1]).toEqual(source);
+  });
+
+  it('returns 4-point step route for target far to the right and below', () => {
+    const source = { x: 100, y: 100 };
+    const target = { x: 300, y: 250 };
+    const result = getPreviewRoutePoints(source, target);
+    expect(result).toHaveLength(4);
+    // First point is source
+    expect(result[0]).toEqual(source);
+    // Last point is target
+    expect(result[3]).toEqual(target);
+    // Middle points share the same X (vertical lane)
+    expect(result[1].x).toBe(result[2].x);
+    // First middle point has source's Y
+    expect(result[1].y).toBe(source.y);
+    // Second middle point has target's Y
+    expect(result[2].y).toBe(target.y);
+  });
+
+  it('places lane at midpoint when target is far ahead', () => {
+    const source = { x: 100, y: 100 };
+    const target = { x: 400, y: 200 };
+    const result = getPreviewRoutePoints(source, target);
+    // midX = (100 + 400) / 2 = 250
+    // source.x + minStub = 100 + 24 = 124
+    // target.x - minStub = 400 - 24 = 376
+    // laneX = max(124, min(250, 376)) = 250
+    expect(result[1].x).toBe(250);
+  });
+
+  it('uses minStub when target is close horizontally but far vertically', () => {
+    const source = { x: 100, y: 100 };
+    const target = { x: 130, y: 300 }; // dx=30 > 24, dy=200 > 24
+    const result = getPreviewRoutePoints(source, target);
+    expect(result).toHaveLength(4);
+    // midX = (100 + 130) / 2 = 115
+    // source.x + minStub = 100 + 24 = 124
+    // target.x - minStub = 130 - 24 = 106
+    // laneX = max(124, min(115, 106)) = max(124, 106) = 124
+    expect(result[1].x).toBe(124);
+  });
+
+  it('handles target to the left of source (behind)', () => {
+    const source = { x: 200, y: 100 };
+    const target = { x: 50, y: 200 };
+    const result = getPreviewRoutePoints(source, target);
+    expect(result).toHaveLength(4);
+    // midX = (200 + 50) / 2 = 125
+    // source.x + minStub = 200 + 24 = 224
+    // target.x - minStub = 50 - 24 = 26
+    // laneX = max(224, min(125, 26)) = max(224, 26) = 224
+    expect(result[1].x).toBe(224);
+    // Lane is to the right of source, looping out before coming back
+    expect(result[1].x).toBeGreaterThan(source.x);
+  });
+
+  it('handles horizontal target (same Y)', () => {
+    const source = { x: 100, y: 200 };
+    const target = { x: 300, y: 200 };
+    const result = getPreviewRoutePoints(source, target);
+    expect(result).toHaveLength(4);
+    // p1 and p2 will have same Y since source.y === target.y
+    // The dedup in buildRoundedConnectionGeometry will handle collapsing
+    expect(result[1].y).toBe(result[2].y);
+    expect(result[1].y).toBe(200);
+  });
+
+  it('handles vertical target (same X but far vertically)', () => {
+    const source = { x: 100, y: 100 };
+    const target = { x: 100, y: 300 };
+    const result = getPreviewRoutePoints(source, target);
+    expect(result).toHaveLength(4);
+    // midX = (100 + 100) / 2 = 100
+    // source.x + minStub = 100 + 24 = 124
+    // target.x - minStub = 100 - 24 = 76
+    // laneX = max(124, min(100, 76)) = max(124, 76) = 124
+    expect(result[1].x).toBe(124);
+  });
+
+  it('accepts custom radius parameter', () => {
+    const source = { x: 100, y: 100 };
+    const target = { x: 105, y: 105 }; // within 2*R for R=12, but not for R=2
+    // With default R=12, minStub = 24, dx=5 < 24 and dy=5 < 24 → straight
+    expect(getPreviewRoutePoints(source, target, 12)).toHaveLength(2);
+    // With R=2, minStub = 4, dx=5 > 4 or dy=5 > 4 → NOT both < minStub
+    // Actually dx=5 > 4 AND dy=5 > 4 → step route
+    expect(getPreviewRoutePoints(source, target, 2)).toHaveLength(4);
+  });
+
+  it('always exits horizontally to the right (no jitter)', () => {
+    const source = { x: 100, y: 100 };
+    // Target above-left
+    const t1 = getPreviewRoutePoints(source, { x: 50, y: 50 });
+    // Target below-left
+    const t2 = getPreviewRoutePoints(source, { x: 50, y: 200 });
+    // Target above-right
+    const t3 = getPreviewRoutePoints(source, { x: 300, y: 50 });
+    // Target below-right
+    const t4 = getPreviewRoutePoints(source, { x: 300, y: 200 });
+
+    // All should have the first segment horizontal (same Y as source)
+    for (const result of [t1, t2, t3, t4]) {
+      if (result.length >= 3) {
+        expect(result[1].y).toBe(source.y);
+      }
+    }
+  });
+
+  it('laneX is always >= source.x + minStub', () => {
+    const source = { x: 100, y: 100 };
+    const minStub = 2 * R;
+    const targets = [
+      { x: 50, y: 200 },
+      { x: 100, y: 200 },
+      { x: 130, y: 200 },
+      { x: 500, y: 200 },
+    ];
+    for (const target of targets) {
+      const result = getPreviewRoutePoints(source, target);
+      if (result.length === 4) {
+        expect(result[1].x).toBeGreaterThanOrEqual(source.x + minStub);
+      }
+    }
+  });
+});

--- a/apps/web/src/widgets/scene-canvas/__tests__/previewRoutePoints.test.ts
+++ b/apps/web/src/widgets/scene-canvas/__tests__/previewRoutePoints.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { getPreviewRoutePoints } from '../previewRoutePoints';
+import { CONNECTION_CORNER_RADIUS } from '../../../shared/tokens/designTokens';
 
-const R = 12; // CONNECTION_CORNER_RADIUS default
+const R = CONNECTION_CORNER_RADIUS;
 
 describe('getPreviewRoutePoints', () => {
   it('returns straight line when source and target are very close', () => {

--- a/apps/web/src/widgets/scene-canvas/__tests__/previewRoutePoints.test.ts
+++ b/apps/web/src/widgets/scene-canvas/__tests__/previewRoutePoints.test.ts
@@ -43,20 +43,20 @@ describe('getPreviewRoutePoints', () => {
     const target = { x: 400, y: 200 };
     const result = getPreviewRoutePoints(source, target);
     // midX = (100 + 400) / 2 = 250
-    // source.x + minStub = 100 + 24 = 124
-    // target.x - minStub = 400 - 24 = 376
+    // source.x + minExit = 100 + 24 = 124
+    // target.x - minExit = 400 - 24 = 376
     // laneX = max(124, min(250, 376)) = 250
     expect(result[1].x).toBe(250);
   });
 
-  it('uses minStub when target is close horizontally but far vertically', () => {
+  it('uses minExit when target is close horizontally but far vertically', () => {
     const source = { x: 100, y: 100 };
     const target = { x: 130, y: 300 }; // dx=30 > 24, dy=200 > 24
     const result = getPreviewRoutePoints(source, target);
     expect(result).toHaveLength(4);
     // midX = (100 + 130) / 2 = 115
-    // source.x + minStub = 100 + 24 = 124
-    // target.x - minStub = 130 - 24 = 106
+    // source.x + minExit = 100 + 24 = 124
+    // target.x - minExit = 130 - 24 = 106
     // laneX = max(124, min(115, 106)) = max(124, 106) = 124
     expect(result[1].x).toBe(124);
   });
@@ -67,8 +67,8 @@ describe('getPreviewRoutePoints', () => {
     const result = getPreviewRoutePoints(source, target);
     expect(result).toHaveLength(4);
     // midX = (200 + 50) / 2 = 125
-    // source.x + minStub = 200 + 24 = 224
-    // target.x - minStub = 50 - 24 = 26
+    // source.x + minExit = 200 + 24 = 224
+    // target.x - minExit = 50 - 24 = 26
     // laneX = max(224, min(125, 26)) = max(224, 26) = 224
     expect(result[1].x).toBe(224);
     // Lane is to the right of source, looping out before coming back
@@ -92,8 +92,8 @@ describe('getPreviewRoutePoints', () => {
     const result = getPreviewRoutePoints(source, target);
     expect(result).toHaveLength(4);
     // midX = (100 + 100) / 2 = 100
-    // source.x + minStub = 100 + 24 = 124
-    // target.x - minStub = 100 - 24 = 76
+    // source.x + minExit = 100 + 24 = 124
+    // target.x - minExit = 100 - 24 = 76
     // laneX = max(124, min(100, 76)) = max(124, 76) = 124
     expect(result[1].x).toBe(124);
   });
@@ -101,9 +101,9 @@ describe('getPreviewRoutePoints', () => {
   it('accepts custom radius parameter', () => {
     const source = { x: 100, y: 100 };
     const target = { x: 105, y: 105 }; // within 2*R for R=12, but not for R=2
-    // With default R=12, minStub = 24, dx=5 < 24 and dy=5 < 24 → straight
+    // With default R=12, minExit = 24, dx=5 < 24 and dy=5 < 24 → straight
     expect(getPreviewRoutePoints(source, target, 12)).toHaveLength(2);
-    // With R=2, minStub = 4, dx=5 > 4 or dy=5 > 4 → NOT both < minStub
+    // With R=2, minExit = 4, dx=5 > 4 or dy=5 > 4 → NOT both < minExit
     // Actually dx=5 > 4 AND dy=5 > 4 → step route
     expect(getPreviewRoutePoints(source, target, 2)).toHaveLength(4);
   });
@@ -127,9 +127,9 @@ describe('getPreviewRoutePoints', () => {
     }
   });
 
-  it('laneX is always >= source.x + minStub', () => {
+  it('laneX is always >= source.x + minExit', () => {
     const source = { x: 100, y: 100 };
-    const minStub = 2 * R;
+    const minExit = 2 * R;
     const targets = [
       { x: 50, y: 200 },
       { x: 100, y: 200 },
@@ -139,7 +139,7 @@ describe('getPreviewRoutePoints', () => {
     for (const target of targets) {
       const result = getPreviewRoutePoints(source, target);
       if (result.length === 4) {
-        expect(result[1].x).toBeGreaterThanOrEqual(source.x + minStub);
+        expect(result[1].x).toBeGreaterThanOrEqual(source.x + minExit);
       }
     }
   });

--- a/apps/web/src/widgets/scene-canvas/previewRoutePoints.ts
+++ b/apps/web/src/widgets/scene-canvas/previewRoutePoints.ts
@@ -33,19 +33,19 @@ export function getPreviewRoutePoints(
 ): ScreenPoint[] {
   const dx = target.x - source.x;
   const dy = target.y - source.y;
-  const minStub = radius * 2;
+  const minExit = radius * 2;
 
   // Very close targets: collapse to straight line to avoid crushed elbows.
-  if (Math.abs(dx) < minStub && Math.abs(dy) < minStub) {
+  if (Math.abs(dx) < minExit && Math.abs(dy) < minExit) {
     return [source, target];
   }
 
   // Compute the vertical lane X position.
-  // Clamp so the lane stays at least minStub from source (exit stub)
-  // and minStub from target (approach clearance).
+  // Clamp so the lane stays at least minExit from source (exit clearance)
+  // and minExit from target (approach clearance).
   const laneX = Math.max(
-    source.x + minStub,
-    Math.min((source.x + target.x) / 2, target.x - minStub),
+    source.x + minExit,
+    Math.min((source.x + target.x) / 2, target.x - minExit),
   );
 
   const p1: ScreenPoint = { x: laneX, y: source.y };

--- a/apps/web/src/widgets/scene-canvas/previewRoutePoints.ts
+++ b/apps/web/src/widgets/scene-canvas/previewRoutePoints.ts
@@ -41,8 +41,11 @@ export function getPreviewRoutePoints(
   }
 
   // Compute the vertical lane X position.
-  // Clamp so the lane stays at least minExit from source (exit clearance)
-  // and minExit from target (approach clearance).
+  // The outer Math.max guarantees at least minExit clearance from the source
+  // (horizontal exit). When the target is behind or very near the source,
+  // the target-side clearance (target.x - minExit) may be negative, so the
+  // source-side floor wins — this is intentional: the route loops right
+  // before coming back, and the rounded-corner builder handles the geometry.
   const laneX = Math.max(
     source.x + minExit,
     Math.min((source.x + target.x) / 2, target.x - minExit),

--- a/apps/web/src/widgets/scene-canvas/previewRoutePoints.ts
+++ b/apps/web/src/widgets/scene-canvas/previewRoutePoints.ts
@@ -1,0 +1,60 @@
+/**
+ * Preview connection route point builder.
+ *
+ * Computes a simplified orthogonal (Manhattan) polyline between a source
+ * port and a cursor/snap target. The resulting points are intended to be
+ * fed into `buildRoundedConnectionGeometry()` so the preview uses the
+ * same rounded-corner rendering as committed connections.
+ *
+ * Algorithm designed by Oracle consultation (Issue #1831).
+ *
+ * Strategy: smart step-route with at most 2 elbows.
+ *   source → (laneX, source.y) → (laneX, target.y) → target
+ *
+ * The first move is always horizontal (matching outbound port exit
+ * direction) to avoid jitter from orientation switching.
+ */
+
+import type { ScreenPoint } from '../../shared/utils/isometric';
+import { CONNECTION_CORNER_RADIUS } from '../../shared/tokens/designTokens';
+
+/**
+ * Compute the preview route polyline between source and target.
+ *
+ * @param source - Screen-space outbound port position
+ * @param target - Screen-space cursor or magnetic snap position
+ * @param radius - Corner radius (default: CONNECTION_CORNER_RADIUS)
+ * @returns Array of 2-4 ScreenPoints forming an orthogonal route
+ */
+export function getPreviewRoutePoints(
+  source: ScreenPoint,
+  target: ScreenPoint,
+  radius: number = CONNECTION_CORNER_RADIUS,
+): ScreenPoint[] {
+  const dx = target.x - source.x;
+  const dy = target.y - source.y;
+  const minStub = radius * 2;
+
+  // Very close targets: collapse to straight line to avoid crushed elbows.
+  if (Math.abs(dx) < minStub && Math.abs(dy) < minStub) {
+    return [source, target];
+  }
+
+  // Compute the vertical lane X position.
+  // Clamp so the lane stays at least minStub from source (exit stub)
+  // and minStub from target (approach clearance).
+  const laneX = Math.max(
+    source.x + minStub,
+    Math.min((source.x + target.x) / 2, target.x - minStub),
+  );
+
+  const p1: ScreenPoint = { x: laneX, y: source.y };
+  const p2: ScreenPoint = { x: laneX, y: target.y };
+
+  // Deduplicate: if source.y === target.y, p1 and p2 collapse
+  // and buildRoundedConnectionGeometry will handle the dedup.
+  // If laneX === source.x, p1 collapses with source.
+  // If laneX === target.x, p2 collapses with target.
+  // We let the geometry builder's dedupeConsecutivePoints handle these.
+  return [source, p1, p2, target];
+}


### PR DESCRIPTION
## Summary

Aligns the connection preview path (shown during connection creation) with the committed connection rendering. The preview now uses the same rounded orthogonal path style as committed connections, eliminating the jarring visual inconsistency.

Fixes #1831

## Changes

### New: `previewRoutePoints.ts` (61 lines)
- `getPreviewRoutePoints(source, target, radius?)` — computes a simplified 4-point Manhattan route
- Strategy: `source -> (laneX, source.y) -> (laneX, target.y) -> target`
- Always exits horizontally to the right (matching outbound port direction, no jitter)
- Lane X position: `max(source.x + minStub, min(midX, target.x - minStub))`
- Close targets (within 2x corner radius) collapse to straight line

### New: `previewRoutePoints.test.ts` (147 lines, 11 tests)
- Covers close targets, far targets in all quadrants, behind-source targets
- Lane position clamping, horizontal/vertical alignment edge cases
- Custom radius parameter, exit direction consistency

### Modified: `ConnectionPreview.tsx`
- Replaced quadratic Bezier (`Q` command) with orthogonal Manhattan route
- Added imports for `getPreviewRoutePoints` and `buildRoundedConnectionGeometry`
- Preview now uses the same `buildRoundedConnectionGeometry()` pipeline as committed connections

## Before/After

- **Before**: `M src.x src.y Q midX midY tgt.x tgt.y` — smooth Bezier arc (looks nothing like committed)
- **After**: `M src.x src.y L ... A ... L ...` — rounded orthogonal path (matches committed style)

## Design Decisions

- **Oracle consultation**: Smart step-route chosen over simple L-route or midpoint elbow
- **Horizontal-first exit**: Always horizontal to avoid jitter when cursor crosses diagonals
- **Reuses `buildRoundedConnectionGeometry()`**: Same rounded-corner rendering pipeline as committed connections
- **Straight fallback**: When source and target are within `2 * CONNECTION_CORNER_RADIUS`, avoids crushed elbows

## Testing

- 11 new tests for `getPreviewRoutePoints`
- All 10 existing ConnectionPreview tests pass unchanged
- Full suite: 3438 tests passing
- Build clean, lint clean
