### PR TITLE
feat(web): add ELKjs auto-layout for one-click node arrangement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,21 +156,38 @@ jobs:
 
       - name: Check bundle size budget
         run: |
-          MAX_TOTAL_KB=1024
+          MAX_EAGER_KB=1024
+          MAX_LAZY_TOTAL_KB=2560
           MAX_ENTRY_KB=350
           DIST_DIR="apps/web/dist/assets"
 
           TOTAL_KB=$(du -sk "$DIST_DIR" | cut -f1)
-          echo "Total assets: ${TOTAL_KB} KB (budget: ${MAX_TOTAL_KB} KB)"
 
-          LARGEST_JS=$(find "$DIST_DIR" -name '*.js' -exec du -k {} + | sort -rn | head -1)
+          # Separate eager vs lazy-loaded chunks
+          # Lazy chunks: dynamically import()-ed libs (e.g. elkjs layout engine)
+          LAZY_KB=0
+          for f in $(find "$DIST_DIR" -name 'elk.bundled-*.js' 2>/dev/null); do
+            chunk_kb=$(du -k "$f" | cut -f1)
+            LAZY_KB=$((LAZY_KB + chunk_kb))
+            echo "Lazy chunk: $(basename "$f") (${chunk_kb} KB)"
+          done
+          EAGER_KB=$((TOTAL_KB - LAZY_KB))
+          echo "Eager assets: ${EAGER_KB} KB (budget: ${MAX_EAGER_KB} KB)"
+          echo "Lazy assets: ${LAZY_KB} KB"
+          echo "Total assets: ${TOTAL_KB} KB (budget: ${MAX_LAZY_TOTAL_KB} KB)"
+
+          LARGEST_JS=$(find "$DIST_DIR" -name '*.js' ! -name 'elk.bundled-*' -exec du -k {} + | sort -rn | head -1)
           LARGEST_KB=$(echo "$LARGEST_JS" | cut -f1)
           LARGEST_FILE=$(echo "$LARGEST_JS" | cut -f2)
-          echo "Largest JS chunk: ${LARGEST_KB} KB — $(basename "$LARGEST_FILE") (budget: ${MAX_ENTRY_KB} KB)"
+          echo "Largest eager JS chunk: ${LARGEST_KB} KB — $(basename "$LARGEST_FILE") (budget: ${MAX_ENTRY_KB} KB)"
 
           FAIL=0
-          if [ "$TOTAL_KB" -gt "$MAX_TOTAL_KB" ]; then
-            echo "::error::Bundle size ${TOTAL_KB} KB exceeds budget of ${MAX_TOTAL_KB} KB"
+          if [ "$EAGER_KB" -gt "$MAX_EAGER_KB" ]; then
+            echo "::error::Eager bundle ${EAGER_KB} KB exceeds budget of ${MAX_EAGER_KB} KB"
+            FAIL=1
+          fi
+          if [ "$TOTAL_KB" -gt "$MAX_LAZY_TOTAL_KB" ]; then
+            echo "::error::Total bundle ${TOTAL_KB} KB exceeds lazy budget of ${MAX_LAZY_TOTAL_KB} KB"
             FAIL=1
           fi
           if [ "$LARGEST_KB" -gt "$MAX_ENTRY_KB" ]; then
@@ -183,7 +200,7 @@ jobs:
           find "$DIST_DIR" -name '*.js' -exec du -k {} + | sort -rn | while read -r size file; do
             echo "  ${size} KB — $(basename "$file")"
           done
-          echo "========================="
+          echo "=========================="
 
           exit $FAIL
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@cloudblocks/domain": "workspace:*",
     "@cloudblocks/schema": "workspace:*",
+    "elkjs": "^0.11.1",
     "interactjs": "^1.10.27",
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -47,7 +49,6 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.3",
-    "vitest": "^4.1.2",
-    "@playwright/test": "^1.59.1"
+    "vitest": "^4.1.2"
   }
 }

--- a/apps/web/src/app/BuilderView.tsx
+++ b/apps/web/src/app/BuilderView.tsx
@@ -15,6 +15,7 @@ import { useUIStore } from '../entities/store/uiStore';
 import { syncWorkspaceUI } from '../entities/store/uiSync';
 import { audioService } from '../shared/utils/audioService';
 import { isApiConfigured } from '../shared/api/client';
+import { runAutoLayout } from '../features/layout/autoLayout';
 import { useIsMobile } from '../shared/hooks/useIsMobile';
 import { MobilePaletteSheet } from '../widgets/mobile-palette-sheet';
 import { Plus } from 'lucide-react';
@@ -244,6 +245,21 @@ export function BuilderView() {
       if (e.key === 'M' && e.shiftKey && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
         useUIStore.getState().toggleMiniMap();
+        return;
+      }
+
+      // Auto Layout: Ctrl/Cmd+Shift+L
+      if (e.key === 'L' && (e.ctrlKey || e.metaKey) && e.shiftKey) {
+        e.preventDefault();
+        runAutoLayout()
+          .then((applied) => {
+            if (applied) {
+              toast.success('Auto layout applied');
+            }
+          })
+          .catch(() => {
+            toast.error('Auto layout failed');
+          });
         return;
       }
     };

--- a/apps/web/src/features/layout/autoLayout.test.ts
+++ b/apps/web/src/features/layout/autoLayout.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import type { ArchitectureModel, Block, ContainerBlock, ResourceBlock } from '@cloudblocks/schema';
+import {
+  makeTestArchitecture,
+  makeTestBlock,
+  makeTestPlate,
+} from '../../__tests__/legacyModelTestUtils';
+import { applyLayoutPatch } from './autoLayout';
+import type { LayoutPatchEntry } from './elkAdapter';
+
+/* ── Test helpers ─────────────────────────────────────────────────── */
+
+function makeContainer(overrides: Partial<ContainerBlock> = {}): ContainerBlock {
+  return makeTestPlate({
+    id: 'vnet-1',
+    name: 'VNet',
+    type: 'region',
+    parentId: null,
+    position: { x: 10, y: 0, z: 20 },
+    frame: { width: 16, height: 0.3, depth: 20 },
+    ...overrides,
+  });
+}
+
+function makeResource(overrides: Partial<ResourceBlock> = {}): ResourceBlock {
+  return makeTestBlock({
+    id: 'vm-1',
+    name: 'VM',
+    category: 'compute',
+    parentId: 'vnet-1',
+    position: { x: 5, y: 0, z: 8 },
+    ...overrides,
+  });
+}
+
+function makeArch(
+  nodes: Block[],
+  connections: ArchitectureModel['connections'] = [],
+): ArchitectureModel {
+  return makeTestArchitecture({ nodes, connections });
+}
+
+/* ── applyLayoutPatch ─────────────────────────────────────────────── */
+
+describe('applyLayoutPatch', () => {
+  it('returns unchanged model when no patches match', () => {
+    const container = makeContainer();
+    const model = makeArch([container]);
+
+    const patches: LayoutPatchEntry[] = [{ id: 'nonexistent', position: { x: 99, y: 0, z: 99 } }];
+
+    const result = applyLayoutPatch(model, patches);
+    expect(result.nodes[0].position).toEqual(container.position);
+  });
+
+  it('updates position for matched resource block', () => {
+    const resource = makeResource({
+      position: { x: 5, y: 0, z: 8 },
+    });
+    const model = makeArch([resource]);
+
+    const patches: LayoutPatchEntry[] = [{ id: 'vm-1', position: { x: 12, y: 0, z: 15 } }];
+
+    const result = applyLayoutPatch(model, patches);
+    expect(result.nodes[0].position).toEqual({ x: 12, y: 0, z: 15 });
+  });
+
+  it('updates both position and frame for container blocks', () => {
+    const container = makeContainer({
+      position: { x: 10, y: 0, z: 20 },
+      frame: { width: 16, height: 0.3, depth: 20 },
+    });
+    const model = makeArch([container]);
+
+    const patches: LayoutPatchEntry[] = [
+      {
+        id: 'vnet-1',
+        position: { x: 5, y: 0, z: 10 },
+        frame: { width: 24, height: 0.3, depth: 30 },
+      },
+    ];
+
+    const result = applyLayoutPatch(model, patches);
+    expect(result.nodes[0].position).toEqual({ x: 5, y: 0, z: 10 });
+    expect((result.nodes[0] as ContainerBlock).frame).toEqual({
+      width: 24,
+      height: 0.3,
+      depth: 30,
+    });
+  });
+
+  it('does not mutate the original model', () => {
+    const resource = makeResource({
+      position: { x: 5, y: 0, z: 8 },
+    });
+    const model = makeArch([resource]);
+    const originalPosition = { ...resource.position };
+
+    applyLayoutPatch(model, [{ id: 'vm-1', position: { x: 99, y: 0, z: 99 } }]);
+
+    expect(resource.position).toEqual(originalPosition);
+  });
+
+  it('applies patches to multiple nodes simultaneously', () => {
+    const container = makeContainer();
+    const res1 = makeResource({ id: 'vm-1', parentId: 'vnet-1' });
+    const res2 = makeResource({ id: 'vm-2', name: 'VM 2', parentId: 'vnet-1' });
+    const model = makeArch([container, res1, res2]);
+
+    const patches: LayoutPatchEntry[] = [
+      {
+        id: 'vnet-1',
+        position: { x: 0, y: 0, z: 0 },
+        frame: { width: 20, height: 0.3, depth: 24 },
+      },
+      { id: 'vm-1', position: { x: 3, y: 0, z: 3 } },
+      { id: 'vm-2', position: { x: 7, y: 0, z: 3 } },
+    ];
+
+    const result = applyLayoutPatch(model, patches);
+    expect(result.nodes).toHaveLength(3);
+    expect(result.nodes.find((n) => n.id === 'vnet-1')!.position).toEqual({ x: 0, y: 0, z: 0 });
+    expect(result.nodes.find((n) => n.id === 'vm-1')!.position).toEqual({ x: 3, y: 0, z: 3 });
+    expect(result.nodes.find((n) => n.id === 'vm-2')!.position).toEqual({ x: 7, y: 0, z: 3 });
+  });
+
+  it('preserves connections and other model properties', () => {
+    const resource = makeResource();
+    const model = makeArch([resource]);
+
+    const patches: LayoutPatchEntry[] = [{ id: 'vm-1', position: { x: 99, y: 0, z: 99 } }];
+
+    const result = applyLayoutPatch(model, patches);
+    expect(result.id).toBe(model.id);
+    expect(result.name).toBe(model.name);
+    expect(result.version).toBe(model.version);
+    expect(result.connections).toBe(model.connections);
+  });
+
+  it('does not add frame to resource blocks even if patch has frame', () => {
+    const resource = makeResource();
+    const model = makeArch([resource]);
+
+    const patches: LayoutPatchEntry[] = [
+      {
+        id: 'vm-1',
+        position: { x: 99, y: 0, z: 99 },
+        frame: { width: 10, height: 1, depth: 10 },
+      },
+    ];
+
+    const result = applyLayoutPatch(model, patches);
+    // Resource blocks don't have frame, patch.frame is ignored for non-containers
+    expect('frame' in result.nodes[0]).toBe(false);
+  });
+});

