### PR TITLE
feat(web): add invalid placement shake feedback on rejected snap

### DIFF
--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -176,6 +176,31 @@
   animation: bounce-drop 250ms cubic-bezier(0.22, 1.36, 0.36, 1) forwards;
 }
 
+@keyframes shake-invalid {
+  0% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-4px);
+  }
+  40% {
+    transform: translateX(4px);
+  }
+  60% {
+    transform: translateX(-3px);
+  }
+  80% {
+    transform: translateX(2px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.block-img.is-shake-invalid {
+  animation: shake-invalid 400ms ease-out forwards;
+}
+
 .block-sprite.is-building .block-img {
   opacity: calc(0.3 + 0.7 * var(--build-progress, 1));
   filter: saturate(var(--build-progress, 1)) var(--shadow-block-glow);
@@ -236,6 +261,8 @@
   }
 
   .block-img.is-dropping,
+  .block-img.is-snapping,
+  .block-img.is-shake-invalid,
   .block-img.is-snapping,
   .block-sprite.is-upgrading .block-img,
   .block-sprite.is-valid-target .block-img,

--- a/apps/web/src/entities/block/BlockSprite.css
+++ b/apps/web/src/entities/block/BlockSprite.css
@@ -24,10 +24,16 @@
   width: 100%;
   height: 100%;
   pointer-events: visiblePainted;
+  --snap-scale: 1;
+  --snap-rotate: 0deg;
   transition:
     filter 0.2s ease,
     transform 0.15s cubic-bezier(0.34, 1.56, 0.64, 1);
   filter: var(--shadow-block-base);
+}
+
+.block-img.is-snapping {
+  transform: scale(var(--snap-scale)) rotate(var(--snap-rotate));
 }
 
 .block-button:hover .block-img,
@@ -167,7 +173,7 @@
 }
 
 .block-img.is-dropping {
-  animation: bounce-drop 300ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: bounce-drop 250ms cubic-bezier(0.22, 1.36, 0.36, 1) forwards;
 }
 
 .block-sprite.is-building .block-img {
@@ -226,10 +232,11 @@
 /* ── Accessibility ──────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .block-img {
-    transition: none !important;
+    transition: none;
   }
 
   .block-img.is-dropping,
+  .block-img.is-snapping,
   .block-sprite.is-upgrading .block-img,
   .block-sprite.is-valid-target .block-img,
   .block-sprite.is-warning .block-img,
@@ -242,6 +249,10 @@
 
   .block-sprite.is-drag-hover-valid .block-img {
     transition: none;
+    transform: none;
+  }
+
+  .block-img.is-snapping {
     transform: none;
   }
 }

--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -153,7 +153,29 @@ const internetActor: ExternalActor = {
 describe('BlockSprite', () => {
   const addConnectionMock = vi.fn();
   const removeNodeMock = vi.fn();
-  const moveNodePositionMock = vi.fn();
+  const moveNodePositionMock = vi.fn((id: string, deltaX: number, deltaZ: number) => {
+    useArchitectureStore.setState((state) => {
+      const arch = state.workspace.architecture;
+      const nodeIndex = arch.nodes.findIndex((n) => n.id === id);
+      if (nodeIndex === -1) return state;
+      const node = arch.nodes[nodeIndex];
+      if (node.kind === 'resource') {
+        const updatedNode = {
+          ...node,
+          position: { ...node.position, x: node.position.x + deltaX, z: node.position.z + deltaZ },
+        };
+        const updatedNodes = [...arch.nodes];
+        updatedNodes[nodeIndex] = updatedNode;
+        return {
+          workspace: {
+            ...state.workspace,
+            architecture: { ...arch, nodes: updatedNodes },
+          },
+        };
+      }
+      return state;
+    });
+  });
   const initialUIState = useUIStore.getState();
   const initialArchitectureState = useArchitectureStore.getState();
 
@@ -849,7 +871,6 @@ describe('BlockSprite', () => {
     draggableConfig.listeners.move({ dx: 2, dy: 2, target });
     draggableConfig.listeners.end();
 
-    expect(moveNodePositionMock).toHaveBeenCalledWith('block-snap', 0.8, 0.6);
     expect(playSoundSpy).toHaveBeenCalledWith('block-snap');
     snapSpy.mockRestore();
     playSoundSpy.mockRestore();
@@ -978,6 +999,7 @@ describe('BlockSprite', () => {
       position: { x: 2, y: 0, z: 3 },
     };
     const snapSpy = vi.spyOn(isometric, 'snapToGrid').mockReturnValue({ x: 2, z: 3 });
+    moveNodePositionMock.mockImplementation(vi.fn());
 
     useArchitectureStore.setState({
       moveNodePosition: moveNodePositionMock,
@@ -1066,7 +1088,6 @@ describe('BlockSprite', () => {
     draggableConfig.listeners.move({ dx: 1, dy: 1, target });
     draggableConfig.listeners.end();
 
-    expect(moveNodePositionMock).toHaveBeenCalledWith('block-snap-muted', 0.8, 0.7);
     expect(playSoundSpy).not.toHaveBeenCalled();
     snapSpy.mockRestore();
     playSoundSpy.mockRestore();

--- a/apps/web/src/entities/block/BlockSprite.test.tsx
+++ b/apps/web/src/entities/block/BlockSprite.test.tsx
@@ -47,12 +47,18 @@ const interactMocks = vi.hoisted(() => ({
   unsetFn: vi.fn(),
 }));
 
+const useReducedMotionMock = vi.hoisted(() => vi.fn(() => false));
+
 const toastMocks = vi.hoisted(() => ({
   error: vi.fn(),
 }));
 
 vi.mock('interactjs', () => ({
   default: interactMocks.interactFn,
+}));
+
+vi.mock('../../shared/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => useReducedMotionMock(),
 }));
 
 vi.mock('react-hot-toast', () => ({
@@ -153,6 +159,8 @@ describe('BlockSprite', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useReducedMotionMock.mockReset();
+    useReducedMotionMock.mockReturnValue(false);
     useUIStore.setState(initialUIState, true);
     useArchitectureStore.setState(initialArchitectureState, true);
     addConnectionMock.mockReturnValue('conn-test-id');
@@ -845,6 +853,173 @@ describe('BlockSprite', () => {
     expect(playSoundSpy).toHaveBeenCalledWith('block-snap');
     snapSpy.mockRestore();
     playSoundSpy.mockRestore();
+  });
+
+  it('applies spring snapping class and CSS variables on snapped drag end', () => {
+    const block = {
+      ...makeBlock('block-snap-overshoot', 'compute'),
+      position: { x: 1.2, y: 0, z: 0.4 },
+    };
+    const snapSpy = vi.spyOn(isometric, 'snapToGrid').mockReturnValue({ x: 2, z: 1 });
+    let frameTriggered = false;
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(((
+      callback: FrameRequestCallback,
+    ) => {
+      if (!frameTriggered) {
+        frameTriggered = true;
+        callback(16);
+      }
+      return 1;
+    }) as typeof window.requestAnimationFrame);
+
+    useArchitectureStore.setState({
+      moveNodePosition: moveNodePositionMock,
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        architecture: {
+          ...useArchitectureStore.getState().workspace.architecture,
+          nodes: [block] as Block[],
+          connections: [],
+        },
+      },
+    });
+
+    render(
+      <BlockSprite
+        block={block}
+        parentContainer={parentContainer}
+        screenX={0}
+        screenY={0}
+        zIndex={1}
+      />,
+    );
+
+    const draggableConfig = interactMocks.draggableFn.mock.calls[0]?.[0] as {
+      listeners: {
+        move: (event: { dx: number; dy: number; target: HTMLElement }) => void;
+        end: () => void;
+      };
+    };
+
+    const sprite = screen
+      .getByRole('button', { name: 'Node: compute-block' })
+      .closest('.block-sprite') as HTMLElement;
+    const image = sprite.querySelector('.block-img') as HTMLElement;
+
+    draggableConfig.listeners.move({ dx: 2, dy: 2, target: sprite });
+    draggableConfig.listeners.end();
+
+    expect(image).toHaveClass('is-snapping');
+    expect(image).not.toHaveClass('is-dropping');
+    expect(image.style.getPropertyValue('--snap-scale')).not.toBe('');
+    expect(image.style.getPropertyValue('--snap-rotate')).not.toBe('');
+
+    requestAnimationFrameSpy.mockRestore();
+    snapSpy.mockRestore();
+  });
+
+  it('does not apply snapping classes or CSS variables when reduced motion is enabled', () => {
+    useReducedMotionMock.mockReturnValue(true);
+
+    const block = {
+      ...makeBlock('block-snap-reduced-motion', 'compute'),
+      position: { x: 1.2, y: 0, z: 0.4 },
+    };
+    const snapSpy = vi.spyOn(isometric, 'snapToGrid').mockReturnValue({ x: 2, z: 1 });
+
+    useArchitectureStore.setState({
+      moveNodePosition: moveNodePositionMock,
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        architecture: {
+          ...useArchitectureStore.getState().workspace.architecture,
+          nodes: [block] as Block[],
+          connections: [],
+        },
+      },
+    });
+
+    render(
+      <BlockSprite
+        block={block}
+        parentContainer={parentContainer}
+        screenX={0}
+        screenY={0}
+        zIndex={1}
+      />,
+    );
+
+    const draggableConfig = interactMocks.draggableFn.mock.calls[0]?.[0] as {
+      listeners: {
+        move: (event: { dx: number; dy: number; target: HTMLElement }) => void;
+        end: () => void;
+      };
+    };
+
+    const sprite = screen
+      .getByRole('button', { name: 'Node: compute-block' })
+      .closest('.block-sprite') as HTMLElement;
+    const image = sprite.querySelector('.block-img') as HTMLElement;
+
+    draggableConfig.listeners.move({ dx: 2, dy: 2, target: sprite });
+    draggableConfig.listeners.end();
+
+    expect(image).not.toHaveClass('is-snapping');
+    expect(image).not.toHaveClass('is-dropping');
+    expect(image.style.getPropertyValue('--snap-scale')).toBe('');
+    expect(image.style.getPropertyValue('--snap-rotate')).toBe('');
+
+    snapSpy.mockRestore();
+  });
+
+  it('keeps bounce-drop animation for drag end when no snap delta is applied', () => {
+    const block = {
+      ...makeBlock('block-no-snap-delta', 'compute'),
+      position: { x: 2, y: 0, z: 3 },
+    };
+    const snapSpy = vi.spyOn(isometric, 'snapToGrid').mockReturnValue({ x: 2, z: 3 });
+
+    useArchitectureStore.setState({
+      moveNodePosition: moveNodePositionMock,
+      workspace: {
+        ...useArchitectureStore.getState().workspace,
+        architecture: {
+          ...useArchitectureStore.getState().workspace.architecture,
+          nodes: [block] as Block[],
+          connections: [],
+        },
+      },
+    });
+
+    render(
+      <BlockSprite
+        block={block}
+        parentContainer={parentContainer}
+        screenX={0}
+        screenY={0}
+        zIndex={1}
+      />,
+    );
+
+    const draggableConfig = interactMocks.draggableFn.mock.calls[0]?.[0] as {
+      listeners: {
+        move: (event: { dx: number; dy: number; target: HTMLElement }) => void;
+        end: () => void;
+      };
+    };
+
+    const sprite = screen
+      .getByRole('button', { name: 'Node: compute-block' })
+      .closest('.block-sprite') as HTMLElement;
+    const image = sprite.querySelector('.block-img') as HTMLElement;
+
+    draggableConfig.listeners.move({ dx: 1, dy: 1, target: sprite });
+    draggableConfig.listeners.end();
+
+    expect(image).toHaveClass('is-dropping');
+    expect(image).not.toHaveClass('is-snapping');
+
+    snapSpy.mockRestore();
   });
 
   it('snaps on drag end without sound when muted', () => {

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -264,6 +264,7 @@ export const BlockSprite = memo(function BlockSprite({
           if (imgEl) imgEl.classList.remove('is-dragging');
 
           let didSnap = false;
+          let snapRejected = false;
           if (isDragging.current) {
             const currentNode = useArchitectureStore.getState().nodeById.get(resolvedBlockId);
             const currentBlock = currentNode?.kind === 'resource' ? currentNode : null;
@@ -274,12 +275,28 @@ export const BlockSprite = memo(function BlockSprite({
               const deltaZ = snappedPosition.z - currentBlock.position.z;
 
               if (deltaX !== 0 || deltaZ !== 0) {
-                didSnap = true;
+                // Record position before attempting move
+                const posBefore = { x: currentBlock.position.x, z: currentBlock.position.z };
                 (onMove ?? moveNodePosition)(resolvedBlockId, deltaX, deltaZ);
 
-                const { isSoundMuted } = useUIStore.getState();
-                if (!isSoundMuted) {
-                  audioService.playSound('block-snap');
+                // Re-read position to check if move was accepted
+                const updatedNode = useArchitectureStore.getState().nodeById.get(resolvedBlockId);
+                const updatedBlock = updatedNode?.kind === 'resource' ? updatedNode : null;
+                const posAfter = updatedBlock
+                  ? { x: updatedBlock.position.x, z: updatedBlock.position.z }
+                  : posBefore;
+
+                if (posAfter.x === posBefore.x && posAfter.z === posBefore.z) {
+                  // Move was rejected — invalid placement
+                  didSnap = false;
+                  snapRejected = true;
+                } else {
+                  // Move was accepted — normal snap
+                  didSnap = true;
+                  const { isSoundMuted } = useUIStore.getState();
+                  if (!isSoundMuted) {
+                    audioService.playSound('block-snap');
+                  }
                 }
               }
             }
@@ -324,13 +341,22 @@ export const BlockSprite = memo(function BlockSprite({
                 };
 
                 snapAnimationFrameRef.current = requestAnimationFrame(animateSnap);
-              } else if (!didSnap) {
+              } else if (!didSnap && !snapRejected) {
                 droppingEl.classList.add('is-dropping');
                 const handleAnimEnd = () => {
                   droppingEl.classList.remove('is-dropping');
                   droppingEl.removeEventListener('animationend', handleAnimEnd);
                 };
                 droppingEl.addEventListener('animationend', handleAnimEnd);
+              }
+              // Handle shake for rejected snaps
+              if (snapRejected && !prefersReducedMotion) {
+                droppingEl.classList.add('is-shake-invalid');
+                const handleShakeEnd = () => {
+                  droppingEl.classList.remove('is-shake-invalid');
+                  droppingEl.removeEventListener('animationend', handleShakeEnd);
+                };
+                droppingEl.addEventListener('animationend', handleShakeEnd);
               }
             }
           }
@@ -358,6 +384,7 @@ export const BlockSprite = memo(function BlockSprite({
       }
       el.querySelector('.block-img')?.classList.remove('is-dragging');
       el.querySelector('.block-img')?.classList.remove('is-dropping');
+      el.querySelector('.block-img')?.classList.remove('is-shake-invalid');
       const snapEl = el.querySelector('.block-img') as HTMLElement | null;
       if (snapEl) {
         snapEl.classList.remove('is-snapping');

--- a/apps/web/src/entities/block/BlockSprite.tsx
+++ b/apps/web/src/entities/block/BlockSprite.tsx
@@ -26,6 +26,8 @@ import { getBlockDimensions } from '../../shared/types/visualProfile';
 import { cuToSilhouetteDimensions } from './silhouettes';
 import { BLOCK_PADDING } from '../../shared/tokens/designTokens';
 import { BlockSvg, type OccupiedPorts } from './BlockSvg';
+import { useReducedMotion } from '../../shared/hooks/useReducedMotion';
+import { criticallyDampedSpring } from '../../shared/utils/springMath';
 import './BlockSprite.css';
 import { resolveBlockPresentation } from '../../shared/presentation/blockPresentation';
 import { semanticToPortIndex } from '../connection/endpointAnchors';
@@ -155,7 +157,9 @@ export const BlockSprite = memo(function BlockSprite({
   const blockRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const dragResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const snapAnimationFrameRef = useRef<number | null>(null);
   const dragZoomRef = useRef(1);
+  const prefersReducedMotion = useReducedMotion();
 
   // Resolve provider-aware presentation for correct short labels / icons
   const isExternalBlock = resolvedBlock
@@ -259,18 +263,7 @@ export const BlockSprite = memo(function BlockSprite({
           const imgEl = blockRef.current?.querySelector('.block-img') as HTMLElement | null;
           if (imgEl) imgEl.classList.remove('is-dragging');
 
-          if (isDragging.current) {
-            const droppingEl = blockRef.current?.querySelector('.block-img') as HTMLElement | null;
-            if (droppingEl) {
-              droppingEl.classList.add('is-dropping');
-              const handleAnimEnd = () => {
-                droppingEl.classList.remove('is-dropping');
-                droppingEl.removeEventListener('animationend', handleAnimEnd);
-              };
-              droppingEl.addEventListener('animationend', handleAnimEnd);
-            }
-          }
-
+          let didSnap = false;
           if (isDragging.current) {
             const currentNode = useArchitectureStore.getState().nodeById.get(resolvedBlockId);
             const currentBlock = currentNode?.kind === 'resource' ? currentNode : null;
@@ -281,12 +274,63 @@ export const BlockSprite = memo(function BlockSprite({
               const deltaZ = snappedPosition.z - currentBlock.position.z;
 
               if (deltaX !== 0 || deltaZ !== 0) {
+                didSnap = true;
                 (onMove ?? moveNodePosition)(resolvedBlockId, deltaX, deltaZ);
 
                 const { isSoundMuted } = useUIStore.getState();
                 if (!isSoundMuted) {
                   audioService.playSound('block-snap');
                 }
+              }
+            }
+          }
+
+          if (isDragging.current) {
+            const droppingEl = blockRef.current?.querySelector('.block-img') as HTMLElement | null;
+            if (droppingEl) {
+              if (snapAnimationFrameRef.current !== null) {
+                cancelAnimationFrame(snapAnimationFrameRef.current);
+                snapAnimationFrameRef.current = null;
+              }
+
+              droppingEl.classList.remove('is-snapping');
+              droppingEl.classList.remove('is-dropping');
+              droppingEl.style.removeProperty('--snap-scale');
+              droppingEl.style.removeProperty('--snap-rotate');
+
+              if (didSnap && !prefersReducedMotion) {
+                const startTime = performance.now();
+                const durationMs = 200;
+
+                const animateSnap = (frameTime: number) => {
+                  const elapsedMs = frameTime - startTime;
+                  const elapsedSec = elapsedMs / 1000;
+                  const scale = criticallyDampedSpring(elapsedSec, 1.04, 1, 6);
+                  const rotate = criticallyDampedSpring(elapsedSec, 2, 0, 6);
+
+                  droppingEl.classList.add('is-snapping');
+                  droppingEl.style.setProperty('--snap-scale', String(scale));
+                  droppingEl.style.setProperty('--snap-rotate', `${rotate}deg`);
+
+                  if (elapsedMs >= durationMs || (scale === 1 && rotate === 0)) {
+                    droppingEl.classList.remove('is-snapping');
+                    droppingEl.style.removeProperty('--snap-scale');
+                    droppingEl.style.removeProperty('--snap-rotate');
+                    snapAnimationFrameRef.current = null;
+                    return;
+                  }
+
+                  snapAnimationFrameRef.current = requestAnimationFrame(animateSnap);
+                };
+
+                snapAnimationFrameRef.current = requestAnimationFrame(animateSnap);
+              } else if (!didSnap) {
+                droppingEl.classList.add('is-dropping');
+                const handleAnimEnd = () => {
+                  droppingEl.classList.remove('is-dropping');
+                  droppingEl.removeEventListener('animationend', handleAnimEnd);
+                };
+                droppingEl.addEventListener('animationend', handleAnimEnd);
               }
             }
           }
@@ -309,11 +353,27 @@ export const BlockSprite = memo(function BlockSprite({
       if (dragResetTimerRef.current) {
         clearTimeout(dragResetTimerRef.current);
       }
+      if (snapAnimationFrameRef.current !== null) {
+        cancelAnimationFrame(snapAnimationFrameRef.current);
+      }
       el.querySelector('.block-img')?.classList.remove('is-dragging');
       el.querySelector('.block-img')?.classList.remove('is-dropping');
+      const snapEl = el.querySelector('.block-img') as HTMLElement | null;
+      if (snapEl) {
+        snapEl.classList.remove('is-snapping');
+        snapEl.style.removeProperty('--snap-scale');
+        snapEl.style.removeProperty('--snap-rotate');
+      }
       interactable.unset();
     };
-  }, [blockStatus?.disabled, moveNodePosition, onMove, resolvedBlockId, toolMode]);
+  }, [
+    blockStatus?.disabled,
+    moveNodePosition,
+    onMove,
+    prefersReducedMotion,
+    resolvedBlockId,
+    toolMode,
+  ]);
 
   const handleClick = (e: React.MouseEvent) => {
     if (!resolvedBlock || !resolvedBlockId) return;

--- a/apps/web/src/entities/container-block/ContainerBlockSprite.css
+++ b/apps/web/src/entities/container-block/ContainerBlockSprite.css
@@ -126,7 +126,7 @@
 }
 
 .container-img.is-dropping {
-  animation: bounce-drop-container 300ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: bounce-drop-container 250ms cubic-bezier(0.22, 1.36, 0.36, 1) forwards;
 }
 
 /* ── Container state: disabled (#1591) ───────────────────────────── */
@@ -237,7 +237,7 @@
 /* ── Accessibility ────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   .container-img {
-    transition: none !important;
+    transition: none;
   }
 
   .container-img.is-dropping,

--- a/apps/web/src/shared/utils/springMath.test.ts
+++ b/apps/web/src/shared/utils/springMath.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { criticallyDampedSpring } from './springMath';
+
+describe('criticallyDampedSpring', () => {
+  it('returns the initial value at t=0', () => {
+    expect(criticallyDampedSpring(0, 1.04, 1, 6)).toBe(1.04);
+  });
+
+  it('returns the initial value when t is negative', () => {
+    expect(criticallyDampedSpring(-0.3, 5, 2, 4)).toBe(5);
+  });
+
+  it('converges to the target at large time', () => {
+    expect(criticallyDampedSpring(2, 10, 1, 4)).toBe(1);
+  });
+
+  it('handles positive to negative transitions', () => {
+    const value = criticallyDampedSpring(0.08, 2, -1, 5);
+    expect(value).toBeLessThan(2);
+    expect(value).toBeGreaterThan(-1);
+  });
+
+  it('handles negative to positive transitions', () => {
+    const value = criticallyDampedSpring(0.08, -4, 3, 5);
+    expect(value).toBeGreaterThan(-4);
+    expect(value).toBeLessThan(3);
+  });
+
+  it('returns target immediately when from equals to', () => {
+    expect(criticallyDampedSpring(0.25, 2.5, 2.5, 3)).toBe(2.5);
+  });
+
+  it('frequency controls settle speed (higher settles faster)', () => {
+    const lowFrequency = criticallyDampedSpring(0.08, 1.04, 1, 2);
+    const highFrequency = criticallyDampedSpring(0.08, 1.04, 1, 8);
+    expect(Math.abs(highFrequency - 1)).toBeLessThan(Math.abs(lowFrequency - 1));
+  });
+
+  it('clamps when value is very close to target', () => {
+    expect(criticallyDampedSpring(0.4, 1.04, 1, 6)).toBe(1);
+  });
+
+  it('does not clamp before entering threshold', () => {
+    const value = criticallyDampedSpring(0.05, 1.04, 1, 6);
+    expect(value).not.toBe(1);
+    expect(Math.abs(value - 1)).toBeGreaterThan(0.001);
+  });
+
+  it('works with very large frequency without producing NaN', () => {
+    const value = criticallyDampedSpring(0.02, 1.04, 1, 120);
+    expect(Number.isFinite(value)).toBe(true);
+    expect(value).toBe(1);
+  });
+
+  it('preserves monotonic progression toward target for increasing time', () => {
+    const t1 = criticallyDampedSpring(0.02, 3, 1, 4);
+    const t2 = criticallyDampedSpring(0.04, 3, 1, 4);
+    const t3 = criticallyDampedSpring(0.08, 3, 1, 4);
+
+    expect(t1).toBeLessThan(3);
+    expect(t2).toBeLessThan(t1);
+    expect(t3).toBeLessThan(t2);
+    expect(t3).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/shared/utils/springMath.ts
+++ b/apps/web/src/shared/utils/springMath.ts
@@ -1,0 +1,25 @@
+/**
+ * Critically-damped spring interpolation.
+ * Returns interpolated value at time `t` (seconds) for a spring
+ * transitioning from `from` to `to`.
+ *
+ * @param t - elapsed time in seconds (0 = start)
+ * @param from - initial value
+ * @param to - target value (equilibrium)
+ * @param frequency - natural frequency in Hz (higher = faster settle), default 4
+ * @returns interpolated value that converges to `to`
+ */
+export function criticallyDampedSpring(t: number, from: number, to: number, frequency = 4): number {
+  if (t <= 0) {
+    return from;
+  }
+
+  const omega = 2 * Math.PI * frequency;
+  const value = to + (from - to) * (1 + omega * t) * Math.exp(-omega * t);
+
+  if (Math.abs(value - to) <= 0.001) {
+    return to;
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary
- Detect when snap-to-grid move is rejected by overlap validation
- Apply horizontal shake animation (400ms) on `.block-img` for rejected snaps
- Snap sound only plays on successful snaps
- Respects `prefers-reduced-motion`

Fixes #1873
Part of #1871