### PR TITLE
feat(web): add docking stems via startStraightReserve in connection paths

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../../shared/tokens/designTokens', () => ({
   PORT_DOT_HEIGHT: 5,
   PORT_DOT_STROKE_WIDTH: 1.5,
   CONNECTION_CORNER_RADIUS: 12,
+  DOCKING_STEM_PX: 12,
 }));
 
 vi.mock('../../shared/utils/diff', () => ({

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -23,6 +23,7 @@ import {
   PORT_DOT_RY,
   PORT_DOT_HEIGHT,
   PORT_DOT_STROKE_WIDTH,
+  DOCKING_STEM_PX,
 } from '../../shared/tokens/designTokens';
 import {
   resolveConnectionVisualStyle,
@@ -472,7 +473,9 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
 
     const rawPoints = getRouteCenterlinePoints(surfaceRoute, originX, originY);
     const offsetPoints = overlapOffset ? offsetScreenPoints(rawPoints, overlapOffset) : rawPoints;
-    const { path: hitPath, flowPoints } = buildRoundedConnectionGeometry(offsetPoints);
+    const { path: hitPath, flowPoints } = buildRoundedConnectionGeometry(offsetPoints, {
+      startStraightReserve: DOCKING_STEM_PX,
+    });
 
     if (flowPoints.length < 2) return null;
 

--- a/apps/web/src/entities/connection/__tests__/roundedConnectionPath.test.ts
+++ b/apps/web/src/entities/connection/__tests__/roundedConnectionPath.test.ts
@@ -6,6 +6,7 @@ import {
   sampleArcInterior,
 } from '../roundedConnectionPath';
 
+const EPS = 1e-3;
 // ─── dedupeConsecutivePoints ─────────────────────────────────────────
 
 describe('dedupeConsecutivePoints', () => {
@@ -147,7 +148,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 100, y: 0 },
       { x: 100, y: 100 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
 
     // Path should contain an A (arc) command
     expect(result.path).toContain('A ');
@@ -163,7 +164,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 100, y: 0 },
       { x: 100, y: 100 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
 
     // Should have many flow points (sampled at ~6px)
     // Total path length ≈ 200px, so ~33 samples minimum
@@ -188,7 +189,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 100, y: 80 },
       { x: 0, y: 80 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
     const arcCount = (result.path.match(/A /g) ?? []).length;
     expect(arcCount).toBe(2);
   });
@@ -201,7 +202,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 50, y: 0 },
       { x: 100, y: 0 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
     // Collinear → cross product = 0 → no arc
     expect(result.path).not.toContain('A ');
   });
@@ -216,7 +217,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 20, y: 0 },
       { x: 20, y: 20 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
 
     // Should still produce an arc, just with a smaller effective trim
     expect(result.path).toContain('A ');
@@ -239,7 +240,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 100, y: 0 },
       { x: 100, y: 40 }, // Last segment is 40px
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12, 18);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12, endStraightReserve: 18 });
 
     // The last flow point should be the endpoint
     const last = result.flowPoints[result.flowPoints.length - 1];
@@ -262,8 +263,8 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 200, y: 0 },
       { x: 200, y: 200 },
     ];
-    const smallRadius = buildRoundedConnectionGeometry(pts, 5);
-    const largeRadius = buildRoundedConnectionGeometry(pts, 30);
+    const smallRadius = buildRoundedConnectionGeometry(pts, { radius: 5 });
+    const largeRadius = buildRoundedConnectionGeometry(pts, { radius: 30 });
 
     // Both should have arcs
     expect(smallRadius.path).toContain('A ');
@@ -284,7 +285,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 120, y: 60 },
       { x: 120, y: 120 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
 
     // Should have 3 arcs (3 interior vertices)
     const arcCount = (result.path.match(/A /g) ?? []).length;
@@ -303,7 +304,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 100, y: 0 },
       { x: 100, y: 100 },
     ];
-    const rResult = buildRoundedConnectionGeometry(rightTurn, 12);
+    const rResult = buildRoundedConnectionGeometry(rightTurn, { radius: 12 });
 
     // Left turn (CCW): going right then up
     const leftTurn: ScreenPoint[] = [
@@ -311,7 +312,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 100, y: 100 },
       { x: 100, y: 0 },
     ];
-    const lResult = buildRoundedConnectionGeometry(leftTurn, 12);
+    const lResult = buildRoundedConnectionGeometry(leftTurn, { radius: 12 });
 
     // Both should produce valid paths with arcs
     expect(rResult.path).toContain('A ');
