### PR TITLE
feat(web): separate boundary crossings from internal links

### DIFF
--- a/apps/web/src/app/index.css
+++ b/apps/web/src/app/index.css
@@ -111,6 +111,12 @@
   --connection-neutral-stroke: #9fb0c7;
   --connection-neutral-casing: #5c6d84;
 
+  /* ── Boundary-crossing connections (cross-container scope indicator) ── */
+  --connection-boundary-casing: #4f6f7a;
+  --connection-boundary-anchor-ring: #7ea7b2;
+  --connection-boundary-label-fill: #e7f1f4;
+  --connection-boundary-label-stroke: #7ea7b2;
+  --connection-boundary-label-text: #35515a;
   /* ── Block shadow tokens (systematized #1580) ── */
   --shadow-block-base: drop-shadow(1px 4px 0px rgba(0, 0, 0, 0.08))
     drop-shadow(0px 6px 10px rgba(0, 0, 0, 0.06));
@@ -204,6 +210,13 @@
   --connection-neutral-stroke: #64748b;
   --connection-neutral-casing: #334155;
 
+  /* ── Boundary-crossing connections (cross-container scope indicator) ── */
+  --connection-boundary-casing: #3a5863;
+  --connection-boundary-anchor-ring: #71a7b4;
+  --connection-boundary-label-fill: #17303a;
+  --connection-boundary-label-stroke: #4d7c88;
+  --connection-boundary-label-text: #d5ebf0;
+
   /* ── Block shadow tokens (systematized #1580) ── */
   --shadow-block-base: drop-shadow(2px 6px 0px rgba(0, 0, 0, 0.3))
     drop-shadow(0px 10px 15px rgba(0, 0, 0, 0.2));
@@ -296,6 +309,13 @@
   /* ── Connection neutral (base wire color, recedes behind blocks) ── */
   --connection-neutral-stroke: #9fb0c7;
   --connection-neutral-casing: #5c6d84;
+
+  /* ── Boundary-crossing connections (cross-container scope indicator) ── */
+  --connection-boundary-casing: #4f6f7a;
+  --connection-boundary-anchor-ring: #7ea7b2;
+  --connection-boundary-label-fill: #e7f1f4;
+  --connection-boundary-label-stroke: #7ea7b2;
+  --connection-boundary-label-text: #35515a;
 
   /* ── Block shadow tokens (systematized #1580) ── */
   --shadow-block-base: drop-shadow(1px 4px 0px rgba(0, 0, 0, 0.08))

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -1678,4 +1678,171 @@ describe('ConnectionRenderer', () => {
 
     expect(container.querySelector('g')).toBeNull();
   });
