### PR TITLE
feat(web): calm default connection motion and stronger selection focus

### DIFF
--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -130,7 +130,7 @@ describe('ConnectionRenderer', () => {
     expect(container.querySelector('[data-testid="connection-hit-area"]')).toBeInTheDocument();
   });
 
-  it('renders packet flow layer in default idle mode', () => {
+  it('renders packet flow layer with static direction chevrons in default mode', () => {
     const { container } = renderConnector();
     expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
   });
@@ -747,15 +747,15 @@ describe('ConnectionRenderer', () => {
     expect(trace?.getAttribute('marker-end')).toBe(`url(#arrow-${connection.id})`);
   });
 
-  it('hover increases casing and trace widths by +1.25 (dataflow default)', () => {
+  it('hover increases casing and trace widths by +2.0 (dataflow default)', () => {
     const { container } = renderConnector();
     const casing = container.querySelector('[data-testid="connection-casing"]');
     const trace = container.querySelector('[data-testid="connection-trace"]');
     expect(casing?.getAttribute('stroke-width')).toBe('6');
     expect(trace?.getAttribute('stroke-width')).toBe('3.5');
     fireEvent.mouseEnter(container.querySelector('[data-testid="connection-hit-area"]') as Element);
-    expect(casing?.getAttribute('stroke-width')).toBe('7.25');
-    expect(trace?.getAttribute('stroke-width')).toBe('4.75');
+    expect(casing?.getAttribute('stroke-width')).toBe('8');
+    expect(trace?.getAttribute('stroke-width')).toBe('5.5');
   });
 
   describe('surface render path', () => {
@@ -959,8 +959,8 @@ describe('ConnectionRenderer', () => {
         const trace = container.querySelector('[data-testid="connection-trace"]');
         const casing = container.querySelector('[data-testid="connection-casing"]');
 
-        expect(trace?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 1.25));
-        expect(casing?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 3.75));
+        expect(trace?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 2.0));
+        expect(casing?.getAttribute('stroke-width')).toBe(String(spec.baseWidth + 4.5));
       });
     }
 
@@ -1051,7 +1051,7 @@ describe('ConnectionRenderer', () => {
       const { container } = renderConnector(conn);
       const selectionOutline = container.querySelector('[data-layer="selection-outline"]');
       expect(selectionOutline).toBeInTheDocument();
-      expect(selectionOutline?.getAttribute('stroke-width')).toBe('12.75');
+      expect(selectionOutline?.getAttribute('stroke-width')).toBe('13.5');
     });
   });
 
@@ -1320,7 +1320,7 @@ describe('ConnectionRenderer', () => {
       expect(container.querySelector('[data-testid="connection-invalid"]')).not.toBeInTheDocument();
     });
 
