### PR TITLE
feat(web): add smooth CSS transitions for connection hover/selection states

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -494,9 +494,11 @@ describe('ConnectionRenderer', () => {
     expect(hoverOutline?.getAttribute('stroke-opacity')).toBe('0.7');
   });
 
-  it('does not render glow outline when not hovered and not selected', () => {
+  it('renders glow outline with zero opacity when not hovered and not selected', () => {
     const { container } = renderConnector();
-    expect(container.querySelector('[data-layer="selection-outline"]')).not.toBeInTheDocument();
+    const outline = container.querySelector('[data-layer="selection-outline"]');
+    expect(outline).toBeInTheDocument();
+    expect(outline?.getAttribute('stroke-opacity')).toBe('0');
   });
 
   it('renders hover-equivalent packet visuals on keyboard focus', () => {
@@ -531,7 +533,9 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-layer="selection-outline"]')).toBeInTheDocument();
 
     fireEvent.blur(link);
-    expect(container.querySelector('[data-layer="selection-outline"]')).not.toBeInTheDocument();
+    const outlineAfterBlur = container.querySelector('[data-layer="selection-outline"]');
+    expect(outlineAfterBlur).toBeInTheDocument();
+    expect(outlineAfterBlur?.getAttribute('stroke-opacity')).toBe('0');
   });
 
   it('maintains highlight when hover leaves but keyboard focus remains', () => {
@@ -589,9 +593,11 @@ describe('ConnectionRenderer', () => {
       container.querySelector('[data-layer="packet-core"]')?.getAttribute('fill-opacity'),
     ).toBe('0.72');
 
-    // Remove focus — now highlight should be gone
+    // Remove focus — now glow should fade to zero opacity
     fireEvent.blur(link);
-    expect(container.querySelector('[data-layer="selection-outline"]')).not.toBeInTheDocument();
+    const outlineAfterClear = container.querySelector('[data-layer="selection-outline"]');
+    expect(outlineAfterClear).toBeInTheDocument();
+    expect(outlineAfterClear?.getAttribute('stroke-opacity')).toBe('0');
   });
 
   it('renders accessible label on SVG link', () => {

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -496,7 +496,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     <g
       opacity={colors.opacity}
       data-connector-type={connectionType ?? 'dataflow'}
-      data-selected={isSelected ? 'true' : undefined}
+      data-highlighted={isHighlighted ? 'true' : 'false'}
+      data-selected={isSelected ? 'true' : 'false'}
     >
       {shouldRenderVisuals && (
         <defs>
@@ -514,6 +515,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
               d={`M0,0 L${ARROW_MARKER_W},${ARROW_MARKER_H / 2} L0,${ARROW_MARKER_H} Z`}
               fill={colors.stroke}
               fillOpacity={isHighlighted ? 1.0 : 0.95}
+              data-layer="arrow-head"
             />
           </marker>
         </defs>
@@ -583,20 +585,18 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
             canvasZoom={canvasZoom}
           />
 
-          {/* Provider-accent glow: hover = subtle, selection = stronger */}
-          {isHighlighted && (
-            <path
-              d={hitPath}
-              stroke="var(--provider-accent-glow)"
-              strokeWidth={isSelected ? casingWidth + 4 : casingWidth + 2}
-              strokeOpacity={isSelected ? 1 : 0.7}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              fill="none"
-              pointerEvents="none"
-              data-layer="selection-outline"
-            />
-          )}
+          {/* Provider-accent glow: always rendered, faded via CSS transition */}
+          <path
+            d={hitPath}
+            stroke="var(--provider-accent-glow)"
+            strokeWidth={isSelected ? casingWidth + 4 : casingWidth + 2}
+            strokeOpacity={isHighlighted ? (isSelected ? 1 : 0.7) : 0}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill="none"
+            pointerEvents="none"
+            data-layer="selection-outline"
+          />
 
           {/* Snap flash animation overlay — skip for visual-only and skip replay on deselection */}
           {overlayMode !== 'visual-only' && !entranceComplete && (

--- a/apps/web/src/widgets/scene-canvas/SceneCanvas.css
+++ b/apps/web/src/widgets/scene-canvas/SceneCanvas.css
@@ -158,6 +158,33 @@
   transition: opacity 80ms ease-out;
 }
 
+/* ── Connector hover/selection transition refinement (#1833) ── */
+.connection-layer
+  > g[data-connector-type]
+  :is([data-layer='casing'], [data-layer='trace'], [data-layer='selection-outline']) {
+  transition-property: stroke-width, stroke-opacity;
+  transition-duration: var(--duration-normal, 200ms);
+  transition-timing-function: var(--easing-default, cubic-bezier(0.2, 0, 0, 1));
+}
+
+.connection-layer > g[data-connector-type] [data-layer='arrow-head'] {
+  transition-property: fill-opacity;
+  transition-duration: var(--duration-normal, 200ms);
+  transition-timing-function: var(--easing-default, cubic-bezier(0.2, 0, 0, 1));
+}
+
+/* Fast hover-in / focus-in; normal hover-out and selection transitions */
+.connection-layer
+  > g[data-highlighted='true']:not([data-selected='true'])
+  :is(
+    [data-layer='casing'],
+    [data-layer='trace'],
+    [data-layer='selection-outline'],
+    [data-layer='arrow-head']
+  ) {
+  transition-duration: var(--duration-fast, 100ms);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .flow-focus-active .connection-layer > g,
   .flow-focus-active .connection-layer > g:is(:hover, :focus-within, [data-selected='true']),
@@ -165,6 +192,17 @@
   .flow-focus-active > .block-layer,
   .connection-layer:has(a:is(:hover, :focus-visible)) > g,
   .connection-layer:has(a:is(:hover, :focus-visible)) > g:is(:hover, :focus-within) {
+    transition: none;
+  }
+
+  .connection-layer
+    > g[data-connector-type]
+    :is(
+      [data-layer='casing'],
+      [data-layer='trace'],
+      [data-layer='selection-outline'],
+      [data-layer='arrow-head']
+    ) {
     transition: none;
   }
 }


### PR DESCRIPTION
## Summary

- Replace instant visual jumps with smooth CSS transitions on connection hover/selection state changes
- Glow/selection outline path is now always rendered (opacity 0 when idle) to enable CSS fade transitions
- Asymmetric timing: 100ms hover-in (snappy), 200ms hover-out/selection (smooth)
- Full `prefers-reduced-motion: reduce` support — all new transitions disabled

## Changes

### ConnectionRenderer.tsx (3 modifications)
- Add `data-highlighted` and `data-selected` attributes to root `<g>` (always `'true'`/`'false'`, not conditional `undefined`)
- Add `data-layer="arrow-head"` to arrow marker path for CSS targeting
- Always render glow path with `strokeOpacity={isHighlighted ? ... : 0}` instead of conditional mount/unmount

### SceneCanvas.css (25 new lines)
- CSS transition rules for `stroke-width`, `stroke-opacity` on casing, trace, selection-outline paths
- CSS transition for `fill-opacity` on arrow-head markers  
- Fast hover-in duration (100ms) when highlighted but not selected
- Reduced-motion media query disables all new transitions

### ConnectionRenderer.test.tsx (3 test updates)
- "does not render glow outline" → "renders glow outline with zero opacity" (presence → opacity check)
- Blur/clear assertions now check `stroke-opacity="0"` instead of `not.toBeInTheDocument()`

## Testing

- ✅ All 3456 tests pass (154 files)
- ✅ Build clean
- ✅ Lint clean
- ✅ No LSP diagnostics

Fixes #1833