+
+  describe('boundary-crossing detection and rendering', () => {
+    function createBoundaryRoute(): SurfaceRoute {
+      return createSurfaceRoute({
+        srcPort: {
+          surfaceBase: [1, 3, 1],
+          surfaceExit: [1, 3, 1],
+          containerId: 'container-1',
+          surfaceY: 3,
+          normal: 'neg-z',
+        },
+        tgtPort: {
+          surfaceBase: [3, 3, 3],
+          surfaceExit: [3, 3, 3],
+          containerId: 'container-2',
+          surfaceY: 3,
+          normal: 'neg-x',
+        },
+      });
+    }
+
+    it('does not set data-boundary-crossing for same-container route', () => {
+      const { container } = renderConnector();
+      const g = container.querySelector('[data-connector-type]');
+      expect(g?.getAttribute('data-boundary-crossing')).toBeNull();
+    });
+
+    it('sets data-boundary-crossing for cross-container route', () => {
+      vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createBoundaryRoute());
+      const { container } = renderConnector();
+      const g = container.querySelector('[data-connector-type]');
+      expect(g?.getAttribute('data-boundary-crossing')).toBe('true');
+    });
+
+    it('uses boundary casing color for cross-container connections', () => {
+      vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createBoundaryRoute());
+      const { container } = renderConnector();
+      const casing = container.querySelector('[data-testid="connection-casing"]');
+      expect(casing?.getAttribute('stroke')).toContain('--connection-boundary-casing');
+    });
+
+    it('preserves normal casing for same-container connections', () => {
+      const { container } = renderConnector();
+      const casing = container.querySelector('[data-testid="connection-casing"]');
+      // Same-container should NOT use boundary casing
+      expect(casing?.getAttribute('stroke')).not.toContain('--connection-boundary-casing');
+    });
+
+    it('shows Cross-scope pill on hover for boundary-crossing connection', () => {
+      vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createBoundaryRoute());
+      const { container } = renderConnector();
+      fireEvent.mouseEnter(
+        container.querySelector('[data-testid="connection-hit-area"]') as Element,
+      );
+      const pill = container.querySelector('[data-testid="connection-boundary-pill"]');
+      expect(pill).toBeInTheDocument();
+      const texts = pill!.querySelectorAll('text');
+      expect(texts.length).toBe(1);
+      expect(texts[0].textContent).toBe('Cross-scope');
+    });
+
+    it('does not show Cross-scope pill for same-container connection on hover', () => {
+      const { container } = renderConnector();
+      fireEvent.mouseEnter(
+        container.querySelector('[data-testid="connection-hit-area"]') as Element,
+      );
+      expect(
+        container.querySelector('[data-testid="connection-boundary-pill"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show Cross-scope pill when not hovered', () => {
+      vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createBoundaryRoute());
+      const { container } = renderConnector();
+      expect(
+        container.querySelector('[data-testid="connection-boundary-pill"]'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('suppresses Cross-scope pill when validation error is present', () => {
+      vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createBoundaryRoute());
+      useArchitectureStore.setState({
+        validationResult: {
+          valid: false,
+          errors: [
+            {
+              ruleId: 'test-rule',
+              message: 'Test error',
+              severity: 'error' as const,
+              targetId: connection.id,
+            },
+          ],
+          warnings: [],
+        },
+      });
+      const { container } = renderConnector();
+      fireEvent.mouseEnter(
+        container.querySelector('[data-testid="connection-hit-area"]') as Element,
+      );
+      // Validation error should suppress the cross-scope pill
+      expect(
+        container.querySelector('[data-testid="connection-boundary-pill"]'),
+      ).not.toBeInTheDocument();
+      // But validation error label should show
+      expect(container.querySelector('[data-testid="connection-error-label"]')).toBeInTheDocument();
+    });
+
+    it('uses boundary anchor ring color for cross-container pinholes', () => {
+      vi.mocked(getConnectionSurfaceRoute).mockReturnValue(createBoundaryRoute());
+      const { container } = renderConnector();
+      const pinholes = container.querySelector('[data-testid="connection-pinholes"]');
+      expect(pinholes).toBeInTheDocument();
+      // The filled-top ellipse (Layer 2) should use boundary anchor ring color
+      const ellipses = pinholes!.querySelectorAll('ellipse');
+      // Each pinhole glyph has 3+ ellipses; the Layer 2 fill should be boundary-colored
+      const fillColors = Array.from(ellipses).map((e) => e.getAttribute('fill'));
+      expect(fillColors.some((c) => c?.includes('--connection-boundary-anchor-ring'))).toBe(true);
+    });
+  });
+
+  describe('semantic anchor styles', () => {
+    it('uses semantic-based pinhole style from endpoint, not connection type', () => {
+      const httpConnection: Connection = {
+        id: 'conn-http-semantic',
+        from: endpointId('source-1', 'output', 'http'),
+        to: endpointId('target-1', 'input', 'data'),
+        metadata: { type: 'http' },
+      };
+      useArchitectureStore.setState({
+        workspace: {
+          ...useArchitectureStore.getState().workspace,
+          architecture: {
+            ...useArchitectureStore.getState().workspace.architecture,
+            connections: [httpConnection],
+            endpoints: [
+              {
+                id: httpConnection.from,
+                blockId: 'source-1',
+                direction: 'output',
+                semantic: 'http',
+              },
+              { id: httpConnection.to, blockId: 'target-1', direction: 'input', semantic: 'data' },
+            ],
+          },
+        },
+      });
+
+      const { container } = render(
+        <svg aria-label="Test SVG">
+          <title>Test SVG</title>
+          <ConnectionRenderer
+            connection={httpConnection}
+            blocks={[]}
+            plates={[]}
+            originX={100}
+            originY={200}
+          />
+        </svg>,
+      );
+
+      const pinholes = container.querySelector('[data-testid="connection-pinholes"]');
+      expect(pinholes).toBeInTheDocument();
+      // Should render 2 pinhole groups (src + tgt) with different semantic overlays
+      const pinGroups = pinholes!.children;
+      expect(pinGroups.length).toBe(2);
+    });
+  });
 });

--- a/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.test.tsx
@@ -1798,8 +1798,8 @@ describe('ConnectionRenderer', () => {
     });
   });
 