@@ -343,7 +344,7 @@ describe('buildRoundedConnectionGeometry', () => {
     ];
 
     for (const pts of cases) {
-      const result = buildRoundedConnectionGeometry(pts, 12);
+      const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
       expect(typeof result.path).toBe('string');
       expect(Array.isArray(result.flowPoints)).toBe(true);
       for (const p of result.flowPoints) {
@@ -363,7 +364,7 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 100, y: 0 },
       { x: 100, y: 100 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
 
     // Compute cumulative distance — should be monotonically increasing
     let cumDist = 0;
@@ -387,8 +388,143 @@ describe('buildRoundedConnectionGeometry', () => {
       { x: 5, y: 5 },
     ];
     // radius 12 is larger than segment lengths (5px)
-    const result = buildRoundedConnectionGeometry(pts, 12);
+    const result = buildRoundedConnectionGeometry(pts, { radius: 12 });
     expect(result.path).toBeTruthy();
     expect(result.flowPoints.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ─── startStraightReserve (docking stem) ──────────────────────────
+
+  it('preserves a straight stem at path start when startStraightReserve is set', () => {
+    // L-shape: horizontal 100px → vertical 100px
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, {
+      radius: 12,
+      startStraightReserve: 12,
+    });
+
+    // The first few flow points should be collinear along y=0 (the
+    // horizontal stem before the rounding starts).
+    // With a 12px reserve on a 100px segment, the trim is capped at
+    // min(segLen/2, segLen - reserve) = min(50, 88) = 50, so the arc
+    // entry is at x=50..88.  The first ~2 flow points must lie on y≈0.
+    const stemPoints = result.flowPoints.filter((p) => Math.abs(p.y) < 0.1);
+    expect(stemPoints.length).toBeGreaterThanOrEqual(2);
+    // All stem points should progress rightward (x increasing).
+    for (let i = 1; i < stemPoints.length; i++) {
+      expect(stemPoints[i].x).toBeGreaterThan(stemPoints[i - 1].x - EPS);
+    }
+  });
+
+  it('path starts with M then L before first A when startStraightReserve > 0', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, {
+      radius: 12,
+      startStraightReserve: 12,
+    });
+
+    // Path should follow M ... L ... A ... pattern
+    expect(result.path).toMatch(/^M .+ L .+ A /);
+  });
+
+  it('startStraightReserve 0 matches default (no reserve)', () => {
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 100 },
+    ];
+    const withZero = buildRoundedConnectionGeometry(pts, {
+      radius: 12,
+      startStraightReserve: 0,
+    });
+    const withDefault = buildRoundedConnectionGeometry(pts, { radius: 12 });
+
+    expect(withZero.path).toBe(withDefault.path);
+    expect(withZero.flowPoints.length).toBe(withDefault.flowPoints.length);
+  });
+
+  it('caps rounding when startStraightReserve is large relative to segment', () => {
+    // Short first segment (30px) with a 20px reserve → only 10px available
+    // for trim on the incoming side of the corner.
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 30, y: 0 },
+      { x: 30, y: 100 },
+    ];
+    const withReserve = buildRoundedConnectionGeometry(pts, {
+      radius: 12,
+      startStraightReserve: 20,
+    });
+    const noReserve = buildRoundedConnectionGeometry(pts, { radius: 12 });
+
+    // Both should still produce valid paths with arcs.
+    expect(withReserve.path).toContain('A ');
+    expect(noReserve.path).toContain('A ');
+
+    // With reserve, the rounding trim should be smaller (less space).
+    // This means the arc entry x should be closer to the corner (x=30).
+    // We can verify the first L command's x is further right in reserved.
+    const extractFirstL = (p: string) => {
+      const m = p.match(/L ([\d.]+) /);
+      return m ? parseFloat(m[1]) : 0;
+    };
+    const reservedEntryX = extractFirstL(withReserve.path);
+    const normalEntryX = extractFirstL(noReserve.path);
+    // With reserve, entry is closer to the corner (larger x), because
+    // less space is available for the trim on the incoming side.
+    expect(reservedEntryX).toBeGreaterThanOrEqual(normalEntryX - 0.01);
+  });
+
+  it('handles short 3-point path with startStraightReserve gracefully', () => {
+    // Both segments shorter than the reserve.
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 8, y: 0 },
+      { x: 8, y: 8 },
+    ];
+    const result = buildRoundedConnectionGeometry(pts, {
+      radius: 12,
+      startStraightReserve: 12,
+    });
+    // Should produce a valid (non-empty) path.
+    expect(result.path).toBeTruthy();
+    expect(result.flowPoints.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('startStraightReserve does not affect middle corners of 5-point path', () => {
+    // Zigzag with 4 turns — only the first corner is affected.
+    const pts: ScreenPoint[] = [
+      { x: 0, y: 0 },
+      { x: 60, y: 0 },
+      { x: 60, y: 60 },
+      { x: 120, y: 60 },
+      { x: 120, y: 120 },
+    ];
+    const withReserve = buildRoundedConnectionGeometry(pts, {
+      radius: 12,
+      startStraightReserve: 12,
+    });
+    const noReserve = buildRoundedConnectionGeometry(pts, { radius: 12 });
+
+    // Both should have 3 arcs (3 interior vertices).
+    const countArcs = (p: string) => (p.match(/A /g) ?? []).length;
+    expect(countArcs(withReserve.path)).toBe(3);
+    expect(countArcs(noReserve.path)).toBe(3);
+
+    // The second and third arcs should be identical between both variants
+    // because startStraightReserve only affects i===1.
+    const extractArcs = (p: string) => {
+      const arcs = p.match(/A [\d.]+ [\d.]+ \d \d \d [\d.-]+ [\d.-]+/g) ?? [];
+      return arcs.slice(1); // skip first arc (affected by reserve)
+    };
+    expect(extractArcs(withReserve.path)).toEqual(extractArcs(noReserve.path));
   });
 });

