### PR TITLE
feat(web): explicit port anchors with 3-layer glyphs and occupied state

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -8,7 +8,11 @@ import type {
   ResourceBlock,
   ResourceCategory,
 } from '@cloudblocks/schema';
-import { generateEndpointsForBlock, isExternalResourceType } from '@cloudblocks/schema';
+import {
+  generateEndpointsForBlock,
+  isExternalResourceType,
+  CATEGORY_PORTS,
+} from '@cloudblocks/schema';
 import { useUIStore } from '../store/uiStore';
 import { useArchitectureStore } from '../store/architectureStore';
 import type { DiffDelta } from '../../shared/types/diff';
@@ -21,9 +25,10 @@ import { validatePlacement } from '../validation/placement';
 import { getBlockDimensions } from '../../shared/types/visualProfile';
 import { cuToSilhouetteDimensions } from './silhouettes';
 import { BLOCK_PADDING } from '../../shared/tokens/designTokens';
-import { BlockSvg } from './BlockSvg';
+import { BlockSvg, type OccupiedPorts } from './BlockSvg';
 import './BlockSprite.css';
 import { resolveBlockPresentation } from '../../shared/presentation/blockPresentation';
+import { semanticToPortIndex } from '../connection/endpointAnchors';
 
 /** Derive screen size for the block clickable area from CU dimensions. */
 function getBlockScreenSize(
@@ -107,6 +112,42 @@ export const BlockSprite = memo(function BlockSprite({
       return [...relevantConnectionIds];
     }),
   );
+  // Encode occupied ports as a flat sorted array: [inboundCount, ...inbound, ...outbound]
+  // so useShallow can do element-wise comparison on a single array.
+  const occupiedPortKey = useArchitectureStore(
+    useShallow((state) => {
+      if (!resolvedBlockId) return undefined;
+      const block = state.nodeById.get(resolvedBlockId);
+      if (!block || block.kind !== 'resource') return undefined;
+      const ports = CATEGORY_PORTS[block.category];
+      if (!ports) return undefined;
+      const inbound: number[] = [];
+      const outbound: number[] = [];
+      for (const endpoint of generateEndpointsForBlock(resolvedBlockId)) {
+        const connections = state.connectionsByEndpoint.get(endpoint.id);
+        if (connections && connections.length > 0) {
+          const side = endpoint.direction === 'output' ? 'outbound' : 'inbound';
+          const total = side === 'inbound' ? ports.inbound : ports.outbound;
+          const portIndex = semanticToPortIndex(endpoint.semantic, total);
+          if (portIndex !== null) {
+            if (side === 'inbound') inbound.push(portIndex);
+            else outbound.push(portIndex);
+          }
+        }
+      }
+      if (inbound.length === 0 && outbound.length === 0) return undefined;
+      inbound.sort();
+      outbound.sort();
+      // Flat array: [inboundCount, ...inboundPorts, ...outboundPorts]
+      return [inbound.length, ...inbound, ...outbound];
+    }),
+  );
+  const occupiedPorts: OccupiedPorts | undefined = occupiedPortKey
+    ? {
+        inbound: new Set(occupiedPortKey.slice(1, 1 + occupiedPortKey[0])),
+        outbound: new Set(occupiedPortKey.slice(1 + occupiedPortKey[0])),
+      }
+    : undefined;
 
   const activeProvider = useUIStore((s) => s.activeProvider);
   const diffMode = useUIStore((s) => s.diffMode);
@@ -399,6 +440,7 @@ export const BlockSprite = memo(function BlockSprite({
             aggregationCount={resolvedBlock.aggregation?.count}
             roles={resolvedBlock.roles}
             healthStatus={blockStatus?.disabled ? undefined : blockStatus?.healthStatus}
+            occupiedPorts={occupiedPorts}
           />
         </div>
       </button>

--- a/apps/web/src/entities/block/BlockSvg.tsx
+++ b/apps/web/src/entities/block/BlockSvg.tsx
@@ -15,17 +15,34 @@ import {
   EDGE_HIGHLIGHT_STROKE_WIDTH,
   LABEL_FACE_MIN_PX,
   LABEL_FACE_SCALE,
+  PORT_DOT_HEIGHT,
+  PORT_DOT_OCCUPIED_OPACITY,
   PORT_DOT_OPACITY,
   PORT_DOT_RX,
   PORT_DOT_RY,
-  PORT_DOT_STROKE_WIDTH,
+  PORT_COLOR_HTTP,
+  PORT_COLOR_EVENT,
+  PORT_COLOR_DATA,
   TOP_FACE_STROKE_OPACITY,
   TOP_FACE_STROKE_WIDTH,
 } from '../../shared/tokens/designTokens';
 import { getBlockFaceColors, deriveFaceColors, EXTERNAL_BLOCK_COLOR } from './blockFaceColors';
 import { cuToSilhouetteDimensions, getSilhouetteFromCU } from './silhouettes';
-import { getBlockSvgPortPoints } from './blockGeometry';
+import { getBlockSvgPortPoints, portIndexToSemantic } from './blockGeometry';
 import { useUIStore, type BlockHealthStatus } from '../store/uiStore';
+
+/** Semantic color lookup by endpoint semantic type. */
+const SEMANTIC_PORT_COLORS: Record<string, string> = {
+  http: PORT_COLOR_HTTP,
+  event: PORT_COLOR_EVENT,
+  data: PORT_COLOR_DATA,
+};
+
+/** Occupied port indices per side, passed from BlockSprite. */
+export interface OccupiedPorts {
+  inbound: ReadonlySet<number>;
+  outbound: ReadonlySet<number>;
+}
 
 interface BlockSvgProps {
   category: ResourceCategory;
@@ -36,6 +53,7 @@ interface BlockSvgProps {
   aggregationCount?: number;
   roles?: BlockRole[];
   healthStatus?: BlockHealthStatus;
+  occupiedPorts?: OccupiedPorts;
 }
 
 export const BlockSvg = memo(function BlockSvg({
@@ -47,6 +65,7 @@ export const BlockSvg = memo(function BlockSvg({
   aggregationCount,
   roles,
   healthStatus,
+  occupiedPorts,
 }: BlockSvgProps) {
   // ─── v2.0: CU-based dimension resolution ───────────────────
   const cu = getBlockDimensions(category, provider, subtype);
@@ -286,35 +305,147 @@ export const BlockSvg = memo(function BlockSvg({
         </g>
       )}
 
-      {/* ─── Port dots: generic indicators on block side walls ─── */}
+      {/* ─── Port dots: 3-layer isometric glyphs on block side walls ─── */}
+      {/* Occupied ports: always visible at dim opacity */}
+      {occupiedPorts && (
+        <g data-testid="port-dots-occupied" pointerEvents="none">
+          {portPoints.inbound.map((p, idx) => {
+            if (!occupiedPorts.inbound.has(idx)) return null;
+            const semantic = portIndexToSemantic(idx);
+            const color = SEMANTIC_PORT_COLORS[semantic] ?? PORT_COLOR_HTTP;
+            return (
+              <g key={`occ-in-${idx}`}>
+                <ellipse
+                  cx={p.x}
+                  cy={p.y + PORT_DOT_HEIGHT}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill="rgba(0,0,0,0.2)"
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill={color}
+                  opacity={PORT_DOT_OCCUPIED_OPACITY}
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX * 0.6}
+                  ry={PORT_DOT_RY * 0.6}
+                  fill="none"
+                  stroke="rgba(255,255,255,0.5)"
+                  strokeWidth={1}
+                />
+              </g>
+            );
+          })}
+          {portPoints.outbound.map((p, idx) => {
+            if (!occupiedPorts.outbound.has(idx)) return null;
+            const semantic = portIndexToSemantic(idx);
+            const color = SEMANTIC_PORT_COLORS[semantic] ?? PORT_COLOR_HTTP;
+            return (
+              <g key={`occ-out-${idx}`}>
+                <ellipse
+                  cx={p.x}
+                  cy={p.y + PORT_DOT_HEIGHT}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill="rgba(0,0,0,0.2)"
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill={color}
+                  opacity={PORT_DOT_OCCUPIED_OPACITY}
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX * 0.6}
+                  ry={PORT_DOT_RY * 0.6}
+                  fill="none"
+                  stroke="rgba(255,255,255,0.5)"
+                  strokeWidth={1}
+                />
+              </g>
+            );
+          })}
+        </g>
+      )}
+      {/* Unoccupied ports: visible only in connect mode (showPorts) */}
       {showPorts && (
         <g data-testid="port-dots">
-          {portPoints.inbound.map((p) => (
-            <ellipse
-              key={`in-${p.x}-${p.y}`}
-              cx={p.x}
-              cy={p.y}
-              rx={PORT_DOT_RX}
-              ry={PORT_DOT_RY}
-              fill="none"
-              stroke="rgba(255,255,255,0.5)"
-              strokeWidth={PORT_DOT_STROKE_WIDTH}
-              opacity={PORT_DOT_OPACITY}
-            />
-          ))}
-          {portPoints.outbound.map((p) => (
-            <ellipse
-              key={`out-${p.x}-${p.y}`}
-              cx={p.x}
-              cy={p.y}
-              rx={PORT_DOT_RX}
-              ry={PORT_DOT_RY}
-              fill="none"
-              stroke="rgba(255,255,255,0.5)"
-              strokeWidth={PORT_DOT_STROKE_WIDTH}
-              opacity={PORT_DOT_OPACITY}
-            />
-          ))}
+          {portPoints.inbound.map((p, idx) => {
+            if (occupiedPorts?.inbound.has(idx)) return null;
+            const semantic = portIndexToSemantic(idx);
+            const color = SEMANTIC_PORT_COLORS[semantic] ?? PORT_COLOR_HTTP;
+            return (
+              <g key={`in-${idx}`}>
+                <ellipse
+                  cx={p.x}
+                  cy={p.y + PORT_DOT_HEIGHT}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill="rgba(0,0,0,0.2)"
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill={color}
+                  opacity={PORT_DOT_OPACITY}
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX * 0.6}
+                  ry={PORT_DOT_RY * 0.6}
+                  fill="none"
+                  stroke="rgba(255,255,255,0.5)"
+                  strokeWidth={1}
+                />
+              </g>
+            );
+          })}
+          {portPoints.outbound.map((p, idx) => {
+            if (occupiedPorts?.outbound.has(idx)) return null;
+            const semantic = portIndexToSemantic(idx);
+            const color = SEMANTIC_PORT_COLORS[semantic] ?? PORT_COLOR_HTTP;
+            return (
+              <g key={`out-${idx}`}>
+                <ellipse
+                  cx={p.x}
+                  cy={p.y + PORT_DOT_HEIGHT}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill="rgba(0,0,0,0.2)"
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX}
+                  ry={PORT_DOT_RY}
+                  fill={color}
+                  opacity={PORT_DOT_OPACITY}
+                />
+                <ellipse
+                  cx={p.x}
+                  cy={p.y}
+                  rx={PORT_DOT_RX * 0.6}
+                  ry={PORT_DOT_RY * 0.6}
+                  fill="none"
+                  stroke="rgba(255,255,255,0.5)"
+                  strokeWidth={1}
+                />
+              </g>
+            );
+          })}
         </g>
       )}
 

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
 
 import { BlockSvg } from '../BlockSvg';
@@ -10,6 +10,7 @@ import {
 } from '../../../shared/types/visualProfile';
 import type { BlockRole, ProviderType, ResourceCategory } from '@cloudblocks/schema';
 import { BLOCK_PADDING, TILE_H, TILE_W, TILE_Z } from '../../../shared/tokens/designTokens';
+import { useUIStore } from '../../store/uiStore';
 // ─── Test Helpers ─────────────────────────────────────────────
 
 /** Extract all polygon elements from rendered SVG, excluding those inside defs/clipPath. */
@@ -670,5 +671,59 @@ describe('BlockSvg 3-layer port glyphs (#1859)', () => {
     // Layer 2 (filled top) should have rx=12 ry=6
     expect(ellipses[1].getAttribute('rx')).toBe('12');
     expect(ellipses[1].getAttribute('ry')).toBe('6');
+  });
+});
+
+// ─── showPorts=false Branch Tests (#1859) ────────────────────────────────────────
+
+describe('BlockSvg port visibility when showPorts=false (#1859)', () => {
+  beforeEach(() => {
+    useUIStore.setState({ showPorts: false });
+  });
+
+  afterEach(() => {
+    useUIStore.setState({ showPorts: true });
+  });
+
+  it('hides unoccupied port-dots group when showPorts=false', () => {
+    const { container } = render(<BlockSvg category="compute" />);
+    const portGroup = container.querySelector('[data-testid="port-dots"]');
+    expect(portGroup).toBeNull();
+  });
+
+  it('still shows occupied ports when showPorts=false', () => {
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set<number>(),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    expect(occupiedGroup).not.toBeNull();
+    const portGroup = container.querySelector('[data-testid="port-dots"]');
+    expect(portGroup).toBeNull();
+  });
+
+  it('excludes occupied ports from unoccupied group when showPorts=true', () => {
+    useUIStore.setState({ showPorts: true });
+
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set([1]),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+
+    // Unoccupied group should render but with fewer ports
+    const portGroup = container.querySelector('[data-testid="port-dots"]');
+    expect(portGroup).not.toBeNull();
+    const unoccupiedEllipses = portGroup!.querySelectorAll('ellipse');
+    // compute: 2 inbound + 2 outbound = 4 total. 1 inbound + 1 outbound occupied = 2 unoccupied
+    // 2 unoccupied ports × 3 layers = 6 ellipses
+    expect(unoccupiedEllipses.length).toBe(6);
+
+    // Occupied group should have 2 occupied × 3 layers = 6 ellipses
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    expect(occupiedGroup).not.toBeNull();
+    const occupiedEllipses = occupiedGroup!.querySelectorAll('ellipse');
+    expect(occupiedEllipses.length).toBe(6);
   });
 });

--- a/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
+++ b/apps/web/src/entities/block/__tests__/BlockSvg.test.tsx
@@ -24,7 +24,10 @@ function getFaceColors(container: HTMLElement) {
   const svg = container.querySelector('svg')!;
   const allEllipses = Array.from(svg.querySelectorAll('ellipse'));
   const cylinderEllipse = allEllipses.find(
-    (el) => !el.closest('defs') && !el.closest('[data-testid="port-dots"]'),
+    (el) =>
+      !el.closest('defs') &&
+      !el.closest('[data-testid="port-dots"]') &&
+      !el.closest('[data-testid="port-dots-occupied"]'),
   );
   if (cylinderEllipse) {
     const allRects = Array.from(svg.querySelectorAll('rect'));
@@ -41,7 +44,10 @@ function getFaceColors(container: HTMLElement) {
   // Polygon rendering (standard 3-face isometric) — skip port dot polygons
   const allPolygons = Array.from(svg.querySelectorAll('polygon'));
   const facePolygons = allPolygons.filter(
-    (el) => !el.closest('defs') && !el.closest('[data-testid="port-dots"]'),
+    (el) =>
+      !el.closest('defs') &&
+      !el.closest('[data-testid="port-dots"]') &&
+      !el.closest('[data-testid="port-dots-occupied"]'),
   );
   return {
     topFaceColor: facePolygons[0]?.getAttribute('fill') ?? null,
@@ -539,5 +545,130 @@ describe('BlockSvg health badge (#1591)', () => {
     const vbWithout = without.querySelector('svg')!.getAttribute('viewBox');
     const vbWith = withBadge.querySelector('svg')!.getAttribute('viewBox');
     expect(vbWith).toBe(vbWithout);
+  });
+});
+
+// ─── 3-Layer Port Glyph Tests (#1859) ────────────────────────────────────────
+
+describe('BlockSvg 3-layer port glyphs (#1859)', () => {
+  it('renders unoccupied port dots when showPorts is true (default) and no occupiedPorts', () => {
+    // showPorts defaults to true in the UI store
+    const { container } = render(<BlockSvg category="compute" />);
+    const portGroup = container.querySelector('[data-testid="port-dots"]');
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    // Unoccupied ports should render (showPorts=true by default)
+    expect(portGroup).not.toBeNull();
+    // No occupied ports group since occupiedPorts prop is undefined
+    expect(occupiedGroup).toBeNull();
+    // Each unoccupied port should have 3 ellipses (shadow + filled + ring)
+    const portEllipses = portGroup!.querySelectorAll('ellipse');
+    // compute category has 2 inbound + 2 outbound = 4 ports × 3 layers = 12 ellipses
+    expect(portEllipses.length).toBe(12);
+  });
+
+  it('renders occupied port glyphs always (even when showPorts is false)', () => {
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set<number>(),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    // Occupied group should always render
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    expect(occupiedGroup).not.toBeNull();
+    // Each occupied port has 3 ellipses (shadow + filled + ring)
+    const ellipses = occupiedGroup!.querySelectorAll('ellipse');
+    expect(ellipses.length).toBe(3);
+  });
+
+  it('renders 3-layer structure per port: shadow, filled, inner ring', () => {
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set<number>(),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    const ellipses = Array.from(occupiedGroup!.querySelectorAll('ellipse'));
+    // Layer 1: Shadow (offset down) — has fill rgba(0,0,0,0.2)
+    expect(ellipses[0].getAttribute('fill')).toBe('rgba(0,0,0,0.2)');
+    // Layer 2: Filled top — has fill equal to semantic color
+    expect(ellipses[1].getAttribute('fill')).not.toBe('none');
+    expect(ellipses[1].getAttribute('fill')).not.toBe('rgba(0,0,0,0.2)');
+    // Layer 3: Inner ring — fill=none with stroke
+    expect(ellipses[2].getAttribute('fill')).toBe('none');
+    expect(ellipses[2].getAttribute('stroke')).toBe('rgba(255,255,255,0.5)');
+  });
+
+  it('occupied ports use PORT_DOT_OCCUPIED_OPACITY (0.4)', () => {
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set<number>(),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    const ellipses = Array.from(occupiedGroup!.querySelectorAll('ellipse'));
+    // Layer 2 (filled) should have occupied opacity
+    expect(ellipses[1].getAttribute('opacity')).toBe('0.4');
+  });
+
+  it('occupied outbound ports render correctly', () => {
+    const occupiedPorts = {
+      inbound: new Set<number>(),
+      outbound: new Set([0]),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    expect(occupiedGroup).not.toBeNull();
+    // 3 ellipses for the one occupied outbound port
+    const ellipses = occupiedGroup!.querySelectorAll('ellipse');
+    expect(ellipses.length).toBe(3);
+  });
+
+  it('does not render occupied group when occupiedPorts is undefined', () => {
+    const { container } = render(<BlockSvg category="compute" />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    expect(occupiedGroup).toBeNull();
+  });
+
+  it('does not double-render occupied ports in the unoccupied group', () => {
+    // This test verifies that when showPorts is true but a port is occupied,
+    // it doesn't appear in the unoccupied port-dots group.
+    // Since showPorts requires useUIStore (connect mode), we can at least verify
+    // the occupied port group renders correctly without duplication.
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set([0]),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    // 2 ports × 3 ellipses = 6 ellipses
+    const ellipses = occupiedGroup!.querySelectorAll('ellipse');
+    expect(ellipses.length).toBe(6);
+  });
+
+  it('shadow ellipse is offset down by PORT_DOT_HEIGHT', () => {
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set<number>(),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    const ellipses = Array.from(occupiedGroup!.querySelectorAll('ellipse'));
+    // Shadow (ellipses[0]) cy should be > filled (ellipses[1]) cy by PORT_DOT_HEIGHT (5)
+    const shadowCy = Number(ellipses[0].getAttribute('cy'));
+    const filledCy = Number(ellipses[1].getAttribute('cy'));
+    expect(shadowCy - filledCy).toBe(5);
+  });
+
+  it('port rx/ry match Universal Port Standard (rx=12, ry=6)', () => {
+    const occupiedPorts = {
+      inbound: new Set([0]),
+      outbound: new Set<number>(),
+    };
+    const { container } = render(<BlockSvg category="compute" occupiedPorts={occupiedPorts} />);
+    const occupiedGroup = container.querySelector('[data-testid="port-dots-occupied"]');
+    const ellipses = Array.from(occupiedGroup!.querySelectorAll('ellipse'));
+    // Layer 2 (filled top) should have rx=12 ry=6
+    expect(ellipses[1].getAttribute('rx')).toBe('12');
+    expect(ellipses[1].getAttribute('ry')).toBe('6');
   });
 });

--- a/apps/web/src/entities/block/__tests__/blockFaceColors.test.ts
+++ b/apps/web/src/entities/block/__tests__/blockFaceColors.test.ts
@@ -320,6 +320,24 @@ describe('adjustColorHsl', () => {
   });
 });
 
+it('handles light red-dominant colors with blue > green (HSL hue branch coverage)', () => {
+  // #FF8090: r=255, g=128, b=144 → max=rn, l>0.5, gn<bn
+  const result = adjustColorHsl('#FF8090', { saturationScale: 0.5, lightnessBoost: 0 });
+  expect(result).toMatch(hexColorPattern);
+});
+
+it('handles green-dominant hue with high lightness (HSL branch coverage)', () => {
+  // #80FF90: g>r>b → max=gn, l>0.5
+  const result = adjustColorHsl('#80FF90', { saturationScale: 0.5, lightnessBoost: 0 });
+  expect(result).toMatch(hexColorPattern);
+});
+
+it('handles blue-dominant hue with high lightness (HSL branch coverage)', () => {
+  // #9080FF: b>r>g → max=bn, l>0.5
+  const result = adjustColorHsl('#9080FF', { saturationScale: 0.5, lightnessBoost: 0 });
+  expect(result).toMatch(hexColorPattern);
+});
+
 // ─── Container Face Color Derivation ────────────────────────
 
 describe('deriveContainerFaceColors', () => {

--- a/apps/web/src/entities/block/__tests__/portRendering.test.tsx
+++ b/apps/web/src/entities/block/__tests__/portRendering.test.tsx
@@ -1,11 +1,18 @@
 import { describe, expect, it } from 'vitest';
+import type { EndpointSemantic } from '@cloudblocks/schema';
 import { portIndexToSemantic } from '../blockGeometry';
 import {
   PORT_COLOR_HTTP,
   PORT_COLOR_EVENT,
   PORT_COLOR_DATA,
   PORT_COLOR_OCCUPIED,
+  PORT_DOT_RX,
+  PORT_DOT_RY,
+  PORT_DOT_HEIGHT,
+  PORT_DOT_OCCUPIED_OPACITY,
+  PORT_DOT_OPACITY,
 } from '../../../shared/tokens/designTokens';
+import { semanticToPortIndex } from '../../connection/endpointAnchors';
 
 // ---------------------------------------------------------------------------
 // portIndexToSemantic
@@ -41,5 +48,65 @@ describe('Port color design tokens', () => {
     expect(PORT_COLOR_EVENT).toBe('#F59E0B');
     expect(PORT_COLOR_DATA).toBe('#14B8A6');
     expect(PORT_COLOR_OCCUPIED).toBe('#475569');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// semanticToPortIndex (exported from endpointAnchors)
+// ---------------------------------------------------------------------------
+
+describe('semanticToPortIndex', () => {
+  it('maps http to index 0 when total >= 1', () => {
+    expect(semanticToPortIndex('http', 3)).toBe(0);
+    expect(semanticToPortIndex('http', 1)).toBe(0);
+  });
+
+  it('maps event to index 1 when total >= 2', () => {
+    expect(semanticToPortIndex('event', 3)).toBe(1);
+    expect(semanticToPortIndex('event', 2)).toBe(1);
+  });
+
+  it('maps data to index 2 when total >= 3', () => {
+    expect(semanticToPortIndex('data', 3)).toBe(2);
+  });
+
+  it('wraps indices when total is small', () => {
+    // With 1 port total, all semantics map to index 0
+    expect(semanticToPortIndex('http', 1)).toBe(0);
+    expect(semanticToPortIndex('event', 1)).toBe(0);
+    expect(semanticToPortIndex('data', 1)).toBe(0);
+  });
+
+  it('returns null for unknown semantic', () => {
+    expect(semanticToPortIndex('unknown' as unknown as EndpointSemantic, 3)).toBeNull();
+  });
+
+  it('returns null for total <= 0', () => {
+    expect(semanticToPortIndex('http', 0)).toBeNull();
+    expect(semanticToPortIndex('http', -1)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Port glyph design tokens (3-layer spec)
+// ---------------------------------------------------------------------------
+
+describe('Port glyph design tokens', () => {
+  it('PORT_DOT_RX=12 and PORT_DOT_RY=6 per Universal Port Standard', () => {
+    expect(PORT_DOT_RX).toBe(12);
+    expect(PORT_DOT_RY).toBe(6);
+  });
+
+  it('PORT_DOT_HEIGHT=5 for shadow offset', () => {
+    expect(PORT_DOT_HEIGHT).toBe(5);
+  });
+
+  it('PORT_DOT_OCCUPIED_OPACITY < PORT_DOT_OPACITY (occupied dimmer)', () => {
+    expect(PORT_DOT_OCCUPIED_OPACITY).toBeLessThan(PORT_DOT_OPACITY);
+  });
+
+  it('occupied opacity is 0.4 and normal opacity is 0.7', () => {
+    expect(PORT_DOT_OCCUPIED_OPACITY).toBe(0.4);
+    expect(PORT_DOT_OPACITY).toBe(0.7);
   });
 });

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -25,8 +25,9 @@ vi.mock('../../shared/tokens/designTokens', () => ({
   ARROW_MARKER_W: 6,
   ARROW_MARKER_H: 6,
   ARROW_MARKER_REF_X: 5.5,
-  PORT_DOT_RX: 4,
-  PORT_DOT_RY: 2.5,
+  PORT_DOT_RX: 12,
+  PORT_DOT_RY: 6,
+  PORT_DOT_HEIGHT: 5,
   PORT_DOT_STROKE_WIDTH: 1.5,
   CONNECTION_CORNER_RADIUS: 12,
 }));

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -21,6 +21,7 @@ import {
   ARROW_MARKER_REF_X,
   PORT_DOT_RX,
   PORT_DOT_RY,
+  PORT_DOT_HEIGHT,
   PORT_DOT_STROKE_WIDTH,
 } from '../../shared/tokens/designTokens';
 import {
@@ -165,7 +166,9 @@ function getLabelPosition(points: readonly ScreenPoint[]): ScreenPoint | null {
 
 import type { PinHoleStyle } from './connectorTheme';
 
-/** Render a pinhole glyph at a connection endpoint. */
+/** Render a pinhole glyph at a connection endpoint.
+ *  3-layer base (shadow + filled top + inner ring) with type-specific overlay.
+ */
 function renderPinhole(
   x: number,
   y: number,
@@ -177,62 +180,87 @@ function renderPinhole(
   const ry = PORT_DOT_RY;
   const sw = PORT_DOT_STROKE_WIDTH;
 
+  // Type-specific overlay rendered on top of the base glyph
+  let overlay: React.ReactElement | null = null;
   switch (style) {
     case 'filled':
-      return <ellipse key={key} cx={x} cy={y} rx={r} ry={ry} fill={stroke} opacity={0.8} />;
+      // No overlay needed — base glyph is already filled
+      break;
     case 'cross':
-      return (
-        <g key={key} opacity={0.8}>
-          <line x1={x - r} y1={y} x2={x + r} y2={y} stroke={stroke} strokeWidth={sw} />
-          <line x1={x} y1={y - ry} x2={x} y2={y + ry} stroke={stroke} strokeWidth={sw} />
-        </g>
-      );
-    case 'double':
-      return (
-        <g key={key} opacity={0.8}>
-          <ellipse cx={x} cy={y} rx={r} ry={ry} fill="none" stroke={stroke} strokeWidth={sw} />
-          <ellipse
-            cx={x}
-            cy={y}
-            rx={r * 0.5}
-            ry={ry * 0.5}
-            fill="none"
-            stroke={stroke}
-            strokeWidth={sw * 0.8}
+      overlay = (
+        <g opacity={0.9}>
+          <line
+            x1={x - r * 0.45}
+            y1={y}
+            x2={x + r * 0.45}
+            y2={y}
+            stroke="rgba(255,255,255,0.8)"
+            strokeWidth={sw}
+          />
+          <line
+            x1={x}
+            y1={y - ry * 0.45}
+            x2={x}
+            y2={y + ry * 0.45}
+            stroke="rgba(255,255,255,0.8)"
+            strokeWidth={sw}
           />
         </g>
       );
-    case 'dashed':
-      return (
+      break;
+    case 'double':
+      overlay = (
         <ellipse
-          key={key}
           cx={x}
           cy={y}
-          rx={r}
-          ry={ry}
+          rx={r * 0.5}
+          ry={ry * 0.5}
           fill="none"
-          stroke={stroke}
+          stroke="rgba(255,255,255,0.6)"
+          strokeWidth={sw * 0.8}
+        />
+      );
+      break;
+    case 'dashed':
+      overlay = (
+        <ellipse
+          cx={x}
+          cy={y}
+          rx={r * 0.7}
+          ry={ry * 0.7}
+          fill="none"
+          stroke="rgba(255,255,255,0.5)"
           strokeWidth={sw}
           strokeDasharray="2 2"
-          opacity={0.8}
         />
       );
+      break;
     case 'open':
     default:
-      return (
-        <ellipse
-          key={key}
-          cx={x}
-          cy={y}
-          rx={r}
-          ry={ry}
-          fill="none"
-          stroke={stroke}
-          strokeWidth={sw}
-          opacity={0.8}
-        />
-      );
+      // Inner ring from base glyph is sufficient for open style
+      break;
   }
+
+  return (
+    <g key={key} opacity={0.8}>
+      {/* Layer 1: Shadow */}
+      <ellipse cx={x} cy={y + PORT_DOT_HEIGHT} rx={r} ry={ry} fill="rgba(0,0,0,0.2)" />
+      {/* Layer 2: Filled top */}
+      <ellipse cx={x} cy={y} rx={r} ry={ry} fill={stroke} />
+      {/* Layer 3: Inner ring */}
+      <ellipse
+        cx={x}
+        cy={y}
+        rx={r * 0.6}
+        ry={ry * 0.6}
+        fill="none"
+        stroke="rgba(255,255,255,0.5)"
+        strokeWidth={1}
+      />
+      {/* Type-specific overlay */}
+      {overlay}
+    </g>
+  );
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: rendering component with dual path requires unified control flow

--- a/apps/web/src/entities/connection/endpointAnchors.ts
+++ b/apps/web/src/entities/connection/endpointAnchors.ts
@@ -147,7 +147,7 @@ function resolveEndpoint(
   return { point: anchors.center, floorY };
 }
 
-function semanticToPortIndex(semantic: EndpointSemantic, total: number): number | null {
+export function semanticToPortIndex(semantic: EndpointSemantic, total: number): number | null {
   if (total <= 0) {
     return null;
   }

--- a/apps/web/src/shared/tokens/designTokens.ts
+++ b/apps/web/src/shared/tokens/designTokens.ts
@@ -45,11 +45,13 @@ export const TOP_FACE_STROKE_OPACITY = 0.45;
 // Small screen-space offset so connector endpoints sit just outside block face.
 export const PORT_OUT_PX = 8;
 // Port dot dimensions for visual rendering on block faces (BlockSvg).
-export const PORT_DOT_RX = 4;
-export const PORT_DOT_RY = 2.5;
+export const PORT_DOT_RX = 12;
+export const PORT_DOT_RY = 6;
+export const PORT_DOT_HEIGHT = 5; // Isometric height offset for 3-layer port glyph shadow
 export const PORT_DOT_STROKE_WIDTH = 1.5;
 export const PORT_DOT_OPACITY = 0.7;
 export const PORT_DOT_ACTIVE_OPACITY = 1.0;
+export const PORT_DOT_OCCUPIED_OPACITY = 0.4; // Dim but always-visible occupied port
 // -- Port Semantic Colors (Endpoint Types) --
 // Colors match endpoint semantic types: http, event, data.
 // Used for port dot rendering in connect mode.


### PR DESCRIPTION
## Summary

- Implement Universal Port Standard (rx=12, ry=6, height=5) 3-layer port glyphs on blocks: shadow → filled top → inner ring
- Add semantic coloring per port type: HTTP (blue), Event (amber), Data (teal)
- Split ports into occupied (always visible, 0.4 opacity) and unoccupied (showPorts toggle) groups
- Update ConnectionRenderer pinholes to match the same 3-layer glyph spec
- Stable Zustand selector using flat array encoding to prevent React 19 infinite re-renders

## Changes

| File | Change |
|------|--------|
| `designTokens.ts` | PORT_DOT_RX=12, RY=6, HEIGHT=5, OCCUPIED_OPACITY=0.4 |
| `BlockSvg.tsx` | 3-layer port rendering with occupied/unoccupied split |
| `BlockSprite.tsx` | `occupiedPorts` Zustand selector with flat array encoding |
| `endpointAnchors.ts` | Export `semanticToPortIndex` for reuse |
| `ConnectionRenderer.tsx` | 3-layer renderPinhole with type overlays |
| `portRendering.test.tsx` | 15 tests for port index mapping and tokens |
| `BlockSvg.test.tsx` | 10 new tests for 3-layer glyph rendering |
| `ConnectionRenderer.test.tsx` | Updated mock for new token values |

## Test Results

- **3579 tests pass** across 158 test files
- Build ✅ | Lint ✅ | Type check ✅

Fixes #1859
Part of #1858