### PR TITLE
chore: release v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ This project uses [Semantic Versioning](https://semver.org/). Version numbers fo
 
 ---
 
+## [v0.50.0] — 2026-04-15
+
+**Milestone 50 — Production Hotfix & Theme Defaults**
+
+Production hotfix for infinite re-render crash and white/light theme defaults.
+
+### Fixed
+
+- Infinite re-render loop (React error #301) in connection path transition caused by referential equality check (#1850, #1851)
+
+### Changed
+
+- Default CSS root theme to workshop (light) for white pre-JS render (#1852, #1853)
+- ErrorBoundary fallback screen from dark to white background (#1852, #1853)
+
+---
+
 ## [v0.49.0] — 2026-04-15
 
 **Milestone 49 — Canvas UX Polish & Enhancement**
@@ -1405,6 +1422,7 @@ Milestone 4 (Workspace Management):
 [v0.37.0]: https://github.com/yeongseon/cloudblocks/compare/v0.36.0...v0.37.0
 [v0.36.0]: https://github.com/yeongseon/cloudblocks/compare/v0.35.0...v0.36.0
 [v0.35.0]: https://github.com/yeongseon/cloudblocks/compare/v0.34.0...v0.35.0
+[v0.50.0]: https://github.com/yeongseon/cloudblocks/compare/v0.49.0...v0.50.0
 [v0.49.0]: https://github.com/yeongseon/cloudblocks/compare/v0.47.0...v0.49.0
 [v0.47.0]: https://github.com/yeongseon/cloudblocks/compare/v0.46.0...v0.47.0
 [v0.46.0]: https://github.com/yeongseon/cloudblocks/compare/v0.45.0...v0.46.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1413,15 +1413,6 @@ Milestone 4 (Workspace Management):
 
 ---
 
-[v0.43.0]: https://github.com/yeongseon/cloudblocks/compare/v0.42.0...v0.43.0
-[v0.42.0]: https://github.com/yeongseon/cloudblocks/compare/v0.41.0...v0.42.0
-[v0.41.0]: https://github.com/yeongseon/cloudblocks/compare/v0.40.0...v0.41.0
-[v0.40.0]: https://github.com/yeongseon/cloudblocks/compare/v0.39.0...v0.40.0
-[v0.39.0]: https://github.com/yeongseon/cloudblocks/compare/v0.38.0...v0.39.0
-[v0.38.0]: https://github.com/yeongseon/cloudblocks/compare/v0.37.0...v0.38.0
-[v0.37.0]: https://github.com/yeongseon/cloudblocks/compare/v0.36.0...v0.37.0
-[v0.36.0]: https://github.com/yeongseon/cloudblocks/compare/v0.35.0...v0.36.0
-[v0.35.0]: https://github.com/yeongseon/cloudblocks/compare/v0.34.0...v0.35.0
 [v0.50.0]: https://github.com/yeongseon/cloudblocks/compare/v0.49.0...v0.50.0
 [v0.49.0]: https://github.com/yeongseon/cloudblocks/compare/v0.47.0...v0.49.0
 [v0.47.0]: https://github.com/yeongseon/cloudblocks/compare/v0.46.0...v0.47.0

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -89,7 +89,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 app = FastAPI(
     title="CloudBlocks API",
     description="Thin orchestration backend for CloudBlocks Platform",
-    version="0.49.0",
+    version="0.50.0",
     lifespan=lifespan,
 )
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloudblocks-api"
-version = "0.49.0"
+version = "0.50.0"
 description = "CloudBlocks API — optional backend for auth, GitHub sync, and learning tool integrations"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cloudblocks/web",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "type": "module",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cloudblocks",
   "private": true,
-  "version": "0.49.0",
+  "version": "0.50.0",
   "description": "Visual cloud learning tool for beginners — learn cloud architecture patterns with guided templates and export Terraform starter code",
   "type": "module",
   "repository": {

--- a/packages/cloudblocks-domain/package.json
+++ b/packages/cloudblocks-domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/domain",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblocks/schema",
-  "version": "0.49.0",
+  "version": "0.50.0",
   "private": true,
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Version bump to `0.50.0` across all 6 package sources
- CHANGELOG entry for Milestone 50 — Production Hotfix & Theme Defaults

### Milestone 50 Changes

**Fixed:**
- Infinite re-render loop (React error #301) in connection path transition caused by referential equality check (#1850, #1851)

**Changed:**
- Default CSS root theme to workshop (light) for white pre-JS render (#1852, #1853)
- ErrorBoundary fallback screen from dark to white background (#1852, #1853)

Both fixes were merged to main before this release commit.