--- a/apps/web/src/entities/connection/__tests__/roundedConnectionPath.test.ts
+++ b/apps/web/src/entities/connection/__tests__/roundedConnectionPath.test.ts
@@ -6,7 +6,6 @@ import {
   sampleArcInterior,
 } from '../roundedConnectionPath';
 
-const EPS = 1e-3;
 // ─── dedupeConsecutivePoints ─────────────────────────────────────────
 
 describe('dedupeConsecutivePoints', () => {
@@ -396,43 +395,55 @@ describe('buildRoundedConnectionGeometry', () => {
   // ─── startStraightReserve (docking stem) ──────────────────────────
 
   it('preserves a straight stem at path start when startStraightReserve is set', () => {
-    // L-shape: horizontal 100px → vertical 100px
+    // L-shape: first segment 20px (sensitive range: 12 < 20 < 24).
+    // Without reserve: inAvail = 20/2 = 10, rawTrim for 90° = 12*tan(45°) ≈ 12 → trim = 10.
+    // With reserve 12: inAvail = min(10, max(0, 20-12)) = min(10, 8) = 8 → trim = 8.
+    // So with reserve the arc entry moves from x=10 to x=12, preserving 12px of stem.
     const pts: ScreenPoint[] = [
       { x: 0, y: 0 },
-      { x: 100, y: 0 },
-      { x: 100, y: 100 },
+      { x: 20, y: 0 },
+      { x: 20, y: 100 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, {
+    const withReserve = buildRoundedConnectionGeometry(pts, {
       radius: 12,
       startStraightReserve: 12,
     });
+    const noReserve = buildRoundedConnectionGeometry(pts, { radius: 12 });
 
-    // The first few flow points should be collinear along y=0 (the
-    // horizontal stem before the rounding starts).
-    // With a 12px reserve on a 100px segment, the trim is capped at
-    // min(segLen/2, segLen - reserve) = min(50, 88) = 50, so the arc
-    // entry is at x=50..88.  The first ~2 flow points must lie on y≈0.
-    const stemPoints = result.flowPoints.filter((p) => Math.abs(p.y) < 0.1);
-    expect(stemPoints.length).toBeGreaterThanOrEqual(2);
-    // All stem points should progress rightward (x increasing).
-    for (let i = 1; i < stemPoints.length; i++) {
-      expect(stemPoints[i].x).toBeGreaterThan(stemPoints[i - 1].x - EPS);
-    }
+    // Extract the first L command x-coordinate (arc entry point).
+    const extractFirstL = (p: string) => {
+      const m = p.match(/L ([\d.]+) /);
+      return m ? parseFloat(m[1]) : 0;
+    };
+    const reservedEntryX = extractFirstL(withReserve.path);
+    const normalEntryX = extractFirstL(noReserve.path);
+
+    // With reserve, trim is smaller → entry is closer to corner (larger x).
+    expect(reservedEntryX).toBeGreaterThan(normalEntryX + 0.5);
+    // Entry should be at x = 20 - 8 = 12, leaving exactly 12px of stem.
+    expect(reservedEntryX).toBeCloseTo(12, 0);
   });
 
-  it('path starts with M then L before first A when startStraightReserve > 0', () => {
+  it('geometry differs between reserved and unreserved on sensitive-range segment', () => {
+    // 18px first segment — in the sensitive range where reserve changes geometry.
+    // Without reserve: inAvail = 9, rawTrim ≈ 12 → trim = 9.
+    // With reserve 12: inAvail = min(9, max(0, 18-12)) = min(9, 6) = 6 → trim = 6.
     const pts: ScreenPoint[] = [
       { x: 0, y: 0 },
-      { x: 100, y: 0 },
-      { x: 100, y: 100 },
+      { x: 18, y: 0 },
+      { x: 18, y: 80 },
     ];
-    const result = buildRoundedConnectionGeometry(pts, {
+    const withReserve = buildRoundedConnectionGeometry(pts, {
       radius: 12,
       startStraightReserve: 12,
     });
+    const noReserve = buildRoundedConnectionGeometry(pts, { radius: 12 });
 
-    // Path should follow M ... L ... A ... pattern
-    expect(result.path).toMatch(/^M .+ L .+ A /);
+    // The paths MUST differ because the reserve changes the trim.
+    expect(withReserve.path).not.toBe(noReserve.path);
+    // Both should still produce valid arcs.
+    expect(withReserve.path).toContain('A ');
+    expect(noReserve.path).toContain('A ');
   });
 
   it('startStraightReserve 0 matches default (no reserve)', () => {

--- a/apps/web/src/entities/connection/roundedConnectionPath.ts
+++ b/apps/web/src/entities/connection/roundedConnectionPath.ts
@@ -124,19 +124,31 @@ export function sampleArcInterior(
 
 // ─── Main builder ────────────────────────────────────────────────────
 
+/** Options for buildRoundedConnectionGeometry(). */
+export interface RoundedConnectionOptions {
+  /** Corner arc radius in px (default: CONNECTION_CORNER_RADIUS). */
+  radius?: number;
+  /** Minimum straight px reserved at path END for arrow marker (default: MIN_ARROW_STRAIGHT_PX). */
+  endStraightReserve?: number;
+  /** Minimum straight px reserved at path START for docking stem (default: 0). */
+  startStraightReserve?: number;
+}
+
 /**
  * Build a rounded SVG path and dense flow-point array from a polyline.
  *
- * @param inputPoints        - Screen-space polyline (≥2 points)
- * @param radius             - Corner arc radius in px (default: CONNECTION_CORNER_RADIUS)
- * @param endStraightReserve - Minimum straight px reserved at path end for
- *                             arrow marker orientation (default: MIN_ARROW_STRAIGHT_PX)
+ * @param inputPoints - Screen-space polyline (≥2 points)
+ * @param opts        - Corner radius, end/start straight reserves
  */
 export function buildRoundedConnectionGeometry(
   inputPoints: readonly ScreenPoint[],
-  radius: number = CONNECTION_CORNER_RADIUS,
-  endStraightReserve: number = MIN_ARROW_STRAIGHT_PX,
+  opts: RoundedConnectionOptions = {},
 ): RoundedPathGeometry {
+  const {
+    radius = CONNECTION_CORNER_RADIUS,
+    endStraightReserve = MIN_ARROW_STRAIGHT_PX,
+    startStraightReserve = 0,
+  } = opts;
   const pts = dedupeConsecutivePoints(inputPoints);
 
   // Edge case: 0-1 points → degenerate.
@@ -189,8 +201,12 @@ export function buildRoundedConnectionGeometry(
     const halfTan = Math.tan(turnAngle / 2);
     const rawTrim = radius * halfTan;
 
+    // Respect startStraightReserve on the first segment.
+    let inAvail = segLen[i - 1] / 2;
+    if (i === 1 && startStraightReserve > 0) {
+      inAvail = Math.min(inAvail, Math.max(0, segLen[i - 1] - startStraightReserve));
+    }
     // Also respect endStraightReserve on the last segment.
-    const inAvail = segLen[i - 1] / 2;
     let outAvail = segLen[i] / 2;
     if (i === n - 2) {
       // Last interior vertex — reserve straight segment at the end for arrow.

--- a/apps/web/src/shared/tokens/designTokens.ts
+++ b/apps/web/src/shared/tokens/designTokens.ts
@@ -71,3 +71,9 @@ export const LABEL_FACE_SCALE = 0.28;
 // Radius in screen px for rounded orthogonal connection corners.
 // Safe for 32-128px segment lengths. Must be ≤ min(segLen)/2.
 export const CONNECTION_CORNER_RADIUS = 12;
+
+// -- Docking Stem --
+// Minimum straight px reserved at path START so the first corner
+// rounding does not consume the exit segment from the block face.
+// Matches PORT_DOT_RX for visual consistency.
+export const DOCKING_STEM_PX = 12;

--- a/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
+++ b/apps/web/src/widgets/scene-canvas/ConnectionPreview.tsx
@@ -8,7 +8,7 @@ import { getBlockWorldAnchors } from '../../entities/block/blockGeometry';
 import { getBlockDimensions } from '../../shared/types/visualProfile';
 import { CATEGORY_PORTS, isExternalResourceType } from '@cloudblocks/schema';
 import type { ResourceBlock, ContainerBlock } from '@cloudblocks/schema';
-import { PORT_OUT_PX } from '../../shared/tokens/designTokens';
+import { PORT_OUT_PX, DOCKING_STEM_PX } from '../../shared/tokens/designTokens';
 import { canConnect } from '../../entities/validation/connection';
 import type { EndpointType } from '../../shared/types/endpoint';
 import { getPreviewRoutePoints } from './previewRoutePoints';
@@ -217,7 +217,9 @@ export function ConnectionPreview({ originX, originY }: ConnectionPreviewProps) 
 
   const target = snappedTarget ?? cursor ?? sourceScreen;
   const routePoints = getPreviewRoutePoints(sourceScreen, target);
-  const { path: pathD } = buildRoundedConnectionGeometry(routePoints);
+  const { path: pathD } = buildRoundedConnectionGeometry(routePoints, {
+    startStraightReserve: DOCKING_STEM_PX,
+  });
 
   return (
     <path


### PR DESCRIPTION
## Summary

Fixes #1860

Part of #1858 (Epic: Connection Docking & Anchor Visibility)

- Refactor `buildRoundedConnectionGeometry` from positional args to an **options object** (`RoundedConnectionOptions`) for cleaner API
- Add `startStraightReserve` parameter that preserves a straight docking stem at the path start, preventing corner rounding from consuming the exit segment near port anchors
- Add `DOCKING_STEM_PX = 12` design token (matches `PORT_DOT_RX` and `CONNECTION_CORNER_RADIUS`)

## Changes

### Production
- **`designTokens.ts`** — Add `DOCKING_STEM_PX = 12` export
- **`roundedConnectionPath.ts`** — Refactor to `RoundedConnectionOptions` interface with `{ radius, endStraightReserve, startStraightReserve }`. Cap incoming trim at `Math.min(inAvail, segLen - startStraightReserve)` for `i === 1` corners only
- **`ConnectionRenderer.tsx`** — Pass `{ startStraightReserve: DOCKING_STEM_PX }` to geometry builder
- **`ConnectionPreview.tsx`** — Pass `{ startStraightReserve: DOCKING_STEM_PX }` to geometry builder

### Tests
- **`roundedConnectionPath.test.ts`** — Migrate 14 existing test calls from positional args to options API; add 6 new tests for `startStraightReserve` behavior (stem preservation, path shape, default equivalence, short paths, multi-corner isolation)
- **`ConnectionRenderer.test.tsx`** — Add `DOCKING_STEM_PX: 12` to designTokens mock

## Design Decisions (Oracle-reviewed)

1. **Options object over positional params** — Avoids `undefined` placeholders, cleaner for future extensions
2. **No `Math.max(reserve, radius * 1.5)` for start** — Unlike end reserve, start reserve uses exact cap because `radius * 1.5 = 18` would silently override the 12px token
3. **Only affects `i === 1`** — Middle and later corners are unaffected, preserving existing behavior
4. **12px matches port geometry** — `DOCKING_STEM_PX = PORT_DOT_RX = CONNECTION_CORNER_RADIUS = 12`

## Verification

- ✅ `pnpm lint` — clean
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm test -- --coverage` — 3591 tests pass, branch coverage 90.08%