--- a/apps/web/src/features/layout/autoLayout.test.ts
+++ b/apps/web/src/features/layout/autoLayout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ArchitectureModel, Block, ContainerBlock, ResourceBlock } from '@cloudblocks/schema';
 import {
   makeTestArchitecture,
@@ -152,5 +152,107 @@ describe('applyLayoutPatch', () => {
     const result = applyLayoutPatch(model, patches);
     // Resource blocks don't have frame, patch.frame is ignored for non-containers
     expect('frame' in result.nodes[0]).toBe(false);
+  });
+});
+
+/* ── runAutoLayout ────────────────────────────────────────────────── */
+
+// Mock the architecture store
+vi.mock('../../entities/store/architectureStore', () => ({
+  useArchitectureStore: {
+    getState: vi.fn(),
+    setState: vi.fn(),
+  },
+}));
+
+// Mock elkjs dynamic import
+vi.mock('elkjs/lib/elk.bundled', () => ({
+  default: class MockELK {
+    async layout(graph: Record<string, unknown>) {
+      // Return the graph with positions assigned
+      const typedGraph = graph as {
+        children?: { id: string; width?: number; height?: number; children?: unknown[] }[];
+      };
+      return {
+        ...graph,
+        children: (typedGraph.children ?? []).map(
+          (
+            child: { id: string; width?: number; height?: number; children?: unknown[] },
+            i: number,
+          ) => ({
+            ...child,
+            x: i * 5,
+            y: i * 3,
+            width: child.width ?? 2,
+            height: child.height ?? 2,
+          }),
+        ),
+      };
+    }
+  },
+}));
+
+describe('runAutoLayout', () => {
+  let runAutoLayout: typeof import('./autoLayout').runAutoLayout;
+  let storeModule: typeof import('../../entities/store/architectureStore');
+
+  beforeEach(async () => {
+    vi.resetModules();
+    const autoLayoutMod = await import('./autoLayout');
+    runAutoLayout = autoLayoutMod.runAutoLayout;
+    storeModule = await import('../../entities/store/architectureStore');
+  });
+
+  it('returns false when architecture has no nodes', async () => {
+    const emptyArch = makeArch([]);
+    vi.mocked(storeModule.useArchitectureStore.getState).mockReturnValue({
+      workspace: { architecture: emptyArch },
+    } as ReturnType<typeof storeModule.useArchitectureStore.getState>);
+
+    const result = await runAutoLayout();
+    expect(result).toBe(false);
+    expect(storeModule.useArchitectureStore.setState).not.toHaveBeenCalled();
+  });
+
+  it('returns true and applies layout when nodes exist', async () => {
+    const resource = {
+      ...makeResource({ id: 'vm-1', position: { x: 0, y: 0, z: 0 } }),
+      parentId: null as string | null,
+    };
+    const arch = makeArch([resource]);
+    vi.mocked(storeModule.useArchitectureStore.getState).mockReturnValue({
+      workspace: { architecture: arch },
+    } as ReturnType<typeof storeModule.useArchitectureStore.getState>);
+
+    const result = await runAutoLayout();
+    expect(result).toBe(true);
+    expect(storeModule.useArchitectureStore.setState).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies layout as a single undo step via setState callback', async () => {
+    const resource = {
+      ...makeResource({ id: 'vm-1', position: { x: 0, y: 0, z: 0 } }),
+      parentId: null as string | null,
+    };
+    const arch = makeArch([resource]);
+    vi.mocked(storeModule.useArchitectureStore.getState).mockReturnValue({
+      workspace: { architecture: arch },
+    } as ReturnType<typeof storeModule.useArchitectureStore.getState>);
+
+    await runAutoLayout();
+    const setStateFn = vi.mocked(storeModule.useArchitectureStore.setState);
+    expect(setStateFn).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('handles container and resource blocks together', async () => {
+    const container = makeContainer();
+    const resource = makeResource({ parentId: 'vnet-1' });
+    const arch = makeArch([container, resource]);
+    vi.mocked(storeModule.useArchitectureStore.getState).mockReturnValue({
+      workspace: { architecture: arch },
+    } as ReturnType<typeof storeModule.useArchitectureStore.getState>);
+
+    const result = await runAutoLayout();
+    expect(result).toBe(true);
   });
 });

--- a/apps/web/src/features/layout/autoLayout.ts
+++ b/apps/web/src/features/layout/autoLayout.ts
@@ -1,0 +1,115 @@
+/**
+ * Auto Layout Orchestrator
+ *
+ * Coordinates the ELK layout computation and applies results to the architecture store.
+ * Uses dynamic import() for elkjs to keep it out of the main bundle.
+ */
+
+import type { ELK } from 'elkjs/lib/elk-api';
+import type { ArchitectureModel } from '@cloudblocks/schema';
+import { useArchitectureStore } from '../../entities/store/architectureStore';
+import { withHistory } from '../../entities/store/slices/helpers';
+import { architectureToElkGraph, readElkPositions, type LayoutPatchEntry } from './elkAdapter';
+
+/* ── ELK instance cache ──────────────────────────────────────────── */
+
+let elkPromise: Promise<ELK> | null = null;
+
+/**
+ * Lazy-load the ELK layout engine.
+ * Uses dynamic import() to keep elkjs (~600KB) out of the initial bundle.
+ * Caches the instance for subsequent calls.
+ */
+async function getElkInstance(): Promise<ELK> {
+  if (!elkPromise) {
+    elkPromise = import('elkjs/lib/elk.bundled').then((mod) => {
+      return new mod.default();
+    });
+  }
+  return elkPromise;
+}
+
+/* ── Layout patch application ────────────────────────────────────── */
+
+/**
+ * Apply a set of position/frame patches to the architecture model.
+ * Returns a new ArchitectureModel with updated node positions.
+ */
+export function applyLayoutPatch(
+  model: ArchitectureModel,
+  patches: LayoutPatchEntry[],
+): ArchitectureModel {
+  const patchMap = new Map(patches.map((p) => [p.id, p]));
+
+  const updatedNodes = model.nodes.map((node) => {
+    const patch = patchMap.get(node.id);
+    if (!patch) return node;
+
+    const updatedNode = {
+      ...node,
+      position: { ...patch.position },
+    };
+
+    // Update container frame if patch includes it
+    if (patch.frame && node.kind === 'container') {
+      return {
+        ...updatedNode,
+        frame: { ...patch.frame },
+      };
+    }
+
+    return updatedNode;
+  });
+
+  return {
+    ...model,
+    nodes: updatedNodes,
+  };
+}
+
+/* ── Public API ───────────────────────────────────────────────────── */
+
+/**
+ * Run ELK auto-layout on the current architecture and apply the results.
+ *
+ * Flow:
+ * 1. Read current architecture model from store
+ * 2. Convert to ELK graph format
+ * 3. Run ELK layout computation (async)
+ * 4. Extract computed positions, snap to CU grid
+ * 5. Apply all position changes as a single undo step
+ *
+ * @returns true if layout was applied, false if no nodes to layout
+ * @throws if ELK layout computation fails
+ */
+export async function runAutoLayout(): Promise<boolean> {
+  const state = useArchitectureStore.getState();
+  const architecture = state.workspace.architecture;
+
+  // Nothing to layout if no nodes
+  if (architecture.nodes.length === 0) {
+    return false;
+  }
+
+  // 1. Convert to ELK graph
+  const { graph, nodeMap } = architectureToElkGraph(architecture);
+
+  // 2. Run ELK layout
+  const elk = await getElkInstance();
+  const layoutResult = await elk.layout(graph);
+
+  // 3. Extract positions
+  const patches = readElkPositions(layoutResult, nodeMap);
+
+  // Nothing changed
+  if (patches.length === 0) {
+    return false;
+  }
+
+  // 4. Apply as single undo step
+  const newArch = applyLayoutPatch(architecture, patches);
+
+  useArchitectureStore.setState((currentState) => withHistory(currentState, newArch));
+
+  return true;
+}

--- a/apps/web/src/features/layout/autoLayout.ts
+++ b/apps/web/src/features/layout/autoLayout.ts
@@ -17,14 +17,18 @@ let elkPromise: Promise<ELK> | null = null;
 
 /**
  * Lazy-load the ELK layout engine.
- * Uses dynamic import() to keep elkjs (~600KB) out of the initial bundle.
+ * Uses dynamic import() to keep elkjs out of the initial bundle.
  * Caches the instance for subsequent calls.
  */
 async function getElkInstance(): Promise<ELK> {
   if (!elkPromise) {
-    elkPromise = import('elkjs/lib/elk.bundled').then((mod) => {
-      return new mod.default();
-    });
+    elkPromise = import('elkjs/lib/elk.bundled')
+      .then((mod) => new mod.default())
+      .catch((err: unknown) => {
+        // Reset so next call retries instead of caching the rejection
+        elkPromise = null;
+        throw err;
+      });
   }
   return elkPromise;
 }
@@ -106,10 +110,12 @@ export async function runAutoLayout(): Promise<boolean> {
     return false;
   }
 
-  // 4. Apply as single undo step
-  const newArch = applyLayoutPatch(architecture, patches);
-
-  useArchitectureStore.setState((currentState) => withHistory(currentState, newArch));
+  // 4. Apply as single undo step against latest state to avoid race conditions
+  useArchitectureStore.setState((currentState) => {
+    const freshArch = currentState.workspace.architecture;
+    const newArch = applyLayoutPatch(freshArch, patches);
+    return withHistory(currentState, newArch);
+  });
 
   return true;
 }

--- a/apps/web/src/features/layout/elkAdapter.test.ts
+++ b/apps/web/src/features/layout/elkAdapter.test.ts
@@ -43,6 +43,9 @@ function makeArch(
   });
 }
 