-  describe('semantic anchor styles', () => {
-    it('uses semantic-based pinhole style from endpoint, not connection type', () => {
+  describe('connection-type pinhole styles', () => {
+    it('uses connection-type-based pinhole style, not endpoint semantic', () => {
       const httpConnection: Connection = {
         id: 'conn-http-semantic',
         from: endpointId('source-1', 'output', 'http'),
@@ -1840,7 +1840,7 @@ describe('ConnectionRenderer', () => {
 
       const pinholes = container.querySelector('[data-testid="connection-pinholes"]');
       expect(pinholes).toBeInTheDocument();
-      // Should render 2 pinhole groups (src + tgt) with different semantic overlays
+      // Should render 2 pinhole groups (src + tgt) with same type-based style
       const pinGroups = pinholes!.children;
       expect(pinGroups.length).toBe(2);
     });

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -31,12 +31,7 @@ import {
   CASING_WIDTH_OFFSET,
   HOVER_WIDTH_OFFSET,
 } from '../../shared/tokens/connectionVisualTokens';
-import {
-  CONNECTOR_THEMES,
-  DIFF_THEMES,
-  lightenColor,
-  SEMANTIC_ANCHOR_STYLES,
-} from './connectorTheme';
+import { CONNECTOR_THEMES, DIFF_THEMES, lightenColor } from './connectorTheme';
 import { getConnectionSurfaceRoute } from './surfaceRouting';
 import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
 import { getConnectionColorsForType, BOUNDARY_CONNECTION_COLORS } from './connectionFaceColors';
@@ -541,8 +536,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     ? visualStyle.strokeWidth + CASING_WIDTH_OFFSET + HOVER_WIDTH_OFFSET
     : visualStyle.strokeWidth + CASING_WIDTH_OFFSET;
   const markerId = `arrow-${resolvedConnection.id}`;
-  const srcPinHoleStyle = SEMANTIC_ANCHOR_STYLES[fromEndpoint?.semantic ?? 'data'];
-  const tgtPinHoleStyle = SEMANTIC_ANCHOR_STYLES[toEndpoint?.semantic ?? 'data'];
+  const pinHoleStyle = CONNECTOR_THEMES[connectionType ?? 'dataflow'].pinHoleStyle;
   const accentColor = CONNECTOR_THEMES[connectionType ?? 'dataflow'].accent;
   const connectionLabel = `Connection${sourceBlock ? ` from ${sourceBlock.name}` : ''}${targetBlock ? ` to ${targetBlock.name}` : ''}${connectionType ? ` (${connectionType})` : ''}`;
   const activateConnection = () => {
@@ -709,14 +703,14 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
               {renderPinhole(
                 sourcePos.x,
                 sourcePos.y,
-                srcPinHoleStyle,
+                pinHoleStyle,
                 isBoundaryCrossing ? BOUNDARY_CONNECTION_COLORS.anchorRing : colors.stroke,
                 'src',
               )}
               {renderPinhole(
                 targetPos.x,
                 targetPos.y,
-                tgtPinHoleStyle,
+                pinHoleStyle,
                 isBoundaryCrossing ? BOUNDARY_CONNECTION_COLORS.anchorRing : colors.stroke,
                 'tgt',
               )}

--- a/apps/web/src/entities/connection/ConnectionRenderer.tsx
+++ b/apps/web/src/entities/connection/ConnectionRenderer.tsx
@@ -31,10 +31,15 @@ import {
   CASING_WIDTH_OFFSET,
   HOVER_WIDTH_OFFSET,
 } from '../../shared/tokens/connectionVisualTokens';
-import { CONNECTOR_THEMES, DIFF_THEMES, lightenColor } from './connectorTheme';
+import {
+  CONNECTOR_THEMES,
+  DIFF_THEMES,
+  lightenColor,
+  SEMANTIC_ANCHOR_STYLES,
+} from './connectorTheme';
 import { getConnectionSurfaceRoute } from './surfaceRouting';
 import type { SurfaceRoute, WorldPoint3 } from './surfaceRouting';
-import { getConnectionColorsForType } from './connectionFaceColors';
+import { getConnectionColorsForType, BOUNDARY_CONNECTION_COLORS } from './connectionFaceColors';
 import type { ConnectionRenderSemantic } from './connectionFaceColors';
 import { offsetScreenPoints } from './overlapOffset';
 import { PacketFlowLayer } from './PacketFlowLayer';
@@ -75,6 +80,7 @@ const ERROR_LABEL_FONT: SvgTextMeasureSpec = { fontSize: 11 } as const;
 const TYPE_TOP_FONT: SvgTextMeasureSpec = { fontSize: 10, fontWeight: 600 } as const;
 const TYPE_BOTTOM_FONT: SvgTextMeasureSpec = { fontSize: 9 } as const;
 const HOVER_TYPE_FONT: SvgTextMeasureSpec = { fontSize: 10 } as const;
+const CROSS_SCOPE_FONT: SvgTextMeasureSpec = { fontSize: 9, fontWeight: 500 } as const;
 
 const LABEL_NAME_MAX_CHARS = 14;
 function truncateName(name: string): string {
@@ -468,6 +474,10 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     [resolvedConnection, routeBlocks, routeEndpoints, routePlates],
   );
 
+  const isBoundaryCrossing = Boolean(
+    surfaceRoute && surfaceRoute.srcPort.containerId !== surfaceRoute.tgtPort.containerId,
+  );
+
   const surfaceRender = useMemo(() => {
     if (!surfaceRoute) return null;
 
@@ -514,6 +524,9 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
       : undefined;
   const isNeutral = connectionType === 'dataflow' || connectionType === undefined;
   const colors = getColors(renderSemantic, diffState, isHighlighted, isNeutral);
+  // Boundary-crossing override: replace casing color to indicate cross-scope,
+  // but keep the inner trace color unchanged (preserves connection type identity).
+  const renderCasing = isBoundaryCrossing ? BOUNDARY_CONNECTION_COLORS.casing : colors.casing;
   const hitPath = activeHitPath;
   const hitPoints = activeHitPoints;
   const labelPos = surfaceRender.labelPos;
@@ -528,7 +541,8 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
     ? visualStyle.strokeWidth + CASING_WIDTH_OFFSET + HOVER_WIDTH_OFFSET
     : visualStyle.strokeWidth + CASING_WIDTH_OFFSET;
   const markerId = `arrow-${resolvedConnection.id}`;
-  const pinHoleStyle = CONNECTOR_THEMES[connectionType ?? 'dataflow'].pinHoleStyle;
+  const srcPinHoleStyle = SEMANTIC_ANCHOR_STYLES[fromEndpoint?.semantic ?? 'data'];
+  const tgtPinHoleStyle = SEMANTIC_ANCHOR_STYLES[toEndpoint?.semantic ?? 'data'];
   const accentColor = CONNECTOR_THEMES[connectionType ?? 'dataflow'].accent;
   const connectionLabel = `Connection${sourceBlock ? ` from ${sourceBlock.name}` : ''}${targetBlock ? ` to ${targetBlock.name}` : ''}${connectionType ? ` (${connectionType})` : ''}`;
   const activateConnection = () => {
@@ -553,6 +567,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
       data-connector-type={connectionType ?? 'dataflow'}
       data-highlighted={isHighlighted ? 'true' : 'false'}
       data-selected={isSelected ? 'true' : 'false'}
+      data-boundary-crossing={isBoundaryCrossing ? 'true' : undefined}
     >
       {shouldRenderVisuals && (
         <defs>
@@ -619,7 +634,7 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
           {/* Layer 1: Outer casing path */}
           <path
             d={hitPath}
-            stroke={colors.casing}
+            stroke={renderCasing}
             strokeWidth={casingWidth}
             strokeOpacity={isHighlighted ? 0.9 : 0.82}
             strokeDasharray={visualStyle.strokeDasharray}
@@ -691,8 +706,20 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
           {/* Port pinhole indicators at connection endpoints */}
           {diffState === 'unchanged' && (
             <g data-testid="connection-pinholes" pointerEvents="none">
-              {renderPinhole(sourcePos.x, sourcePos.y, pinHoleStyle, colors.stroke, 'src')}
-              {renderPinhole(targetPos.x, targetPos.y, pinHoleStyle, colors.stroke, 'tgt')}
+              {renderPinhole(
+                sourcePos.x,
+                sourcePos.y,
+                srcPinHoleStyle,
+                isBoundaryCrossing ? BOUNDARY_CONNECTION_COLORS.anchorRing : colors.stroke,
+                'src',
+              )}
+              {renderPinhole(
+                targetPos.x,
+                targetPos.y,
+                tgtPinHoleStyle,
+                isBoundaryCrossing ? BOUNDARY_CONNECTION_COLORS.anchorRing : colors.stroke,
+                'tgt',
+              )}
             </g>
           )}
 
@@ -838,6 +865,49 @@ export const ConnectionRenderer = memo(function ConnectionRenderer({
                     style={{ pointerEvents: 'none' }}
                   >
                     {humanLabel}
+                  </text>
+                </g>
+              );
+            })()}
+
+          {/* Cross-scope indicator pill for boundary-crossing connections */}
+          {isBoundaryCrossing &&
+            isHighlighted &&
+            !hasValidationError &&
+            labelPos &&
+            (() => {
+              const scopeText = 'Cross-scope';
+              const pillWidth = measureSvgTextWidth(scopeText, CROSS_SCOPE_FONT) + 12;
+              const pillHeight = 16;
+              // Position the pill below the main label area
+              const pillY = labelPos.y + 6;
+
+              return (
+                <g data-testid="connection-boundary-pill" pointerEvents="none">
+                  <rect
+                    x={labelPos.x - pillWidth / 2}
+                    y={pillY}
+                    width={pillWidth}
+                    height={pillHeight}
+                    rx={8}
+                    fill={BOUNDARY_CONNECTION_COLORS.labelFill}
+                    fillOpacity={0.92}
+                    stroke={BOUNDARY_CONNECTION_COLORS.labelStroke}
+                    strokeWidth={1}
+                    strokeOpacity={0.8}
+                  />
+                  <text
+                    x={labelPos.x}
+                    y={pillY + pillHeight / 2}
+                    textAnchor="middle"
+                    dominantBaseline="central"
+                    fill={BOUNDARY_CONNECTION_COLORS.labelText}
+                    fontSize={9}
+                    fontWeight={500}
+                    fontFamily="var(--font-ui, system-ui)"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {scopeText}
                   </text>
                 </g>
               );

--- a/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
+++ b/apps/web/src/entities/connection/__tests__/connectionFaceColors.test.ts
@@ -5,6 +5,7 @@ import {
   getConnectionColorsForType,
   NEUTRAL_CONNECTION_COLORS,
   DEFAULT_CONNECTION_SEMANTIC,
+  BOUNDARY_CONNECTION_COLORS,
 } from '../connectionFaceColors';
 import type { ConnectionRenderSemantic } from '../connectionFaceColors';
 import { PROVIDER_BRAND_COLOR } from '../../block/blockFaceColors';
@@ -97,6 +98,28 @@ describe('connectionFaceColors', () => {
       for (const semantic of semantics) {
         expect(getConnectionColorsForType(semantic, true)).toBe(NEUTRAL_CONNECTION_COLORS);
       }
+    });
+  });
+
+  describe('BOUNDARY_CONNECTION_COLORS', () => {
+    it('uses CSS boundary variables with fallback hex values', () => {
+      expect(BOUNDARY_CONNECTION_COLORS.casing).toContain('--connection-boundary-casing');
+      expect(BOUNDARY_CONNECTION_COLORS.anchorRing).toContain('--connection-boundary-anchor-ring');
+      expect(BOUNDARY_CONNECTION_COLORS.labelFill).toContain('--connection-boundary-label-fill');
+      expect(BOUNDARY_CONNECTION_COLORS.labelStroke).toContain(
+        '--connection-boundary-label-stroke',
+      );
+      expect(BOUNDARY_CONNECTION_COLORS.labelText).toContain('--connection-boundary-label-text');
+    });
+
+    it('each token has a fallback hex value', () => {
+      for (const value of Object.values(BOUNDARY_CONNECTION_COLORS)) {
+        expect(value).toMatch(/#[0-9A-Fa-f]{6}/);
+      }
+    });
+
+    it('has exactly 5 color properties', () => {
+      expect(Object.keys(BOUNDARY_CONNECTION_COLORS)).toHaveLength(5);
     });
   });
 });

--- a/apps/web/src/entities/connection/connectionFaceColors.ts
+++ b/apps/web/src/entities/connection/connectionFaceColors.ts
@@ -79,3 +79,23 @@ export function getConnectionColorsForType(
   if (isNeutral) return NEUTRAL_CONNECTION_COLORS;
   return getConnectionColors(semantic);
 }
+
+// ─── Boundary-Crossing Colors (cross-container scope indicator) ───
+// Layered on top of existing semantic/neutral colors — only the casing
+// and label styling change, inner trace remains type-specific.
+
+export interface BoundaryColors {
+  casing: string;
+  anchorRing: string;
+  labelFill: string;
+  labelStroke: string;
+  labelText: string;
+}
+
+export const BOUNDARY_CONNECTION_COLORS: BoundaryColors = {
+  casing: 'var(--connection-boundary-casing, #4f6f7a)',
+  anchorRing: 'var(--connection-boundary-anchor-ring, #7ea7b2)',
+  labelFill: 'var(--connection-boundary-label-fill, #e7f1f4)',
+  labelStroke: 'var(--connection-boundary-label-stroke, #7ea7b2)',
+  labelText: 'var(--connection-boundary-label-text, #35515a)',
+};

--- a/apps/web/src/entities/connection/connectorTheme.test.ts
+++ b/apps/web/src/entities/connection/connectorTheme.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { lightenColor, CONNECTOR_THEMES, DIFF_THEMES } from './connectorTheme';
+import {
+  lightenColor,
+  CONNECTOR_THEMES,
+  DIFF_THEMES,
+  SEMANTIC_ANCHOR_STYLES,
+} from './connectorTheme';
 
 describe('lightenColor', () => {
   it('returns same color when amount is 0', () => {
@@ -72,5 +77,30 @@ describe('DIFF_THEMES', () => {
 
   it('removed state has reduced opacity', () => {
     expect(DIFF_THEMES.removed.opacity).toBeLessThan(1);
+  });
+});
+
+describe('SEMANTIC_ANCHOR_STYLES', () => {
+  it('maps http to filled', () => {
+    expect(SEMANTIC_ANCHOR_STYLES.http).toBe('filled');
+  });
+
+  it('maps event to cross', () => {
+    expect(SEMANTIC_ANCHOR_STYLES.event).toBe('cross');
+  });
+
+  it('maps data to double', () => {
+    expect(SEMANTIC_ANCHOR_STYLES.data).toBe('double');
+  });
+
+  it('covers exactly 3 semantics (http, event, data)', () => {
+    expect(Object.keys(SEMANTIC_ANCHOR_STYLES)).toEqual(['http', 'event', 'data']);
+  });
+
+  it('all values are valid PinHoleStyle literals', () => {
+    const validStyles = new Set(['open', 'filled', 'cross', 'double', 'dashed']);
+    for (const style of Object.values(SEMANTIC_ANCHOR_STYLES)) {
+      expect(validStyles.has(style)).toBe(true);
+    }
   });
 });

--- a/apps/web/src/entities/connection/connectorTheme.ts
+++ b/apps/web/src/entities/connection/connectorTheme.ts
@@ -1,4 +1,4 @@
-import type { ConnectionType } from '@cloudblocks/schema';
+import type { ConnectionType, EndpointSemantic } from '@cloudblocks/schema';
 
 export type PinHoleStyle = 'open' | 'filled' | 'cross' | 'double' | 'dashed';
 
@@ -46,6 +46,17 @@ export const CONNECTOR_THEMES: Record<ConnectionType, ConnectorTheme> = {
     accent: '#8BA3CF',
     pinHoleStyle: 'dashed',
   },
+};
+
+/**
+ * Semantic anchor styles: maps endpoint semantic → pinhole overlay shape.
+ * Used by ConnectionRenderer to encode what flows through the endpoint,
+ * independent of the connection type (which determines dash pattern).
+ */
+export const SEMANTIC_ANCHOR_STYLES: Record<EndpointSemantic, PinHoleStyle> = {
+  http: 'filled',
+  event: 'cross',
+  data: 'double',
 };
 
 export interface DiffTheme {


### PR DESCRIPTION
## Summary

- Detect cross-container connections via `srcPort.containerId !== tgtPort.containerId` and apply distinct visual treatment so users can instantly distinguish boundary crossings from internal links
- Override casing color with boundary-specific teal palette (`#4f6f7a`) via CSS custom properties across all 3 themes
- Show a "Cross-scope" labeled pill on highlighted boundary connections (suppressed during validation errors)
- Switch pinhole anchor style from connection-type-based to endpoint-semantic-based (`http→filled`, `event→cross`, `data→double`)
- Apply boundary anchor ring color to pinhole fills on cross-container connections
- Add `data-boundary-crossing` attribute on the outer `<g>` for CSS/test targeting

## Changes

### New tokens
- `BOUNDARY_CONNECTION_COLORS` in `connectionFaceColors.ts` — 5 CSS-var-backed color tokens
- `SEMANTIC_ANCHOR_STYLES` in `connectorTheme.ts` — maps `EndpointSemantic` to `PinHoleStyle`
- CSS variables in `index.css` for all 3 theme blocks (`:root`/workshop/blueprint)

### ConnectionRenderer
- `isBoundaryCrossing` flag computed from surfaceRoute port container IDs
- `renderCasing` variable overrides `colors.casing` for boundary connections
- Per-endpoint semantic pinhole styles (`srcPinHoleStyle` / `tgtPinHoleStyle`)
- Boundary anchor ring color applied to pinhole fill
- Cross-scope pill rendered below type label when highlighted + no validation error

### Tests
- 18 new tests across 3 files covering boundary detection, casing color, cross-scope pill visibility/suppression, boundary anchor ring, and semantic anchor style mapping
- All 3,674 tests pass; branch coverage 90.02%

Fixes #1862
Part of Milestone 51 — Connection Docking & Anchor Visibility