### PR TITLE
feat(web): replace label width heuristics with canvas text measurement

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -35,6 +35,13 @@ vi.mock('../../shared/utils/diff', () => ({
   getDiffState: vi.fn(),
 }));
 
+vi.mock('../../shared/utils/svgTextMeasure', () => ({
+  measureSvgTextWidth: vi.fn((text: string, spec: { fontSize: number }) =>
+    Math.ceil(text.length * spec.fontSize * 0.6),
+  ),
+  clearSvgTextMeasureCache: vi.fn(),
+}));
+
 const connection: Connection = {
   id: 'conn-1',
   from: endpointId('source-1', 'output', 'data'),

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -39,6 +39,8 @@ import { PacketFlowLayer } from './PacketFlowLayer';
 import { contrastTextColor } from './contrastTextColor';
 import { CONNECTION_TYPE_LABELS } from '../../shared/tokens/connectionTypeLabels';
 import { buildRoundedConnectionGeometry } from './roundedConnectionPath';
+import { measureSvgTextWidth } from '../../shared/utils/svgTextMeasure';
+import type { SvgTextMeasureSpec } from '../../shared/utils/svgTextMeasure';
 
 interface ConnectionRendererProps {
   connectionId?: string;
@@ -61,6 +63,12 @@ interface TraceColors {
 }
 
 const HIT_AREA_WIDTH = 20;
+
+// Font specs for label text measurement (used by measureSvgTextWidth).
+const ERROR_LABEL_FONT: SvgTextMeasureSpec = { fontSize: 11 } as const;
+const TYPE_TOP_FONT: SvgTextMeasureSpec = { fontSize: 10, fontWeight: 600 } as const;
+const TYPE_BOTTOM_FONT: SvgTextMeasureSpec = { fontSize: 9 } as const;
+const HOVER_TYPE_FONT: SvgTextMeasureSpec = { fontSize: 10 } as const;
 
 const LABEL_NAME_MAX_CHARS = 14;
 function truncateName(name: string): string {
@@ -636,7 +644,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
             (() => {
               if (!labelPos) return null;
               const msg = connectionErrors[0].message;
-              const textWidth = Math.min(msg.length * 6.5, 220);
+              const errorText = msg.length > 35 ? `${msg.slice(0, 32)}\u2026` : msg;
+              const textWidth = Math.min(measureSvgTextWidth(errorText, ERROR_LABEL_FONT), 220);
               const padding = 6;
               const rectWidth = textWidth + padding * 2;
               const rectHeight = 22;
@@ -662,7 +671,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
                     fontFamily="var(--font-ui, system-ui)"
                     style={{ pointerEvents: 'none' }}
                   >
-                    {msg.length > 35 ? msg.slice(0, 32) + '\u2026' : msg}
+                    {errorText}
                   </text>
                 </g>
               );
@@ -681,8 +690,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
                 const srcName = sourceBlock ? truncateName(sourceBlock.name) : '?';
                 const tgtName = targetBlock ? truncateName(targetBlock.name) : '?';
                 const directionLabel = `${srcName} → ${tgtName}`;
-                const topWidth = humanLabel.length * 7 + 16;
-                const bottomWidth = directionLabel.length * 5.5 + 16;
+                const topWidth = measureSvgTextWidth(humanLabel, TYPE_TOP_FONT) + 16;
+                const bottomWidth = measureSvgTextWidth(directionLabel, TYPE_BOTTOM_FONT) + 16;
                 const rectWidth = Math.max(topWidth, bottomWidth);
                 const rectHeight = 32;
 
@@ -729,7 +738,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
                 );
               }
 
-              const rectWidth = humanLabel.length * 6.5 + 12;
+              const rectWidth = measureSvgTextWidth(humanLabel, HOVER_TYPE_FONT) + 12;
               const rectHeight = 18;
 
               return (

--- a/apps/web/src/shared/utils/__tests__/svgTextMeasure.test.ts
+++ b/apps/web/src/shared/utils/__tests__/svgTextMeasure.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { clearSvgTextMeasureCache, measureSvgTextWidth } from '../svgTextMeasure';
+import type { SvgTextMeasureSpec } from '../svgTextMeasure';
+
+// ---------------------------------------------------------------------------
+// Mock canvas context
+// ---------------------------------------------------------------------------
+
+let mockMeasureText: ReturnType<typeof vi.fn>;
+let mockFont: string;
+let canvasAvailable: boolean;
+
+function createMockContext() {
+  mockFont = '';
+  return {
+    get font() {
+      return mockFont;
+    },
+    set font(value: string) {
+      mockFont = value;
+    },
+    measureText: mockMeasureText,
+  } as unknown as CanvasRenderingContext2D;
+}
+
+// Store the original createElement before any mocking
+const originalCreateElement = document.createElement.bind(document);
+
+beforeEach(() => {
+  clearSvgTextMeasureCache();
+  canvasAvailable = true;
+
+  // Deterministic mock: width = text.length * fontSize * 0.6
+  mockMeasureText = vi.fn((text: string) => {
+    const sizeMatch = mockFont.match(/(\d+)px/);
+    const fontSize = sizeMatch ? Number(sizeMatch[1]) : 10;
+    return { width: text.length * fontSize * 0.6 };
+  });
+
+  vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+    if (tag === 'canvas') {
+      return {
+        getContext: (_: string) => (canvasAvailable ? createMockContext() : null),
+      } as unknown as HTMLCanvasElement;
+    }
+    return originalCreateElement(tag);
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('measureSvgTextWidth', () => {
+  it('returns 0 for empty string', () => {
+    expect(measureSvgTextWidth('', { fontSize: 10 })).toBe(0);
+  });
+
+  it('measures text using canvas context', () => {
+    const width = measureSvgTextWidth('Hello', { fontSize: 10 });
+    // 5 chars * 10 * 0.6 = 30 → ceil = 30
+    expect(width).toBe(30);
+    expect(mockMeasureText).toHaveBeenCalledWith('Hello');
+  });
+
+  it('sets correct font string on canvas context', () => {
+    measureSvgTextWidth('Test', { fontSize: 11, fontWeight: 600 });
+    expect(mockFont).toBe('600 11px system-ui');
+  });
+
+  it('uses default fontWeight 400 and fontFamily system-ui', () => {
+    measureSvgTextWidth('Test', { fontSize: 9 });
+    expect(mockFont).toBe('400 9px system-ui');
+  });
+
+  it('respects custom fontFamily', () => {
+    measureSvgTextWidth('X', { fontSize: 10, fontFamily: 'monospace' });
+    expect(mockFont).toBe('400 10px monospace');
+  });
+
+  it('caches results for identical inputs', () => {
+    const spec: SvgTextMeasureSpec = { fontSize: 10 };
+    const w1 = measureSvgTextWidth('cached', spec);
+    const w2 = measureSvgTextWidth('cached', spec);
+    expect(w1).toBe(w2);
+    // measureText should only be called once due to caching
+    expect(mockMeasureText).toHaveBeenCalledTimes(1);
+  });
+
+  it('produces different cache entries for different font sizes', () => {
+    const w10 = measureSvgTextWidth('AB', { fontSize: 10 });
+    const w11 = measureSvgTextWidth('AB', { fontSize: 11 });
+    // 2 * 10 * 0.6 = 12, 2 * 11 * 0.6 = 13.2 → ceil = 14
+    expect(w10).toBe(12);
+    expect(w11).toBe(14);
+  });
+
+  it('produces different cache entries for different font weights', () => {
+    const w400 = measureSvgTextWidth('AB', { fontSize: 10, fontWeight: 400 });
+    clearSvgTextMeasureCache();
+    // Same text, different weight → different cache key
+    const w600 = measureSvgTextWidth('AB', { fontSize: 10, fontWeight: 600 });
+    // In our mock both return same width, but they are cached separately
+    expect(w400).toBe(w600); // mock doesn't vary by weight
+    expect(mockMeasureText).toHaveBeenCalledTimes(2);
+  });
+
+  it('ceils the measured width', () => {
+    // 3 chars * 11 * 0.6 = 19.8 → ceil = 20
+    const width = measureSvgTextWidth('abc', { fontSize: 11 });
+    expect(width).toBe(20);
+  });
+
+  it('clearSvgTextMeasureCache resets the cache', () => {
+    const spec: SvgTextMeasureSpec = { fontSize: 10 };
+    measureSvgTextWidth('test', spec);
+    expect(mockMeasureText).toHaveBeenCalledTimes(1);
+
+    clearSvgTextMeasureCache();
+    measureSvgTextWidth('test', spec);
+    expect(mockMeasureText).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('measureSvgTextWidth fallback', () => {
+  beforeEach(() => {
+    canvasAvailable = false;
+    clearSvgTextMeasureCache();
+  });
+
+  it('falls back to heuristic when canvas is unavailable (11px/400)', () => {
+    const width = measureSvgTextWidth('Hello', { fontSize: 11 });
+    // Heuristic: 5 * 6.5 = 32.5 → ceil = 33
+    expect(width).toBe(33);
+  });
+
+  it('falls back with 10px/600 heuristic', () => {
+    const width = measureSvgTextWidth('HTTP', { fontSize: 10, fontWeight: 600 });
+    // Heuristic: 4 * 7.0 = 28 → ceil = 28
+    expect(width).toBe(28);
+  });
+
+  it('falls back with 10px/400 heuristic', () => {
+    const width = measureSvgTextWidth('Data', { fontSize: 10 });
+    // Heuristic: 4 * 6.5 = 26 → ceil = 26
+    expect(width).toBe(26);
+  });
+
+  it('falls back with 9px/400 heuristic', () => {
+    const width = measureSvgTextWidth('web → db', { fontSize: 9 });
+    // Heuristic: 8 * 5.5 = 44 → ceil = 44
+    expect(width).toBe(44);
+  });
+
+  it('caches fallback results too', () => {
+    const spec: SvgTextMeasureSpec = { fontSize: 11 };
+    const w1 = measureSvgTextWidth('same', spec);
+    const w2 = measureSvgTextWidth('same', spec);
+    expect(w1).toBe(w2);
+  });
+});
+
+describe('measureSvgTextWidth edge cases', () => {
+  it('handles single character', () => {
+    const width = measureSvgTextWidth('X', { fontSize: 10 });
+    // 1 * 10 * 0.6 = 6
+    expect(width).toBe(6);
+  });
+
+  it('handles special characters (arrow)', () => {
+    const width = measureSvgTextWidth('A → B', { fontSize: 9 });
+    // 5 chars * 9 * 0.6 = 27
+    expect(width).toBe(27);
+  });
+
+  it('handles ellipsis character', () => {
+    const width = measureSvgTextWidth('Long te…', { fontSize: 11 });
+    // 8 chars * 11 * 0.6 = 52.8 → ceil = 53
+    expect(width).toBe(53);
+  });
+});

--- a/apps/web/src/shared/utils/svgTextMeasure.ts
+++ b/apps/web/src/shared/utils/svgTextMeasure.ts
@@ -1,0 +1,129 @@
+/**
+ * SVG text width measurement utility.
+ *
+ * Uses an off-screen Canvas 2D context for accurate text width measurement
+ * without DOM insertion or SVG layout reads. Falls back to a per-character
+ * heuristic when canvas is unavailable (e.g. JSDOM/Vitest).
+ *
+ * Designed for Oracle consultation on Issue #1832.
+ */
+
+/** Font specification for measurement. */
+export interface SvgTextMeasureSpec {
+  fontSize: number;
+  fontWeight?: number;
+  fontFamily?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic fallback factors — match the legacy per-character multipliers
+// that were previously inlined in ConnectionRenderer.tsx.
+// ---------------------------------------------------------------------------
+
+/** Average character width multiplier for each (fontSize, fontWeight) pair. */
+function heuristicCharWidth(fontSize: number, fontWeight: number): number {
+  // Legacy values:
+  //   11px / 400 → 6.5  (error labels)
+  //   10px / 600 → 7.0  (selected type label, top line)
+  //   10px / 400 → 6.5  (hover type label)
+  //    9px / 400 → 5.5  (selected type label, bottom line — direction)
+  if (fontSize >= 11) return 6.5;
+  if (fontSize >= 10) return fontWeight >= 600 ? 7.0 : 6.5;
+  return 5.5;
+}
+
+// ---------------------------------------------------------------------------
+// Module-level singleton canvas context + cache
+// ---------------------------------------------------------------------------
+
+let ctx: CanvasRenderingContext2D | null | undefined;
+
+/** Lazily create or return the singleton canvas 2D context. */
+function getCanvasContext(): CanvasRenderingContext2D | null {
+  if (ctx === undefined) {
+    try {
+      const canvas = document.createElement('canvas');
+      ctx = canvas.getContext('2d');
+    } catch {
+      ctx = null;
+    }
+  }
+  return ctx;
+}
+
+const cache = new Map<string, number>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Measure the pixel width of `text` rendered in the given font spec.
+ *
+ * Uses Canvas 2D `measureText()` when available and caches results.
+ * Falls back to a per-character heuristic when canvas is unavailable
+ * (JSDOM, SSR, or if `measureText` returns non-positive values).
+ *
+ * @param text  - The string to measure.
+ * @param spec  - Font specification (fontSize, optional fontWeight, fontFamily).
+ * @returns The pixel width of the rendered text (ceiled to integer).
+ */
+export function measureSvgTextWidth(text: string, spec: SvgTextMeasureSpec): number {
+  if (text.length === 0) return 0;
+
+  const weight = spec.fontWeight ?? 400;
+  const family = spec.fontFamily ?? 'system-ui';
+  const cacheKey = `${weight}|${spec.fontSize}|${family}|${text}`;
+
+  const cached = cache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  let width = canvasMeasure(text, spec.fontSize, weight, family);
+  if (width <= 0) {
+    // Fallback: per-character heuristic
+    width = text.length * heuristicCharWidth(spec.fontSize, weight);
+  }
+
+  const result = Math.ceil(width);
+  cache.set(cacheKey, result);
+  return result;
+}
+
+/**
+ * Clear the measurement cache and reset the canvas context singleton.
+ *
+ * Call in test `beforeEach()` to ensure deterministic results.
+ */
+export function clearSvgTextMeasureCache(): void {
+  cache.clear();
+  ctx = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Internal
+// ---------------------------------------------------------------------------
+
+/**
+ * Measure text width via Canvas 2D context.
+ * Returns 0 if canvas is unavailable.
+ */
+function canvasMeasure(
+  text: string,
+  fontSize: number,
+  fontWeight: number,
+  fontFamily: string,
+): number {
+  const context = getCanvasContext();
+  if (!context) return 0;
+
+  // Canvas font strings do NOT resolve CSS custom properties —
+  // always pass a real family name (e.g. 'system-ui').
+  context.font = `${fontWeight} ${fontSize}px ${fontFamily}`;
+
+  try {
+    const metrics = context.measureText(text);
+    return metrics.width;
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #1832
Part of #1829

Replace character-count-based width estimation (`msg.length * 6.5`, `humanLabel.length * 7 + 16`, etc.) in ConnectionRenderer with accurate Canvas 2D `measureText()` via a new `svgTextMeasure` utility module.

## Changes

### New: `svgTextMeasure.ts` (shared utility)
- `measureSvgTextWidth(text, spec)` — measures text width using a lazy singleton canvas 2D context
- Caches results by `fontWeight|fontSize|fontFamily|text` key
- Falls back to per-character heuristic when canvas is unavailable (JSDOM/test environments)
- `clearSvgTextMeasureCache()` — resets cache + singleton for test isolation

### Modified: `ConnectionRenderer.tsx`
- Replaced 4 inline width estimation expressions with `measureSvgTextWidth()` calls
- Added 4 font spec constants: `ERROR_LABEL_FONT`, `TYPE_TOP_FONT`, `TYPE_BOTTOM_FONT`, `HOVER_TYPE_FONT`
- **Bug fix**: Now measures the displayed (truncated) error text, not the raw message

### Tests
- 18 new unit tests for `svgTextMeasure` utility (canvas mock, fallback heuristic, caching, edge cases)
- Updated `ConnectionRenderer.test.tsx` mock to include `svgTextMeasure` module

## Design

Oracle-designed approach (Canvas 2D over SVG `getBBox()` or lookup table):
- No DOM insertion or SVG layout reads — zero layout thrash
- Synchronous measurement during render (labels only show on hover, max 2-3 at once)
- JSDOM fallback preserves existing per-char factors: `11px→6.5`, `10px/600→7.0`, `10px/400→6.5`, `9px→5.5`
- Canvas font strings use `'system-ui'` directly (not CSS custom properties, which canvas cannot resolve)