+// Compute/medium tier: width=2, depth=2, height=2
+const COMPUTE_DIMS = { width: 2, depth: 2 };
+
 /* ── architectureToElkGraph ───────────────────────────────────────── */
 
 describe('architectureToElkGraph', () => {
@@ -83,6 +86,9 @@ describe('architectureToElkGraph', () => {
 
     expect(graph.children).toHaveLength(1);
     expect(graph.children![0].id).toBe('vm-1');
+    // Root resource: center (4,6), dims (2,2) → top-left (4-1, 6-1) = (3, 5)
+    expect(graph.children![0].x).toBe(3);
+    expect(graph.children![0].y).toBe(5);
   });
 
   it('nests resource blocks inside their parent container ELK node', () => {
@@ -95,6 +101,47 @@ describe('architectureToElkGraph', () => {
     expect(containerElk.id).toBe('vnet-1');
     expect(containerElk.children).toHaveLength(1);
     expect(containerElk.children![0].id).toBe('vm-1');
+  });
+
+  it('computes correct parent-relative coordinates for nested resources', () => {
+    // Container: pos=(10,0,20), frame=(16,0.3,20)
+    // Resource: parentId='vnet-1', pos=(5,0,8) [parent-center-relative], dims=(2,2)
+    // elkX = pos.x - dims.w/2 + parentDims.w/2 = 5 - 1 + 8 = 12
+    // elkY = pos.z - dims.d/2 + parentDims.d/2 = 8 - 1 + 10 = 17
+    const container = makeContainer();
+    const resource = makeResource({ parentId: 'vnet-1', position: { x: 5, y: 0, z: 8 } });
+    const model = makeArch([container, resource]);
+    const { graph } = architectureToElkGraph(model);
+
+    const childElk = graph.children![0].children![0];
+    expect(childElk.x).toBe(12);
+    expect(childElk.y).toBe(17);
+    expect(childElk.width).toBe(COMPUTE_DIMS.width);
+    expect(childElk.height).toBe(COMPUTE_DIMS.depth);
+  });
+
+  it('computes correct parent-relative coordinates for nested containers', () => {
+    // Outer: pos=(10,0,20), frame=(16,0.3,20) → top-left (2,10)
+    // Inner: pos=(8,0,16), frame=(8,0.3,8), parentId='vnet'
+    // Inner abs top-left: (8-4, 16-4) = (4, 12)
+    // Parent-relative: (4-2, 12-10) = (2, 2)
+    const outer = makeContainer({ id: 'vnet', position: { x: 10, y: 0, z: 20 } });
+    const inner = makeContainer({
+      id: 'subnet',
+      type: 'subnet',
+      parentId: 'vnet',
+      position: { x: 8, y: 0, z: 16 },
+      frame: { width: 8, height: 0.3, depth: 8 },
+    });
+    const resource = makeResource({ id: 'vm', parentId: 'subnet' });
+    const model = makeArch([outer, inner, resource]);
+    const { graph } = architectureToElkGraph(model);
+
+    const outerElk = graph.children![0];
+    const innerElk = outerElk.children![0];
+    expect(innerElk.id).toBe('subnet');
+    expect(innerElk.x).toBe(2);
+    expect(innerElk.y).toBe(2);
   });
 
   it('sets layout options on compound container nodes', () => {
@@ -218,16 +265,15 @@ describe('readElkPositions', () => {
     expect(patches).toEqual([]);
   });
 
-  it('converts ELK top-left positions to CloudBlocks center positions', () => {
-    const resource = makeResource({
-      id: 'vm-1',
-      position: { x: 5, y: 0, z: 8 },
-    });
+  it('converts root-level resource ELK positions to absolute center coordinates', () => {
+    // Resource at ELK top-left (3,4), dims (2,2), no parent in ELK tree
+    // Absolute center: (0+3 + 2/2, 0+4 + 2/2) = (4, 5)
+    const resource = {
+      ...makeResource({ id: 'vm-1', position: { x: 5, y: 0, z: 8 } }),
+      parentId: null as string | null,
+    };
     const nodeMap = new Map<string, Block>([['vm-1', resource]]);
 
-    // ELK places the node at top-left (3, 4)
-    // Resource dims: getBlockDimensions('compute', 'azure', ...) → width, depth
-    // The test verifies center = topLeft + dims/2
     const elkRoot: ElkNode = {
       id: 'root',
       children: [{ id: 'vm-1', x: 3, y: 4, width: 2, height: 2 }],
@@ -235,19 +281,56 @@ describe('readElkPositions', () => {
 
     const patches = readElkPositions(elkRoot, nodeMap);
     expect(patches).toHaveLength(1);
-    // Center = topLeft + actualDims/2 (from getBlockDimensions)
-    // The actual dims depend on getBlockDimensions but the test validates structure
     expect(patches[0].id).toBe('vm-1');
-    expect(patches[0].position.y).toBe(0); // elevation preserved
-    expect(typeof patches[0].position.x).toBe('number');
-    expect(typeof patches[0].position.z).toBe('number');
+    expect(patches[0].position).toEqual({ x: 4, y: 0, z: 5 });
+  });
+
+  it('converts nested resource ELK positions to parent-center-relative coordinates', () => {
+    // Container: frame (16,0.3,20), resource has parentId='vnet-1'
+    // Resource at ELK (3,5) relative to parent, dims (2,2)
+    // Parent dims: (16, 20)
+    // patchX = round(3 + 2/2 - 16/2) = round(3+1-8) = -4
+    // patchZ = round(5 + 2/2 - 20/2) = round(5+1-10) = -4
+    const container = makeContainer({
+      id: 'vnet-1',
+      position: { x: 10, y: 0, z: 20 },
+      frame: { width: 16, height: 0.3, depth: 20 },
+    });
+    const resource = makeResource({
+      id: 'vm-1',
+      parentId: 'vnet-1',
+      position: { x: 5, y: 2, z: 8 },
+    });
+    const nodeMap = new Map<string, Block>([
+      ['vnet-1', container],
+      ['vm-1', resource],
+    ]);
+
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [
+        {
+          id: 'vnet-1',
+          x: 2,
+          y: 10,
+          width: 20,
+          height: 24,
+          children: [{ id: 'vm-1', x: 3, y: 5, width: 2, height: 2 }],
+        },
+      ],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    const vmPatch = patches.find((p) => p.id === 'vm-1')!;
+    expect(vmPatch).toBeDefined();
+    expect(vmPatch.position).toEqual({ x: -4, y: 2, z: -4 });
   });
 
   it('preserves y (elevation) from original block', () => {
-    const resource = makeResource({
-      id: 'vm-1',
-      position: { x: 5, y: 3, z: 8 },
-    });
+    const resource = {
+      ...makeResource({ id: 'vm-1', position: { x: 5, y: 3, z: 8 } }),
+      parentId: null as string | null,
+    };
     const nodeMap = new Map<string, Block>([['vm-1', resource]]);
 
     const elkRoot: ElkNode = {
@@ -260,10 +343,10 @@ describe('readElkPositions', () => {
   });
 
   it('snaps positions to integer CU grid', () => {
-    const resource = makeResource({
-      id: 'vm-1',
-      position: { x: 0, y: 0, z: 0 },
-    });
+    const resource = {
+      ...makeResource({ id: 'vm-1', position: { x: 0, y: 0, z: 0 } }),
+      parentId: null as string | null,
+    };
     const nodeMap = new Map<string, Block>([['vm-1', resource]]);
 
     const elkRoot: ElkNode = {
@@ -272,7 +355,9 @@ describe('readElkPositions', () => {
     };
 
     const patches = readElkPositions(elkRoot, nodeMap);
-    // Positions should be rounded integers
+    // Center = (1.7 + 1, 2.3 + 1) = (2.7, 3.3) → round → (3, 3)
+    expect(patches[0].position.x).toBe(3);
+    expect(patches[0].position.z).toBe(3);
     expect(Number.isInteger(patches[0].position.x)).toBe(true);
     expect(Number.isInteger(patches[0].position.z)).toBe(true);
   });
@@ -296,6 +381,9 @@ describe('readElkPositions', () => {
     expect(patches[0].frame!.width).toBe(24);
     expect(patches[0].frame!.depth).toBe(30);
     expect(patches[0].frame!.height).toBe(0.3); // vertical height preserved
+    // Container absolute center: (0 + 24/2, 0 + 30/2) = (12, 15)
+    expect(patches[0].position.x).toBe(12);
+    expect(patches[0].position.z).toBe(15);
   });
 
   it('does not shrink container frame below original size', () => {
@@ -318,10 +406,10 @@ describe('readElkPositions', () => {
   });
 
   it('does not add frame patch for resource blocks', () => {
-    const resource = makeResource({
-      id: 'vm-1',
-      position: { x: 5, y: 0, z: 8 },
-    });
+    const resource = {
+      ...makeResource({ id: 'vm-1', position: { x: 5, y: 0, z: 8 } }),
+      parentId: null as string | null,
+    };
     const nodeMap = new Map<string, Block>([['vm-1', resource]]);
 
     const elkRoot: ElkNode = {
@@ -333,7 +421,7 @@ describe('readElkPositions', () => {
     expect(patches[0].frame).toBeUndefined();
   });
 
-  it('accumulates parent offsets for nested nodes', () => {
+  it('accumulates parent offsets for nested nodes and computes correct coordinates', () => {
     const vnet = makeContainer({
       id: 'vnet',
       position: { x: 10, y: 0, z: 20 },
@@ -349,7 +437,7 @@ describe('readElkPositions', () => {
       ['vm', resource],
     ]);
 
-    // Parent at (2, 4), child at (3, 5) relative to parent
+    // Parent at ELK (2, 4), child at (3, 5) relative to parent
     const elkRoot: ElkNode = {
       id: 'root',
       children: [
@@ -365,11 +453,19 @@ describe('readElkPositions', () => {
     };
 
     const patches = readElkPositions(elkRoot, nodeMap);
+
+    // Container (vnet): absolute center using post-layout dims
+    // absTopLeft = (0+2, 0+4) = (2,4), layoutWidth=20, layoutDepth=24
+    // center = (2+20/2, 4+24/2) = (12, 16)
+    const vnetPatch = patches.find((p) => p.id === 'vnet')!;
+    expect(vnetPatch.position).toEqual({ x: 12, y: 0, z: 16 });
+
+    // Resource (vm): parent-center-relative
+    // patchX = round(3 + 2/2 - 16/2) = round(4 - 8) = -4
+    // patchZ = round(5 + 2/2 - 20/2) = round(6 - 10) = -4
     const vmPatch = patches.find((p) => p.id === 'vm')!;
-    // Child absolute top-left = parent(2,4) + child(3,5) = (5, 9)
-    // Then convert to center by adding dims/2
     expect(vmPatch).toBeDefined();
-    expect(vmPatch.position.y).toBe(0); // elevation preserved
+    expect(vmPatch.position).toEqual({ x: -4, y: 0, z: -4 });
   });
 
   it('skips nodes not found in nodeMap', () => {
@@ -394,10 +490,10 @@ describe('readElkPositions', () => {
   });
 
   it('handles ELK nodes with undefined x/y coordinates', () => {
-    const resource = makeResource({
-      id: 'vm-1',
-      position: { x: 5, y: 0, z: 8 },
-    });
+    const resource = {
+      ...makeResource({ id: 'vm-1', position: { x: 5, y: 0, z: 8 } }),
+      parentId: null as string | null,
+    };
     const nodeMap = new Map<string, Block>([['vm-1', resource]]);
 
     // ELK node with no x/y — should default to 0
@@ -408,8 +504,29 @@ describe('readElkPositions', () => {
 
     const patches = readElkPositions(elkRoot, nodeMap);
     expect(patches).toHaveLength(1);
-    // x/y default to 0, so center = 0 + dims/2
-    expect(typeof patches[0].position.x).toBe('number');
-    expect(typeof patches[0].position.z).toBe('number');
+    // x/y default to 0, center = (0 + 2/2, 0 + 2/2) = (1, 1)
+    expect(patches[0].position.x).toBe(1);
+    expect(patches[0].position.z).toBe(1);
+  });
+
+  it('uses post-layout dimensions for container center calculation', () => {
+    // Container with small original frame but ELK expands it
+    const container = makeContainer({
+      id: 'vnet-1',
+      position: { x: 10, y: 0, z: 20 },
+      frame: { width: 8, height: 0.3, depth: 8 },
+    });
+    const nodeMap = new Map<string, Block>([['vnet-1', container]]);
+
+    // ELK expands to width=20, height=24
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vnet-1', x: 0, y: 0, width: 20, height: 24 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    // Center should use post-layout dims: (0+20/2, 0+24/2) = (10, 12)
+    expect(patches[0].position.x).toBe(10);
+    expect(patches[0].position.z).toBe(12);
   });
 });

--- a/apps/web/src/features/layout/elkAdapter.test.ts
+++ b/apps/web/src/features/layout/elkAdapter.test.ts
@@ -383,4 +383,33 @@ describe('readElkPositions', () => {
     const patches = readElkPositions(elkRoot, nodeMap);
     expect(patches).toEqual([]);
   });
+
+  it('handles root node without children property', () => {
+    const nodeMap = new Map<string, Block>();
+    // ElkNode with no children field (undefined)
+    const elkRoot: ElkNode = { id: 'root' };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches).toEqual([]);
+  });
+
+  it('handles ELK nodes with undefined x/y coordinates', () => {
+    const resource = makeResource({
+      id: 'vm-1',
+      position: { x: 5, y: 0, z: 8 },
+    });
+    const nodeMap = new Map<string, Block>([['vm-1', resource]]);
+
+    // ELK node with no x/y — should default to 0
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vm-1', width: 2, height: 2 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches).toHaveLength(1);
+    // x/y default to 0, so center = 0 + dims/2
+    expect(typeof patches[0].position.x).toBe('number');
+    expect(typeof patches[0].position.z).toBe('number');
+  });
 });

--- a/apps/web/src/features/layout/elkAdapter.test.ts
+++ b/apps/web/src/features/layout/elkAdapter.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it } from 'vitest';
+import type { ElkNode } from 'elkjs/lib/elk-api';
+import type { ArchitectureModel, Block, ContainerBlock, ResourceBlock } from '@cloudblocks/schema';
+import {
+  makeTestArchitecture,
+  makeTestBlock,
+  makeTestPlate,
+} from '../../__tests__/legacyModelTestUtils';
+import { architectureToElkGraph, readElkPositions } from './elkAdapter';
+
+/* ── Test helpers ─────────────────────────────────────────────────── */
+
+function makeContainer(overrides: Partial<ContainerBlock> = {}): ContainerBlock {
+  return makeTestPlate({
+    id: 'vnet-1',
+    name: 'VNet',
+    type: 'region',
+    parentId: null,
+    position: { x: 10, y: 0, z: 20 },
+    frame: { width: 16, height: 0.3, depth: 20 },
+    ...overrides,
+  });
+}
+
+function makeResource(overrides: Partial<ResourceBlock> = {}): ResourceBlock {
+  return makeTestBlock({
+    id: 'vm-1',
+    name: 'VM',
+    category: 'compute',
+    parentId: 'vnet-1',
+    position: { x: 5, y: 0, z: 8 },
+    ...overrides,
+  });
+}
+
+function makeArch(
+  nodes: Block[],
+  connections: ArchitectureModel['connections'] = [],
+): ArchitectureModel {
+  return makeTestArchitecture({
+    nodes,
+    connections,
+  });
+}
+
+/* ── architectureToElkGraph ───────────────────────────────────────── */
+
+describe('architectureToElkGraph', () => {
+  it('returns empty graph for empty model', () => {
+    const model = makeArch([]);
+    const { graph, nodeMap } = architectureToElkGraph(model);
+
+    expect(graph.id).toBe('root');
+    expect(graph.children).toEqual([]);
+    expect(graph.edges).toEqual([]);
+    expect(nodeMap.size).toBe(0);
+  });
+
+  it('converts a single container to an ELK node with center-to-top-left conversion', () => {
+    const container = makeContainer({
+      position: { x: 10, y: 0, z: 20 },
+      frame: { width: 16, height: 0.3, depth: 20 },
+    });
+    const model = makeArch([container]);
+    const { graph } = architectureToElkGraph(model);
+
+    const elkNode = graph.children![0];
+    expect(elkNode.id).toBe('vnet-1');
+    // Center (10, 20) with size (16, 20) → top-left (10-8, 20-10) = (2, 10)
+    expect(elkNode.x).toBe(2);
+    expect(elkNode.y).toBe(10);
+    expect(elkNode.width).toBe(16);
+    expect(elkNode.height).toBe(20); // ELK height = CloudBlocks depth
+  });
+
+  it('places resource blocks as root children when they have no parent container', () => {
+    const resource = {
+      ...makeResource({ position: { x: 4, y: 0, z: 6 } }),
+      parentId: null as string | null,
+    };
+    const model = makeArch([resource]);
+    const { graph } = architectureToElkGraph(model);
+
+    expect(graph.children).toHaveLength(1);
+    expect(graph.children![0].id).toBe('vm-1');
+  });
+
+  it('nests resource blocks inside their parent container ELK node', () => {
+    const container = makeContainer();
+    const resource = makeResource({ parentId: 'vnet-1' });
+    const model = makeArch([container, resource]);
+    const { graph } = architectureToElkGraph(model);
+
+    const containerElk = graph.children![0];
+    expect(containerElk.id).toBe('vnet-1');
+    expect(containerElk.children).toHaveLength(1);
+    expect(containerElk.children![0].id).toBe('vm-1');
+  });
+
+  it('sets layout options on compound container nodes', () => {
+    const container = makeContainer();
+    const resource = makeResource({ parentId: 'vnet-1' });
+    const model = makeArch([container, resource]);
+    const { graph } = architectureToElkGraph(model);
+
+    const containerElk = graph.children![0];
+    expect(containerElk.layoutOptions).toBeDefined();
+    expect(containerElk.layoutOptions!['elk.algorithm']).toBe('layered');
+    expect(containerElk.layoutOptions!['elk.direction']).toBe('RIGHT');
+    expect(containerElk.layoutOptions!['elk.spacing.nodeNode']).toBe('3');
+    expect(containerElk.layoutOptions!['elk.layered.spacing.nodeNodeBetweenLayers']).toBe('4');
+    expect(containerElk.layoutOptions!['elk.padding']).toContain('top=2');
+  });
+
+  it('does not set layout options on leaf containers (no children)', () => {
+    const container = makeContainer();
+    const model = makeArch([container]);
+    const { graph } = architectureToElkGraph(model);
+
+    const containerElk = graph.children![0];
+    expect(containerElk.layoutOptions).toBeUndefined();
+  });
+
+  it('sets root-level layout options with hierarchy handling', () => {
+    const model = makeArch([makeContainer()]);
+    const { graph } = architectureToElkGraph(model);
+
+    expect(graph.layoutOptions!['elk.hierarchyHandling']).toBe('INCLUDE_CHILDREN');
+    expect(graph.layoutOptions!['elk.algorithm']).toBe('layered');
+    expect(graph.layoutOptions!['elk.direction']).toBe('RIGHT');
+  });
+
+  it('populates nodeMap with all blocks', () => {
+    const container = makeContainer();
+    const resource = makeResource();
+    const model = makeArch([container, resource]);
+    const { nodeMap } = architectureToElkGraph(model);
+
+    expect(nodeMap.size).toBe(2);
+    expect(nodeMap.get('vnet-1')).toBe(container);
+    expect(nodeMap.get('vm-1')).toBe(resource);
+  });
+
+  it('converts connections to ELK edges', () => {
+    const container = makeContainer();
+    const res1 = makeResource({ id: 'vm-1', parentId: 'vnet-1' });
+    const res2 = makeResource({ id: 'vm-2', name: 'VM 2', parentId: 'vnet-1' });
+    const model = makeArch(
+      [container, res1, res2],
+      [
+        {
+          id: 'conn-1',
+          from: 'endpoint-vm-1-output-http',
+          to: 'endpoint-vm-2-input-http',
+          metadata: {},
+        },
+      ],
+    );
+    const { graph } = architectureToElkGraph(model);
+
+    expect(graph.edges).toHaveLength(1);
+    expect(graph.edges![0]).toEqual({
+      id: 'conn-1',
+      sources: ['vm-1'],
+      targets: ['vm-2'],
+    });
+  });
+
+  it('skips edges where source or target is missing', () => {
+    const resource = makeResource({ id: 'vm-1', parentId: null });
+    const model = makeArch(
+      [resource],
+      [
+        {
+          id: 'conn-1',
+          from: 'endpoint-vm-1-output-http',
+          to: 'endpoint-missing-node-input-http',
+          metadata: {},
+        },
+      ],
+    );
+    const { graph } = architectureToElkGraph(model);
+
+    expect(graph.edges).toHaveLength(0);
+  });
+
+  it('handles deeply nested container hierarchy', () => {
+    const vnet = makeContainer({ id: 'vnet', type: 'region' });
+    const subnet = makeContainer({
+      id: 'subnet',
+      type: 'subnet',
+      parentId: 'vnet',
+      frame: { width: 8, height: 0.3, depth: 8 },
+    });
+    const resource = makeResource({ id: 'vm', parentId: 'subnet' });
+    const model = makeArch([vnet, subnet, resource]);
+    const { graph } = architectureToElkGraph(model);
+
+    const vnetElk = graph.children![0];
+    expect(vnetElk.id).toBe('vnet');
+    expect(vnetElk.children).toHaveLength(1);
+
+    const subnetElk = vnetElk.children![0];
+    expect(subnetElk.id).toBe('subnet');
+    expect(subnetElk.children).toHaveLength(1);
+    expect(subnetElk.children![0].id).toBe('vm');
+  });
+});
+
+/* ── readElkPositions ─────────────────────────────────────────────── */
+
+describe('readElkPositions', () => {
+  it('returns empty array for root-only graph', () => {
+    const elkRoot: ElkNode = { id: 'root', children: [] };
+    const nodeMap = new Map<string, Block>();
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches).toEqual([]);
+  });
+
+  it('converts ELK top-left positions to CloudBlocks center positions', () => {
+    const resource = makeResource({
+      id: 'vm-1',
+      position: { x: 5, y: 0, z: 8 },
+    });
+    const nodeMap = new Map<string, Block>([['vm-1', resource]]);
+
+    // ELK places the node at top-left (3, 4)
+    // Resource dims: getBlockDimensions('compute', 'azure', ...) → width, depth
+    // The test verifies center = topLeft + dims/2
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vm-1', x: 3, y: 4, width: 2, height: 2 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches).toHaveLength(1);
+    // Center = topLeft + actualDims/2 (from getBlockDimensions)
+    // The actual dims depend on getBlockDimensions but the test validates structure
+    expect(patches[0].id).toBe('vm-1');
+    expect(patches[0].position.y).toBe(0); // elevation preserved
+    expect(typeof patches[0].position.x).toBe('number');
+    expect(typeof patches[0].position.z).toBe('number');
+  });
+
+  it('preserves y (elevation) from original block', () => {
+    const resource = makeResource({
+      id: 'vm-1',
+      position: { x: 5, y: 3, z: 8 },
+    });
+    const nodeMap = new Map<string, Block>([['vm-1', resource]]);
+
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vm-1', x: 10, y: 20, width: 2, height: 2 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches[0].position.y).toBe(3);
+  });
+
+  it('snaps positions to integer CU grid', () => {
+    const resource = makeResource({
+      id: 'vm-1',
+      position: { x: 0, y: 0, z: 0 },
+    });
+    const nodeMap = new Map<string, Block>([['vm-1', resource]]);
+
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vm-1', x: 1.7, y: 2.3, width: 2, height: 2 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    // Positions should be rounded integers
+    expect(Number.isInteger(patches[0].position.x)).toBe(true);
+    expect(Number.isInteger(patches[0].position.z)).toBe(true);
+  });
+
+  it('updates container frame when ELK resizes it', () => {
+    const container = makeContainer({
+      id: 'vnet-1',
+      position: { x: 10, y: 0, z: 20 },
+      frame: { width: 16, height: 0.3, depth: 20 },
+    });
+    const nodeMap = new Map<string, Block>([['vnet-1', container]]);
+
+    // ELK gives a bigger size than the original
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vnet-1', x: 0, y: 0, width: 24, height: 30 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches[0].frame).toBeDefined();
+    expect(patches[0].frame!.width).toBe(24);
+    expect(patches[0].frame!.depth).toBe(30);
+    expect(patches[0].frame!.height).toBe(0.3); // vertical height preserved
+  });
+
+  it('does not shrink container frame below original size', () => {
+    const container = makeContainer({
+      id: 'vnet-1',
+      position: { x: 10, y: 0, z: 20 },
+      frame: { width: 16, height: 0.3, depth: 20 },
+    });
+    const nodeMap = new Map<string, Block>([['vnet-1', container]]);
+
+    // ELK gives a smaller size
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vnet-1', x: 0, y: 0, width: 8, height: 10 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches[0].frame!.width).toBe(16); // max(8, 16) = 16
+    expect(patches[0].frame!.depth).toBe(20); // max(10, 20) = 20
+  });
+
+  it('does not add frame patch for resource blocks', () => {
+    const resource = makeResource({
+      id: 'vm-1',
+      position: { x: 5, y: 0, z: 8 },
+    });
+    const nodeMap = new Map<string, Block>([['vm-1', resource]]);
+
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'vm-1', x: 3, y: 4, width: 5, height: 5 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches[0].frame).toBeUndefined();
+  });
+
+  it('accumulates parent offsets for nested nodes', () => {
+    const vnet = makeContainer({
+      id: 'vnet',
+      position: { x: 10, y: 0, z: 20 },
+      frame: { width: 16, height: 0.3, depth: 20 },
+    });
+    const resource = makeResource({
+      id: 'vm',
+      parentId: 'vnet',
+      position: { x: 5, y: 0, z: 8 },
+    });
+    const nodeMap = new Map<string, Block>([
+      ['vnet', vnet],
+      ['vm', resource],
+    ]);
+
+    // Parent at (2, 4), child at (3, 5) relative to parent
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [
+        {
+          id: 'vnet',
+          x: 2,
+          y: 4,
+          width: 20,
+          height: 24,
+          children: [{ id: 'vm', x: 3, y: 5, width: 2, height: 2 }],
+        },
+      ],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    const vmPatch = patches.find((p) => p.id === 'vm')!;
+    // Child absolute top-left = parent(2,4) + child(3,5) = (5, 9)
+    // Then convert to center by adding dims/2
+    expect(vmPatch).toBeDefined();
+    expect(vmPatch.position.y).toBe(0); // elevation preserved
+  });
+
+  it('skips nodes not found in nodeMap', () => {
+    const nodeMap = new Map<string, Block>();
+
+    const elkRoot: ElkNode = {
+      id: 'root',
+      children: [{ id: 'unknown', x: 0, y: 0, width: 2, height: 2 }],
+    };
+
+    const patches = readElkPositions(elkRoot, nodeMap);
+    expect(patches).toEqual([]);
+  });
+});

--- a/apps/web/src/features/layout/elkAdapter.ts
+++ b/apps/web/src/features/layout/elkAdapter.ts
@@ -5,10 +5,11 @@
  * No store dependencies — all inputs/outputs are plain data.
  *
  * Coordinate mapping:
- *   CloudBlocks world (x, z) in CU → ELK (x, y) in CU
- *   CloudBlocks positions are absolute world coordinates.
- *   ELK positions are relative to the parent node.
- *   All CU values are used directly (no pixel conversion needed).
+ *   CloudBlocks uses (x, z) in CU; ELK uses (x, y) in CU.
+ *   Container positions are always absolute world coordinates.
+ *   Resource positions with parentId are relative to the parent container center.
+ *   Root-level resources (no parentId) use absolute world coordinates.
+ *   ELK child node positions are relative to the parent node's top-left corner.
  */
 
 import type { ElkNode, ElkExtendedEdge } from 'elkjs/lib/elk-api';
@@ -71,11 +72,11 @@ function getNodeDimensions(node: Block): BlockDimensionsCU {
  * Convert a CloudBlocks ArchitectureModel to an ELK JSON graph.
  *
  * Strategy:
- * - Root-level containers become children of the ELK root node.
+ * - Root-level containers become children of the ELK root node (absolute coords).
  * - Nested containers and resource blocks become children of their parent ELK node.
- * - ELK uses top-left coordinate convention; we convert from CloudBlocks center-based.
- * - All dimensions are in CU (composition units), used directly.
- * - Containers let ELK determine size (Option B) to produce optimal layouts.
+ * - ELK child coordinates are relative to parent's top-left corner.
+ * - Container positions are absolute; resource positions are parent-center-relative.
+ * - We convert both to ELK parent-relative top-left coordinates.
  */
 export function architectureToElkGraph(model: ArchitectureModel): ElkConversionResult {
   const nodeMap = new Map<string, Block>();
@@ -92,25 +93,60 @@ export function architectureToElkGraph(model: ArchitectureModel): ElkConversionR
     childrenByParent.set(parentKey, siblings);
   }
 
-  // Recursively build ELK nodes
-  function buildElkNode(node: Block): ElkNode {
+  /**
+   * Build an ELK node for a CloudBlocks block.
+   *
+   * @param node - The CloudBlocks block
+   * @param parentBlock - The parent container block (null for root-level nodes)
+   */
+  function buildElkNode(node: Block, parentBlock: Block | null): ElkNode {
     const dims = getNodeDimensions(node);
     const children = childrenByParent.get(node.id) ?? [];
-    // Convert center-based position to top-left for ELK
-    const topLeftX = node.position.x - dims.width / 2;
-    const topLeftZ = node.position.z - dims.depth / 2;
+
+    // Compute ELK position (parent-relative top-left)
+    let elkX: number;
+    let elkY: number;
+
+    if (!parentBlock) {
+      // Root-level node: position is absolute world center → absolute top-left
+      elkX = node.position.x - dims.width / 2;
+      elkY = node.position.z - dims.depth / 2;
+    } else if (isContainer(node)) {
+      // Nested container: position is absolute world center
+      // Parent's top-left = parentPos - parentDims/2
+      const parentDims = getNodeDimensions(parentBlock);
+      const parentTopLeftX = parentBlock.position.x - parentDims.width / 2;
+      const parentTopLeftZ = parentBlock.position.z - parentDims.depth / 2;
+      // Node's absolute top-left
+      const absTopLeftX = node.position.x - dims.width / 2;
+      const absTopLeftZ = node.position.z - dims.depth / 2;
+      // Parent-relative top-left
+      elkX = absTopLeftX - parentTopLeftX;
+      elkY = absTopLeftZ - parentTopLeftZ;
+    } else {
+      // Resource with parent: position is center-relative to parent center
+      // Parent center = (0, 0) in relative coords
+      // node.position is offset from parent center → top-left = position - dims/2
+      elkX = node.position.x - dims.width / 2;
+      elkY = node.position.z - dims.depth / 2;
+      // But ELK coordinates are relative to parent's top-left, not parent center.
+      // Offset: parent center = parent dims / 2 from top-left
+      const parentDims = getNodeDimensions(parentBlock);
+      elkX += parentDims.width / 2;
+      elkY += parentDims.depth / 2;
+    }
 
     const elkNode: ElkNode = {
       id: node.id,
-      x: topLeftX,
-      y: topLeftZ, // ELK y = CloudBlocks z-axis
+      x: elkX,
+      y: elkY,
       width: dims.width,
       height: dims.depth, // ELK height = CloudBlocks depth (z-axis)
     };
 
     if (isContainer(node) && children.length > 0) {
       // Compound node: add children and padding
-      elkNode.children = children.map(buildElkNode);
+      elkNode.children = children.map((child) => buildElkNode(child, node));
       elkNode.layoutOptions = {
         'elk.algorithm': 'layered',
         'elk.direction': 'RIGHT',
@@ -125,7 +161,7 @@ export function architectureToElkGraph(model: ArchitectureModel): ElkConversionR
 
   // Build root-level children
   const rootChildren = childrenByParent.get(null) ?? [];
-  const elkChildren = rootChildren.map(buildElkNode);
+  const elkChildren = rootChildren.map((node) => buildElkNode(node, null));
 
   // Build edges from connections
   const edges = connectionsToElkEdges(model.connections, nodeMap);
@@ -175,10 +211,13 @@ function connectionsToElkEdges(
 
 /**
  * Extract laid-out positions from an ELK result and convert back to
- * absolute CloudBlocks world coordinates (CU, snapped to integers).
+ * CloudBlocks coordinates:
+ * - Container positions → absolute world center coordinates.
+ * - Resource positions with parentId → center-relative to parent container center.
+ * - Root-level resources → absolute world center coordinates.
  *
  * ELK returns positions relative to the parent node's top-left corner.
- * We convert to absolute by accumulating parent offsets.
+ * We convert accordingly based on the node type and parent context.
  */
 export function readElkPositions(
   elkRoot: ElkNode,
@@ -186,11 +225,22 @@ export function readElkPositions(
 ): LayoutPatchEntry[] {
   const patches: LayoutPatchEntry[] = [];
 
-  function traverse(elkNode: ElkNode, parentAbsX: number, parentAbsZ: number): void {
+  /**
+   * @param elkNode - Current ELK node
+   * @param parentAbsX - Parent's absolute top-left X in world coords
+   * @param parentAbsZ - Parent's absolute top-left Z in world coords
+   * @param parentBlock - The parent CloudBlocks block (null for root children)
+   */
+  function traverse(
+    elkNode: ElkNode,
+    parentAbsX: number,
+    parentAbsZ: number,
+    parentBlock: Block | null,
+  ): void {
     // Skip the root synthetic node
     if (elkNode.id === 'root') {
       for (const child of elkNode.children ?? []) {
-        traverse(child, 0, 0);
+        traverse(child, 0, 0, null);
       }
       return;
     }
@@ -198,25 +248,46 @@ export function readElkPositions(
     const original = nodeMap.get(elkNode.id);
     if (!original) return;
 
-    // ELK x,y → CloudBlocks x,z (absolute)
-    const elkTopLeftX = parentAbsX + (elkNode.x ?? 0);
-    const elkTopLeftZ = parentAbsZ + (elkNode.y ?? 0);
+    // ELK position is relative to parent top-left
+    const elkRelX = elkNode.x ?? 0;
+    const elkRelZ = elkNode.y ?? 0;
 
-    // Convert ELK top-left back to CloudBlocks center-based
+    // Compute absolute top-left position
+    const absTopLeftX = parentAbsX + elkRelX;
+    const absTopLeftZ = parentAbsZ + elkRelZ;
+
+    // Use post-layout dimensions for center calculation
     const dims = getNodeDimensions(original);
-    const centerX = elkTopLeftX + dims.width / 2;
-    const centerZ = elkTopLeftZ + dims.depth / 2;
+    const layoutWidth = isContainer(original) && elkNode.width != null ? elkNode.width : dims.width;
+    const layoutDepth =
+      isContainer(original) && elkNode.height != null ? elkNode.height : dims.depth;
 
-    // Snap to CU grid (round to nearest integer)
-    const snappedX = Math.round(centerX);
-    const snappedZ = Math.round(centerZ);
+    // Compute the position in CloudBlocks coordinate convention
+    let patchX: number;
+    let patchZ: number;
+
+    if (isContainer(original) || !parentBlock) {
+      // Containers always use absolute world center
+      // Root-level resources also use absolute world center
+      patchX = Math.round(absTopLeftX + layoutWidth / 2);
+      patchZ = Math.round(absTopLeftZ + layoutDepth / 2);
+    } else {
+      // Resource with parent: convert to parent-center-relative
+      // ELK gives position relative to parent's top-left
+      // CloudBlocks wants position relative to parent center
+      const parentDims = getNodeDimensions(parentBlock);
+      // Parent center in parent-local coords = (parentDims.width/2, parentDims.depth/2)
+      // Node center in parent-local coords = (elkRelX + dims.width/2, elkRelZ + dims.depth/2)
+      patchX = Math.round(elkRelX + dims.width / 2 - parentDims.width / 2);
+      patchZ = Math.round(elkRelZ + dims.depth / 2 - parentDims.depth / 2);
+    }
 
     const patch: LayoutPatchEntry = {
       id: elkNode.id,
       position: {
-        x: snappedX,
+        x: patchX,
         y: original.position.y, // preserve elevation
-        z: snappedZ,
+        z: patchZ,
       },
     };
 
@@ -233,12 +304,12 @@ export function readElkPositions(
 
     patches.push(patch);
 
-    // Recurse into children with accumulated absolute offset
+    // Recurse into children with this node's absolute top-left
     for (const child of elkNode.children ?? []) {
-      traverse(child, elkTopLeftX, elkTopLeftZ);
+      traverse(child, absTopLeftX, absTopLeftZ, original);
     }
   }
 
-  traverse(elkRoot, 0, 0);
+  traverse(elkRoot, 0, 0, null);
   return patches;
 }

--- a/apps/web/src/features/layout/elkAdapter.ts
+++ b/apps/web/src/features/layout/elkAdapter.ts
@@ -1,0 +1,244 @@
+/**
+ * ELK Graph Adapter
+ *
+ * Pure functions to convert between CloudBlocks ArchitectureModel and ELK JSON graph format.
+ * No store dependencies — all inputs/outputs are plain data.
+ *
+ * Coordinate mapping:
+ *   CloudBlocks world (x, z) in CU → ELK (x, y) in CU
+ *   CloudBlocks positions are absolute world coordinates.
+ *   ELK positions are relative to the parent node.
+ *   All CU values are used directly (no pixel conversion needed).
+ */
+
+import type { ElkNode, ElkExtendedEdge } from 'elkjs/lib/elk-api';
+import type { ArchitectureModel, Block, ContainerBlock, Connection } from '@cloudblocks/schema';
+import { resolveConnectionNodes } from '@cloudblocks/schema';
+import type { BlockDimensionsCU } from '../../shared/types/visualProfile';
+import { getBlockDimensions } from '../../shared/types/visualProfile';
+
+/* ── Constants ────────────────────────────────────────────────────── */
+
+/** Internal padding (CU) inside ELK compound nodes for container blocks */
+const CONTAINER_PADDING_CU = 2;
+
+/** Spacing between sibling nodes (CU) */
+const NODE_SPACING_CU = 3;
+
+/** Spacing between layers (CU) */
+const LAYER_SPACING_CU = 4;
+
+/* ── Types ────────────────────────────────────────────────────────── */
+
+/** Position patch entry produced by readElkPositions */
+export interface LayoutPatchEntry {
+  id: string;
+  position: { x: number; y: number; z: number };
+  frame?: { width: number; height: number; depth: number };
+}
+
+/** Result of converting architecture model to ELK graph */
+export interface ElkConversionResult {
+  graph: ElkNode;
+  /** Original node data keyed by id, for reverse mapping */
+  nodeMap: Map<string, Block>;
+}
+
+/* ── Helpers ──────────────────────────────────────────────────────── */
+
+function isContainer(node: Block): node is ContainerBlock {
+  return node.kind === 'container';
+}
+
+/**
+ * Get CU dimensions for a block (resource or container).
+ * For containers, uses frame. For resources, uses getBlockDimensions.
+ */
+function getNodeDimensions(node: Block): BlockDimensionsCU {
+  if (isContainer(node)) {
+    return {
+      width: node.frame.width,
+      depth: node.frame.depth,
+      height: node.frame.height,
+    };
+  }
+  return getBlockDimensions(node.category, node.provider, node.subtype);
+}
+
+/* ── Model → ELK ─────────────────────────────────────────────────── */
+
+/**
+ * Convert a CloudBlocks ArchitectureModel to an ELK JSON graph.
+ *
+ * Strategy:
+ * - Root-level containers become children of the ELK root node.
+ * - Nested containers and resource blocks become children of their parent ELK node.
+ * - ELK uses top-left coordinate convention; we convert from CloudBlocks center-based.
+ * - All dimensions are in CU (composition units), used directly.
+ * - Containers let ELK determine size (Option B) to produce optimal layouts.
+ */
+export function architectureToElkGraph(model: ArchitectureModel): ElkConversionResult {
+  const nodeMap = new Map<string, Block>();
+  for (const node of model.nodes) {
+    nodeMap.set(node.id, node);
+  }
+
+  // Build parent→children index
+  const childrenByParent = new Map<string | null, Block[]>();
+  for (const node of model.nodes) {
+    const parentKey = node.parentId ?? null;
+    const siblings = childrenByParent.get(parentKey) ?? [];
+    siblings.push(node);
+    childrenByParent.set(parentKey, siblings);
+  }
+
+  // Recursively build ELK nodes
+  function buildElkNode(node: Block): ElkNode {
+    const dims = getNodeDimensions(node);
+    const children = childrenByParent.get(node.id) ?? [];
+    // Convert center-based position to top-left for ELK
+    const topLeftX = node.position.x - dims.width / 2;
+    const topLeftZ = node.position.z - dims.depth / 2;
+
+    const elkNode: ElkNode = {
+      id: node.id,
+      x: topLeftX,
+      y: topLeftZ, // ELK y = CloudBlocks z-axis
+      width: dims.width,
+      height: dims.depth, // ELK height = CloudBlocks depth (z-axis)
+    };
+
+    if (isContainer(node) && children.length > 0) {
+      // Compound node: add children and padding
+      elkNode.children = children.map(buildElkNode);
+      elkNode.layoutOptions = {
+        'elk.algorithm': 'layered',
+        'elk.direction': 'RIGHT',
+        'elk.padding': `[top=${CONTAINER_PADDING_CU},left=${CONTAINER_PADDING_CU},bottom=${CONTAINER_PADDING_CU},right=${CONTAINER_PADDING_CU}]`,
+        'elk.spacing.nodeNode': String(NODE_SPACING_CU),
+        'elk.layered.spacing.nodeNodeBetweenLayers': String(LAYER_SPACING_CU),
+      };
+    }
+
+    return elkNode;
+  }
+
+  // Build root-level children
+  const rootChildren = childrenByParent.get(null) ?? [];
+  const elkChildren = rootChildren.map(buildElkNode);
+
+  // Build edges from connections
+  const edges = connectionsToElkEdges(model.connections, nodeMap);
+
+  const graph: ElkNode = {
+    id: 'root',
+    layoutOptions: {
+      'elk.algorithm': 'layered',
+      'elk.direction': 'RIGHT',
+      'elk.spacing.nodeNode': String(NODE_SPACING_CU),
+      'elk.layered.spacing.nodeNodeBetweenLayers': String(LAYER_SPACING_CU),
+      'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+    },
+    children: elkChildren,
+    edges,
+  };
+
+  return { graph, nodeMap };
+}
+
+/**
+ * Convert connections to ELK extended edges.
+ * Only includes edges where both source and target blocks exist in the model.
+ */
+function connectionsToElkEdges(
+  connections: Connection[],
+  nodeMap: Map<string, Block>,
+): ElkExtendedEdge[] {
+  const edges: ElkExtendedEdge[] = [];
+
+  for (const conn of connections) {
+    const { sourceId, targetId } = resolveConnectionNodes(conn);
+    // Only include edges where both endpoints exist
+    if (nodeMap.has(sourceId) && nodeMap.has(targetId)) {
+      edges.push({
+        id: conn.id,
+        sources: [sourceId],
+        targets: [targetId],
+      });
+    }
+  }
+
+  return edges;
+}
+
+/* ── ELK → Model (position extraction) ───────────────────────────── */
+
+/**
+ * Extract laid-out positions from an ELK result and convert back to
+ * absolute CloudBlocks world coordinates (CU, snapped to integers).
+ *
+ * ELK returns positions relative to the parent node's top-left corner.
+ * We convert to absolute by accumulating parent offsets.
+ */
+export function readElkPositions(
+  elkRoot: ElkNode,
+  nodeMap: Map<string, Block>,
+): LayoutPatchEntry[] {
+  const patches: LayoutPatchEntry[] = [];
+
+  function traverse(elkNode: ElkNode, parentAbsX: number, parentAbsZ: number): void {
+    // Skip the root synthetic node
+    if (elkNode.id === 'root') {
+      for (const child of elkNode.children ?? []) {
+        traverse(child, 0, 0);
+      }
+      return;
+    }
+
+    const original = nodeMap.get(elkNode.id);
+    if (!original) return;
+
+    // ELK x,y → CloudBlocks x,z (absolute)
+    const elkTopLeftX = parentAbsX + (elkNode.x ?? 0);
+    const elkTopLeftZ = parentAbsZ + (elkNode.y ?? 0);
+
+    // Convert ELK top-left back to CloudBlocks center-based
+    const dims = getNodeDimensions(original);
+    const centerX = elkTopLeftX + dims.width / 2;
+    const centerZ = elkTopLeftZ + dims.depth / 2;
+
+    // Snap to CU grid (round to nearest integer)
+    const snappedX = Math.round(centerX);
+    const snappedZ = Math.round(centerZ);
+
+    const patch: LayoutPatchEntry = {
+      id: elkNode.id,
+      position: {
+        x: snappedX,
+        y: original.position.y, // preserve elevation
+        z: snappedZ,
+      },
+    };
+
+    // For containers, also update frame if ELK resized
+    if (isContainer(original) && elkNode.width != null && elkNode.height != null) {
+      const newWidth = Math.max(Math.round(elkNode.width), original.frame.width);
+      const newDepth = Math.max(Math.round(elkNode.height), original.frame.depth);
+      patch.frame = {
+        width: newWidth,
+        height: original.frame.height, // preserve vertical height
+        depth: newDepth,
+      };
+    }
+
+    patches.push(patch);
+
+    // Recurse into children with accumulated absolute offset
+    for (const child of elkNode.children ?? []) {
+      traverse(child, elkTopLeftX, elkTopLeftZ);
+    }
+  }
+
+  traverse(elkRoot, 0, 0);
+  return patches;
+}

--- a/apps/web/src/widgets/keyboard-shortcuts/KeyboardShortcuts.tsx
+++ b/apps/web/src/widgets/keyboard-shortcuts/KeyboardShortcuts.tsx
@@ -28,6 +28,8 @@ const SHORTCUT_GROUPS = [
       { keys: 'Ctrl+0', description: 'Fit to screen' },
       { keys: 'Scroll', description: 'Zoom in/out' },
       { keys: 'Shift+Drag', description: 'Lasso select' },
+      { keys: 'Shift+M', description: 'Toggle mini-map' },
+      { keys: 'Ctrl+Shift+L', description: 'Auto layout' },
     ],
   },
   {

--- a/apps/web/src/widgets/menu-bar/MenuBar.tsx
+++ b/apps/web/src/widgets/menu-bar/MenuBar.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '../../entities/store/authStore';
 import { useUIStore } from '../../entities/store/uiStore';
 import { clearWorkspaceDiffUI, syncWorkspaceUI } from '../../entities/store/uiSync';
 import { computeArchitectureDiff } from '../../features/diff/engine';
+import { runAutoLayout } from '../../features/layout/autoLayout';
 import { apiPost, getApiErrorMessage } from '../../shared/api/client';
 import { confirmDialog } from '../../shared/ui/ConfirmDialog';
 import { LogoIcon } from '../../shared/ui/LogoIcon';
@@ -556,6 +557,20 @@ export function MenuBar() {
     clearSelection();
   };
 
+  const handleAutoLayout = async () => {
+    try {
+      const applied = await runAutoLayout();
+      if (applied) {
+        toast.success('Auto layout applied');
+        playSound('block-snap');
+      } else {
+        toast('No nodes to layout');
+      }
+    } catch {
+      toast.error('Auto layout failed');
+    }
+  };
+
   const handleValidate = () => {
     const result = validate();
     if (!showValidation) toggleValidation();
@@ -816,6 +831,17 @@ export function MenuBar() {
               <Trash2 size={14} /> Delete Selection
             </span>
             <span className="menu-shortcut">Del</span>
+          </button>
+          <button
+            type="button"
+            className="menu-item"
+            role="menuitem"
+            onClick={() => handleAction(handleAutoLayout)}
+          >
+            <span className="menu-item-left">
+              <LayoutGrid size={14} /> Auto Layout
+            </span>
+            <span className="menu-shortcut">Ctrl+Shift+L</span>
           </button>
 
           <hr className="menu-separator" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@cloudblocks/schema':
         specifier: workspace:*
         version: link:../../packages/schema
+      elkjs:
+        specifier: ^0.11.1
+        version: 0.11.1
       interactjs:
         specifier: ^1.10.27
         version: 1.10.27
@@ -977,6 +980,9 @@ packages:
 
   electron-to-chromium@1.5.313:
     resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
+
+  elkjs@0.11.1:
+    resolution: {integrity: sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2586,6 +2592,8 @@ snapshots:
   dom-accessibility-api@0.6.3: {}
 
   electron-to-chromium@1.5.313: {}
+
+  elkjs@0.11.1: {}
 
   emoji-regex@10.6.0: {}
 


### PR DESCRIPTION
## Summary

- Integrate **elkjs** as a dynamically-loaded layout engine for automatic node arrangement on the isometric canvas
- Add `elkAdapter.ts` for bidirectional ELK ↔ CloudBlocks coordinate conversion (center ↔ top-left, x/z ↔ x/y mapping)
- Add `autoLayout.ts` orchestrator with lazy `import()` loading, single-undo-step application via `withHistory`
- Add "Auto Layout" button in Edit menu + `Ctrl+Shift+L` keyboard shortcut
- Update CI bundle budget to separate eager (1024 KB) vs lazy-loaded chunks (2560 KB total) — elkjs is ~1400 KB but only loaded on first use
- 27 new tests: 20 for adapter (coordinate conversion, hierarchy, edges, frame sizing) + 7 for orchestrator (patch application, immutability, multi-node)

### Architecture Decisions (per Oracle consultation)

- **Algorithm**: `elk.layered` with `RIGHT` direction, orthogonal edge routing
- **Hierarchy**: `INCLUDE_CHILDREN` for compound container nodes
- **Spacing**: nodeNode=3 CU, nodeNodeBetweenLayers=4 CU, container padding=2 CU
- **No ELK ports**: Canvas already owns orthogonal routing via `surfaceRouting.ts`
- **Coordinate conversion**: ELK uses top-left; CloudBlocks stores center positions — adapter handles bidirectional mapping
- **Lazy loading**: `import('elkjs/lib/elk.bundled')` keeps ~1.4 MB out of the initial bundle

Fixes #1836
Part of #1829