-    it('renders idle packet flow even when connection has only validation warnings', () => {
+    it('renders static packet flow even when connection has only validation warnings', () => {
       useArchitectureStore.setState({
         validationResult: {
           valid: true,

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -448,7 +448,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     if (creationBurstActive) return 'creation' as const;
     if (isSelected) return 'selected' as const;
     if (isHovered || isFocused) return 'hover' as const;
-    return 'idle' as const;
+    return 'static' as const;
   })();
 
   // Creation bursts use a connection-local elapsed derived from the shared clock

--- a/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.test.tsx
@@ -164,10 +164,13 @@ describe('PacketFlowLayer', () => {
     });
   });
 
-  it('returns null in static mode', () => {
+  it('renders direction chevrons in static mode', () => {
     const { container } = renderLayer('static');
 
-    expect(container.querySelector('[data-testid="packet-flow-layer"]')).not.toBeInTheDocument();
+    expect(container.querySelector('[data-testid="packet-flow-layer"]')).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('[data-testid="packet-direction-chevron"]').length,
+    ).toBeGreaterThan(0);
   });
 
   it('renders static chevrons when reduced motion is enabled', () => {

--- a/apps/web/src/entities/connection/PacketFlowLayer.tsx
+++ b/apps/web/src/entities/connection/PacketFlowLayer.tsx
@@ -133,7 +133,7 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
 
   // Reduced motion: show static direction chevrons instead of animated packets
   if (reducedMotion) {
-    if (mode === 'static' || hitPoints.length < 2 || totalLength <= 0) {
+    if (hitPoints.length < 2 || totalLength <= 0) {
       return null;
     }
     return (
@@ -143,12 +143,19 @@ export const PacketFlowLayer = memo(function PacketFlowLayer({
     );
   }
 
-  if (
-    mode === 'static' ||
-    hitPoints.length < 2 ||
-    totalLength <= 0 ||
-    (mode === 'creation' && creationCompleted)
-  ) {
+  // Static mode: render direction chevrons only (no animation).
+  if (mode === 'static') {
+    if (hitPoints.length < 2 || totalLength <= 0) {
+      return null;
+    }
+    return (
+      <g pointerEvents="none" data-testid="packet-flow-layer" data-connection-type={connectionType}>
+        {renderStaticDirectionGlyphs(segments, totalLength, packetColors)}
+      </g>
+    );
+  }
+
+  if (hitPoints.length < 2 || totalLength <= 0 || (mode === 'creation' && creationCompleted)) {
     return null;
   }
 

--- a/apps/web/src/entities/connection/packetFlowTokens.test.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.test.ts
@@ -29,8 +29,8 @@ describe('packetFlowTokens M46 tuning', () => {
     expect(PACKET_TAIL_LENGTH).toBe(20);
   });
 
-  it('PACKET_OPACITY idle is 0.56', () => {
-    expect(PACKET_OPACITY.idle).toBe(0.56);
+  it('PACKET_OPACITY idle is 0', () => {
+    expect(PACKET_OPACITY.idle).toBe(0);
   });
 
   it('PACKET_OPACITY hover is 0.72', () => {

--- a/apps/web/src/entities/connection/packetFlowTokens.ts
+++ b/apps/web/src/entities/connection/packetFlowTokens.ts
@@ -13,7 +13,7 @@ export const SHORT_PATH_THRESHOLD = 80;
 export const MEDIUM_PATH_THRESHOLD = 180;
 
 export const PACKET_OPACITY = {
-  idle: 0.56,
+  idle: 0,
   hover: 0.72,
   selected: 1.0,
   creation: 1.0,

--- a/apps/web/src/shared/tokens/__tests__/connectionVisualTokens.test.ts
+++ b/apps/web/src/shared/tokens/__tests__/connectionVisualTokens.test.ts
@@ -49,8 +49,8 @@ describe('connectionVisualTokens', () => {
       expect(CASING_WIDTH_OFFSET).toBe(2.5);
     });
 
-    it('HOVER_WIDTH_OFFSET is 1.25', () => {
-      expect(HOVER_WIDTH_OFFSET).toBe(1.25);
+    it('HOVER_WIDTH_OFFSET is 2.0', () => {
+      expect(HOVER_WIDTH_OFFSET).toBe(2.0);
     });
   });
 

--- a/apps/web/src/shared/tokens/connectionVisualTokens.ts
+++ b/apps/web/src/shared/tokens/connectionVisualTokens.ts
@@ -37,7 +37,7 @@ export const CONNECTION_VISUAL_STYLES: Record<ConnectionType, ConnectionVisualSt
 export const CASING_WIDTH_OFFSET = 2.5;
 
 /** Hover width offset added to the base stroke width. */
-export const HOVER_WIDTH_OFFSET = 1.25;
+export const HOVER_WIDTH_OFFSET = 2.0;
 
 /** Perpendicular offset (screen px) applied to each connection in an overlap group. */
 export const OVERLAP_OFFSET_PX = 8;


### PR DESCRIPTION
## Summary

- Default packet mode changed from `idle` to `static` — connections now show **direction chevrons** at rest instead of animated packets, reducing visual noise on the canvas
- `PACKET_OPACITY.idle` set to `0` so idle mode shows no packets at all
- `HOVER_WIDTH_OFFSET` increased from `1.25` to `2.0` for **stronger hover/selection contrast**
- `PacketFlowLayer` static mode now renders chevrons via `renderStaticDirectionGlyphs()` instead of returning null
- Fixed `reducedMotion` guard to still show static chevrons when default mode is `static`

## Changes

| File | Change |
|------|--------|
| `packetFlowTokens.ts` | `PACKET_OPACITY.idle`: `0.56` → `0` |
| `ConnectionRenderer.tsx` | Default packetMode: `'idle'` → `'static'` |
| `PacketFlowLayer.tsx` | Static mode renders chevrons; reducedMotion guard fixed |
| `connectionVisualTokens.ts` | `HOVER_WIDTH_OFFSET`: `1.25` → `2.0` |
| `*test*` files (4) | Updated assertions to match new values |

## Testing

- All 89 ConnectionRenderer tests pass
- All 35 PacketFlowLayer tests pass
- Branch coverage: 90.07% ✅
- Lint + typecheck clean

Fixes #1861
Part of #1858