### PR TITLE
fix(web): use content equality for connection path transition to prevent infinite re-render

### DIFF
--- a/apps/web/src/entities/connection/useConnectionPathTransition.test.ts
+++ b/apps/web/src/entities/connection/useConnectionPathTransition.test.ts
@@ -337,4 +337,51 @@ describe('useConnectionPathTransition', () => {
     expect(lastPoint.x).toBeCloseTo(pointsC[pointsC.length - 1].x);
     expect(lastPoint.y).toBeCloseTo(pointsC[pointsC.length - 1].y);
   });
+
+  it('does not loop when rerendered with fresh cloned arrays of identical coordinates', () => {
+    // Regression: fresh array references with same content must not cause infinite re-render.
+    // Before fix, referential inequality (a !== b) triggered setPrevFlowPoints on every render,
+    // causing React error #301. Fix uses pointsEqual() content comparison instead.
+    const { result, rerender } = renderHook(
+      ({ pts, state, elapsed }) => useConnectionPathTransition(pts, state, elapsed, false),
+      {
+        initialProps: {
+          pts: pointsA,
+          state: 'idle' as State,
+          elapsed: 0,
+        },
+      },
+    );
+
+    // Rerender with a cloned array (new reference, same coordinates)
+    const clonedA = pointsA.map((p) => ({ x: p.x, y: p.y }));
+    rerender({ pts: clonedA, state: 'idle' as const, elapsed: 0 });
+
+    // Should not be transitioning — content is identical
+    expect(result.current.isTransitioning).toBe(false);
+    expect(result.current.flowPoints).toHaveLength(pointsA.length);
+    expect(result.current.flowPoints[0]).toEqual(pointsA[0]);
+  });
+
+  it('does not animate on dragging → idle when geometry is unchanged (fresh array reference)', () => {
+    // Regression: dragging → idle with cloned points (new ref, same geometry) must not animate.
+    const { result, rerender } = renderHook(
+      ({ pts, state, elapsed }) => useConnectionPathTransition(pts, state, elapsed, false),
+      {
+        initialProps: {
+          pts: pointsA,
+          state: 'dragging' as State,
+          elapsed: 100,
+        },
+      },
+    );
+
+    // Transition from dragging → idle with fresh array reference but identical geometry
+    const clonedA = pointsA.map((p) => ({ x: p.x, y: p.y }));
+    rerender({ pts: clonedA, state: 'idle' as const, elapsed: 100 });
+
+    // Should NOT animate — geometry content is the same
+    expect(result.current.isTransitioning).toBe(false);
+    expect(result.current.flowPoints).toHaveLength(pointsA.length);
+  });
 });

--- a/apps/web/src/entities/connection/useConnectionPathTransition.ts
+++ b/apps/web/src/entities/connection/useConnectionPathTransition.ts
@@ -222,7 +222,7 @@ export function useConnectionPathTransition(
   }
 
   // Update previous flowPoints (always track the latest geometry)
-  if (currentFlowPoints !== prevFlowPoints) {
+  if (!pointsEqual(currentFlowPoints, prevFlowPoints)) {
     setPrevFlowPoints(currentFlowPoints);
   }
 


### PR DESCRIPTION
## Summary

- Fix infinite re-render loop (React error #301) in `useConnectionPathTransition` caused by referential inequality check on `prevFlowPoints`
- Replace `currentFlowPoints !== prevFlowPoints` with `!pointsEqual(currentFlowPoints, prevFlowPoints)` for content-based comparison
- Add 2 regression tests covering cloned array references with identical coordinates

## Root Cause

`ConnectionRenderer.tsx` creates a new `currentFlowPoints` array reference on every render via `useMemo` (lines 449-465). The guard on line 225 used `!==` (referential equality), which was always `true` for new references even when geometry content was identical. This triggered `setPrevFlowPoints()` → state update → re-render → infinite loop → React error #301.

## Fix

One-line change: use the existing `pointsEqual()` utility (content comparison with ε=0.5 sub-pixel threshold) instead of `!==`.

## Verification

- ✅ All 3560 unit tests pass (158 files)
- ✅ `pnpm build` passes
- ✅ `pnpm lint` passes
- ✅ Browser verified: Three-Tier Web App template loads with zero React errors
- ✅ Oracle consultation confirmed `useState` pattern is safe; `useRef` rejected for React 19 concurrent mode safety

Fixes #1850