### PR TITLE
docs: update ROADMAP.md for M49 and M50 completion

### DIFF
--- a/docs/concept/ROADMAP.md
+++ b/docs/concept/ROADMAP.md
@@ -77,11 +77,13 @@ CloudBlocks evolves through four stages — from visual cloud learning tool to e
 | M45       | Packet & Container Visual Tuning              | ✅ Done |
 | M46       | Packet Flow UX & Visual Hierarchy              | ✅ Done |
 | M47       | Repository Review Follow-up                  | ✅ Done |
+| M49       | Canvas UX Polish & Enhancement               | ✅ Done |
+| M50       | Production Hotfix & Theme Defaults            | ✅ Done |
 
 ### Version Transition
 
 ```
-v0.{milestone}.0 per milestone (current: v0.47.0)
+v0.{milestone}.0 per milestone (current: v0.50.0)
 ```
 
 Version numbers follow `v0.N.0` where N is the milestone number. This convention continues through V1 development. See `docs/design/VERSION_POLICY.md` for details.
@@ -130,8 +132,8 @@ Version numbers follow `v0.N.0` where N is the milestone number. This convention
 
 | Metric                   | Value                                                                                                     |
 | ------------------------ | --------------------------------------------------------------------------------------------------------- |
-| 0.x milestones completed | 47 (M8–M47, all closed)                                                                                   |
-| Tests passing            | 3,739+                                                                                                     |
+| 0.x milestones completed | 50 (M8–M50, all closed; M48 empty/skipped)                                                                |
+| Tests passing            | 3,903+                                                                                                     |
 | Branch coverage          | ≥ 90%                                                                                                     |
 | Codebase                 | TypeScript (React 19) + Python (FastAPI) monorepo                                                         |
 | Architecture             | Block-based composition with `kind` + `traits` type system ([ADR-0013](../adr/0013-block-unification.md)) |


### PR DESCRIPTION
## Summary

Update ROADMAP.md to reflect M49 and M50 completion:

- Add M49 (Canvas UX Polish) and M50 (Production Hotfix & Theme Defaults) to V1 Milestones table
- Update version reference from v0.47.0 to v0.50.0
- Update milestone count from 47 to 50
- Update test count from 3,739+ to 3,903+

Fixes #1856